### PR TITLE
feat: expand code review skills for Kotlin backend projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Mobile Development Plugin
 
-A portable AI skill suite for Android/Kotlin projects — code review, feature implementation, and developer tooling. Install once, use from any AI coding agent.
+A portable AI skill suite for Android, KMP, and Kotlin backend projects — code review, feature implementation, and developer tooling. Install once, use from any AI coding agent.
 
 ## What Is This?
 
-This plugin is a collection of 16 AI skills (slash commands) that help with code review, feature development, and project maintenance. Instead of maintaining separate prompts for each AI agent, all skills live in one place and are distributed via symlinks to every agent you use.
+This plugin is a collection of 19 AI skills (slash commands) that help with code review, feature development, and project maintenance. Instead of maintaining separate prompts for each AI agent, all skills live in one place and are distributed via symlinks to every agent you use.
 
 **The key idea**: edit a skill once in this repo, and every agent sees the update instantly. No copy-pasting, no drift between agents.
 
@@ -53,7 +53,7 @@ plugin/skills/mdp-code-review/           <-- source of truth (this repo)
 ~/.glm/commands/mdp-code-review/         <-- secondary agent
 ```
 
-That's it. All 16 skills are now available as slash commands in every agent you selected.
+That's it. All 19 skills are now available as slash commands in every agent you selected.
 
 **Re-running the installer is safe.** It only touches `mdp-*` skills that belong to this plugin — any custom skills you created independently in your agent's directory are left untouched. Plugin skills are refreshed with updated symlinks.
 
@@ -77,20 +77,23 @@ No config files to edit — the installer handles everything interactively.
 
 ## Skills Included
 
-### Code Review (8 skills)
+### Code Review (11 skills)
 
-Run `/mdp-code-review` to start a review. The orchestrator analyzes the diff and spawns 2-6 specialist agents in parallel, then merges and deduplicates findings.
+Run `/mdp-code-review` to start a review. The orchestrator classifies the project type conservatively, preserves the full Android/KMP review path when mobile signals are strong, and spawns 2-6 specialist agents in parallel before merging and deduplicating findings.
 
 | Skill | Description |
 |-------|-------------|
-| `/mdp-code-review` | Orchestrator: spawns 2-6 specialist reviews, merges results |
-| `/mdp-code-review-architecture` | Architecture, boundaries, DI, source-of-truth |
+| `/mdp-code-review` | Orchestrator: classifies project type, spawns 2-6 specialist reviews, merges results |
+| `/mdp-code-review-architecture` | Architecture, boundaries, DI, source-of-truth across Android/KMP/backend |
 | `/mdp-code-review-compose-check` | Jetpack Compose best practices and optimization |
-| `/mdp-code-review-platform-correctness` | Lifecycle, coroutines, threading, Flow composition |
-| `/mdp-code-review-performance` | Recomposition, main-thread work, resource usage |
-| `/mdp-code-review-security` | Secrets, auth, PII, transport/storage |
+| `/mdp-code-review-platform-correctness` | Lifecycle, coroutines, threading, Flow composition, server correctness |
+| `/mdp-code-review-performance` | Recomposition, hot-path work, blocking I/O, resource usage |
+| `/mdp-code-review-security` | Secrets, auth, PII, transport/storage across mobile and backend |
 | `/mdp-code-review-testing` | Coverage gaps, flaky tests, regression risk |
 | `/mdp-code-review-ux-accessibility` | UX states, a11y, validation |
+| `/mdp-code-review-backend-api-contracts` | Backend API contracts, validation, serialization, compatibility |
+| `/mdp-code-review-backend-persistence` | Backend persistence, transactions, migrations, data consistency |
+| `/mdp-code-review-backend-reliability` | Backend timeouts, retries, jobs, caching, observability |
 
 ### Feature Lifecycle (4 skills)
 

--- a/skills/mdp-code-review-architecture/SKILL.md
+++ b/skills/mdp-code-review-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdp-code-review-architecture
-description: Review architecture, boundaries, DI scopes, and source-of-truth consistency in Kotlin/Android changes.
+description: Review architecture, boundaries, DI scopes, and source-of-truth consistency in Kotlin Android, KMP, and backend/server changes.
 ---
 
 # Architecture Review Specialist
@@ -8,16 +8,26 @@ description: Review architecture, boundaries, DI scopes, and source-of-truth con
 Review only high-signal architectural issues.
 
 ## Focus
-- Layer boundaries (presentation/domain/data)
-- Dependency direction and module ownership
-- Source-of-truth consistency and fallback correctness
+- Layer boundaries and dependency direction
+- Module ownership and source-of-truth consistency
 - Sync/merge semantics, idempotency, and data ownership
 - DI scope correctness and lifecycle-safe wiring
+- Separation between transport, domain, and persistence concerns
 
 ## Ignore
 - Formatting/style-only comments
 - Naming preferences without architectural impact
 - Localization and string resource issues (owned by `mdp-code-review-ux-accessibility`)
+
+## Applicability
+
+First determine whether the code under review is:
+- Android/KMP UI or app-layer code
+- KMP shared/common code
+- Backend/server code
+- Generic Kotlin library code
+
+Apply the shared Kotlin rules to every review. Apply Android/KMP-only rules only when Android/KMP signals are present. Apply backend/server-only rules only when backend/server signals are present. If both appear in one change, review each changed area with the relevant rules instead of forcing one model onto the other.
 
 ## Project Overrides
 
@@ -25,58 +35,62 @@ If an `AGENTS.md` file exists in the project root, read it and apply its rules a
 
 ## Project-Specific Rules
 
-### Layer Boundaries
+### Shared Kotlin Architecture
+- Keep domain/business logic independent from transport and storage concerns unless the project intentionally uses a simpler shape
+- Dependencies must point inward toward stable business rules, not outward toward frameworks or concrete infra details
+- Preserve a single source of truth for each piece of business state; avoid duplicated ownership across layers
+- Do not leak framework-specific models across boundaries when that couples unrelated layers
+- External systems (network, database, messaging, file system) should be behind explicit adapters or repository/client boundaries
+- Prefer constructor injection and explicit dependencies over service locators or hidden globals
+- Avoid `kotlin.Result` and `Any` in core architecture contracts unless the project explicitly standardizes on them
+
+### Android/KMP-Specific Rules
+
+#### Layer Boundaries
 - Domain layer must be pure Kotlin — no Android framework imports
 - Domain must not depend on data or presentation
 - Feature modules must not depend on each other — shared code goes in core modules
-- Module structure: `core:common`, `core:data`, `core:domain`, `core:presentation`, `feature:*`
+- Module structure typically follows `core:common`, `core:data`, `core:domain`, `core:presentation`, `feature:*`
 
-### Repository Pattern
-- Repositories never throw exceptions — return concrete types (Boolean, nullable, empty collections)
-- Wrap all database/network operations in try-catch with logging
-- Factory pattern: interface in `core/domain/.../di/`, impl in `core/data/.../repository/`
-- Implementation uses `@AssistedInject`, factory bound in `FactoryModule.kt` with `@Provides`
-- Inject factory (not repository) in ViewModels
+#### Repository Pattern
+- Repositories are failure boundaries — absorb infra/data errors and return stable outputs per project contract
+- Wrap database/network operations in explicit handling with structured logging
+- Factory pattern, assisted injection, and `FactoryModule.kt` rules apply when the project already uses that pattern
+- Inject factories rather than concrete repositories into ViewModels when that is the established project convention
 - Bulk operations (`insertMany`/`updateMany`) over N individual calls
-- Prefer meaningful implementation names over generic `*Impl` suffix
+- Prefer meaningful implementation names over generic `*Impl` suffix when the codebase already distinguishes responsibilities
 
-### Repository Resilience Contracts
-- Repositories are failure boundaries — absorb infra/data errors, return stable outputs
-- `Flow` APIs: catch and emit safe defaults per contract
-  - Single entity: `Flow<T?>` → emit `null` on error
-  - List: `Flow<List<T>>` → emit `emptyList()` on error
-- `suspend` APIs: return concrete failure values (`false`, `null`, typed result), never throw
-- No `printStackTrace` — use structured logging with context
-- ViewModels must be able to consume repositories without defensive catches
+#### ViewModel Contracts
+- Each screen should have a clear State/Event/Effect contract
+- State uses read-only `StateFlow` outside the ViewModel
+- Events/effects should avoid direct Android resource dependencies
+- Derive state reactively from data sources rather than imperative `init { load() }` patterns when the screen is fundamentally state-stream driven
 
-### ViewModel Contracts
-- Each screen has State/Event/Effect contract
-- State: `StateFlow` (read-only outside ViewModel)
-- Events: `SharedFlow`
-- No string resources in ViewModels — emit effects describing what happened, UI decides strings
-- No analytics in ViewModels — emit declarative effects (e.g., `Effect.OccurrenceSaved`), UI calls analytics
-- Create state from data sources (`repository.observeX().map`), never `init { load() }`
-
-### DI
-- Hilt only, constructor injection exclusively
-- `@HiltViewModel` with assisted injection
+#### DI
+- Hilt-specific rules apply only when Hilt is already the chosen DI framework
+- `@HiltViewModel`, constructor injection, and assisted injection should be wired consistently when present
 - Never pass ViewModels down the UI hierarchy
 
-### Data Flow
-- Pass IDs between screens, not full objects
-- Single source of truth — derive state reactively
-- No data duplication across layers
+#### Data Flow
+- Pass IDs between screens rather than full objects
+- Shared KMP code should stay platform-neutral unless platform APIs are intentionally abstracted
+- Use `DispatcherProvider` instead of direct `Dispatchers.*` when that is the project convention
 
-### Naming & Types
-- Data models: `*DataModel`, not `*Dto`
-- Never use `kotlin.Result` or `Any` type
-- Use `DispatcherProvider` instead of `Dispatchers.*`
-- Use `.orEmpty()` instead of `?: ""`
-- GraphQL queries use fragments for repeated field sets
+#### Naming & Data Safety
+- DataStore file renames require migration
+- Removed proto fields should be marked `reserved`
+- Use `.orEmpty()` instead of `?: ""` when consistent with project style and semantics
 
-### DataStore Safety
-- Never rename DataStore files without migration
-- Mark removed proto fields as `reserved`
+### Backend/Server-Specific Rules
+- Controllers/routes/handlers stay thin: validate input, derive auth context, call a service/use case, map the response
+- Do not embed business workflows directly inside controllers, request filters, or ORM entities
+- Keep API DTOs, domain models, and persistence entities separate when shapes or lifecycle constraints differ
+- Repository/DAO boundaries must not leak ORM sessions, transaction handles, or SQL-building details into higher layers unless that is an explicit architectural choice
+- Transaction boundaries should be explicit and owned consistently; avoid splitting one business operation across multiple implicit transactions
+- External clients (HTTP, gRPC, queues, third-party SDKs) should sit behind dedicated adapters/interfaces for testability and swapability
+- Migration/schema changes must consider rollout compatibility, existing data, and mixed-version deployments when relevant
+- Constructor injection is preferred, but the DI framework may be Spring, Koin, Dagger, Micronaut, or manual wiring; judge scope clarity, not framework choice itself
+- Background jobs, consumers, and schedulers should call the same use cases/services as the synchronous entry points instead of duplicating business logic
 
 ## Output Rules
 - Report at most 7 findings.

--- a/skills/mdp-code-review-backend-api-contracts/SKILL.md
+++ b/skills/mdp-code-review-backend-api-contracts/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: mdp-code-review-backend-api-contracts
+description: Review Kotlin backend/server API boundaries including request validation, serialization, HTTP or RPC contracts, status-code mapping, and backward compatibility.
+---
+
+# Backend API & Contract Review Specialist
+
+Review only backend/service API contract issues that can break clients, allow invalid behavior, or create hard-to-debug production regressions.
+
+## Focus
+- Request validation and boundary enforcement
+- Serialization/deserialization mismatches
+- Backward compatibility of request/response schemas
+- Status-code and error-contract correctness
+- Pagination, filtering, and idempotency semantics on public endpoints
+
+## Ignore
+- Pure style feedback
+- Internal refactors that do not change externally observable behavior
+
+## Applicability
+
+Use this specialist for backend/server code only. It is most relevant for Ktor, Spring, Micronaut, Quarkus, http4k, Javalin, gRPC, or similar transport layers.
+
+## Project Overrides
+
+If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+
+## Project-Specific Rules
+
+- Validate untrusted input at the boundary before business logic depends on it
+- Distinguish absent vs null vs defaulted fields when that changes semantics
+- Do not leak internal/domain/persistence models directly as public API contracts unless that coupling is an explicit, stable decision
+- Breaking contract changes require explicit versioning, coordinated migration, or a compatibility story
+- Error mapping should be stable, intentional, and not collapse distinct client outcomes into the same generic failure
+- Mutating endpoints, commands, and webhook handlers should define idempotency behavior clearly when retries are plausible
+- Pagination and filtering should preserve deterministic ordering and bounded result sizes
+- Serialization defaults must match the compatibility expectations of existing clients
+
+## Output Rules
+- Report at most 7 findings.
+- Include client-visible consequence for each finding.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/mdp-code-review-backend-persistence/SKILL.md
+++ b/skills/mdp-code-review-backend-persistence/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: mdp-code-review-backend-persistence
+description: Review Kotlin backend/server persistence risks including transaction boundaries, query correctness, migration safety, concurrency, and data-consistency behavior.
+---
+
+# Backend Persistence Review Specialist
+
+Review only backend persistence issues that can corrupt data, break consistency, or create high-risk operational regressions.
+
+## Focus
+- Transaction boundaries and atomicity
+- Query correctness and tenant/filter scoping
+- Lost updates, race-prone write patterns, and idempotent persistence behavior
+- Migration/schema compatibility risks
+- ORM/SQL mapping mismatches that break reads or writes
+
+## Ignore
+- Harmless query-style preferences
+- Micro-optimizations with no correctness or production impact
+
+## Applicability
+
+Use this specialist for backend/server persistence code only: repositories, DAOs, SQL, migrations, jOOQ, Exposed, JDBC, Hibernate/JPA, R2DBC, or similar layers.
+
+## Project Overrides
+
+If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+
+## Project-Specific Rules
+
+- Do not split one business write across multiple implicit transactions unless partial completion is explicitly intended
+- Avoid load-modify-save patterns that can lose concurrent updates when atomic SQL or version checks are required
+- Repository methods must apply required tenant/account/ownership filters consistently
+- Upserts, deduplication, and unique-constraint behavior should match the intended idempotency contract
+- Migrations must account for existing data, nullability transitions, indexes, and rollout compatibility
+- Connection pools, database sessions, cursors, ResultSets, and Statements must be closed reliably; use `use {}` or the framework equivalent consistently
+- Avoid holding connections across async boundaries or long-running operations where pool exhaustion could occur
+- Do not hold persistence transactions open while waiting on remote I/O
+- Bulk operations should preserve correctness, not just speed; verify partial-failure behavior
+
+## Output Rules
+- Report at most 7 findings.
+- Include data-loss or consistency consequence for each Major/Blocker.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/mdp-code-review-backend-reliability/SKILL.md
+++ b/skills/mdp-code-review-backend-reliability/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: mdp-code-review-backend-reliability
+description: Review Kotlin backend/server reliability risks including timeouts, retries, background work, concurrency under load, caching, and observability-critical failures.
+---
+
+# Backend Reliability Review Specialist
+
+Review only backend/service reliability issues that can cause outages, stuck work, runaway retries, or production incidents.
+
+## Focus
+- Timeout, retry, and backoff correctness
+- Background jobs, consumers, schedulers, and replay safety
+- Blocking work on request/event-loop threads
+- Cache, queue, and downstream dependency failure behavior
+- Logging/metrics/tracing gaps that hide real failures
+
+## Ignore
+- Pure style comments
+- Tiny observability niceties without incident impact
+
+## Applicability
+
+Use this specialist for backend/server code only.
+
+## Project Overrides
+
+If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+
+## Project-Specific Rules
+
+- Retries must be bounded and reserved for transient failures; include backoff and jitter where stampedes are possible
+- Circuit breakers, bulkheads, and rate-limiting configuration must have sensible thresholds and avoid infinite blocks, silent drops, or retry storms
+- External calls should have explicit timeout behavior and a clear cancellation story
+- Message consumers and scheduled jobs must be safe under duplicate delivery, replay, or partial failure
+- Acknowledge/commit work only after durable success, not before
+- Avoid blocking request/event-loop threads with slow I/O or heavy CPU work
+- Cache fill, refresh, and invalidation logic must not create obvious thundering-herd or stale-data incidents
+- Degradation and fallback behavior should fail gracefully and make partial availability explicit where clients or operators need to know
+- Logging, metrics, and tracing should include enough contextual identifiers to debug failures without leaking secrets or PII
+- Startup and shutdown hooks must initialize and close long-lived resources predictably
+
+## Output Rules
+- Report at most 7 findings.
+- Include production failure scenario for each Major/Blocker.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/mdp-code-review-performance/SKILL.md
+++ b/skills/mdp-code-review-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdp-code-review-performance
-description: Review performance risks including recomposition, main-thread work, retry behavior, and resource usage.
+description: Review performance risks in Android, KMP, backend/server, and general Kotlin code, including UI jank, hot-path work, blocking I/O, and resource waste.
 ---
 
 # Performance Review Specialist
@@ -8,22 +8,26 @@ description: Review performance risks including recomposition, main-thread work,
 Review only high-impact performance issues.
 
 ## Focus
-- Main-thread blocking and ANR risk
+- Main-thread or request-thread blocking
 - Expensive or repeated work in hot paths
-- Compose recomposition triggers and unstable parameters
 - Inefficient DB/network access patterns (N+1, redundant calls)
-- Retry/backoff inefficiency and battery/network waste
+- Retry/backoff inefficiency and battery/network/CPU waste
+- Memory pressure, buffering, or startup/latency regressions users or operators would notice
 
 ## Ignore — DO NOT report these
-- Micro-optimizations without measurable user-facing impact
+- Micro-optimizations without measurable user-facing or production-facing impact
 - Style feedback
 - Snapshot record overhead from unconditional `mutableStateOf` writes (equality guard is nice but negligible)
 - Small list allocations on recomposition (e.g., `.filter {}` on <20 items)
 - `SharedTransitionLayout` vs `Crossfade` differences (unless in a scroll/animation hot path)
 - `remember` vs `derivedStateOf` for cheap computations on small collections
-- Single extra object allocation per recomposition
+- Single extra object allocation per recomposition or request
 
-**Litmus test before reporting:** Would a user ever notice this on a real device? Does it cause jank, ANR, memory pressure, or battery drain? If neither, skip it.
+**Litmus test before reporting:** Would a user or operator ever notice this in production? Does it cause jank, ANR, latency spikes, memory pressure, throughput collapse, or battery drain? If neither, skip it.
+
+## Applicability
+
+Apply shared Kotlin performance rules everywhere. Apply Android/KMP-only rules only when Android/KMP signals are present. Apply backend/server-only rules only when backend/server signals are present.
 
 ## Project Overrides
 
@@ -31,27 +35,43 @@ If an `AGENTS.md` file exists in the project root, read it and apply its rules a
 
 ## Project-Specific Rules
 
-### Compose Recomposition
-- `LaunchedEffect` keys must be stable — using full data objects (e.g., sealed class instances with changing fields) causes unnecessary restarts; derive a stable boolean or ID instead
-- `List<T>` where T is stable is inferred stable — do not flag as instability
+### Shared Kotlin Performance
+- Avoid repeated expensive work in hot paths when inputs are unchanged
+- Watch for N+1 query/call patterns and redundant round-trips
+- Use bounded retries with backoff and jitter for transient failures
+- Large batch processing must avoid unbounded memory growth
+
+### Android/KMP-Specific Rules
+
+#### Compose Recomposition
+- `LaunchedEffect` keys must be stable — using full data objects causes unnecessary restarts; derive a stable boolean or ID instead
+- `List<T>` where `T` is stable is inferred stable — do not flag as instability
 - Verify `remember` keys match actual dependencies
 
-### Database
+#### Database
 - Use atomic SQL updates over load-modify-save patterns
 - Use bulk operations (`insertMany`/`updateMany`) instead of N individual calls in loops
 - Transactions only for multi-table operations, not simple reads
 - Watch for N+1 query patterns
 
-### Dispatchers
-- Never use `Dispatchers.*` directly — use `DispatcherProvider`
+#### Dispatchers
+- Never use `Dispatchers.*` directly when the project standard is `DispatcherProvider`
 - Heavy computation must not run on Main dispatcher
 
-### Image Loading
-- Project uses Coil for Compose — verify proper caching and sizing
+#### Image Loading
+- If the project uses Coil/Compose image loading, verify proper caching and sizing
+
+### Backend/Server-Specific Rules
+- Do not perform blocking work on event-loop or request-processing threads without explicit offloading
+- Watch for per-item downstream calls inside request handlers, consumers, or schedulers
+- Reuse expensive clients/serializers/parsers where construction cost is significant instead of rebuilding them per request
+- Bound pagination, batch sizes, queue drains, and in-memory buffering
+- Flag cache stampede or thundering-herd patterns only when they can realistically spike load or latency
+- Watch for duplicate serialization, duplicate auth lookups, or repeated config parsing inside hot paths
 
 ## Output Rules
 - Report at most 7 findings.
-- Include expected impact statement (latency/memory/battery/startup) per finding.
+- Include expected impact statement (latency/memory/battery/startup/throughput) per finding.
 - Include `file:line` evidence for each finding.
 - Severity: `Blocker | Major | Minor`
 - Confidence: `High | Medium | Low`

--- a/skills/mdp-code-review-platform-correctness/SKILL.md
+++ b/skills/mdp-code-review-platform-correctness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdp-code-review-platform-correctness
-description: Review lifecycle, coroutine, threading, and logic correctness risks in Android/Kotlin code.
+description: Review lifecycle, coroutine, threading, and logic correctness risks in Android, KMP, backend/server, and general Kotlin code.
 ---
 
 # Platform & Correctness Review Specialist
@@ -8,14 +8,18 @@ description: Review lifecycle, coroutine, threading, and logic correctness risks
 Review only correctness and runtime-safety issues.
 
 ## Focus
-- Lifecycle correctness and leak-prone ownership
-- Coroutine scoping, cancellation, and dispatcher correctness
+- Coroutine scoping, cancellation, and dispatcher/thread correctness
 - Race conditions, ordering bugs, and stale-state updates
 - Nullability/edge-case failures and crash paths
 - State-machine and contract handling correctness
+- Resource ownership and lifecycle safety where relevant
 
 ## Ignore
 - Style or readability feedback without correctness impact
+
+## Applicability
+
+Apply shared Kotlin correctness rules to all code. Apply Android/KMP-only rules only when Android/KMP signals are present. Apply backend/server-only rules only when backend/server signals are present.
 
 ## Project Overrides
 
@@ -23,39 +27,55 @@ If an `AGENTS.md` file exists in the project root, read it and apply its rules a
 
 ## Project-Specific Rules
 
-### Dispatchers
-- Never use `Dispatchers.IO`, `Dispatchers.Main`, etc. directly
-- Always use `DispatcherProvider` interface for all async operations
+### Shared Kotlin Correctness
+- Never use `GlobalScope`
+- Long-lived coroutine scopes must have an explicit owner and cancellation strategy
+- Shared mutable state must be synchronized, serialized, or replaced with immutable/message-driven flow
+- Cancellation and timeout behavior must be explicit around long-running or external operations
+- Do not introduce silent fallback behavior that hides failures unless the contract explicitly requires it
+- Validate ordering guarantees where multiple async sources can race or overwrite each other
+
+### Android/KMP-Specific Rules
+
+#### Dispatchers
+- Never use `Dispatchers.IO`, `Dispatchers.Main`, etc. directly when the project standard is `DispatcherProvider`
 - Check that injected `DispatcherProvider` is used consistently
 
-### Coroutine Scoping
+#### Coroutine Scoping
 - ViewModels use `viewModelScope`
-- Fire-and-forget operations that must survive ViewModel clearing use `@ApplicationScope`
-- Never use `GlobalScope`
-- `LaunchedEffect` keys must be stable — avoid using full data objects as keys when a derived boolean or ID suffices (causes unnecessary restarts)
+- Fire-and-forget operations that must survive ViewModel clearing use `@ApplicationScope` or the project equivalent
+- `LaunchedEffect` keys must be stable — avoid using full data objects as keys when a derived boolean or ID suffices
 
-### Flow & State
+#### Flow & State
 - Use `collectAsStateWithLifecycle()` in Compose, never `collectAsState()`
-- `StateFlow` for UI state, `SharedFlow` for one-time events
+- `StateFlow` for UI state, `SharedFlow` for one-time events unless the project intentionally standardizes on another pattern
 - Side effects emitted via `SharedFlow` must not be lost — verify collector is active
 - Check for race conditions between auto-dismiss timers and user interactions
 
-### Flow Composition
+#### Flow Composition
 - When combining multiple flows, define source priority explicitly (primary vs enrichment streams)
 - Keep transformations pure and deterministic — no hidden fallback behavior
-- Emit a complete sealed UI state (`Loading`, `Content`, `Error`, `Empty`)
-- Add `.catch { emit(UiState.Error(...)) }` before terminal `.stateIn()` for transformation-level failures
+- Emit a complete sealed UI state (`Loading`, `Content`, `Error`, `Empty`) where the screen contract expects it
+- Add `.catch { ... }` before terminal `.stateIn()` for transformation-level failures when the contract requires resilient UI state
 - Verify: primary present + enrichment missing, primary missing, one stream fails
 
-### Lifecycle
+#### Lifecycle
 - No Activity/Fragment references held in ViewModels or repositories
 - `DisposableEffect` for cleanup of listeners/callbacks
 - `rememberSaveable` for state surviving configuration changes
 
-### Error Handling
-- Repositories handle all exceptions internally — callers should not need try-catch
-- Network/database failures return fallback values (null, false, empty list)
-- Log with context (include relevant IDs) using Timber
+#### Error Handling
+- Repositories should absorb infra exceptions per project contract so callers do not need defensive try/catch everywhere
+- Log with context (include relevant IDs) using the project logger
+
+### Backend/Server-Specific Rules
+- Do not block event-loop/request threads with JDBC, file I/O, crypto, or HTTP calls unless explicitly shifted to a dedicated dispatcher/executor
+- Request handlers should not launch untracked coroutines that outlive the request unless work is delegated to a managed background component
+- Message consumers, schedulers, and jobs must be safe under retry/replay; acknowledge or commit only after durable success
+- Do not hold database transactions open across remote network calls or long waits
+- Concurrent writes need atomic statements, locking, version checks, or another explicit consistency mechanism
+- Application/service scopes created at startup must be cancelled cleanly on shutdown
+- Verify timeout/cancellation propagation on outbound calls so abandoned requests do not continue wasting resources
 
 ## Output Rules
 - Report at most 7 findings.

--- a/skills/mdp-code-review-security/SKILL.md
+++ b/skills/mdp-code-review-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdp-code-review-security
-description: Review secrets handling, auth/session safety, sensitive data exposure, and transport/storage security.
+description: Review secrets handling, auth/session safety, sensitive data exposure, and transport/storage security in Android, KMP, backend/server, and general Kotlin code.
 ---
 
 # Security Review Specialist
@@ -17,27 +17,42 @@ Review only exploitable or compliance-relevant issues.
 ## Ignore
 - Non-security style comments
 
+## Applicability
+
+Apply shared security rules to all code. Apply Android/KMP-only rules only when Android/KMP signals are present. Apply backend/server-only rules only when backend/server signals are present.
+
 ## Project Overrides
 
 If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
 
 ## Project-Specific Rules
 
-### HTTP & Auth
+### Shared Kotlin Security
+- No secrets, tokens, passwords, or private keys in code, logs, tests, or repo config
+- Sensitive identifiers and personal data must not be logged or exposed without explicit need and protection
+- New code paths must preserve auth/authz guarantees and avoid bypassable feature-flag checks
+
+### Android/KMP-Specific Rules
+
+#### HTTP & Auth
 - Verify request signing/authentication interceptors are used correctly
 - Verify no credentials in `local.properties` or code — use external config or secrets management
 
-### Logging
+#### Logging
 - No PII or tokens in log output
 - Do not add debug logs unless actively debugging
 - Use structured logging with consistent tags
 
-### Storage
+#### Storage
 - Verify no sensitive data stored unencrypted
 - Never rename DataStore files without migration (data loss risk)
 
-### Feature Flags
-- Verify feature flags don't expose sensitive logic paths
+### Backend/Server-Specific Rules
+- Enforce authn/authz at entry points; do not trust client-supplied role, tenant, or actor IDs without server-side verification
+- Secrets/config must come from env vars, vaults, or secret-management systems — not committed config files
+- Do not expose stack traces, internal exception messages, or sensitive failure details in API responses
+- Verify webhook signatures, internal-service auth, or mTLS assumptions when new external entry points are introduced
+- Avoid logging raw auth headers, session cookies, full request bodies, or other high-risk payloads by default
 
 ## Output Rules
 - Report at most 7 findings.

--- a/skills/mdp-code-review-testing/SKILL.md
+++ b/skills/mdp-code-review-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mdp-code-review-testing
-description: Review test coverage quality, regression protection, and test reliability risks.
+description: Review test coverage quality, regression protection, and test reliability risks in Android, KMP, backend/server, and general Kotlin code.
 ---
 
 # Testing Review Specialist
@@ -18,36 +18,50 @@ Review only test gaps that create real regression risk.
 - Test style preferences without risk impact
 - Missing tests for trivial mappers (e.g., `toUiModel()` that only copy properties)
 
+## Applicability
+
+Apply shared test-risk rules to all code. Apply Android/KMP-only rules only when Android/KMP signals are present. Apply backend/server-only rules only when backend/server signals are present.
+
 ## Project Overrides
 
 If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
 
 ## Project-Specific Rules
 
-### Test Runner
-- JUnit4 (`@Test`, `@Before`, `@After`) — NOT Kotest FunSpec
-- Kotest assertions (`shouldBe`, etc.) are used alongside JUnit4
-- Do not suggest migrating to Kotest FunSpec
+### Shared Kotlin Testing
+- Changed behavior and failure paths should be covered at the layer where regressions would surface first
+- Prefer tests that validate real behavior over tests that only mirror implementation details
+- Mock only true external boundaries; over-mocking internal collaborators can hide regressions
+- Coroutine tests should control time/dispatchers deterministically where ordering or retry behavior matters
 
-### Mocking
-- Use `@MockK` annotations, not `mockk()` calls
-- `relaxedUnitFun = true` is OK
-- `relaxed = true` is NEVER OK — flag as blocker
+### Android/KMP-Specific Rules
+
+#### Test Runner
+- JUnit4 (`@Test`, `@Before`, `@After`) rules apply only when the project already uses JUnit4
+- Kotest assertions (`shouldBe`, etc.) alongside JUnit4 are acceptable when already established
+- Do not suggest framework migration unless the change itself introduces a mismatch
+
+#### Mocking
+- If the project standard is MockK annotations, prefer `@MockK` over ad hoc `mockk()` creation
+- `relaxedUnitFun = true` is OK where already allowed
+- `relaxed = true` is a high-risk smell when it can hide real behavior
 - Mock external dependencies only
 
-### Flow Testing
-- Use Turbine for testing coroutine Flows (ViewModel states, events)
+#### Flow Testing
+- Use Turbine for coroutine `Flow` testing when that is the project standard
 - Verify emissions in order with `awaitItem()`
-- Always `cancelAndIgnoreRemainingEvents()` or `cancelAndConsumeRemainingEvents()`
+- Always cancel remaining events explicitly
 
-### Coroutine Testing
-- Use `runTest` with `TestDispatcher`
-- Verify `DispatcherProvider` is injected and testable
-
-### Test Scope
-- Tests run only on debug variants
-- Shared test utilities in `core:testing` module
+#### Test Scope
+- Shared test utilities may live in `core:testing` or an equivalent module
 - Focus test effort on logic that adds value — not trivial mappings
+
+### Backend/Server-Specific Rules
+- Endpoint/controller/route changes need contract or integration tests when status codes, validation, auth context, or serialization changed
+- Persistence changes need repository/integration tests around transactions, constraints, locking, and migration-sensitive behavior
+- Retry, timeout, scheduler, consumer, and idempotency logic needs deterministic tests that control time and replay
+- Prefer real serializers/request objects at API boundary tests; mock downstream systems, not the transport contract itself
+- Verify negative-path coverage for malformed input, forbidden access, downstream failures, and duplicate delivery where relevant
 
 ## Output Rules
 - Report at most 7 findings.

--- a/skills/mdp-code-review/SKILL.md
+++ b/skills/mdp-code-review/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: mdp-code-review
-description: Conduct a thorough Android PR code review following Clean Architecture, MVVM, Jetpack Compose, and Kotlin Coroutines best practices. Use when reviewing pull requests, specific files, git commits, or working changes in Android/Kotlin projects. Produces a structured review with risk register, architecture analysis, scoring, and prioritized action items.
+description: Conduct a thorough Kotlin PR code review across Android, KMP, and backend/server projects. Detect project type conservatively, preserve Android/KMP review depth, and select the right specialist agents for the diff. Produces a structured review with risk register and prioritized action items.
 ---
 
-# Android PR Review
+# Adaptive Kotlin PR Review
 
-You are an experienced Android architect conducting a code review.
+You are an experienced Kotlin architect conducting a code review.
+
+Your first job is to classify the project safely so Android/KMP reviews stay as deep as before. This skill must expand coverage without weakening the existing Android/KMP review path.
 
 ## Project Overrides
 
@@ -21,15 +23,68 @@ Determine the review scope:
 
 ---
 
+## Project Classification
+
+Inspect both the changed files and repo markers (`build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`, `pom.xml`, `application.yml`, `application.conf`, source set layout, module names, imports).
+
+Classify the review as one of:
+- `Android`
+- `KMP`
+- `Backend/Server`
+- `Generic Kotlin`
+- `Mixed`
+
+### Android/KMP Signals
+
+- `com.android.application`, `com.android.library`, `androidx`, `androidMain`, `iosMain`, `commonMain`
+- `kotlin("multiplatform")`, `org.jetbrains.kotlin.multiplatform`, `expect` / `actual`
+- `AndroidManifest.xml`, `res/`, `R.string`, Activities, Fragments, `ViewModel`
+- `@Composable`, `remember`, `LaunchedEffect`, `collectAsStateWithLifecycle()`
+
+### Backend/Server Signals
+
+- `io.ktor.server`, `routing {}`, `Application.module`
+- `spring-boot`, `@RestController`, `@Controller`, `@Service`, `@Repository`, `@Transactional`
+- Micronaut, Quarkus, http4k, Javalin, gRPC server code
+- `application.yml`, `application.yaml`, `application.conf`
+- SQL/ORM/data-access layers: Exposed, jOOQ, Hibernate/JPA, JDBC, R2DBC, Flyway, Liquibase
+- Queues, schedulers, consumers, caches, metrics, tracing, server auth middleware
+
+### Decision Rules
+
+- If Android/KMP signals are strong, use the Android/KMP route. Do **not** replace that route with backend specialists.
+- If backend/server signals clearly dominate and there are no meaningful Android/KMP signals in scope, use the backend/server route.
+- If neither route is clear, use the generic Kotlin route.
+- If both appear in one PR, classify it as `Mixed`, choose specialists based on the changed areas, and do not drop Android/KMP specialists for Android/KMP files.
+- When uncertain, prefer the safer route that preserves Android/KMP review depth.
+
+---
+
 ## Dynamic Agent Selection
 
 ### Step 1: Always spawn `mdp-code-review-architecture`
 
 Architecture review is relevant for every non-trivial change.
 
-### Step 2: Analyze the diff and select additional agents
+### Step 2: Choose route baseline
 
-Read the changed files and match against these triggers:
+- `Android` / `KMP`: preserve the existing mobile review behavior
+- `Backend/Server`: baseline is `architecture` + `mdp-code-review-platform-correctness`
+- `Generic Kotlin`: baseline is `architecture` + `mdp-code-review-platform-correctness`
+- `Mixed`: baseline is `architecture` + `mdp-code-review-platform-correctness`, then add route-specific specialists for the touched areas
+
+### Step 3: Analyze the diff and select additional agents
+
+For `Mixed` classification, inspect each changed file or tightly related change cluster separately:
+- If a file/change has Android/KMP signals, apply the Android/KMP Route triggers
+- If a file/change has backend/server signals, apply the Backend/Server Route triggers
+- If a file/change is only generic Kotlin infrastructure, apply the Generic Kotlin Route triggers
+- A single PR may spawn specialists from multiple routes, but keep the total at 6 or fewer
+- Preserve Android/KMP specialists for any Android/KMP files even when backend files are changed in the same PR
+
+#### Android/KMP Route
+
+Keep the current mobile triggers intact:
 
 | Signal in the diff | Agent to spawn |
 |---------------------|----------------|
@@ -40,15 +95,38 @@ Read the changed files and match against these triggers:
 | Test files modified (`*Test.kt`), new test classes, mock setup changes | `mdp-code-review-testing` |
 | User-facing UI changes, `stringResource`, accessibility attributes, navigation, error states, localization files | `mdp-code-review-ux-accessibility` |
 
-### Step 3: Apply minimum
+#### Backend/Server Route
+
+| Signal in the diff | Agent to spawn |
+|---------------------|----------------|
+| Routes/controllers, request/response DTOs, serializers, content negotiation, validation, status-code mapping, OpenAPI/schema changes | `mdp-code-review-backend-api-contracts` |
+| Repositories/DAOs, SQL, ORM mappings, transactions, migrations, optimistic locking, upserts, bulk writes | `mdp-code-review-backend-persistence` |
+| Timeouts, retries, circuit breakers, queues, schedulers, idempotency, caching, metrics, tracing, startup/shutdown lifecycle | `mdp-code-review-backend-reliability` |
+| `launch`, `Flow`, `StateFlow`, `Mutex`, `Semaphore`, `suspend fun`, coroutine scopes, concurrent mutation | `mdp-code-review-platform-correctness` |
+| Auth, tokens, keys, passwords, request signing, sensitive data, security middleware | `mdp-code-review-security` |
+| Heavy request-path work, blocking I/O, N+1 queries, redundant downstream calls, unbounded buffering | `mdp-code-review-performance` |
+| Test files modified (`*Test.kt`), contract/integration tests, mock setup changes | `mdp-code-review-testing` |
+
+#### Generic Kotlin Route
+
+| Signal in the diff | Agent to spawn |
+|---------------------|----------------|
+| `launch`, `Flow`, `StateFlow`, `Mutex`, `Semaphore`, `suspend fun`, coroutine scopes | `mdp-code-review-platform-correctness` |
+| Auth, tokens, keys, passwords, encryption, sensitive data | `mdp-code-review-security` |
+| Heavy computation, retry/backoff loops, bulk data processing, redundant I/O | `mdp-code-review-performance` |
+| Test files modified (`*Test.kt`), new test classes, mock setup changes | `mdp-code-review-testing` |
+
+### Step 4: Apply minimum
 
 - Minimum 2 agents (architecture + at least one other)
-- If no additional triggers match, spawn `mdp-code-review-platform-correctness` as default second agent
+- If no additional triggers match, spawn `mdp-code-review-platform-correctness` as the default second agent
 - Maximum 6 agents
+- On Android/KMP reviews, prefer the established mobile specialists before backend specialists
 
-### Step 4: Launch in parallel
+### Step 5: Launch in parallel
 
 Spawn all selected agents simultaneously using the `task` tool. Each agent gets:
+- The detected project type
 - The list of changed files
 - Instructions to read its own skill file for the review rubric
 - The shared contract below
@@ -91,10 +169,12 @@ Spawn all selected agents simultaneously using the `task` tool. Each agent gets:
 
 ## Review Output Format
 
-### 1. Agent Selection Summary
+### 1. Classification & Agent Summary
 ```
-Agents spawned: architecture, mdp-code-review-compose-check, platform-correctness
-Reason: Compose files modified, coroutine scoping in delegate
+Detected project type: Android | KMP | Backend/Server | Generic Kotlin | Mixed
+Signals: @Composable, AndroidManifest.xml, ViewModel
+Agents spawned: mdp-code-review-architecture, mdp-code-review-platform-correctness, mdp-code-review-compose-check
+Reason: Android/KMP signals were high-confidence, so the preserved mobile path was used
 ```
 
 ### 2. Risk Register
@@ -130,7 +210,7 @@ Effort: S (<1h) | M (1-4h) | L (>4h)
 
 After review, ask: **"Which item would you like me to fix?"**
 
-After all P0 and P1 items are resolved, run `mdp-gcheck` as final verification.
+After all P0 and P1 items are resolved, run `mdp-gcheck` as final verification when the project uses Gradle.
 
 ---
 
@@ -141,5 +221,5 @@ After all P0 and P1 items are resolved, run `mdp-gcheck` as final verification.
 - Project-aware: each agent has project-specific rules in its skill file
 - Actionable: every issue must have a concrete fix
 - Proportional: don't nitpick style if architecture is broken
-- No overoptimization: do not report negligible performance findings that have no measurable user-facing impact. Only flag performance issues that cause jank, ANR, memory pressure, or battery drain.
+- No overoptimization: do not report negligible performance findings with no measurable user-facing or production-facing impact
 - Honest: if unsure, say what context is missing

--- a/skills/mdp-feature-verify/SKILL.md
+++ b/skills/mdp-feature-verify/SKILL.md
@@ -178,5 +178,5 @@ If the user wants a PR comment:
 ## Skills Reused
 
 This skill orchestrates:
-- `mdp-code-review` — full dynamic-agent code review (and its sub-agents: architecture, mdp-code-review-compose-check, platform-correctness, security, performance, testing, ux-accessibility)
+- `mdp-code-review` — full dynamic-agent code review (and its sub-agents: architecture, mdp-code-review-compose-check, platform-correctness, security, performance, testing, ux-accessibility, mdp-code-review-backend-api-contracts, mdp-code-review-backend-persistence, mdp-code-review-backend-reliability)
 - `mdp-feature-guard` — feature flag compliance checklist (read inline, not spawned)


### PR DESCRIPTION
# Summary

Expand the `mdp-code-review` skill family to support Kotlin backend/server projects without weakening the existing Android/KMP review path. The orchestrator now classifies project type conservatively, preserves the full mobile review route when Android/KMP signals are strong, and adds backend-specific specialists where server concerns are present.

- Added backend review specialists for API/contracts, persistence, and reliability
- Updated shared review specialists to separate shared Kotlin guidance from Android/KMP-only and backend-only rules
- Clarified mixed-repo routing so mobile and backend specialists can be combined safely in monorepos
- Updated plugin documentation and feature verification references to reflect the expanded review suite

## Feature Flags

N/A

# How Has This Been Tested?

Validated through manual review of the generated skill definitions and by syncing the updated skills to all configured agents with `./install.sh`.

1. Open `skills/mdp-code-review/SKILL.md` and confirm Android/KMP remains the preserved high-confidence route, with explicit mixed-project routing.
2. Verify the new backend skills exist: `mdp-code-review-backend-api-contracts`, `mdp-code-review-backend-persistence`, and `mdp-code-review-backend-reliability`.
3. Run `./install.sh` and confirm the new skills are linked into the configured agent directories (`~/.copilot/skills`, `~/.claude/commands`, `~/.glm/commands`).
4. Expected result: the plugin exposes 19 skills total, including 11 code review skills, and the backend review path is additive without diluting Android/KMP coverage.
