### PR TITLE
feat: add skill override customization

### DIFF
--- a/.agents/skill-overrides.example.md
+++ b/.agents/skill-overrides.example.md
@@ -1,0 +1,9 @@
+# Skill Overrides
+
+## bill-kotlin-quality-check
+- Treat warnings as blocking work.
+- Skip formatting-only rewrites unless the user explicitly asks for them.
+
+## bill-pr-description
+- Always include ticket links when the branch name contains one.
+- Keep QA steps concise unless the user asks for a full matrix.

--- a/README.md
+++ b/README.md
@@ -138,9 +138,38 @@ Run `/bill-kotlin-code-review` to start a review. The orchestrator classifies th
 
 ## Project Customization
 
-Every review and check skill looks for an **`AGENTS.md`** file in the project root. If found, its rules are applied on top of the built-in defaults. Project rules take precedence when they conflict.
+Use **`AGENTS.md`** in the project root for repo-wide conventions that should influence multiple skills.
 
-Use this to define project-specific conventions (naming, test framework, architecture rules, etc.) without modifying the plugin itself. Each project can have its own `AGENTS.md`.
+Use **`.agents/skill-overrides.md`** for per-skill customization without modifying this plugin. Each skill looks for a matching `## bill-...` section and treats that section as the highest-priority instruction for that skill only.
+
+The file is intentionally strict so CI can validate it:
+
+- first line must be `# Skill Overrides`
+- each override section must be `## <existing-skill-name>`
+- each section body must be a bullet list
+- freeform text outside sections is invalid
+
+Precedence is:
+
+1. Matching section in `.agents/skill-overrides.md`
+2. `AGENTS.md`
+3. Built-in skill defaults
+
+Example `.agents/skill-overrides.md`:
+
+```md
+# Skill Overrides
+
+## bill-kotlin-quality-check
+- Treat warnings as blocking work.
+- Skip formatting-only rewrites unless the user explicitly asks for them.
+
+## bill-pr-description
+- Always include ticket links when the branch name contains one.
+- Keep QA steps concise unless the user asks for a full matrix.
+```
+
+Use `AGENTS.md` for project-wide conventions (naming, test framework, architecture rules, etc.) and `.agents/skill-overrides.md` for targeted skill behavior changes.
 
 ## Automatic Validation
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ That's it. All 20 skills are now available in every agent you selected.
 Installer modes:
 
 - `--mode safe` — replace symlinks, migrate legacy plugin installs, skip non-symlink conflicts
-- `--mode overwrite` — replace any existing target path, including local copies
+- `--mode override` — replace any existing target path, including local copies, and prune stale installed `bill-*` skills that are no longer in this repo
 - `--mode interactive` — prompt before replacing non-symlink conflicts
 
 ### Source Layout
@@ -130,7 +130,7 @@ Run `/bill-kotlin-code-review` to start a review. The orchestrator classifies th
 
 | Skill | Description |
 |-------|-------------|
-| `/bill-gradle-gcheck` | Run `./gradlew check` and fix all issues (no suppressions) |
+| `/bill-kotlin-quality-check` | Run `./gradlew check` and fix all issues (no suppressions) |
 | `/bill-module-history` | Update module-level agent/history.md with feature history |
 | `/bill-unit-test-value-check` | Standalone audit for unit tests with real business value instead of tautological coverage padding |
 | `/bill-pr-description` | Generate PR title, description, and QA steps |
@@ -146,7 +146,7 @@ Use this to define project-specific conventions (naming, test framework, archite
 
 `/bill-kotlin-feature-implement` is the center of gravity for this repo. It now **auto-selects the final validation gate** based on the repository it is changing so the user does not need to decide which checker to run:
 
-- Gradle/Kotlin repos → `bill-gradle-gcheck`
+- Gradle/Kotlin repos → `bill-kotlin-quality-check`
 - Agent-config / skill repos → inline agent-config validation (`agnix` + repo-native drift checks)
 - Mixed repos → both
 
@@ -168,7 +168,7 @@ Use these patterns:
 Examples:
 
 - Shared: `bill-pr-description`, `bill-module-history`, `bill-feature-guard`
-- Kotlin/Gradle: `bill-kotlin-code-review`, `bill-kotlin-feature-implement`, `bill-gradle-gcheck`
+- Kotlin/Gradle: `bill-kotlin-code-review`, `bill-kotlin-feature-implement`, `bill-kotlin-quality-check`
 - KMP/UI specialists: `bill-kmp-code-review-compose-check`, `bill-kmp-code-review-ux-accessibility`
 - PHP: `bill-php-code-review`, `bill-php-feature-implement`, `bill-php-laravel-code-review`
 
@@ -184,9 +184,9 @@ Guidelines:
 Use migration-aware renames instead of one-off manual cleanup:
 
 1. Keep shared skills neutral (`/bill-feature-guard`, `/bill-pr-description`, `/bill-module-history`)
-2. Use explicit stack/tool prefixes for stack-bound skills (`/bill-kotlin-feature-implement`, `/bill-kotlin-code-review`, `/bill-gradle-gcheck`)
+2. Use explicit stack/tool prefixes for stack-bound skills (`/bill-kotlin-feature-implement`, `/bill-kotlin-code-review`, `/bill-kotlin-quality-check`)
 3. When a canonical name changes, add the old name to the installer migration map so legacy plugin-managed installs are removed automatically on rerun
-4. Let `./install.sh --mode safe` skip non-symlink conflicts so local copied variants are preserved unless the user explicitly chooses overwrite
+4. Let `./install.sh --mode safe` skip non-symlink conflicts so local copied variants are preserved unless the user explicitly chooses `override`
 
 This keeps migrations predictable while making room for PHP and future stacks.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Installer modes:
 The repository groups source skills by package:
 
 - `skills/shared/` — cross-stack workflows and utilities
-- `skills/kotlin/` — Kotlin/Gradle-oriented skills
+- `skills/kotlin/` — Kotlin-focused skills
 - `skills/kmp/` — KMP/UI-specific skills
 
 Installed agent commands stay flat, so users still run `/bill-kotlin-code-review` rather than a package-qualified command.

--- a/install.sh
+++ b/install.sh
@@ -18,11 +18,11 @@ err()   { printf "${RED}✗${NC} %s\n" "$1"; }
 
 usage() {
   cat <<USAGE
-Usage: ./install.sh [--mode safe|overwrite|interactive]
+Usage: ./install.sh [--mode safe|override|interactive]
 
 Modes:
   safe         Replace existing symlinks, migrate legacy plugin installs, and skip non-symlink conflicts. (default)
-  overwrite    Replace any existing target path, including local copies.
+  override     Replace any existing target path, including local copies, and prune stale bill-* installs.
   interactive  Prompt before replacing non-symlink conflicts.
 USAGE
 }
@@ -48,7 +48,7 @@ parse_args() {
   done
 
   case "$MODE" in
-    safe|overwrite|interactive) ;;
+    safe|override|interactive) ;;
     *)
       err "Invalid mode: $MODE"
       usage
@@ -102,7 +102,8 @@ declare -a RENAMED_SKILL_PAIRS=(
   'bill-kotlin-code-review-ux-accessibility:bill-kmp-code-review-ux-accessibility'
   'bill-feature-implement:bill-kotlin-feature-implement'
   'bill-feature-verify:bill-kotlin-feature-verify'
-  'bill-gcheck:bill-gradle-gcheck'
+  'bill-gcheck:bill-kotlin-quality-check'
+  'bill-gradle-gcheck:bill-kotlin-quality-check'
 )
 
 declare -a SKILL_NAMES=()
@@ -140,7 +141,7 @@ should_replace_target() {
   fi
 
   case "$MODE" in
-    overwrite)
+    override)
       return 0
       ;;
     interactive)
@@ -148,7 +149,7 @@ should_replace_target() {
       return $?
       ;;
     safe)
-      warn "Skipping '$target' (${reason}) because it is not a symlink. Re-run with --mode overwrite or --mode interactive to replace it."
+      warn "Skipping '$target' (${reason}) because it is not a symlink. Re-run with --mode override or --mode interactive to replace it."
       return 1
       ;;
   esac
@@ -289,6 +290,27 @@ remove_legacy_skill_paths() {
   done
 }
 
+prune_project_skill_paths() {
+  local target_dir="$1"
+  local installed_path skill_name
+
+  [[ -d "$target_dir" ]] || return 0
+
+  while IFS= read -r -d '' installed_path; do
+    skill_name="$(basename "$installed_path")"
+
+    if find_skill_index "$skill_name" >/dev/null 2>&1; then
+      continue
+    fi
+
+    if remove_if_allowed "$installed_path" "stale bill-* skill not present in plugin"; then
+      if [[ ! -e "$installed_path" && ! -L "$installed_path" ]]; then
+        ok "  pruned stale $skill_name"
+      fi
+    fi
+  done < <(find "$target_dir" -mindepth 1 -maxdepth 1 -name 'bill-*' -print0)
+}
+
 install_skill_link() {
   local target="$1"
   local source="$2"
@@ -316,6 +338,8 @@ info "Supported agents: copilot, claude, glm, codex"
 info "Install mode: $MODE"
 if [[ "$MODE" == safe ]]; then
   info "Safe mode replaces symlinks, migrates legacy plugin installs, and skips local directory/file conflicts."
+elif [[ "$MODE" == override ]]; then
+  info "Override mode replaces any existing target path and prunes stale bill-* installs."
 fi
 echo ""
 printf "${CYAN}▸${NC} Enter agents (comma-separated, primary first): "
@@ -352,6 +376,9 @@ echo ""
 
 mkdir -p "$PRIMARY_DIR"
 info "Installing to primary ($PRIMARY): $PRIMARY_DIR"
+if [[ "$MODE" == override ]]; then
+  prune_project_skill_paths "$PRIMARY_DIR"
+fi
 remove_legacy_skill_paths "$PRIMARY_DIR"
 for idx in "${!SKILL_NAMES[@]}"; do
   skill="${SKILL_NAMES[$idx]}"
@@ -371,6 +398,9 @@ for i in "${!AGENT_NAMES[@]}"; do
 
   mkdir -p "$agent_dir"
   info "Symlinking $agent: $agent_dir → $PRIMARY_DIR"
+  if [[ "$MODE" == override ]]; then
+    prune_project_skill_paths "$agent_dir"
+  fi
   remove_legacy_skill_paths "$agent_dir"
 
   for skill in "${SKILL_NAMES[@]}"; do

--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,6 @@ declare -a RENAMED_SKILL_PAIRS=(
   'bill-feature-implement:bill-kotlin-feature-implement'
   'bill-feature-verify:bill-kotlin-feature-verify'
   'bill-gcheck:bill-kotlin-quality-check'
-  'bill-gradle-gcheck:bill-kotlin-quality-check'
 )
 
 declare -a SKILL_NAMES=()

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -14,6 +14,11 @@ README_SKILL_ROW_PATTERN = re.compile(r"^\| `/(bill-[a-z0-9-]+)` \|")
 SKILL_REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9-])(bill-[a-z0-9-]+)(?![A-Za-z0-9-])")
 FRONTMATTER_PATTERN = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
 SKILL_NAME_PATTERN = re.compile(r"^bill-[a-z0-9-]+$")
+PROJECT_OVERRIDES_HEADING = "## Project Overrides"
+SKILL_OVERRIDE_FILE = ".agents/skill-overrides.md"
+SKILL_OVERRIDE_EXAMPLE_FILE = ".agents/skill-overrides.example.md"
+SKILL_OVERRIDE_TITLE = "# Skill Overrides"
+SKILL_OVERRIDE_SECTION_PATTERN = re.compile(r"^## (bill-[a-z0-9-]+)$")
 
 
 def main() -> int:
@@ -28,6 +33,18 @@ def main() -> int:
 
   validate_readme(root / "README.md", skill_names, issues)
   validate_skill_references(root, skill_names, issues)
+  validate_skill_override_markdown(
+    root / SKILL_OVERRIDE_EXAMPLE_FILE,
+    skill_names,
+    issues,
+    required=True,
+  )
+  validate_skill_override_markdown(
+    root / SKILL_OVERRIDE_FILE,
+    skill_names,
+    issues,
+    required=False,
+  )
   validate_plugin_manifest(root / ".claude-plugin" / "plugin.json", issues)
 
   if issues:
@@ -95,6 +112,12 @@ def validate_skill_file(skill_name: str, skill_file: Path, issues: list[str]) ->
   if not description:
     issues.append(f"{skill_file}: frontmatter description is missing")
 
+  if PROJECT_OVERRIDES_HEADING not in text:
+    issues.append(f"{skill_file}: missing '{PROJECT_OVERRIDES_HEADING}' section")
+
+  if SKILL_OVERRIDE_FILE not in text:
+    issues.append(f"{skill_file}: missing reference to '{SKILL_OVERRIDE_FILE}'")
+
 
 def validate_skill_location(skill_name: str, skill_file: Path, issues: list[str]) -> None:
   skills_dir = skill_file.parents[2]
@@ -140,7 +163,7 @@ def expected_prefixes_for_package(package_name: str) -> tuple[str, ...]:
   if package_name == "shared":
     return ()
   if package_name == "kotlin":
-    return ("bill-kotlin-", "bill-gradle-")
+    return ("bill-kotlin-",)
   if package_name == "kmp":
     return ("bill-kmp-",)
   if package_name == "php":
@@ -220,6 +243,98 @@ def validate_skill_references(root: Path, skill_names: list[str], issues: list[s
       if reference not in known_skills:
         relative_path = file_path.relative_to(root)
         issues.append(f"{relative_path}: references unknown skill '{reference}'")
+
+
+def validate_skill_override_markdown(
+  file_path: Path,
+  skill_names: list[str],
+  issues: list[str],
+  *,
+  required: bool,
+) -> None:
+  if not file_path.exists():
+    if required:
+      issues.append(f"{file_path.relative_to(file_path.parent.parent)} is missing")
+    return
+
+  relative_path = file_path.relative_to(file_path.parent.parent)
+  lines = file_path.read_text(encoding="utf-8").splitlines()
+  known_skills = set(skill_names)
+  seen_sections: set[str] = set()
+  current_section: str | None = None
+  current_section_has_bullet = False
+  saw_title = False
+  saw_any_section = False
+
+  for index, line in enumerate(lines, start=1):
+    stripped = line.strip()
+    if not stripped:
+      continue
+
+    if stripped == SKILL_OVERRIDE_TITLE:
+      if saw_title or current_section is not None or index != 1:
+        issues.append(
+          f"{relative_path}:{index}: '{SKILL_OVERRIDE_TITLE}' must appear exactly once as the first line"
+        )
+      saw_title = True
+      continue
+
+    section_match = SKILL_OVERRIDE_SECTION_PATTERN.match(stripped)
+    if section_match:
+      if not saw_title:
+        issues.append(f"{relative_path}:{index}: missing '{SKILL_OVERRIDE_TITLE}' before sections")
+      if current_section is not None and not current_section_has_bullet:
+        issues.append(
+          f"{relative_path}:{index - 1}: section '{current_section}' must contain at least one bullet item"
+        )
+
+      section_name = section_match.group(1)
+      if section_name not in known_skills:
+        issues.append(
+          f"{relative_path}:{index}: section '{section_name}' is not an existing skill name"
+        )
+      if section_name in seen_sections:
+        issues.append(f"{relative_path}:{index}: duplicate section '{section_name}'")
+
+      seen_sections.add(section_name)
+      current_section = section_name
+      current_section_has_bullet = False
+      saw_any_section = True
+      continue
+
+    if stripped.startswith("#"):
+      issues.append(
+        f"{relative_path}:{index}: only '{SKILL_OVERRIDE_TITLE}' and '## bill-...' headings are allowed"
+      )
+      continue
+
+    if current_section is None:
+      issues.append(
+        f"{relative_path}:{index}: freeform text is not allowed outside a '## bill-...' section"
+      )
+      continue
+
+    if line.startswith("- "):
+      current_section_has_bullet = True
+      continue
+
+    if line.startswith("  ") and current_section_has_bullet:
+      continue
+
+    issues.append(
+      f"{relative_path}:{index}: section '{current_section}' must use bullet items; freeform text is not allowed"
+    )
+
+  if not saw_title:
+    issues.append(f"{relative_path}: missing '{SKILL_OVERRIDE_TITLE}' title")
+
+  if current_section is not None and not current_section_has_bullet:
+    issues.append(
+      f"{relative_path}: section '{current_section}' must contain at least one bullet item"
+    )
+
+  if not saw_any_section:
+    issues.append(f"{relative_path}: must contain at least one '## bill-...' section")
 
 
 def validate_plugin_manifest(plugin_path: Path, issues: list[str]) -> None:

--- a/skills/kmp/bill-kmp-code-review-compose-check/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review-compose-check/SKILL.md
@@ -5,9 +5,13 @@ description: Improve, review, or create Jetpack Compose composable functions, sc
 
 # Jetpack Compose Best Practices
 
-You are an expert KMP engineer specializing in Jetpack Compose. When creating, reviewing, or improving composable functions, screens, or components, follow every rule below strictly. The goal is production-grade, idiomatic, performant, accessible Compose code.
+## Project Overrides
 
----
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kmp-code-review-compose-check` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## 1. State Hoisting
 

--- a/skills/kmp/bill-kmp-code-review-ux-accessibility/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review-ux-accessibility/SKILL.md
@@ -22,7 +22,11 @@ Review only user-impacting UX/accessibility issues.
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kmp-code-review-ux-accessibility` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-architecture/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-architecture/SKILL.md
@@ -31,7 +31,11 @@ Apply the shared Kotlin rules to every review. Apply Android/KMP-only rules only
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-architecture` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-backend-api-contracts/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-backend-api-contracts/SKILL.md
@@ -24,7 +24,11 @@ Use this specialist for backend/server code only. It is most relevant for Ktor, 
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-backend-api-contracts` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-backend-persistence/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-backend-persistence/SKILL.md
@@ -24,7 +24,11 @@ Use this specialist for backend/server persistence code only: repositories, DAOs
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-backend-persistence` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-backend-reliability/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-backend-reliability/SKILL.md
@@ -24,7 +24,11 @@ Use this specialist for backend/server code only.
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-backend-reliability` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-performance/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-performance/SKILL.md
@@ -31,7 +31,11 @@ Apply shared Kotlin performance rules everywhere. Apply Android/KMP-only rules o
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-performance` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-platform-correctness/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-platform-correctness/SKILL.md
@@ -23,7 +23,11 @@ Apply shared Kotlin correctness rules to all code. Apply Android/KMP-only rules 
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-platform-correctness` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-security/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-security/SKILL.md
@@ -23,7 +23,11 @@ Apply shared security rules to all code. Apply Android/KMP-only rules only when 
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-security` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review-testing/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review-testing/SKILL.md
@@ -25,7 +25,11 @@ Apply shared test-risk rules to all code. Apply Android/KMP-only rules only when
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review-testing` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Project-Specific Rules
 

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -11,7 +11,11 @@ Your first job is to classify the project safely so Android/KMP reviews stay as 
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults. Project rules take precedence when they conflict. Pass this instruction to all spawned sub-agents.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-code-review` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to all spawned sub-agents.
 
 ## Setup
 

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -213,7 +213,7 @@ If invoked standalone, ask: **"Which item would you like me to fix?"**
 
 If invoked from `bill-kotlin-feature-implement` or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
 
-After all P0 and P1 items are resolved, run `bill-gradle-gcheck` as final verification when the project uses Gradle and this review is being run standalone.
+After all P0 and P1 items are resolved, run `bill-kotlin-quality-check` as final verification when the project uses Gradle and this review is being run standalone.
 
 ---
 

--- a/skills/kotlin/bill-kotlin-feature-implement/SKILL.md
+++ b/skills/kotlin/bill-kotlin-feature-implement/SKILL.md
@@ -5,7 +5,13 @@ description: Use when doing end-to-end feature implementation from design doc to
 
 # Feature Implement v2
 
-End-to-end feature implementation orchestrator. Takes a design doc and delivers reviewed, verified code. **Adapts workflow intensity to feature size.**
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-feature-implement` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. When you read another skill inline, also apply that skill's matching section from `.agents/skill-overrides.md` when present.
 
 ## Workflow Overview
 
@@ -135,7 +141,7 @@ If no history exists, skip.
 
 ### Feature Flag Setup (LARGE only, or when user confirmed flag needed)
 
-- Read the `bill-feature-guard` skill instructions and apply them inline
+- Read the `bill-feature-guard` skill instructions and its matching `.agents/skill-overrides.md` section, then apply them inline
 - Determine the pattern (Legacy / DI Switch / Simple Conditional)
 - Record the chosen pattern, flag name, and switch point
 - Do not auto-apply a fixed prefix (including `me-android-`) when proposing new flag names; only use a prefix if the user explicitly asks for it
@@ -143,13 +149,13 @@ If no history exists, skip.
 ### Discover Codebase Patterns
 
 Explore the codebase concurrently with planning:
-1. Read `CLAUDE.md` / `AGENTS.md` at project root — treat all standards as mandatory
+1. Read `CLAUDE.md`, `AGENTS.md`, and the matching `bill-kotlin-feature-implement` section in `.agents/skill-overrides.md` when present — treat all standards as mandatory
 2. Find similar features referenced in the spec
 3. Identify build dependencies for affected modules
 4. Note reusable components
 5. Identify validation surfaces so the final gate is chosen automatically:
    - Gradle/Kotlin project or modules → `bill-kotlin-quality-check`
-   - Agent-config / skill repository (`SKILL.md`, `AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, installer/config files, repo-native validation scripts) → inline agent-config validation
+   - Agent-config / skill repository (`SKILL.md`, `AGENTS.md`, `.agents/skill-overrides.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, installer/config files, repo-native validation scripts) → inline agent-config validation
    - Mixed repository → run both
 6. If a repo-native validation script already exists, reuse it instead of inventing a new ad hoc checklist
 
@@ -199,7 +205,7 @@ Wait for user confirmation.
 
  Implement each task in order:
  - After each task, print progress: `✅ [3/10] Created PaymentRepository with Room integration`
- - Follow project standards from CLAUDE.md / AGENTS.md
+ - Follow project standards from `CLAUDE.md`, `AGENTS.md`, and any matching `.agents/skill-overrides.md` sections used by this workflow
  - Write clean, production-grade code
   - Never introduce deprecated components, APIs, or patterns when a supported alternative exists. If absolutely no viable alternative exists, call that out explicitly, explain why, and keep the deprecated usage as narrow as possible.
   - **Write tests as specified** in each task's `Tests:` field
@@ -233,7 +239,7 @@ Then re-read `.feature-specs/<feature-name>/spec.md` to refresh acceptance crite
 
 ## Step 5: Code Review
 
-Run the `bill-kotlin-code-review` skill and apply it inline. Treat that skill as the source of truth for:
+Run the `bill-kotlin-code-review` skill and its matching `.agents/skill-overrides.md` section, then apply them inline. Treat that skill as the source of truth for:
 - Project classification
 - Dynamic specialist selection
 - Android/KMP vs backend/server routing
@@ -309,7 +315,7 @@ After completeness audit passes, **infer the final validation gate automatically
 
 ### Inline agent-config validation
 
-When the repo contains agent-config surfaces such as `SKILL.md`, `AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, agent installer/config files, or repo-native validation scripts:
+When the repo contains agent-config surfaces such as `SKILL.md`, `AGENTS.md`, `.agents/skill-overrides.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, agent installer/config files, or repo-native validation scripts:
 
 1. Run `agnix` when available
    - Prefer installed `agnix`
@@ -322,7 +328,7 @@ Do **not** create a separate utility skill just for this validation path unless 
 
 ## Step 7: Write Module History
 
-Run the `bill-module-history` skill and apply it inline.
+Run the `bill-module-history` skill and its matching `.agents/skill-overrides.md` section, then apply them inline.
 
 Pass the required inputs from this run:
 - Feature name
@@ -336,7 +342,7 @@ The `bill-module-history` skill owns the write/skip rules, entry format, and his
 
 ## Step 8: Generate PR Description (All sizes)
 
-Run the `bill-pr-description` skill to generate a PR title, description, and QA steps.
+Run the `bill-pr-description` skill and its matching `.agents/skill-overrides.md` section to generate a PR title, description, and QA steps.
 
 Pass along:
 - Feature name / spec path if available

--- a/skills/kotlin/bill-kotlin-feature-implement/SKILL.md
+++ b/skills/kotlin/bill-kotlin-feature-implement/SKILL.md
@@ -148,7 +148,7 @@ Explore the codebase concurrently with planning:
 3. Identify build dependencies for affected modules
 4. Note reusable components
 5. Identify validation surfaces so the final gate is chosen automatically:
-   - Gradle/Kotlin project or modules → `bill-gradle-gcheck`
+   - Gradle/Kotlin project or modules → `bill-kotlin-quality-check`
    - Agent-config / skill repository (`SKILL.md`, `AGENTS.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, installer/config files, repo-native validation scripts) → inline agent-config validation
    - Mixed repository → run both
 6. If a repo-native validation script already exists, reuse it instead of inventing a new ad hoc checklist
@@ -177,7 +177,7 @@ Do NOT present a separate "codebase patterns" section to the user — fold these
 - Pattern: <pattern> (or N/A)
 
 ### Final Validation
-- Strategy: `bill-gradle-gcheck` | inline agent-config validation | both
+- Strategy: `bill-kotlin-quality-check` | inline agent-config validation | both
 - Reason: <why this gate applies to the affected repo/modules>
 - Commands/scripts: <existing commands or repo-native scripts to run>
 
@@ -302,7 +302,7 @@ After completeness audit passes, **infer the final validation gate automatically
 
 ### Validation strategy
 
-- **Gradle/Kotlin repos or modules touched:** run `bill-gradle-gcheck`
+- **Gradle/Kotlin repos or modules touched:** run `bill-kotlin-quality-check`
 - **Agent-config / skill repos touched:** run inline agent-config validation
 - **Both:** run both gates
 - **Neither:** run the closest existing repo-native validation command or test command already present in the project
@@ -354,7 +354,7 @@ Pass along:
 This skill orchestrates (by reading their instructions and applying inline):
 - `bill-feature-guard` — if feature flag is needed (LARGE, or when confirmed)
 - `bill-kotlin-code-review` — automatic after implementation; it classifies the diff and selects 2-6 specialists dynamically
-- `bill-gradle-gcheck` — when the affected repo/modules use the Gradle/Kotlin validation path
+- `bill-kotlin-quality-check` — when the affected repo/modules use the Gradle/Kotlin validation path
 - `bill-module-history` — writes/maintains `agent/history.md` for impactful or larger features
 
 ## Size Reference

--- a/skills/kotlin/bill-kotlin-feature-verify/SKILL.md
+++ b/skills/kotlin/bill-kotlin-feature-verify/SKILL.md
@@ -5,7 +5,13 @@ description: Verify a PR against a task spec — extract acceptance criteria, ch
 
 # Feature Verify
 
-Structured PR verification against a task specification. Takes a spec + PR diff and produces a verdict with acceptance criteria coverage, feature flag compliance, and code review findings.
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-feature-verify` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. When you reuse another skill as part of this workflow, also apply that skill's matching override section when present.
 
 ## Workflow Overview
 
@@ -113,7 +119,7 @@ Run the `bill-kotlin-code-review` skill against the PR diff. This will:
 4. Merge and deduplicate findings
 5. Produce the risk register and action items
 
-Follow the full `bill-kotlin-code-review` skill instructions — do not abbreviate or skip agents.
+Follow the full `bill-kotlin-code-review` skill instructions, including any matching `.agents/skill-overrides.md` section — do not abbreviate or skip agents.
 
 ## Step 6: Completeness Audit
 

--- a/skills/kotlin/bill-kotlin-quality-check/SKILL.md
+++ b/skills/kotlin/bill-kotlin-quality-check/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: bill-gradle-gcheck
+name: bill-kotlin-quality-check
 description: Run ./gradlew check and systematically fix all issues without using suppressions. Use when running Gradle checks, fixing lint errors, formatting issues, test failures, or deprecation warnings in Android/Kotlin projects. Fixes issues properly at the root cause instead of suppressing them.
 ---
 
-# Gradle Check and Fix
+# Kotlin Quality Check
 
 Execute `./gradlew check` and systematically fix issues **only in files changed in the current unit of work**. Ignore pre-existing issues in untouched files.
 

--- a/skills/kotlin/bill-kotlin-quality-check/SKILL.md
+++ b/skills/kotlin/bill-kotlin-quality-check/SKILL.md
@@ -66,7 +66,11 @@ These issues require file operations and should be fixed before other issues:
 
 ## Project Overrides
 
-If an `AGENTS.md` file exists in the project root, read it and apply its rules alongside the defaults below. Project rules take precedence when they conflict.
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-kotlin-quality-check` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Code Style Guidelines
 

--- a/skills/shared/bill-feature-guard-cleanup/SKILL.md
+++ b/skills/shared/bill-feature-guard-cleanup/SKILL.md
@@ -5,7 +5,13 @@ description: Remove feature flags and legacy code after a feature is fully rolle
 
 # Feature Guard Cleanup
 
-Remove feature flags and their associated legacy code after full rollout.
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-feature-guard-cleanup` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## When To Use
 

--- a/skills/shared/bill-feature-guard-cleanup/SKILL.md
+++ b/skills/shared/bill-feature-guard-cleanup/SKILL.md
@@ -41,7 +41,7 @@ Before deleting anything:
 
 ### Step 4: Verify
 
-Run `bill-gradle-gcheck` to ensure nothing is broken.
+Run `bill-kotlin-quality-check` to ensure nothing is broken.
 
 ## Patterns
 
@@ -95,7 +95,7 @@ navigateTo(CheckoutScreen)
 - [ ] All Legacy files deleted
 - [ ] All Legacy tests deleted
 - [ ] Flag definition removed from registry
-- [ ] `bill-gradle-gcheck` passes
+- [ ] `bill-kotlin-quality-check` passes
 - [ ] No orphaned imports or dependencies
 
 ## When to Ask User

--- a/skills/shared/bill-feature-guard/SKILL.md
+++ b/skills/shared/bill-feature-guard/SKILL.md
@@ -5,7 +5,13 @@ description: Enable feature flag mode - all code changes will be guarded by feat
 
 # Feature Guard Mode
 
-All code changes MUST be guarded by feature flags to ensure 100% safe rollback capability.
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-feature-guard` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Core Principles
 

--- a/skills/shared/bill-module-history/SKILL.md
+++ b/skills/shared/bill-module-history/SKILL.md
@@ -5,7 +5,13 @@ description: Use when updating module-level agent/history.md with reusable, high
 
 # Module History
 
-Update `agent/history.md` in the **primary module** for the implemented feature.
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-module-history` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
 
 ## Inputs Required
 

--- a/skills/shared/bill-new-skill-all-agents/SKILL.md
+++ b/skills/shared/bill-new-skill-all-agents/SKILL.md
@@ -3,6 +3,14 @@ name: bill-new-skill-all-agents
 description: Use when creating a new skill and syncing it to all detected local AI agents (Claude, Copilot, GLM, Codex).
 ---
 
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-new-skill-all-agents` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
 When asked to create a new skill, follow this workflow:
 
 1. Collect inputs:
@@ -22,7 +30,7 @@ When asked to create a new skill, follow this workflow:
 
 1b. Derive the source package from the validated name:
    - `shared` for neutral skills like `bill-pr-description` or `bill-feature-guard`
-   - `kotlin` for Kotlin-prefixed skills and Gradle-specific skills
+   - `kotlin` for Kotlin-prefixed skills
    - `kmp` for KMP-prefixed skills
    - `php` for PHP-prefixed skills
    - If the package is unclear, ask once before creating files
@@ -48,10 +56,11 @@ When asked to create a new skill, follow this workflow:
    b. Each secondary: `ln -s {primary_path}/{slug} {secondary_path}/{slug}`
 
 6. Rules:
-   - Never duplicate file content across agents — always use symlinks
-   - If a target symlink already exists, remove it first and recreate
-   - If an agent root directory does not exist, skip that agent
-   - The skill file must be named `SKILL.md` inside a directory named after the slug
+    - Never duplicate file content across agents — always use symlinks
+    - If a target symlink already exists, remove it first and recreate
+    - If an agent root directory does not exist, skip that agent
+    - The skill file must be named `SKILL.md` inside a directory named after the slug
+    - New skill files must include a `## Project Overrides` section near the top that tells the skill to read `.agents/skill-overrides.md` for a matching `## {slug}` section, with precedence `skill override > AGENTS.md > built-in defaults`
 
 7. Return a short summary:
    - skill slug

--- a/skills/shared/bill-pr-description/SKILL.md
+++ b/skills/shared/bill-pr-description/SKILL.md
@@ -5,13 +5,21 @@ description: Use when generating a PR title, description, and QA steps from the 
 
 # PR Description Generator
 
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-pr-description` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
 Generate a PR title, description, and QA/test steps ready to paste. Present the result to the user for review.
 
 ## How It Works
 
 1. **Determine the comparison base** — use the branch this feature branch was created from when known, otherwise compute the best available merge-base from git context. Never assume `main`.
 2. **Gather context** — read the git diff from that merge-base to `HEAD`, along with the commit log and branch name
-3. **Read project guidelines** — check `CLAUDE.md` / `AGENTS.md` at the project root for any PR conventions
+3. **Read project guidelines** — check `CLAUDE.md`, `AGENTS.md`, and the matching `bill-pr-description` section in `.agents/skill-overrides.md` when present
 4. **Generate** the title and description using the template below
 5. **Present** the result to the user for review and adjustment
 

--- a/skills/shared/bill-unit-test-value-check/SKILL.md
+++ b/skills/shared/bill-unit-test-value-check/SKILL.md
@@ -5,6 +5,14 @@ description: Use when reviewing unit tests in a file, current changes, or a comm
 
 # Unit Test Value Checker
 
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-unit-test-value-check` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
 Review unit tests with one goal: confirm they validate real business logic and would catch meaningful regressions. Reject tests that only exist to inflate coverage or test counts.
 
 ## Supported Scope


### PR DESCRIPTION
# Summary

Add per-skill override customization so projects can tailor individual skills via `.agents/skill-overrides.md` without forking the plugin. This also renames the Kotlin quality-check skill to `bill-kotlin-quality-check`, tightens `skills/kotlin/*` naming to `bill-kotlin-*`, and adds CI validation for both skill structure and override-file format.

- add a strict, section-based `.agents/skill-overrides.md` contract plus an example file
- propagate override handling through orchestrator skills and require the hook in newly created skills
- validate override files in CI, including unknown skill names and freeform-text failures
- rename `bill-gradle-gcheck` to `bill-kotlin-quality-check`

## Feature Flags

N/A

# How Has This Been Tested?

Ran repo-native validation and installer syntax checks.

1. Run `bash -n install.sh`.
2. Run `python3 scripts/validate_agent_configs.py`.
3. Run `npx --yes agnix --strict .`.
4. Optionally copy `.agents/skill-overrides.example.md` to `.agents/skill-overrides.md`, then change a section name to a non-existent skill and rerun `python3 scripts/validate_agent_configs.py`.
5. Confirm the validator fails for the invalid section name or for any freeform text outside bullet-list sections.
