### PR TITLE
Integrate test value checks into code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ No config files to edit — the installer handles everything interactively.
 
 ### Code Review (11 skills)
 
-Run `/bill-code-review` to start a review. The orchestrator classifies the project type conservatively, preserves the full Android/KMP review path when mobile signals are strong, and spawns 2-6 specialist agents in parallel before merging and deduplicating findings.
+Run `/bill-code-review` to start a review. The orchestrator classifies the project type conservatively, preserves the full Android/KMP review path when mobile signals are strong, and spawns 2-6 specialist agents in parallel before merging and deduplicating findings, including a real-test-value pass when tests change.
 
 | Skill | Description |
 |-------|-------------|
@@ -95,7 +95,7 @@ Run `/bill-code-review` to start a review. The orchestrator classifies the proje
 | `/bill-code-review-platform-correctness` | Lifecycle, coroutines, threading, Flow composition, server correctness |
 | `/bill-code-review-performance` | Recomposition, hot-path work, blocking I/O, resource usage |
 | `/bill-code-review-security` | Secrets, auth, PII, transport/storage across mobile and backend |
-| `/bill-code-review-testing` | Coverage gaps, flaky tests, regression risk |
+| `/bill-code-review-testing` | Coverage gaps, flaky tests, tautological tests, and regression risk |
 | `/bill-code-review-ux-accessibility` | UX states, a11y, validation |
 | `/bill-code-review-backend-api-contracts` | Backend API contracts, validation, serialization, compatibility |
 | `/bill-code-review-backend-persistence` | Backend persistence, transactions, migrations, data consistency |
@@ -116,7 +116,7 @@ Run `/bill-code-review` to start a review. The orchestrator classifies the proje
 |-------|-------------|
 | `/bill-gcheck` | Run `./gradlew check` and fix all issues (no suppressions) |
 | `/bill-module-history` | Update module-level agent/history.md with feature history |
-| `/bill-unit-test-value-check` | Review unit tests for real business value instead of tautological coverage padding |
+| `/bill-unit-test-value-check` | Standalone audit for unit tests with real business value instead of tautological coverage padding |
 | `/bill-pr-description` | Generate PR title, description, and QA steps |
 | `/bill-new-skill-all-agents` | Create a new skill and sync it to all agents |
 

--- a/skills/bill-code-review-testing/SKILL.md
+++ b/skills/bill-code-review-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-testing
-description: Review test coverage quality, regression protection, and test reliability risks in Android, KMP, backend/server, and general Kotlin code.
+description: Review test coverage quality, real test value, regression protection, and test reliability risks in Android, KMP, backend/server, and general Kotlin code.
 ---
 
 # Testing Review Specialist
@@ -10,6 +10,7 @@ Review only test gaps that create real regression risk.
 ## Focus
 - Missing tests for changed behavior and failure paths
 - Brittle/flaky test patterns and false-confidence assertions
+- Low-value, tautological, or coverage-padding tests that do not validate real behavior
 - Contract drift between implementation and tests
 - Inadequate negative-path coverage
 - Missing integration points where unit-only tests are insufficient
@@ -30,9 +31,19 @@ If an `AGENTS.md` file exists in the project root, read it and apply its rules a
 
 ### Shared Kotlin Testing
 - Changed behavior and failure paths should be covered at the layer where regressions would surface first
+- A test only adds value if it would fail on a meaningful regression in business behavior
 - Prefer tests that validate real behavior over tests that only mirror implementation details
+- Treat tautological tests as test gaps when they create false confidence without exercising real logic
 - Mock only true external boundaries; over-mocking internal collaborators can hide regressions
 - Coroutine tests should control time/dispatchers deterministically where ordering or retry behavior matters
+
+### Unit Test Value Lens
+- Flag tests that only instantiate a DTO/model, assign values, and assert the same values without logic in between
+- Flag tests that only verify a stubbed return value or a mock interaction without asserting an externally meaningful outcome
+- Flag tests that duplicate the implementation step-for-step and compare against the duplicated result
+- Flag tests that only check `not null`, booleans, or collection size when those assertions are not tied to important behavior
+- Do not request tests for trivial mappers, accessors, or generated code unless they enforce business rules, compatibility, or invariants
+- Constructors, value objects, parsers, and serializers can still be worth testing when they validate, normalize, clamp, reject, or preserve a contract
 
 ### Android/KMP-Specific Rules
 
@@ -66,10 +77,11 @@ If an `AGENTS.md` file exists in the project root, read it and apply its rules a
 ## Output Rules
 - Report at most 7 findings.
 - Include a minimal test plan for top uncovered risks.
+- Report weak or useless tests only when they materially reduce regression confidence.
 - Include `file:line` evidence for each finding.
 - Severity: `Blocker | Major | Minor`
 - Confidence: `High | Medium | Low`
-- Include a minimal, concrete fix.
+- Include a minimal, concrete fix, which may be to rewrite or delete the test and replace it with a behavior-focused one.
 
 ## Output Table
 | Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |

--- a/skills/bill-code-review/SKILL.md
+++ b/skills/bill-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review
-description: Conduct a thorough Kotlin PR code review across Android, KMP, and backend/server projects. Detect project type conservatively, preserve Android/KMP review depth, and select the right specialist agents for the diff. Produces a structured review with risk register and prioritized action items.
+description: Conduct a thorough Kotlin PR code review across Android, KMP, and backend/server projects. Detect project type conservatively, preserve Android/KMP review depth, and select the right specialist agents for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
 ---
 
 # Adaptive Kotlin PR Review
@@ -92,7 +92,7 @@ Keep the current mobile triggers intact:
 | `launch`, `Flow`, `StateFlow`, `viewModelScope`, `LifecycleOwner`, `DispatcherProvider`, `suspend fun` | `bill-code-review-platform-correctness` |
 | Auth, tokens, keys, passwords, encryption, HTTP clients, interceptors, sensitive data | `bill-code-review-security` |
 | `LazyColumn`/`LazyRow`, animations, heavy computation, image loading, retry/polling, bulk DB ops | `bill-code-review-performance` |
-| Test files modified (`*Test.kt`), new test classes, mock setup changes | `bill-code-review-testing` |
+| Test files modified (`*Test.kt`), new test classes, mock setup changes, coverage-padding or tautological tests | `bill-code-review-testing` |
 | User-facing UI changes, `stringResource`, accessibility attributes, navigation, error states, localization files | `bill-code-review-ux-accessibility` |
 
 #### Backend/Server Route
@@ -105,7 +105,7 @@ Keep the current mobile triggers intact:
 | `launch`, `Flow`, `StateFlow`, `Mutex`, `Semaphore`, `suspend fun`, coroutine scopes, concurrent mutation | `bill-code-review-platform-correctness` |
 | Auth, tokens, keys, passwords, request signing, sensitive data, security middleware | `bill-code-review-security` |
 | Heavy request-path work, blocking I/O, N+1 queries, redundant downstream calls, unbounded buffering | `bill-code-review-performance` |
-| Test files modified (`*Test.kt`), contract/integration tests, mock setup changes | `bill-code-review-testing` |
+| Test files modified (`*Test.kt`), contract/integration tests, mock setup changes, coverage-padding or tautological tests | `bill-code-review-testing` |
 
 #### Generic Kotlin Route
 
@@ -114,7 +114,7 @@ Keep the current mobile triggers intact:
 | `launch`, `Flow`, `StateFlow`, `Mutex`, `Semaphore`, `suspend fun`, coroutine scopes | `bill-code-review-platform-correctness` |
 | Auth, tokens, keys, passwords, encryption, sensitive data | `bill-code-review-security` |
 | Heavy computation, retry/backoff loops, bulk data processing, redundant I/O | `bill-code-review-performance` |
-| Test files modified (`*Test.kt`), new test classes, mock setup changes | `bill-code-review-testing` |
+| Test files modified (`*Test.kt`), new test classes, mock setup changes, coverage-padding or tautological tests | `bill-code-review-testing` |
 
 ### Step 4: Apply minimum
 


### PR DESCRIPTION
# Summary

Strengthen the code review flow so test-quality review now treats tautological and coverage-padding tests as meaningful findings, not just missing coverage.

- teach `bill-code-review-testing` to flag low-value tests that do not validate real business behavior
- update `bill-code-review` so the main review flow explicitly includes this real-test-value pass when tests change
- clarify in `README.md` that `bill-unit-test-value-check` remains the standalone focused audit while `/bill-code-review` now applies the same lens automatically

## Feature Flags

N/A

# How Has This Been Tested?

Reviewed the skill diffs and validated the updated review guidance manually.

1. Open `skills/bill-code-review-testing/SKILL.md` and verify it includes the new real-test-value and tautological-test guidance.
2. Open `skills/bill-code-review/SKILL.md` and verify test-file triggers mention coverage-padding or tautological tests.
3. Open `README.md` and verify `/bill-code-review-testing` and `/bill-unit-test-value-check` descriptions reflect the new split.
4. Expected result: the main code-review path now documents automatic low-value-test detection, while the standalone audit skill remains available for focused reviews.
