### PR TITLE
Refine feature implementation skill contracts

### DIFF
--- a/skills/bill-code-review-compose-check/SKILL.md
+++ b/skills/bill-code-review-compose-check/SKILL.md
@@ -333,6 +333,7 @@ Choose the right composable for the job:
 - Use `Scaffold` for screens with top bar, bottom bar, FAB, or snackbar.
 - Use `SnackbarHostState` with `Scaffold` for snackbars — never use `Toast` from a composable.
 - Use `Surface` as a base container when you need elevation, shape, and color from the theme.
+- Never introduce deprecated Compose or Material components when a supported replacement exists. If a dependency or platform constraint leaves no viable alternative, keep the deprecated usage isolated and call it out explicitly in the review.
 
 ---
 

--- a/skills/bill-code-review-platform-correctness/SKILL.md
+++ b/skills/bill-code-review-platform-correctness/SKILL.md
@@ -34,6 +34,7 @@ If an `AGENTS.md` file exists in the project root, read it and apply its rules a
 - Cancellation and timeout behavior must be explicit around long-running or external operations
 - Do not introduce silent fallback behavior that hides failures unless the contract explicitly requires it
 - Validate ordering guarantees where multiple async sources can race or overwrite each other
+- Do not introduce deprecated APIs, components, or patterns when a supported alternative exists; if usage is unavoidable, it must be narrowly scoped and explicitly justified
 
 ### Android/KMP-Specific Rules
 

--- a/skills/bill-code-review/SKILL.md
+++ b/skills/bill-code-review/SKILL.md
@@ -137,6 +137,7 @@ Spawn all selected agents simultaneously using the `task` tool. Each agent gets:
 
 - Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
 - Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
+- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when deprecated usage is broad in scope and not explicitly justified
 - Ignore style, formatting, naming bikeshedding, and pure refactor preferences
 - Evidence is mandatory: include `file:line` + short description
 - Severity: `Blocker | Major | Minor`
@@ -208,9 +209,11 @@ Effort: S (<1h) | M (1-4h) | L (>4h)
 
 ## Implementation Mode
 
-After review, ask: **"Which item would you like me to fix?"**
+If invoked standalone, ask: **"Which item would you like me to fix?"**
 
-After all P0 and P1 items are resolved, run `bill-gcheck` as final verification when the project uses Gradle.
+If invoked from `bill-feature-implement` or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
+
+After all P0 and P1 items are resolved, run `bill-gcheck` as final verification when the project uses Gradle and this review is being run standalone.
 
 ---
 

--- a/skills/bill-feature-implement/SKILL.md
+++ b/skills/bill-feature-implement/SKILL.md
@@ -13,15 +13,15 @@ End-to-end feature implementation orchestrator. Takes a design doc and delivers 
 Design Doc + Issue Key → Assess + Extract Criteria → [Size gate] → Create Branch →
 
   SMALL (≤5 tasks, ≤3 modules):
-    Save Spec → [Read History] → Plan → Implement → Targeted Review → Completeness Audit → bill-gcheck → [Write History if impactful] → PR Description
+    Save Spec → [Read History] → Plan → Implement → bill-code-review (narrow scope, dynamic 2-6 agents) → Completeness Audit → bill-gcheck → [Write History if impactful] → PR Description
 
   MEDIUM (6-15 tasks, ≤6 modules):
     Save Spec → Read History → Plan → Implement →
-    Compact → Code Review (3 agents) → Completeness Audit → bill-gcheck → Write History → PR Description
+    Compact → bill-code-review (dynamic 2-6 agents) → Completeness Audit → bill-gcheck → Write History → PR Description
 
   LARGE (>15 tasks or >6 modules):
     Save Spec → Read History → Feature Flag? → Plan (phased) → Implement →
-    Compact → Code Review (6 agents) → Compact → Completeness Audit → bill-gcheck → Write History → PR Description
+    Compact → bill-code-review (dynamic 2-6 agents) → Compact → Completeness Audit → bill-gcheck → Write History → PR Description
 ```
 
 ## Step 1: Collect Design Doc + Assess Size
@@ -96,7 +96,7 @@ After the user confirms the assessment, create and switch to a new feature branc
 ## Step 2: Pre-Planning
 
 **All sizes:** Always **Save Spec** (the acceptance criteria serve as the contract for the completeness audit) and **Read Module History** if history files exist in affected modules.
-**MEDIUM and LARGE only:** Also perform Feature Flag Setup and Discover Codebase Patterns.
+**MEDIUM and LARGE only:** Also discover codebase patterns. Perform Feature Flag Setup when the feature is LARGE or when the user confirmed a flag is needed.
 
 ### Save Spec
 
@@ -184,14 +184,15 @@ Wait for user confirmation.
 
 ## Step 4: Execute Plan
 
-Implement each task in order:
-- After each task, print progress: `✅ [3/10] Created PaymentRepository with Room integration`
-- Follow project standards from CLAUDE.md / AGENTS.md
-- Write clean, production-grade code
-- **Write tests as specified** in each task's `Tests:` field
-- If a task reveals the plan is wrong, **stop and re-plan from that point**
-- Do NOT skip or combine tasks without user consent
-- If plan has phases, pause between phases for a brief checkpoint
+ Implement each task in order:
+ - After each task, print progress: `✅ [3/10] Created PaymentRepository with Room integration`
+ - Follow project standards from CLAUDE.md / AGENTS.md
+ - Write clean, production-grade code
+ - Never introduce deprecated components, APIs, or patterns when a supported alternative exists. If absolutely no viable alternative exists, call that out explicitly, explain why, and keep the deprecated usage as narrow as possible.
+ - **Write tests as specified** in each task's `Tests:` field
+ - If a task reveals the plan is wrong, **stop and re-plan from that point**
+ - Do NOT skip or combine tasks without user consent
+ - If plan has phases, pause between phases for a brief checkpoint
 - **When removing UI components or code:** immediately clean up orphaned resources (string keys, drawables, imports, unused mappers) in the same task — don't leave dead code for review to catch
 - **Test gate:** Before moving to review/compaction, verify that unit tests were written. If the test task was somehow skipped or omitted from the plan, stop and write tests now. Never proceed to code review without tests.
 
@@ -218,27 +219,25 @@ Then re-read `.feature-specs/<feature-name>/spec.md` to refresh acceptance crite
 
 ## Step 5: Code Review
 
-### Agent Selection
+Run the `bill-code-review` skill and apply it inline. Treat that skill as the source of truth for:
+- Project classification
+- Dynamic specialist selection
+- Android/KMP vs backend/server routing
+- Parallel review execution
+- Finding deduplication and prioritization
 
-**Always spawn:** `bill-code-review-architecture` — boundaries, DI, source-of-truth, state management. Architecture review is relevant for every non-trivial change.
+Pass the following context from this run:
+- Review scope: current unit of work for SMALL features, current branch diff for MEDIUM/LARGE features
+- Confirmed acceptance criteria and spec path
+- Feature size
+- Feature flag name/pattern (or `N/A`)
+- The rule that newly introduced deprecated components, APIs, or patterns are not allowed when a supported alternative exists; any unavoidable usage must be explicitly justified and kept narrowly scoped
 
-**Analyze the actual diff** and spawn additional specialists based on what changed:
-
-| Trigger | Agent |
-|---------|-------|
-| Compose files modified or created (`@Composable`, UI state classes) | `bill-code-review-compose-check` |
-| Coroutines, Flows, lifecycle-aware code, threading (`launch`, `Flow`, `LifecycleOwner`, `Dispatchers`) | `bill-code-review-platform-correctness` |
-| Auth, tokens, keys, passwords, encryption, HTTP clients, or sensitive data handling | `bill-code-review-security` |
-| Lists, lazy layouts, animations, heavy computation, image loading, or retry/polling logic | `bill-code-review-performance` |
-| New/modified tests, or test files touched | `bill-code-review-testing` |
-| User-facing UI changes, accessibility attributes, navigation, error states, localization | `bill-code-review-ux-accessibility` |
-
-**Rules:**
-- Spawn all selected agents **in parallel**
-- Minimum 2 agents (architecture + at least one other), maximum 6
-- If no additional triggers match, spawn `bill-code-review-platform-correctness` as the second agent (coroutine/lifecycle issues are common enough to justify a default)
-- If **blockers or major issues** found: auto-fix, re-run only the affected agents
-- If only minor issues: report them and continue
+### Review loop rules
+- Do not duplicate specialist trigger tables in this skill
+- If Blocker or Major issues are found, auto-fix them and re-run `bill-code-review` (or only the affected specialists if that skill supports it)
+- If only Minor issues remain, report them and continue
+- When `bill-code-review` is invoked from this skill, do not stop to ask the user which finding to fix first
 - Max **3 review iterations** — after that, report remaining issues and hand back to user
 
 ## Step 6: Completeness Audit
@@ -297,12 +296,18 @@ Pass the required inputs from this run:
 - Primary module + affected modules
 - Feature flag name/pattern (or N/A)
 - Acceptance criteria coverage summary
+- Change summary (what changed, reusable components/patterns, breaking changes or limitations)
 
 The `bill-module-history` skill owns the write/skip rules, entry format, and retention limits.
 
 ## Step 8: Generate PR Description (All sizes)
 
 Run the `bill-pr-description` skill to generate a PR title, description, and QA steps.
+
+Pass along:
+- Feature name / spec path if available
+- The actual comparison base used for this feature branch (or enough git context for the skill to compute the merge-base correctly)
+- Manual verification notes from this run
 
 ## Error Recovery
 
@@ -314,7 +319,7 @@ Run the `bill-pr-description` skill to generate a PR title, description, and QA 
 
 This skill orchestrates (by reading their instructions and applying inline):
 - `bill-feature-guard` — if feature flag is needed (LARGE, or when confirmed)
-- `bill-code-review` — automatic after implementation (LARGE uses full 6-agent pass)
+- `bill-code-review` — automatic after implementation; it classifies the diff and selects 2-6 specialists dynamically
 - `bill-gcheck` — always, as final gate after completeness audit
 - `bill-module-history` — writes/maintains `agent/history.md` for impactful or larger features
 
@@ -329,7 +334,7 @@ This skill orchestrates (by reading their instructions and applying inline):
 | Save spec to disk | Yes | Yes | Yes |
 | Read module history | If exists | Yes | Yes |
 | Feature flag ceremony | No | If needed | Full |
-| Codebase discovery section | Inline | Inline | Separate |
+| Codebase discovery section | Inline | Inline | Inline |
 | Compaction steps | No | Post-impl | Post-impl + post-review |
 | Review agents | Dynamic (2-6, based on diff) | Dynamic (2-6, based on diff) | Dynamic (2-6, based on diff) |
 | bill-gcheck | Yes | Yes | Yes |

--- a/skills/bill-module-history/SKILL.md
+++ b/skills/bill-module-history/SKILL.md
@@ -17,6 +17,11 @@ Update `agent/history.md` in the **primary module** for the implemented feature.
 - Acceptance criteria coverage (`implemented/total`)
 - Change summary (what changed, patterns used, reusable components, breaking changes/limits)
 
+## Input Recovery
+
+- If the caller omits part of the context, derive only the missing pieces from the current diff and `.feature-specs/<feature-name>/spec.md` when available
+- Do not skip writing solely because the caller forgot to pass a change summary
+
 ## Write/Skip Rules
 
 - **Always write** for `MEDIUM` and `LARGE` features.

--- a/skills/bill-pr-description/SKILL.md
+++ b/skills/bill-pr-description/SKILL.md
@@ -9,10 +9,11 @@ Generate a PR title, description, and QA/test steps ready to paste. Present the 
 
 ## How It Works
 
-1. **Gather context** — read the git diff (`git diff main...HEAD`), commit log, and branch name
-2. **Read project guidelines** — check `CLAUDE.md` / `AGENTS.md` at the project root for any PR conventions
-3. **Generate** the title and description using the template below
-4. **Present** the result to the user for review and adjustment
+1. **Determine the comparison base** — use the branch this feature branch was created from when known, otherwise compute the best available merge-base from git context. Never assume `main`.
+2. **Gather context** — read the git diff from that merge-base to `HEAD`, along with the commit log and branch name
+3. **Read project guidelines** — check `CLAUDE.md` / `AGENTS.md` at the project root for any PR conventions
+4. **Generate** the title and description using the template below
+5. **Present** the result to the user for review and adjustment
 
 ## PR Title
 
@@ -50,3 +51,4 @@ Use this exact template, filling in the sections:
 - If the feature is behind a flag, mention how to enable it for testing
 - Keep it concise — reviewers appreciate brevity
 - If invoked from `bill-feature-implement`, check `.feature-specs/<feature-name>/spec.md` for additional context (this file only exists when bill-feature-implement created it)
+- If the caller provides an explicit comparison base or merge-base, use it instead of inferring one


### PR DESCRIPTION
# Summary

This updates the skill contracts so `bill-feature-implement` defers review routing to `bill-code-review`, which keeps specialist selection in one place and prevents future drift.

It also aligns the `bill-module-history` and `bill-pr-description` handoffs with the context the orchestrator actually has, and adds explicit guidance to avoid deprecated components, APIs, and patterns unless no supported alternative exists.

## Feature Flags

N/A

# How Has This Been Tested?

Manual verification of the updated skill documents and handoff rules.

1. Review `skills/bill-feature-implement/SKILL.md` and confirm Step 5 now delegates classification and specialist selection to `bill-code-review`.
2. Review `skills/bill-code-review/SKILL.md`, `skills/bill-module-history/SKILL.md`, and `skills/bill-pr-description/SKILL.md` for the aligned orchestration contracts.
3. Review the deprecation guidance added to the review contracts.
