### PR TITLE
feat: add platform-aware install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,39 @@ chmod +x install.sh
 ./install.sh --mode safe
 ```
 
-The installer asks for a comma-separated agent list, primary first:
+The installer first asks which agent targets to install to. You can choose one or more entries, including `all`, and if you choose more than one it then asks which selected agent should be primary:
 
 ```text
-copilot, claude, glm, codex
+all
+claude
 ```
+
+It then shows the available platform packages and asks which ones to install. Base skills in `skills/base/` are always installed; platform packages are installed only when selected.
+
+Available options are shown as separate entries:
+
+```text
+Kotlin backend
+Kotlin
+KMP
+PHP
+all
+```
+
+Example platform selections:
+
+```text
+Kotlin backend, Kotlin, KMP
+PHP
+all
+```
+
+Re-running the installer in `safe` mode is add-only for valid platform packages, so you can install more platforms later without removing ones that were already linked.
 
 Modes:
 
 - `safe` — replace symlinks, migrate plugin-managed legacy installs, skip non-symlink conflicts
-- `override` — replace any existing target path and prune stale `bill-*` installs
+- `override` — run `./uninstall.sh` first, then reinstall only the selected platforms
 - `interactive` — prompt before replacing non-symlink conflicts
 
 If you only use Claude Code, you can also install this repo as a Claude plugin:
@@ -118,6 +141,17 @@ If you only use Claude Code, you can also install this repo as a Claude plugin:
 ```bash
 claude plugin install ~/Development/skill-bill
 ```
+
+## Uninstallation
+
+To remove Skill Bill skill symlinks from the supported agent install paths:
+
+```bash
+chmod +x uninstall.sh
+./uninstall.sh
+```
+
+The uninstaller is idempotent. It removes current Skill Bill skill names plus known legacy install names when they are present as symlinks, and skips non-symlink paths.
 
 ## Skills Included
 

--- a/install.sh
+++ b/install.sh
@@ -109,8 +109,13 @@ declare -a RENAMED_SKILL_PAIRS=(
   'bill-gcheck:bill-quality-check'
 )
 
+declare -a SUPPORTED_AGENTS=(copilot claude glm codex)
 declare -a SKILL_NAMES=()
 declare -a SKILL_PATHS=()
+declare -a INSTALL_SKILL_NAMES=()
+declare -a INSTALL_SKILL_PATHS=()
+declare -a PLATFORM_PACKAGES=()
+declare -a SELECTED_PLATFORM_PACKAGES=()
 declare -a LEGACY_SKILL_NAMES=()
 declare -a SKIPPED_TARGETS=()
 
@@ -205,6 +210,418 @@ find_skill_index() {
   return 1
 }
 
+array_contains() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [[ "$item" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+trim_string() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+normalize_platform_token() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]_/-'
+}
+
+normalize_agent_token() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]'
+}
+
+add_agent_selection() {
+  local agent="$1"
+  if ! array_contains "$agent" "${AGENT_NAMES[@]:-}"; then
+    AGENT_NAMES+=("$agent")
+    AGENT_PATHS+=("$(get_agent_path "$agent")")
+  fi
+}
+
+resolve_agent_selection() {
+  local token="$1"
+  local normalized
+  local index
+  local all_index
+  local agent
+
+  token="$(trim_string "$token")"
+  [[ -n "$token" ]] || return 1
+
+  if [[ "$token" =~ ^[0-9]+$ ]]; then
+    index=$((token - 1))
+    if (( index >= 0 && index < ${#SUPPORTED_AGENTS[@]} )); then
+      printf '%s\n' "${SUPPORTED_AGENTS[$index]}"
+      return 0
+    fi
+    all_index=${#SUPPORTED_AGENTS[@]}
+    if (( index == all_index )); then
+      printf '__all__\n'
+      return 0
+    fi
+    return 1
+  fi
+
+  normalized="$(normalize_agent_token "$token")"
+  if [[ "$normalized" == "all" ]]; then
+    printf '__all__\n'
+    return 0
+  fi
+
+  for agent in "${SUPPORTED_AGENTS[@]}"; do
+    if [[ "$normalized" == "$agent" ]]; then
+      printf '%s\n' "$agent"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+format_agent_list() {
+  local result=""
+  local agent
+
+  for agent in "$@"; do
+    if [[ -z "$result" ]]; then
+      result="$agent"
+    else
+      result="$result, $agent"
+    fi
+  done
+
+  printf '%s' "$result"
+}
+
+set_primary_agent() {
+  local target="$1"
+  local reordered_names=()
+  local reordered_paths=()
+  local idx
+
+  for idx in "${!AGENT_NAMES[@]}"; do
+    if [[ "${AGENT_NAMES[$idx]}" == "$target" ]]; then
+      reordered_names+=("${AGENT_NAMES[$idx]}")
+      reordered_paths+=("${AGENT_PATHS[$idx]}")
+    fi
+  done
+
+  for idx in "${!AGENT_NAMES[@]}"; do
+    if [[ "${AGENT_NAMES[$idx]}" != "$target" ]]; then
+      reordered_names+=("${AGENT_NAMES[$idx]}")
+      reordered_paths+=("${AGENT_PATHS[$idx]}")
+    fi
+  done
+
+  AGENT_NAMES=("${reordered_names[@]}")
+  AGENT_PATHS=("${reordered_paths[@]}")
+  PRIMARY="${AGENT_NAMES[0]}"
+  PRIMARY_DIR="${AGENT_PATHS[0]}"
+}
+
+prompt_for_agent_selection() {
+  local input
+  local raw_tokens=()
+  local invalid_tokens=()
+  local token
+  local resolved
+  local i
+  local option_number
+  local supported_agent
+
+  while true; do
+    echo ""
+    info "Available agents:"
+    for i in "${!SUPPORTED_AGENTS[@]}"; do
+      printf "  %s. %s\n" "$((i + 1))" "${SUPPORTED_AGENTS[$i]}"
+    done
+    option_number=$(( ${#SUPPORTED_AGENTS[@]} + 1 ))
+    printf "  %s. all (install to every supported agent)\n" "$option_number"
+    info "Choose one or more agents (comma-separated)."
+    printf "${CYAN}▸${NC} Enter agents: "
+    read -r input
+
+    if [[ -z "$(trim_string "$input")" ]]; then
+      warn "No agents provided. Choose at least one agent."
+      continue
+    fi
+
+    AGENT_NAMES=()
+    AGENT_PATHS=()
+    invalid_tokens=()
+    IFS=',' read -ra raw_tokens <<< "$input"
+
+    for token in "${raw_tokens[@]:-}"; do
+      token="$(trim_string "$token")"
+      [[ -z "$token" ]] && continue
+      resolved="$(resolve_agent_selection "$token" 2>/dev/null || true)"
+      if [[ -z "$resolved" ]]; then
+        invalid_tokens+=("$token")
+        continue
+      fi
+      if [[ "$resolved" == "__all__" ]]; then
+        for supported_agent in "${SUPPORTED_AGENTS[@]:-}"; do
+          add_agent_selection "$supported_agent"
+        done
+        continue
+      fi
+      add_agent_selection "$resolved"
+    done
+
+    if [[ ${#invalid_tokens[@]} -gt 0 ]]; then
+      warn "Unknown agent selection: $(printf '%s, ' "${invalid_tokens[@]}" | sed 's/, $//')"
+      continue
+    fi
+
+    if [[ ${#AGENT_NAMES[@]} -eq 0 ]]; then
+      warn "No valid agents selected. Choose at least one agent."
+      continue
+    fi
+
+    return 0
+  done
+}
+
+prompt_for_primary_agent() {
+  local input
+  local normalized
+  local idx
+
+  if [[ ${#AGENT_NAMES[@]} -eq 1 ]]; then
+    PRIMARY="${AGENT_NAMES[0]}"
+    PRIMARY_DIR="${AGENT_PATHS[0]}"
+    return 0
+  fi
+
+  while true; do
+    echo ""
+    info "Selected agents: $(format_agent_list "${AGENT_NAMES[@]}")"
+    info "Choose the primary agent:"
+    for idx in "${!AGENT_NAMES[@]}"; do
+      printf "  %s. %s\n" "$((idx + 1))" "${AGENT_NAMES[$idx]}"
+    done
+    printf "${CYAN}▸${NC} Enter primary agent: "
+    read -r input
+    input="$(trim_string "$input")"
+
+    if [[ -z "$input" ]]; then
+      warn "No primary agent provided. Choose one of the selected agents."
+      continue
+    fi
+
+    if [[ "$input" =~ ^[0-9]+$ ]]; then
+      idx=$((input - 1))
+      if (( idx >= 0 && idx < ${#AGENT_NAMES[@]} )); then
+        set_primary_agent "${AGENT_NAMES[$idx]}"
+        return 0
+      fi
+      warn "Unknown primary selection: $input"
+      continue
+    fi
+
+    normalized="$(normalize_agent_token "$input")"
+    for idx in "${!AGENT_NAMES[@]}"; do
+      if [[ "$normalized" == "${AGENT_NAMES[$idx]}" ]]; then
+        set_primary_agent "${AGENT_NAMES[$idx]}"
+        return 0
+      fi
+    done
+
+    warn "Unknown primary selection: $input"
+  done
+}
+
+display_platform_name() {
+  case "$1" in
+    backend-kotlin) printf 'Kotlin backend' ;;
+    kotlin) printf 'Kotlin' ;;
+    kmp) printf 'KMP' ;;
+    php) printf 'PHP' ;;
+    *)
+      local label="${1//-/ }"
+      printf '%s' "$label"
+      ;;
+  esac
+}
+
+build_platform_packages() {
+  local discovered=()
+  local package
+
+  while IFS= read -r package; do
+    [[ "$package" == "base" ]] && continue
+    discovered+=("$package")
+  done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+
+  PLATFORM_PACKAGES=()
+  for package in backend-kotlin kotlin kmp php; do
+    if array_contains "$package" "${discovered[@]:-}"; then
+      PLATFORM_PACKAGES+=("$package")
+    fi
+  done
+
+  for package in "${discovered[@]:-}"; do
+    if ! array_contains "$package" "${PLATFORM_PACKAGES[@]:-}"; then
+      PLATFORM_PACKAGES+=("$package")
+    fi
+  done
+}
+
+resolve_platform_selection() {
+  local token="$1"
+  local normalized
+  local package
+  local index
+  local all_index
+
+  token="$(trim_string "$token")"
+  [[ -n "$token" ]] || return 1
+
+  if [[ "$token" =~ ^[0-9]+$ ]]; then
+    index=$((token - 1))
+    if (( index >= 0 && index < ${#PLATFORM_PACKAGES[@]} )); then
+      printf '%s\n' "${PLATFORM_PACKAGES[$index]}"
+      return 0
+    fi
+    all_index=${#PLATFORM_PACKAGES[@]}
+    if (( index == all_index )); then
+      printf '__all__\n'
+      return 0
+    fi
+    return 1
+  fi
+
+  normalized="$(normalize_platform_token "$token")"
+  case "$normalized" in
+    all)
+      printf '__all__\n'
+      return 0
+      ;;
+    backendkotlin|kotlinbackend)
+      printf 'backend-kotlin\n'
+      return 0
+      ;;
+    kotlin)
+      printf 'kotlin\n'
+      return 0
+      ;;
+    kmp|androidkmp)
+      printf 'kmp\n'
+      return 0
+      ;;
+    php)
+      printf 'php\n'
+      return 0
+      ;;
+  esac
+
+  for package in "${PLATFORM_PACKAGES[@]}"; do
+    if [[ "$normalized" == "$(normalize_platform_token "$package")" ]]; then
+      printf '%s\n' "$package"
+      return 0
+    fi
+    if [[ "$normalized" == "$(normalize_platform_token "$(display_platform_name "$package")")" ]]; then
+      printf '%s\n' "$package"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+format_platform_list() {
+  local result=""
+  local package
+  local label
+
+  for package in "$@"; do
+    label="$(display_platform_name "$package")"
+    if [[ -z "$result" ]]; then
+      result="$label"
+    else
+      result="$result, $label"
+    fi
+  done
+
+  printf '%s' "$result"
+}
+
+prompt_for_platform_selection() {
+  local input
+  local i
+  local option_number
+  local package
+  local token
+  local resolved
+  local invalid_tokens=()
+  local raw_tokens=()
+
+  if [[ ${#PLATFORM_PACKAGES[@]} -eq 0 ]]; then
+    SELECTED_PLATFORM_PACKAGES=()
+    return 0
+  fi
+
+  while true; do
+    echo ""
+    info "Available platforms:"
+    for i in "${!PLATFORM_PACKAGES[@]}"; do
+      package="${PLATFORM_PACKAGES[$i]}"
+      printf "  %s. %s (%s)\n" "$((i + 1))" "$(display_platform_name "$package")" "$package"
+    done
+    option_number=$(( ${#PLATFORM_PACKAGES[@]} + 1 ))
+    printf "  %s. all (install every platform package)\n" "$option_number"
+    info "Base skills are always installed."
+    info "Choose one or more platform options (comma-separated)."
+    printf "${CYAN}▸${NC} Enter platforms (e.g. Kotlin backend, Kotlin, KMP or PHP): "
+    read -r input
+
+    if [[ -z "$(trim_string "$input")" ]]; then
+      warn "No platforms provided. Choose at least one platform."
+      continue
+    fi
+
+    SELECTED_PLATFORM_PACKAGES=()
+    invalid_tokens=()
+    IFS=',' read -ra raw_tokens <<< "$input"
+
+    for token in "${raw_tokens[@]}"; do
+      token="$(trim_string "$token")"
+      [[ -z "$token" ]] && continue
+      resolved="$(resolve_platform_selection "$token" 2>/dev/null || true)"
+      if [[ -z "$resolved" ]]; then
+        invalid_tokens+=("$token")
+        continue
+      fi
+      if [[ "$resolved" == "__all__" ]]; then
+        SELECTED_PLATFORM_PACKAGES=("${PLATFORM_PACKAGES[@]}")
+        break
+      fi
+      if ! array_contains "$resolved" "${SELECTED_PLATFORM_PACKAGES[@]:-}"; then
+        SELECTED_PLATFORM_PACKAGES+=("$resolved")
+      fi
+    done
+
+    if [[ ${#invalid_tokens[@]} -gt 0 ]]; then
+      warn "Unknown platform selection: $(printf '%s, ' "${invalid_tokens[@]}" | sed 's/, $//')"
+      continue
+    fi
+
+    if [[ ${#SELECTED_PLATFORM_PACKAGES[@]} -eq 0 ]]; then
+      warn "No valid platforms selected. Choose at least one platform."
+      continue
+    fi
+
+    return 0
+  done
+}
+
 build_skill_names() {
   local skill_file skill_dir skill_name
   local existing_idx
@@ -226,6 +643,25 @@ build_skill_names() {
     SKILL_NAMES+=("$skill_name")
     SKILL_PATHS+=("$skill_dir")
   done < <(find "$SKILLS_DIR" -type f -name 'SKILL.md' | sort)
+}
+
+build_install_skill_names() {
+  local idx
+  local skill_dir
+  local package_name
+
+  INSTALL_SKILL_NAMES=()
+  INSTALL_SKILL_PATHS=()
+
+  for idx in "${!SKILL_NAMES[@]}"; do
+    skill_dir="${SKILL_PATHS[$idx]}"
+    package_name="$(basename "$(dirname "$skill_dir")")"
+
+    if [[ "$package_name" == "base" ]] || array_contains "$package_name" "${SELECTED_PLATFORM_PACKAGES[@]:-}"; then
+      INSTALL_SKILL_NAMES+=("${SKILL_NAMES[$idx]}")
+      INSTALL_SKILL_PATHS+=("$skill_dir")
+    fi
+  done
 }
 
 add_legacy_name() {
@@ -293,27 +729,6 @@ remove_legacy_skill_paths() {
   done
 }
 
-prune_project_skill_paths() {
-  local target_dir="$1"
-  local installed_path skill_name
-
-  [[ -d "$target_dir" ]] || return 0
-
-  while IFS= read -r -d '' installed_path; do
-    skill_name="$(basename "$installed_path")"
-
-    if find_skill_index "$skill_name" >/dev/null 2>&1; then
-      continue
-    fi
-
-    if remove_if_allowed "$installed_path" "stale bill-* skill not present in plugin"; then
-      if [[ ! -e "$installed_path" && ! -L "$installed_path" ]]; then
-        ok "  pruned stale $skill_name"
-      fi
-    fi
-  done < <(find "$target_dir" -mindepth 1 -maxdepth 1 -name 'bill-*' -print0)
-}
-
 install_skill_link() {
   local target="$1"
   local source="$2"
@@ -333,6 +748,7 @@ install_skill_link() {
 parse_args "$@"
 build_skill_names
 build_legacy_skill_names
+build_platform_packages
 
 echo ""
 printf "${CYAN}━━━ Skill Bill Installer ━━━${NC}\n"
@@ -342,50 +758,35 @@ info "Install mode: $MODE"
 if [[ "$MODE" == safe ]]; then
   info "Safe mode replaces symlinks, migrates legacy plugin installs, and skips local directory/file conflicts."
 elif [[ "$MODE" == override ]]; then
-  info "Override mode replaces any existing target path and prunes stale bill-* installs."
+  info "Override mode runs the uninstaller first, then reinstalls only the selected platforms."
 fi
-echo ""
-printf "${CYAN}▸${NC} Enter agents (comma-separated, primary first): "
-read -r input
-
-if [[ -z "$input" ]]; then
-  err "No agents provided"
-  exit 1
-fi
-
-IFS=',' read -ra RAW_AGENTS <<< "$input"
-
-AGENT_NAMES=()
-AGENT_PATHS=()
-for raw in "${RAW_AGENTS[@]}"; do
-  agent="$(echo "$raw" | tr -d '[:space:]')"
-  path="$(get_agent_path "$agent" 2>/dev/null || true)"
-  if [[ -z "$path" ]]; then
-    err "Unknown agent: $agent"
-    exit 1
-  fi
-  AGENT_NAMES+=("$agent")
-  AGENT_PATHS+=("$path")
-done
-
-PRIMARY="${AGENT_NAMES[0]}"
-PRIMARY_DIR="${AGENT_PATHS[0]}"
+prompt_for_agent_selection
+prompt_for_primary_agent
+prompt_for_platform_selection
+build_install_skill_names
 
 echo ""
 info "Plugin:  $PLUGIN_DIR"
 info "Primary: $PRIMARY ($PRIMARY_DIR)"
+info "Agents selected: $(format_agent_list "${AGENT_NAMES[@]}")"
 info "Skills found: ${#SKILL_NAMES[@]}"
+info "Skills selected: ${#INSTALL_SKILL_NAMES[@]} (base + $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}"))"
 echo ""
+
+if [[ "$MODE" == override ]]; then
+  info "Override mode removes existing Skill Bill symlinks before reinstalling the selected platforms."
+  bash "$PLUGIN_DIR/uninstall.sh"
+  echo ""
+fi
 
 mkdir -p "$PRIMARY_DIR"
 info "Installing to primary ($PRIMARY): $PRIMARY_DIR"
-if [[ "$MODE" == override ]]; then
-  prune_project_skill_paths "$PRIMARY_DIR"
+if [[ "$MODE" != override ]]; then
+  remove_legacy_skill_paths "$PRIMARY_DIR"
 fi
-remove_legacy_skill_paths "$PRIMARY_DIR"
-for idx in "${!SKILL_NAMES[@]}"; do
-  skill="${SKILL_NAMES[$idx]}"
-  install_skill_link "$PRIMARY_DIR/$skill" "${SKILL_PATHS[$idx]}" "$skill → plugin"
+for idx in "${!INSTALL_SKILL_NAMES[@]}"; do
+  skill="${INSTALL_SKILL_NAMES[$idx]}"
+  install_skill_link "$PRIMARY_DIR/$skill" "${INSTALL_SKILL_PATHS[$idx]}" "$skill → plugin"
 done
 echo ""
 
@@ -401,12 +802,11 @@ for i in "${!AGENT_NAMES[@]}"; do
 
   mkdir -p "$agent_dir"
   info "Symlinking $agent: $agent_dir → $PRIMARY_DIR"
-  if [[ "$MODE" == override ]]; then
-    prune_project_skill_paths "$agent_dir"
+  if [[ "$MODE" != override ]]; then
+    remove_legacy_skill_paths "$agent_dir"
   fi
-  remove_legacy_skill_paths "$agent_dir"
 
-  for skill in "${SKILL_NAMES[@]}"; do
+  for skill in "${INSTALL_SKILL_NAMES[@]}"; do
     install_skill_link "$agent_dir/$skill" "$PRIMARY_DIR/$skill" "$skill"
   done
   echo ""
@@ -416,6 +816,7 @@ printf "${GREEN}━━━ Installation complete ━━━${NC}\n"
 echo ""
 info "Source of truth: $PLUGIN_DIR/skills/"
 info "Primary agent:   $PRIMARY → $PRIMARY_DIR"
+info "Platforms:       $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}")"
 for i in "${!AGENT_NAMES[@]}"; do
   [[ "$i" -eq 0 ]] && continue
   agent="${AGENT_NAMES[$i]}"
@@ -435,5 +836,5 @@ fi
 
 echo ""
 info "Edit skills in: $PLUGIN_DIR/skills/"
-info "Run './install.sh --mode safe' again after adding new skills."
+info "Run './install.sh --mode safe' again to add missing platform packages."
 echo ""

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = ROOT / "install.sh"
+SKILLS_DIR = ROOT / "skills"
+
+
+def skill_names(package_name: str) -> set[str]:
+  return {
+    skill_file.parent.name
+    for skill_file in (SKILLS_DIR / package_name).glob("*/SKILL.md")
+  }
+
+
+BASE_SKILLS = skill_names("base")
+BACKEND_KOTLIN_SKILLS = skill_names("backend-kotlin")
+KOTLIN_SKILLS = skill_names("kotlin")
+KMP_SKILLS = skill_names("kmp")
+PHP_SKILLS = skill_names("php")
+
+
+class InstallScriptTest(unittest.TestCase):
+  maxDiff = None
+
+  def test_accepts_separate_agent_selection_and_primary_prompt(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      result = self.run_installer(temp_home, "all\nclaude\nPHP\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+      self.assertIn("Available agents:", result.stdout)
+      self.assertIn("Choose the primary agent:", result.stdout)
+      self.assertIn("Primary: claude", result.stdout)
+
+      for relative_path in (
+        ".copilot/skills/bill-code-review",
+        ".claude/commands/bill-code-review",
+        ".glm/commands/bill-code-review",
+        ".codex/skills/bill-code-review",
+      ):
+        self.assertTrue((Path(temp_home) / relative_path).is_symlink(), relative_path)
+
+  def test_installs_base_and_selected_platform_only(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nPHP\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+      self.assertIn("Available platforms:", result.stdout)
+      self.assertIn("Base skills are always installed.", result.stdout)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS)
+
+  def test_accepts_human_friendly_multi_platform_selection(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nKotlin backend, Kotlin, KMP\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | BACKEND_KOTLIN_SKILLS | KOTLIN_SKILLS | KMP_SKILLS)
+      self.assertTrue(PHP_SKILLS.isdisjoint(installed))
+
+  def test_shows_each_platform_option_and_supports_all(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nall\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+      self.assertIn("Kotlin backend (backend-kotlin)", result.stdout)
+      self.assertIn("Kotlin (kotlin)", result.stdout)
+      self.assertIn("KMP (kmp)", result.stdout)
+      self.assertIn("PHP (php)", result.stdout)
+      self.assertIn("all (install every platform package)", result.stdout)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(
+        installed,
+        BASE_SKILLS | BACKEND_KOTLIN_SKILLS | KOTLIN_SKILLS | KMP_SKILLS | PHP_SKILLS,
+      )
+
+  def test_ignores_empty_platform_tokens(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nPHP, , Kotlin backend\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS | BACKEND_KOTLIN_SKILLS)
+
+  def test_safe_rerun_adds_platform_without_pruning_existing_valid_one(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      first = self.run_installer(temp_home, "copilot\nPHP\n")
+      self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+
+      second = self.run_installer(
+        temp_home,
+        "copilot\nKotlin backend\n",
+      )
+      self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS | BACKEND_KOTLIN_SKILLS)
+
+  def test_override_rerun_reinstalls_only_selected_platforms_after_uninstall(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      first = self.run_installer(temp_home, "copilot\nPHP\n")
+      self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+
+      second = self.run_installer(
+        temp_home,
+        "copilot\nKotlin backend\n",
+        mode="override",
+      )
+      self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+      self.assertIn("Skill Bill Uninstaller", second.stdout)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | BACKEND_KOTLIN_SKILLS)
+
+  def run_installer(
+    self,
+    temp_home: str,
+    user_input: str,
+    mode: str = "safe",
+  ) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = temp_home
+    return subprocess.run(
+      ["bash", str(INSTALL_SCRIPT), "--mode", mode],
+      cwd=ROOT,
+      input=user_input,
+      capture_output=True,
+      text=True,
+      check=False,
+      env=env,
+    )
+
+  def installed_skills(self, temp_home: str) -> set[str]:
+    install_dir = Path(temp_home) / ".copilot" / "skills"
+    if not install_dir.exists():
+      return set()
+    return {path.name for path in install_dir.iterdir()}
+
+  def prepare_agent_homes(self, temp_home: str) -> None:
+    for relative_dir in (
+      ".copilot",
+      ".claude",
+      ".glm",
+      ".codex",
+    ):
+      (Path(temp_home) / relative_dir).mkdir(parents=True, exist_ok=True)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = ROOT / "install.sh"
+UNINSTALL_SCRIPT = ROOT / "uninstall.sh"
+
+
+class UninstallScriptTest(unittest.TestCase):
+  maxDiff = None
+
+  def test_uninstall_removes_skill_symlinks_from_supported_agents(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      install = self.run_script(INSTALL_SCRIPT, temp_home, "copilot, claude\ncopilot\nPHP\n")
+      self.assertEqual(install.returncode, 0, install.stdout + install.stderr)
+      self.assertTrue((Path(temp_home) / ".copilot" / "skills" / "bill-code-review").is_symlink())
+      self.assertTrue((Path(temp_home) / ".claude" / "commands" / "bill-code-review").is_symlink())
+
+      uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
+      self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)
+      self.assertIn("Removed symlinks:", uninstall.stdout)
+      self.assertFalse((Path(temp_home) / ".copilot" / "skills" / "bill-code-review").exists())
+      self.assertFalse((Path(temp_home) / ".claude" / "commands" / "bill-code-review").exists())
+
+  def test_uninstall_removes_legacy_skill_symlinks_and_is_idempotent(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      legacy_target = Path(temp_home) / "legacy-target"
+      legacy_target.write_text("legacy", encoding="utf-8")
+      legacy_symlink = Path(temp_home) / ".copilot" / "skills" / "bill-gcheck"
+      legacy_symlink.symlink_to(legacy_target)
+
+      first = self.run_script(UNINSTALL_SCRIPT, temp_home)
+      self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+      self.assertFalse(legacy_symlink.exists())
+
+      second = self.run_script(UNINSTALL_SCRIPT, temp_home)
+      self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+      self.assertIn("Removed symlinks: 0", second.stdout)
+
+  def prepare_agent_homes(self, temp_home: str) -> None:
+    for relative_dir in (
+      ".copilot/skills",
+      ".claude/commands",
+      ".glm/commands",
+      ".codex/skills",
+      ".agents/skills",
+    ):
+      (Path(temp_home) / relative_dir).mkdir(parents=True, exist_ok=True)
+
+  def run_script(
+    self,
+    script_path: Path,
+    temp_home: str,
+    user_input: str = "",
+  ) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = temp_home
+    return subprocess.run(
+      ["bash", str(script_path)],
+      cwd=ROOT,
+      input=user_input,
+      capture_output=True,
+      text=True,
+      check=False,
+      env=env,
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="$PLUGIN_DIR/skills"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { printf "${CYAN}▸${NC} %s\n" "$1"; }
+ok()    { printf "${GREEN}✓${NC} %s\n" "$1"; }
+warn()  { printf "${YELLOW}⚠${NC} %s\n" "$1"; }
+err()   { printf "${RED}✗${NC} %s\n" "$1"; }
+
+declare -a RENAMED_SKILL_PAIRS=(
+  'bill-module-history:bill-boundary-history'
+  'bill-code-review-architecture:bill-kotlin-code-review-architecture'
+  'bill-code-review-backend-api-contracts:bill-backend-kotlin-code-review-api-contracts'
+  'bill-kotlin-code-review-backend-api-contracts:bill-backend-kotlin-code-review-api-contracts'
+  'bill-code-review-backend-persistence:bill-backend-kotlin-code-review-persistence'
+  'bill-kotlin-code-review-backend-persistence:bill-backend-kotlin-code-review-persistence'
+  'bill-code-review-backend-reliability:bill-backend-kotlin-code-review-reliability'
+  'bill-kotlin-code-review-backend-reliability:bill-backend-kotlin-code-review-reliability'
+  'bill-code-review-compose-check:bill-kmp-code-review-ui'
+  'bill-kotlin-code-review-compose-check:bill-kmp-code-review-ui'
+  'bill-kmp-code-review-compose-check:bill-kmp-code-review-ui'
+  'bill-code-review-performance:bill-kotlin-code-review-performance'
+  'bill-code-review-platform-correctness:bill-kotlin-code-review-platform-correctness'
+  'bill-code-review-security:bill-kotlin-code-review-security'
+  'bill-code-review-testing:bill-kotlin-code-review-testing'
+  'bill-code-review-ux-accessibility:bill-kmp-code-review-ux-accessibility'
+  'bill-kotlin-code-review-ux-accessibility:bill-kmp-code-review-ux-accessibility'
+  'bill-kotlin-feature-implement:bill-feature-implement'
+  'bill-kotlin-feature-verify:bill-feature-verify'
+  'bill-gcheck:bill-quality-check'
+)
+
+declare -a SKILL_NAMES=()
+declare -a LEGACY_SKILL_NAMES=()
+declare -a REMOVED_TARGETS=()
+declare -a SKIPPED_TARGETS=()
+
+array_contains() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [[ "$item" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+build_skill_names() {
+  local skill_file
+  local skill_dir
+  local skill_name
+
+  SKILL_NAMES=()
+
+  while IFS= read -r skill_file; do
+    skill_dir="$(dirname "$skill_file")"
+    skill_name="$(basename "$skill_dir")"
+    if ! array_contains "$skill_name" "${SKILL_NAMES[@]:-}"; then
+      SKILL_NAMES+=("$skill_name")
+    fi
+  done < <(find "$SKILLS_DIR" -type f -name 'SKILL.md' | sort)
+}
+
+add_legacy_name() {
+  local candidate="$1"
+  if ! array_contains "$candidate" "${LEGACY_SKILL_NAMES[@]:-}"; then
+    LEGACY_SKILL_NAMES+=("$candidate")
+  fi
+}
+
+build_legacy_skill_names() {
+  local skill
+  local pair
+  local old_name
+
+  LEGACY_SKILL_NAMES=()
+
+  for skill in "${SKILL_NAMES[@]}"; do
+    if [[ "$skill" == bill-* ]]; then
+      add_legacy_name "mdp-${skill#bill-}"
+    fi
+  done
+
+  for pair in "${RENAMED_SKILL_PAIRS[@]}"; do
+    old_name="${pair%%:*}"
+    add_legacy_name "$old_name"
+    add_legacy_name "mdp-${old_name#bill-}"
+  done
+}
+
+remove_skill_target() {
+  local target="$1"
+
+  if [[ -L "$target" ]]; then
+    rm -f "$target"
+    REMOVED_TARGETS+=("$target")
+    ok "  removed $(basename "$target")"
+    return
+  fi
+
+  if [[ -e "$target" ]]; then
+    SKIPPED_TARGETS+=("$target")
+    warn "  skipped $(basename "$target") (not a symlink)"
+  fi
+}
+
+remove_from_agent_dir() {
+  local label="$1"
+  local target_dir="$2"
+  local before_removed
+  local before_skipped
+  local skill_name
+
+  if [[ ! -d "$target_dir" ]]; then
+    return 0
+  fi
+
+  before_removed=${#REMOVED_TARGETS[@]}
+  before_skipped=${#SKIPPED_TARGETS[@]}
+
+  info "Checking $label: $target_dir"
+  for skill_name in "${SKILL_NAMES[@]}"; do
+    remove_skill_target "$target_dir/$skill_name"
+  done
+  for skill_name in "${LEGACY_SKILL_NAMES[@]}"; do
+    remove_skill_target "$target_dir/$skill_name"
+  done
+
+  if [[ ${#REMOVED_TARGETS[@]} -eq "$before_removed" && ${#SKIPPED_TARGETS[@]} -eq "$before_skipped" ]]; then
+    info "  nothing to remove"
+  fi
+}
+
+build_skill_names
+build_legacy_skill_names
+
+echo ""
+printf "${CYAN}━━━ Skill Bill Uninstaller ━━━${NC}\n"
+echo ""
+info "Removing Skill Bill symlinks from supported agent paths."
+
+remove_from_agent_dir "copilot" "$HOME/.copilot/skills"
+remove_from_agent_dir "claude" "$HOME/.claude/commands"
+remove_from_agent_dir "glm" "$HOME/.glm/commands"
+remove_from_agent_dir "codex" "$HOME/.codex/skills"
+remove_from_agent_dir "codex" "$HOME/.agents/skills"
+
+echo ""
+printf "${GREEN}━━━ Uninstall complete ━━━${NC}\n"
+echo ""
+info "Removed symlinks: ${#REMOVED_TARGETS[@]}"
+if [[ ${#SKIPPED_TARGETS[@]} -gt 0 ]]; then
+  warn "Skipped non-symlink paths: ${#SKIPPED_TARGETS[@]}"
+fi
+echo ""


### PR DESCRIPTION
# Summary

This updates the Skill Bill install lifecycle so setup is clearer and easier to undo. The installer now prompts separately for target agents, primary agent, and platform packages, supports clean platform selection, and override mode consistently resets existing Skill Bill links by running the new uninstaller first.

- add interactive agent selection with a separate primary-agent prompt
- add platform package selection, including `all`, with safe add-only reruns
- add `uninstall.sh` to remove Skill Bill symlinks and known legacy symlink names
- document the new install and uninstall flows and add automated coverage for both scripts

<img width="709" height="602" alt="Screenshot 2026-03-28 at 09 14 53" src="https://github.com/user-attachments/assets/f43d8023-90a2-4b1a-b75d-1c633872fd70" />

## Feature Flags

N/A

# How Has This Been Tested?

Ran the repo validation suite and manually exercised the installer flow across supported agents.

1. Run `python3 -m unittest discover -s tests && npx --yes agnix --strict . && python3 scripts/validate_agent_configs.py`.
2. Run `./install.sh --mode safe`, choose multiple agents, pick a primary agent, then choose `all` platforms.
3. Verify the selected agent paths contain the expected `bill-*` symlinks and that `./uninstall.sh` removes Skill Bill symlinks cleanly.
