### PR TITLE
feat: improve feature workflow validation and history reuse

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
-  "name": "mobile-development",
+  "name": "skill-bill",
   "version": "1.0.0",
-  "description": "Code review, feature lifecycle, and developer tooling skills for Android/Kotlin projects. Includes 8 specialist review agents, feature implementation, feature flags, gcheck, and more.",
+  "description": "Portable AI skill suite centered on feature implementation for Android, KMP, Kotlin backend, and agent-config repositories. Includes adaptive code review, automatic validation gates, feature flags, and developer tooling.",
   "author": {
     "name": "sermilion"
   },
-  "keywords": ["android", "code-review", "kotlin", "compose", "clean-architecture"]
+  "keywords": ["feature-implementation", "android", "kotlin", "code-review", "agents"]
 }

--- a/.github/workflows/validate-agent-configs.yml
+++ b/.github/workflows/validate-agent-configs.yml
@@ -1,0 +1,24 @@
+name: Validate agent configs
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run agnix
+        run: npx --yes agnix --strict .
+
+      - name: Run repo-native validation
+        run: python3 scripts/validate_agent_configs.py

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Run `/bill-code-review` to start a review. The orchestrator classifies the proje
 
 | Skill | Description |
 |-------|-------------|
-| `/bill-feature-implement` | End-to-end: design spec, plan, implement, review, PR |
+| `/bill-feature-implement` | End-to-end: design spec, plan, implement, review, auto-select validation, PR |
 | `/bill-feature-verify` | Verify a PR against a task spec (reverse of implement) |
 | `/bill-feature-guard` | Wrap changes in feature flags for safe rollout |
 | `/bill-feature-guard-cleanup` | Remove feature flags after full rollout |
@@ -125,6 +125,19 @@ Run `/bill-code-review` to start a review. The orchestrator classifies the proje
 Every review and check skill looks for an **`AGENTS.md`** file in the project root. If found, its rules are applied on top of the built-in defaults. Project rules take precedence when they conflict.
 
 Use this to define project-specific conventions (naming, test framework, architecture rules, etc.) without modifying the plugin itself. Each project can have its own `AGENTS.md`.
+
+## Automatic Validation
+
+`/bill-feature-implement` is the center of gravity for this repo. It now **auto-selects the final validation gate** based on the repository it is changing so the user does not need to decide which checker to run:
+
+- Gradle/Kotlin repos → `bill-gcheck`
+- Agent-config / skill repos → inline agent-config validation (`agnix` + repo-native drift checks)
+- Mixed repos → both
+
+For this repository, CI enforces the same path with:
+
+- `npx --yes agnix --strict .`
+- `python3 scripts/validate_agent_configs.py`
 
 ## Adding New Skills
 

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import re
+import sys
+
+
+README_TOTAL_PATTERN = re.compile(r"collection of (\d+) AI skills")
+README_SECTION_PATTERN = re.compile(r"^### (.+) \((\d+) skills\)$")
+README_SKILL_ROW_PATTERN = re.compile(r"^\| `/(bill-[a-z0-9-]+)` \|")
+SKILL_REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9-])(bill-[a-z0-9-]+)(?![A-Za-z0-9-])")
+FRONTMATTER_PATTERN = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+def main() -> int:
+  root = resolve_root()
+  issues: list[str] = []
+
+  skill_files = discover_skill_files(root, issues)
+  skill_names = sorted(skill_files.keys())
+
+  for skill_name, skill_file in skill_files.items():
+    validate_skill_file(skill_name, skill_file, issues)
+
+  validate_readme(root / "README.md", skill_names, issues)
+  validate_skill_references(root, skill_names, issues)
+  validate_plugin_manifest(root / ".claude-plugin" / "plugin.json", issues)
+
+  if issues:
+    print("Agent-config validation failed:")
+    for issue in issues:
+      print(f"- {issue}")
+    return 1
+
+  print("Agent-config validation passed.")
+  print(f"Validated {len(skill_names)} skills, README catalog, skill references, and plugin metadata.")
+  return 0
+
+
+def resolve_root() -> Path:
+  if len(sys.argv) > 2:
+    raise SystemExit("Usage: validate_agent_configs.py [repo-root]")
+  if len(sys.argv) == 2:
+    return Path(sys.argv[1]).resolve()
+  return Path(__file__).resolve().parent.parent
+
+
+def discover_skill_files(root: Path, issues: list[str]) -> dict[str, Path]:
+  skills_dir = root / "skills"
+  if not skills_dir.is_dir():
+    issues.append("skills/ directory is missing")
+    return {}
+
+  skill_files: dict[str, Path] = {}
+  for skill_dir in sorted(skills_dir.iterdir()):
+    if not skill_dir.is_dir():
+      continue
+    skill_file = skill_dir / "SKILL.md"
+    if not skill_file.is_file():
+      issues.append(f"{skill_dir.relative_to(root)} is missing SKILL.md")
+      continue
+    skill_files[skill_dir.name] = skill_file
+
+  if not skill_files:
+    issues.append("No skills were found under skills/")
+  return skill_files
+
+
+def validate_skill_file(skill_name: str, skill_file: Path, issues: list[str]) -> None:
+  text = skill_file.read_text(encoding="utf-8")
+  frontmatter_match = FRONTMATTER_PATTERN.match(text)
+  if not frontmatter_match:
+    issues.append(f"{skill_file}: missing YAML frontmatter block")
+    return
+
+  frontmatter = parse_frontmatter(frontmatter_match.group(1))
+  declared_name = frontmatter.get("name", "")
+  description = frontmatter.get("description", "")
+
+  if declared_name != skill_name:
+    issues.append(
+      f"{skill_file}: frontmatter name '{declared_name}' does not match directory '{skill_name}'"
+    )
+
+  if not description:
+    issues.append(f"{skill_file}: frontmatter description is missing")
+
+
+def parse_frontmatter(block: str) -> dict[str, str]:
+  values: dict[str, str] = {}
+  for line in block.splitlines():
+    if ":" not in line:
+      continue
+    key, value = line.split(":", 1)
+    values[key.strip()] = value.strip()
+  return values
+
+
+def validate_readme(readme_path: Path, skill_names: list[str], issues: list[str]) -> None:
+  text = readme_path.read_text(encoding="utf-8")
+  total_match = README_TOTAL_PATTERN.search(text)
+  if not total_match:
+    issues.append("README.md: total skill count line is missing")
+  else:
+    declared_total = int(total_match.group(1))
+    actual_total = len(skill_names)
+    if declared_total != actual_total:
+      issues.append(
+        f"README.md: declares {declared_total} skills, but skills/ contains {actual_total}"
+      )
+
+  documented_skills: list[str] = []
+  lines = text.splitlines()
+  current_section = ""
+  expected_count = 0
+  section_count = 0
+
+  for line in lines + ["### END (0 skills)"]:
+    section_match = README_SECTION_PATTERN.match(line)
+    if section_match:
+      if current_section and section_count != expected_count:
+        issues.append(
+          f"README.md: section '{current_section}' declares {expected_count} skills but lists {section_count}"
+        )
+      current_section = section_match.group(1)
+      expected_count = int(section_match.group(2))
+      section_count = 0
+      continue
+
+    row_match = README_SKILL_ROW_PATTERN.match(line)
+    if row_match:
+      documented_skills.append(row_match.group(1))
+      section_count += 1
+
+  documented_set = sorted(set(documented_skills))
+  actual_set = sorted(skill_names)
+
+  missing_from_readme = sorted(set(actual_set) - set(documented_set))
+  extra_in_readme = sorted(set(documented_set) - set(actual_set))
+
+  if missing_from_readme:
+    issues.append(
+      "README.md: missing skills in catalog: " + ", ".join(missing_from_readme)
+    )
+  if extra_in_readme:
+    issues.append(
+      "README.md: documents unknown skills: " + ", ".join(extra_in_readme)
+    )
+
+
+def validate_skill_references(root: Path, skill_names: list[str], issues: list[str]) -> None:
+  known_skills = set(skill_names)
+  files_to_scan = sorted((root / "skills").glob("*/SKILL.md"))
+
+  for file_path in files_to_scan:
+    text = file_path.read_text(encoding="utf-8")
+    for reference in sorted(set(SKILL_REFERENCE_PATTERN.findall(text))):
+      if reference not in known_skills:
+        relative_path = file_path.relative_to(root)
+        issues.append(f"{relative_path}: references unknown skill '{reference}'")
+
+
+def validate_plugin_manifest(plugin_path: Path, issues: list[str]) -> None:
+  try:
+    content = plugin_path.read_text(encoding="utf-8")
+    data = json.loads(content)
+  except FileNotFoundError:
+    issues.append(".claude-plugin/plugin.json is missing")
+    return
+  except json.JSONDecodeError as error:
+    issues.append(f".claude-plugin/plugin.json: invalid JSON ({error})")
+    return
+
+  name = data.get("name")
+  description = data.get("description")
+  keywords = data.get("keywords")
+
+  if not isinstance(name, str) or not name.strip():
+    issues.append(".claude-plugin/plugin.json: name must be a non-empty string")
+  if not isinstance(description, str) or not description.strip():
+    issues.append(".claude-plugin/plugin.json: description must be a non-empty string")
+  if not isinstance(keywords, list) or not keywords:
+    issues.append(".claude-plugin/plugin.json: keywords must be a non-empty array")
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/skills/bill-code-review-architecture/SKILL.md
+++ b/skills/bill-code-review-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-architecture
-description: Review architecture, boundaries, DI scopes, and source-of-truth consistency in Kotlin Android, KMP, and backend/server changes.
+description: Use when reviewing architecture, boundaries, DI scopes, and source-of-truth consistency in Kotlin Android, KMP, and backend/server changes.
 ---
 
 # Architecture Review Specialist

--- a/skills/bill-code-review-backend-api-contracts/SKILL.md
+++ b/skills/bill-code-review-backend-api-contracts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-backend-api-contracts
-description: Review Kotlin backend/server API boundaries including request validation, serialization, HTTP or RPC contracts, status-code mapping, and backward compatibility.
+description: Use when reviewing Kotlin backend/server API boundaries including request validation, serialization, HTTP or RPC contracts, status-code mapping, and backward compatibility.
 ---
 
 # Backend API & Contract Review Specialist

--- a/skills/bill-code-review-backend-persistence/SKILL.md
+++ b/skills/bill-code-review-backend-persistence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-backend-persistence
-description: Review Kotlin backend/server persistence risks including transaction boundaries, query correctness, migration safety, concurrency, and data-consistency behavior.
+description: Use when reviewing Kotlin backend/server persistence risks including transaction boundaries, query correctness, migration safety, concurrency, and data-consistency behavior.
 ---
 
 # Backend Persistence Review Specialist

--- a/skills/bill-code-review-backend-reliability/SKILL.md
+++ b/skills/bill-code-review-backend-reliability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-backend-reliability
-description: Review Kotlin backend/server reliability risks including timeouts, retries, background work, concurrency under load, caching, and observability-critical failures.
+description: Use when reviewing Kotlin backend/server reliability risks including timeouts, retries, background work, concurrency under load, caching, and observability-critical failures.
 ---
 
 # Backend Reliability Review Specialist

--- a/skills/bill-code-review-performance/SKILL.md
+++ b/skills/bill-code-review-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-performance
-description: Review performance risks in Android, KMP, backend/server, and general Kotlin code, including UI jank, hot-path work, blocking I/O, and resource waste.
+description: Use when reviewing performance risks in Android, KMP, backend/server, and general Kotlin code, including UI jank, hot-path work, blocking I/O, and resource waste.
 ---
 
 # Performance Review Specialist

--- a/skills/bill-code-review-platform-correctness/SKILL.md
+++ b/skills/bill-code-review-platform-correctness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-platform-correctness
-description: Review lifecycle, coroutine, threading, and logic correctness risks in Android, KMP, backend/server, and general Kotlin code.
+description: Use when reviewing lifecycle, coroutine, threading, and logic correctness risks in Android, KMP, backend/server, and general Kotlin code.
 ---
 
 # Platform & Correctness Review Specialist

--- a/skills/bill-code-review-security/SKILL.md
+++ b/skills/bill-code-review-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-security
-description: Review secrets handling, auth/session safety, sensitive data exposure, and transport/storage security in Android, KMP, backend/server, and general Kotlin code.
+description: Use when reviewing secrets handling, auth/session safety, sensitive data exposure, and transport/storage security in Android, KMP, backend/server, and general Kotlin code.
 ---
 
 # Security Review Specialist

--- a/skills/bill-code-review-testing/SKILL.md
+++ b/skills/bill-code-review-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-testing
-description: Review test coverage quality, real test value, regression protection, and test reliability risks in Android, KMP, backend/server, and general Kotlin code.
+description: Use when reviewing test coverage quality, real test value, regression protection, and test reliability risks in Android, KMP, backend/server, and general Kotlin code.
 ---
 
 # Testing Review Specialist

--- a/skills/bill-code-review-ux-accessibility/SKILL.md
+++ b/skills/bill-code-review-ux-accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review-ux-accessibility
-description: Review UX correctness and accessibility risks, delegating Compose-heavy checks to bill-code-review-compose-check.
+description: Use when reviewing UX correctness and accessibility risks, delegating Compose-heavy checks to bill-code-review-compose-check.
 ---
 
 # UX & Accessibility Review Specialist

--- a/skills/bill-code-review/SKILL.md
+++ b/skills/bill-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-code-review
-description: Conduct a thorough Kotlin PR code review across Android, KMP, and backend/server projects. Detect project type conservatively, preserve Android/KMP review depth, and select the right specialist agents for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
+description: Use when conducting a thorough Kotlin PR code review across Android, KMP, and backend/server projects. Detect project type conservatively, preserve Android/KMP review depth, and select the right specialist agents for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
 ---
 
 # Adaptive Kotlin PR Review

--- a/skills/bill-feature-implement/SKILL.md
+++ b/skills/bill-feature-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-feature-implement
-description: End-to-end feature implementation from design doc to verified code. Automatically scales ceremony based on feature size — lightweight for small changes, full orchestration for large features. Collects design spec, plans, implements, reviews, and audits completeness.
+description: Use when doing end-to-end feature implementation from design doc to verified code. Automatically scales ceremony based on feature size — lightweight for small changes, full orchestration for large features. Collects design spec, plans, implements, reviews, and audits completeness.
 ---
 
 # Feature Implement v2

--- a/skills/bill-feature-implement/SKILL.md
+++ b/skills/bill-feature-implement/SKILL.md
@@ -13,15 +13,15 @@ End-to-end feature implementation orchestrator. Takes a design doc and delivers 
 Design Doc + Issue Key → Assess + Extract Criteria → [Size gate] → Create Branch →
 
   SMALL (≤5 tasks, ≤3 modules):
-    Save Spec → [Read History] → Plan → Implement → bill-code-review (narrow scope, dynamic 2-6 agents) → Completeness Audit → bill-gcheck → [Write History if impactful] → PR Description
+    Save Spec → [Read History] → Plan → Implement → bill-code-review (narrow scope, dynamic 2-6 agents) → Completeness Audit → Final Validation Gate (auto-selected) → [Write History if impactful] → PR Description
 
   MEDIUM (6-15 tasks, ≤6 modules):
     Save Spec → Read History → Plan → Implement →
-    Compact → bill-code-review (dynamic 2-6 agents) → Completeness Audit → bill-gcheck → Write History → PR Description
+    Compact → bill-code-review (dynamic 2-6 agents) → Completeness Audit → Final Validation Gate (auto-selected) → Write History → PR Description
 
   LARGE (>15 tasks or >6 modules):
     Save Spec → Read History → Feature Flag? → Plan (phased) → Implement →
-    Compact → bill-code-review (dynamic 2-6 agents) → Compact → Completeness Audit → bill-gcheck → Write History → PR Description
+    Compact → bill-code-review (dynamic 2-6 agents) → Compact → Completeness Audit → Final Validation Gate (auto-selected) → Write History → PR Description
 ```
 
 ## Step 1: Collect Design Doc + Assess Size
@@ -95,7 +95,7 @@ After the user confirms the assessment, create and switch to a new feature branc
 
 ## Step 2: Pre-Planning
 
-**All sizes:** Always **Save Spec** (the acceptance criteria serve as the contract for the completeness audit) and **Read Module History** if history files exist in affected modules.
+**All sizes:** Always **Save Spec** (the acceptance criteria serve as the contract for the completeness audit), **Read Module History** if history files exist in affected modules, and determine the **final validation strategy** automatically.
 **MEDIUM and LARGE only:** Also discover codebase patterns. Perform Feature Flag Setup when the feature is LARGE or when the user confirmed a flag is needed.
 
 ### Save Spec
@@ -144,6 +144,11 @@ Explore the codebase concurrently with planning:
 2. Find similar features referenced in the spec
 3. Identify build dependencies for affected modules
 4. Note reusable components
+5. Identify validation surfaces so the final gate is chosen automatically:
+   - Gradle/Kotlin project or modules → `bill-gcheck`
+   - Agent-config / skill repository (`SKILL.md`, `AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, installer/config files, repo-native validation scripts) → inline agent-config validation
+   - Mixed repository → run both
+6. If a repo-native validation script already exists, reuse it instead of inventing a new ad hoc checklist
 
 Do NOT present a separate "codebase patterns" section to the user — fold these findings directly into the implementation plan.
 
@@ -168,6 +173,11 @@ Do NOT present a separate "codebase patterns" section to the user — fold these
 - Flag: <name> (or N/A)
 - Pattern: <pattern> (or N/A)
 
+### Final Validation
+- Strategy: `bill-gcheck` | inline agent-config validation | both
+- Reason: <why this gate applies to the affected repo/modules>
+- Commands/scripts: <existing commands or repo-native scripts to run>
+
 ### Tasks
 1. [ ] Task description
    Files: list of files to create/modify
@@ -188,12 +198,13 @@ Wait for user confirmation.
  - After each task, print progress: `✅ [3/10] Created PaymentRepository with Room integration`
  - Follow project standards from CLAUDE.md / AGENTS.md
  - Write clean, production-grade code
- - Never introduce deprecated components, APIs, or patterns when a supported alternative exists. If absolutely no viable alternative exists, call that out explicitly, explain why, and keep the deprecated usage as narrow as possible.
- - **Write tests as specified** in each task's `Tests:` field
- - If a task reveals the plan is wrong, **stop and re-plan from that point**
- - Do NOT skip or combine tasks without user consent
- - If plan has phases, pause between phases for a brief checkpoint
+  - Never introduce deprecated components, APIs, or patterns when a supported alternative exists. If absolutely no viable alternative exists, call that out explicitly, explain why, and keep the deprecated usage as narrow as possible.
+  - **Write tests as specified** in each task's `Tests:` field
+  - If a task reveals the plan is wrong, **stop and re-plan from that point**
+  - Do NOT skip or combine tasks without user consent
+  - If plan has phases, pause between phases for a brief checkpoint
 - **When removing UI components or code:** immediately clean up orphaned resources (string keys, drawables, imports, unused mappers) in the same task — don't leave dead code for review to catch
+- **When changing agent-config or skill repositories:** update adjacent catalogs and wiring in the same task (README skill tables/counts, installer/config references, validation scripts/workflows) so the repo stays self-consistent
 - **Test gate:** Before moving to review/compaction, verify that unit tests were written. If the test task was somehow skipped or omitted from the plan, stop and write tests now. Never proceed to code review without tests.
 
 ### Post-Implementation Compact (MEDIUM and LARGE only)
@@ -282,9 +293,29 @@ If yes: plan missing items → implement → review → re-audit. Max **2 audit 
 
 Update spec status to **Complete** (MEDIUM/LARGE only).
 
-## Step 6b: bill-gcheck (All sizes)
+## Step 6b: Final Validation Gate (All sizes)
 
-**Always run `bill-gcheck` as the final gate** after completeness audit passes. This ensures formatting, lint, and tests pass regardless of feature size. Follow the `bill-gcheck` skill instructions: run `./gradlew check` and fix all issues at root cause without suppressions.
+After completeness audit passes, **infer the final validation gate automatically** from the repo shape and changed files. Do not ask the user to choose.
+
+### Validation strategy
+
+- **Gradle/Kotlin repos or modules touched:** run `bill-gcheck`
+- **Agent-config / skill repos touched:** run inline agent-config validation
+- **Both:** run both gates
+- **Neither:** run the closest existing repo-native validation command or test command already present in the project
+
+### Inline agent-config validation
+
+When the repo contains agent-config surfaces such as `SKILL.md`, `AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, agent installer/config files, or repo-native validation scripts:
+
+1. Run `agnix` when available
+   - Prefer installed `agnix`
+   - Otherwise use `npx agnix .` if Node/npm is available
+2. Run any repo-native validation scripts and workflows already provided by the repo
+3. Fix issues at root cause in the changed files
+4. If the change created repo-wide metadata drift directly tied to the work (README tables/counts, skill references, manifest metadata, workflow wiring), fix that drift in the same pass
+
+Do **not** create a separate utility skill just for this validation path unless the repository itself is explicitly centered on validation as a product concept. `bill-feature-implement` owns this behavior.
 
 ## Step 7: Write Module History
 
@@ -320,7 +351,7 @@ Pass along:
 This skill orchestrates (by reading their instructions and applying inline):
 - `bill-feature-guard` — if feature flag is needed (LARGE, or when confirmed)
 - `bill-code-review` — automatic after implementation; it classifies the diff and selects 2-6 specialists dynamically
-- `bill-gcheck` — always, as final gate after completeness audit
+- `bill-gcheck` — when the affected repo/modules use the Gradle/Kotlin validation path
 - `bill-module-history` — writes/maintains `agent/history.md` for impactful or larger features
 
 ## Size Reference
@@ -337,6 +368,6 @@ This skill orchestrates (by reading their instructions and applying inline):
 | Codebase discovery section | Inline | Inline | Inline |
 | Compaction steps | No | Post-impl | Post-impl + post-review |
 | Review agents | Dynamic (2-6, based on diff) | Dynamic (2-6, based on diff) | Dynamic (2-6, based on diff) |
-| bill-gcheck | Yes | Yes | Yes |
+| Final validation gate | Auto-detected | Auto-detected | Auto-detected |
 | Write module history | If impactful | Yes | Yes |
 | PR description | Yes | Yes | Yes |

--- a/skills/bill-feature-implement/SKILL.md
+++ b/skills/bill-feature-implement/SKILL.md
@@ -124,6 +124,9 @@ Sources: <list of original sources>
 ### Read Module History
 
 Look for `agent/history.md` in each module the feature will touch. If found, use it to:
+- Read newest entries first
+- Keep scanning while entries are still relevant to the current feature, module, entities, or patterns
+- Stop once older entries are clearly no longer relevant or you already have enough signal; do not read the whole file by default
 - Reuse components from previous features
 - Follow the latest patterns (not outdated ones)
 - Account for recent entity changes
@@ -329,7 +332,7 @@ Pass the required inputs from this run:
 - Acceptance criteria coverage summary
 - Change summary (what changed, reusable components/patterns, breaking changes or limitations)
 
-The `bill-module-history` skill owns the write/skip rules, entry format, and retention limits.
+The `bill-module-history` skill owns the write/skip rules, entry format, and history-file hygiene rules.
 
 ## Step 8: Generate PR Description (All sizes)
 

--- a/skills/bill-module-history/SKILL.md
+++ b/skills/bill-module-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-module-history
-description: Update module-level agent/history.md with reusable, high-signal feature history entries and history hygiene rules.
+description: Use when updating module-level agent/history.md with reusable, high-signal feature history entries and history hygiene rules.
 ---
 
 # Module History

--- a/skills/bill-module-history/SKILL.md
+++ b/skills/bill-module-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-module-history
-description: Update module-level agent/history.md with reusable, high-signal feature history entries and retention rules.
+description: Update module-level agent/history.md with reusable, high-signal feature history entries and history hygiene rules.
 ---
 
 # Module History
@@ -50,7 +50,8 @@ Acceptance criteria: <count>/<count> implemented
 - File path: `<primary-module>/agent/history.md`
 - Newest entry first
 - Max **15 lines** per entry
-- Keep only the **last 5 entries** (remove oldest when adding 6th)
+- No fixed entry cap
+- Keep older entries when they still provide reusable context; prune or merge only entries that are obsolete, redundant, or too noisy to help future feature work
 - No code snippets; focus on reusable context for future feature work
 
 ## Output

--- a/skills/bill-new-skill-all-agents/SKILL.md
+++ b/skills/bill-new-skill-all-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-new-skill-all-agents
-description: Create a new skill and sync it to all detected local AI agents (Claude, Copilot, GLM, Codex). Use this when asked to create a new skill for all agents on the user's computer.
+description: Use when creating a new skill and syncing it to all detected local AI agents (Claude, Copilot, GLM, Codex).
 ---
 
 When asked to create a new skill, follow this workflow:

--- a/skills/bill-pr-description/SKILL.md
+++ b/skills/bill-pr-description/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-pr-description
-description: Generate a PR title, description, and QA steps from the current branch changes. Works standalone or as part of bill-feature-implement.
+description: Use when generating a PR title, description, and QA steps from the current branch changes. Works standalone or as part of bill-feature-implement.
 ---
 
 # PR Description Generator

--- a/skills/bill-unit-test-value-check/SKILL.md
+++ b/skills/bill-unit-test-value-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-unit-test-value-check
-description: Review unit tests in a file, current changes, or a commit and flag low-value, tautological, or coverage-only tests that do not validate real behavior.
+description: Use when reviewing unit tests in a file, current changes, or a commit to flag low-value, tautological, or coverage-only tests that do not validate real behavior.
 ---
 
 # Unit Test Value Checker


### PR DESCRIPTION
# Summary

This updates the feature-implementation workflow so skill-bill can automatically choose repo-appropriate validation, surface low-value unit tests during code review, and keep module history useful without a fixed five-entry limit.

- adds repo-native agent-config validation tooling and workflow wiring
- integrates test-value review more directly into the feature/code-review orchestration flow
- changes module-history guidance to read newest entries first and stop when older entries are no longer relevant

## Feature Flags

N/A

# How Has This Been Tested?

Ran the repo-native validator against the updated skills and checked the stricter agnix path to confirm the branch only hits the existing warning baseline.

1. Run `python3 scripts/validate_agent_configs.py`
2. Run `npx --yes agnix --strict .`
3. Confirm the validator passes and agnix reports only the known repo-wide description warnings
