### PR TITLE
feat: add Go platform skill track

### DIFF
--- a/.feature-specs/go-platform-skills/spec.md
+++ b/.feature-specs/go-platform-skills/spec.md
@@ -1,0 +1,31 @@
+# Feature: go-platform-skills
+Created: 2026-03-28
+Status: In Progress
+Sources: User request in chat, confirmed to mirror the PHP platform shape for Go; Jira issue key BILL-0000; Go references: Effective Go, Go Code Review Comments, Google Go Style docs
+
+## Acceptance Criteria
+1. Add a first-class Go platform package under `skills/go/` using the repo's approved naming rules.
+2. Add base-facing Go overrides for shared entry points, including `bill-go-code-review` and `bill-go-quality-check`.
+3. Add approved Go `code-review` specialist skills mirroring the governed taxonomy used for other platforms.
+4. Update routing and validation so the repo recognizes Go signals, allows the `go` package, and routes shared skills to Go when appropriate.
+5. Update installer/docs/catalogs so Go appears as a selectable platform and README counts stay accurate.
+6. Add or update tests covering validator acceptance/rejection, routing contracts, and any installer behavior affected by the new platform.
+7. Run the repo validation suite and leave the repo in a merge-ready state.
+
+---
+
+Add Go platform skills to this governed skill repository, using the existing PHP platform package as the structural template while adapting the content to Go projects. Use the canonical package name `go` so the resulting taxonomy follows the repo's established `bill-<platform>-<capability>` and `bill-<platform>-code-review-<area>` rules.
+
+The new platform should be first-class everywhere the repo currently models supported stacks:
+
+- `skills/go/` should contain the platform-owned installable skills
+- shared routing should classify Go repos and route to the correct Go implementations
+- validation should allow the package and enforce the same rules already applied to Kotlin/KMP/backend-kotlin/PHP
+- documentation and installer output should expose Go as a supported platform
+- tests should cover both acceptance and rejection behavior for the new package and routing
+
+Non-goals:
+
+- Creating new taxonomy shapes outside the existing platform model
+- Adding unapproved `code-review` specialization names
+- Building or testing external Go applications outside this repository

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sKill Bill
 
-sKill Bill is a portable AI skill suite for code review, feature implementation, and developer tooling. It is strongest today for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, and agent-config repositories.
+sKill Bill is a portable AI skill suite for code review, feature implementation, and developer tooling. It is strongest today for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and agent-config repositories.
 
-This repo is a collection of 34 AI skills installed into your coding agents from one source of truth. The goal is simple: keep high-value skills reusable across agents while preventing the skill catalog from turning into a pile of random prompts.
+This repo is a collection of 44 AI skills installed into your coding agents from one source of truth. The goal is simple: keep high-value skills reusable across agents while preventing the skill catalog from turning into a pile of random prompts.
 
 ## Why this exists
 
@@ -41,6 +41,7 @@ Current platform packages:
 - `backend-kotlin`
 - `kmp`
 - `php`
+- `go`
 
 ## Naming and enforcement
 
@@ -76,8 +77,8 @@ Base entry points stay stable for users:
 
 They route internally to platform-specific skills:
 
-- `bill-code-review` -> `bill-kotlin-code-review` | `bill-backend-kotlin-code-review` | `bill-kmp-code-review` | `bill-php-code-review`
-- `bill-quality-check` -> current stack-specific quality checker, including `bill-php-quality-check` for PHP repos
+- `bill-code-review` -> `bill-kotlin-code-review` | `bill-backend-kotlin-code-review` | `bill-kmp-code-review` | `bill-php-code-review` | `bill-go-code-review`
+- `bill-quality-check` -> current stack-specific quality checker, including `bill-php-quality-check` for PHP repos and `bill-go-quality-check` for Go repos
 
 Today, `backend-kotlin` and `kmp` both fall back to `bill-kotlin-quality-check` until dedicated overrides exist.
 
@@ -117,6 +118,7 @@ Kotlin backend
 Kotlin
 KMP
 PHP
+Go
 all
 ```
 
@@ -125,6 +127,7 @@ Example platform selections:
 ```text
 Kotlin backend, Kotlin, KMP
 PHP
+Go
 all
 ```
 
@@ -155,7 +158,7 @@ The uninstaller is idempotent. It removes current Skill Bill skill names plus kn
 
 ## Skills Included
 
-### Code Review (23 skills)
+### Code Review (32 skills)
 
 | Skill | Purpose |
 |-------|---------|
@@ -182,6 +185,15 @@ The uninstaller is idempotent. It removes current Skill Bill skill names plus kn
 | `/bill-php-code-review-security` | PHP security review |
 | `/bill-php-code-review-performance` | PHP performance review |
 | `/bill-php-code-review-testing` | PHP test quality review |
+| `/bill-go-code-review` | Go backend/service review orchestrator |
+| `/bill-go-code-review-architecture` | Go architecture and package-boundary review |
+| `/bill-go-code-review-platform-correctness` | Go correctness, goroutine safety, and context review |
+| `/bill-go-code-review-api-contracts` | Go API contract and serialization review |
+| `/bill-go-code-review-persistence` | Go persistence, transaction, and migration review |
+| `/bill-go-code-review-reliability` | Go reliability, timeout, and observability review |
+| `/bill-go-code-review-security` | Go security review |
+| `/bill-go-code-review-performance` | Go performance review |
+| `/bill-go-code-review-testing` | Go test quality review |
 
 ### Feature Lifecycle (4 skills)
 
@@ -192,13 +204,14 @@ The uninstaller is idempotent. It removes current Skill Bill skill names plus kn
 | `/bill-feature-guard` | Add feature-flag rollout safety |
 | `/bill-feature-guard-cleanup` | Remove feature flags after rollout |
 
-### Utilities (7 skills)
+### Utilities (8 skills)
 
 | Skill | Purpose |
 |-------|---------|
 | `/bill-quality-check` | Shared quality-check router |
 | `/bill-kotlin-quality-check` | Gradle/Kotlin quality-check implementation |
 | `/bill-php-quality-check` | PHP quality-check implementation |
+| `/bill-go-quality-check` | Go quality-check implementation |
 | `/bill-boundary-history` | Maintain `agent/history.md` at module/package/area boundaries |
 | `/bill-unit-test-value-check` | Audit unit tests for real value |
 | `/bill-pr-description` | Generate PR title, description, and QA steps |

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ Usage: ./install.sh [--mode safe|override|interactive]
 
 Modes:
   safe         Replace existing symlinks, migrate legacy plugin installs, and skip non-symlink conflicts. (default)
-  override     Replace any existing target path, including local copies, and prune stale bill-* installs.
+  override     Run uninstall.sh first, then reinstall only the selected platforms.
   interactive  Prompt before replacing non-symlink conflicts.
 USAGE
 }
@@ -444,6 +444,7 @@ display_platform_name() {
     kotlin) printf 'Kotlin' ;;
     kmp) printf 'KMP' ;;
     php) printf 'PHP' ;;
+    go) printf 'Go' ;;
     *)
       local label="${1//-/ }"
       printf '%s' "$label"
@@ -461,7 +462,7 @@ build_platform_packages() {
   done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
 
   PLATFORM_PACKAGES=()
-  for package in backend-kotlin kotlin kmp php; do
+  for package in backend-kotlin kotlin kmp php go; do
     if array_contains "$package" "${discovered[@]:-}"; then
       PLATFORM_PACKAGES+=("$package")
     fi

--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -1,0 +1,105 @@
+---
+name: review-orchestrator
+description: Internal playbook for shared stack-specific code-review orchestrator contracts, merge rules, output structure, and baseline review behavior.
+---
+
+# Shared Code Review Orchestrator Playbook
+
+Use this playbook when a stack-specific `*-code-review` orchestrator needs a shared contract for spawned specialists and
+a consistent final report shape.
+
+This playbook is only for shared review-orchestration behavior. Keep stack-specific routing heuristics, signal tables,
+layering examples, caller-specific notes, and final quality-check command choices in the calling skill.
+
+## Project Guidance
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance when using this playbook.
+
+This playbook supplements, but does not replace, each skill's own `## Project Overrides` section and per-skill override
+precedence.
+
+## Shared Contract For Every Specialist
+
+- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
+- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
+- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when
+  deprecated usage is broad in scope and not explicitly justified
+- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
+- Evidence is mandatory: include `file:line` + short description
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Maximum 7 findings per specialist
+- Include a minimal, concrete fix for each finding
+
+### Required Finding Schema
+
+```text
+[SEVERITY] Area: Issue title
+  Location: file:line
+  Impact: Why it matters (1 sentence)
+  Fix: Concrete fix (1-2 lines)
+  Confidence: High/Medium/Low
+```
+
+## Orchestrator Merge Rules
+
+1. Collect results from every selected review layer. If the orchestrator also runs a baseline review layer, merge those
+   findings first.
+2. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
+3. Deduplicate by root cause (same evidence or same failing behavior).
+4. Keep highest severity/confidence when duplicates conflict.
+5. Prioritize: Blocker > Major > Minor, then blast radius.
+6. Produce one consolidated report.
+
+## Shared Output Format
+
+Stack-specific orchestrator skills should keep their own Section 1 summary example. The rest of the output should use
+the shared structure below.
+
+### 2. Risk Register
+
+Format each issue as:
+
+```text
+[IMPACT_LEVEL] Area: Issue title
+  Location: file:line
+  Impact: Description
+  Fix: Concrete action
+  Confidence: High/Medium/Low
+```
+
+Impact levels: BLOCKER | MAJOR | MINOR
+
+### 3. Action Items (Max 10, prioritized)
+
+```text
+1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
+2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
+3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
+```
+
+Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
+Effort: S (<1h) | M (1-4h) | L (>4h)
+
+### 4. Verdict
+
+`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
+
+## Shared Implementation Baseline
+
+- If invoked standalone, ask: **"Which item would you like me to fix?"**
+- If invoked from another orchestration skill, do not pause for user selection unless the caller explicitly wants
+  interactive triage
+- Let the calling skill specify any stack-specific caller list and the final quality-check command or router
+
+## Review Principles
+
+- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it
+  violates current rules
+- Evidence-based: cite `file:line`
+- Project-aware: each agent applies local `AGENTS.md` and required local docs
+- Actionable: every issue must have a concrete fix
+- Proportional: do not nitpick style when architecture, correctness, or security problems are more important
+- No overoptimization: do not report negligible performance findings with no measurable user-facing or
+  production-facing impact
+- Honest: if unsure, say what context is missing

--- a/orchestration/stack-routing/PLAYBOOK.md
+++ b/orchestration/stack-routing/PLAYBOOK.md
@@ -33,6 +33,7 @@ Classify work as one of:
 - `backend-kotlin`
 - `kotlin`
 - `php`
+- `go`
 - `Unknown/Unsupported`
 
 ## Stack Signals
@@ -63,6 +64,13 @@ Classify work as one of:
 - `.php`, `artisan`, `routes/web.php`, `routes/api.php`, `bootstrap/app.php`
 - Laravel, Symfony, Slim, Doctrine, Eloquent, PHPUnit, Pest, Blade, Twig
 
+### go Signals
+
+- `go.mod`, `go.sum`, `go.work`, `go.work.sum`
+- `.go`, `cmd/`, `internal/`, `pkg/`, `vendor/`
+- `net/http`, `google.golang.org/grpc`, chi, gin, echo, fiber, cobra
+- `database/sql`, sqlx, `gorm.io`, `entgo.io`, migration tooling, worker or service packages using `context.Context`
+
 ## Decision Rules
 
 - If Android/KMP markers are strong, classify as `kmp`.
@@ -70,6 +78,7 @@ Classify work as one of:
 - If backend/server markers are strong without meaningful `kmp` markers, classify as `backend-kotlin`.
 - If generic Kotlin markers are present without meaningful `kmp` or `backend-kotlin` markers, classify as `kotlin`.
 - If PHP markers are strong, classify as `php`.
+- If Go markers are strong, classify as `go`.
 - If multiple supported stacks are present in one unit of work, classify as `Mixed` for routing purposes and delegate to each matching package-aligned stack-specific skill when the caller supports multi-route execution.
 - If no supported stack has clear evidence, classify as `Unknown/Unsupported` and say so explicitly.
 

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -19,7 +19,7 @@ SKILL_OVERRIDE_FILE = ".agents/skill-overrides.md"
 SKILL_OVERRIDE_EXAMPLE_FILE = ".agents/skill-overrides.example.md"
 SKILL_OVERRIDE_TITLE = "# Skill Overrides"
 SKILL_OVERRIDE_SECTION_PATTERN = re.compile(r"^## (bill-[a-z0-9-]+)$")
-ALLOWED_PACKAGES = ("base", "kotlin", "kmp", "backend-kotlin", "php")
+ALLOWED_PACKAGES = ("base", "kotlin", "kmp", "backend-kotlin", "php", "go")
 APPROVED_CODE_REVIEW_AREAS = {
   "api-contracts",
   "architecture",
@@ -42,6 +42,7 @@ REQUIRED_PLAYBOOK_REFERENCES: dict[str, tuple[str, ...]] = {
   "bill-backend-kotlin-code-review": ("stack-routing",),
   "bill-kmp-code-review": ("stack-routing",),
   "bill-php-code-review": ("stack-routing",),
+  "bill-go-code-review": ("stack-routing",),
 }
 
 
@@ -208,7 +209,7 @@ def validate_skill_location(skill_name: str, skill_file: Path, issues: list[str]
 
   expected_prefixes = expected_prefixes_for_package(package_name)
   if package_name == "base":
-    if any(skill_name.startswith(prefix) for prefix in ("bill-kotlin-", "bill-kmp-", "bill-backend-kotlin-", "bill-php-", "bill-gradle-")):
+    if any(skill_name.startswith(prefix) for prefix in ("bill-kotlin-", "bill-kmp-", "bill-backend-kotlin-", "bill-php-", "bill-go-", "bill-gradle-")):
       issues.append(
         f"{skill_file}: base skills must use neutral names; move '{skill_name}' to the matching package"
       )

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
@@ -33,6 +33,8 @@ Inspect both the changed files and repo markers (`build.gradle*`, `settings.grad
 
 Before classifying, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for broad stack signals. This skill owns only the backend/server override that happens after Kotlin is already in scope.
 
+Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
 Classify the review as one of:
 - `backend-kotlin`
 - `mixed-backend-kotlin`
@@ -83,45 +85,9 @@ Spawn all selected backend specialists simultaneously using the `task` tool. Eac
 - the detected project type
 - the list of changed files
 - instructions to read its own skill file for the review rubric
-- the shared contract below
+- the shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
 
 If no backend-only triggers match but backend/server signals are clearly present, keep the baseline Kotlin review output and state that no extra backend-specific specialist was needed for this scope.
-
----
-
-## Shared Contract For Every Specialist
-
-- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
-- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
-- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when deprecated usage is broad in scope and not explicitly justified
-- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
-- Evidence is mandatory: include `file:line` + short description
-- Severity: `Blocker | Major | Minor`
-- Confidence: `High | Medium | Low`
-- Maximum 7 findings per specialist
-- Include a minimal, concrete fix for each finding
-
-### Required Finding Schema
-
-```text
-[SEVERITY] Area: Issue title
-  Location: file:line
-  Impact: Why it matters (1 sentence)
-  Fix: Concrete fix (1-2 lines)
-  Confidence: High/Medium/Low
-```
-
----
-
-## Orchestrator Merge Rules
-
-1. Collect the baseline findings from `bill-kotlin-code-review`.
-2. Collect all backend-specific specialist findings.
-3. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
-4. Deduplicate by root cause (same evidence or same failing behavior).
-5. Keep highest severity/confidence when duplicates conflict.
-6. Prioritize: Blocker > Major > Minor, then blast radius.
-7. Produce one consolidated report.
 
 ---
 
@@ -136,51 +102,10 @@ Backend agents spawned: bill-backend-kotlin-code-review-api-contracts
 Reason: backend/server signals were high-confidence, so the backend layer was added on top of the baseline Kotlin review
 ```
 
-### 2. Risk Register
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow
+`orchestration/review-orchestrator/PLAYBOOK.md`.
 
-Format each issue as:
-```text
-[IMPACT_LEVEL] Area: Issue title
-  Location: file:line
-  Impact: Description
-  Fix: Concrete action
-```
+## Implementation Mode Notes
 
-Impact levels: BLOCKER | MAJOR | MINOR
-
-### 3. Action Items (Max 10, prioritized)
-
-```text
-1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
-2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
-3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
-```
-
-Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
-Effort: S (<1h) | M (1-4h) | L (>4h)
-
-### 4. Verdict
-
-`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
-
----
-
-## Implementation Mode
-
-If invoked standalone, ask: **"Which item would you like me to fix?"**
-
-If invoked from `bill-feature-implement`, `bill-feature-verify`, `bill-kmp-code-review`, or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
-
-After all P0 and P1 items are resolved, run `bill-quality-check` as final verification when the project uses a routed quality-check path and this review is being run standalone.
-
----
-
-## Review Principles
-
-- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it violates current rules
-- Evidence-based: cite `file:line`
-- Project-aware: each agent has project-specific rules in its skill file
-- Actionable: every issue must have a concrete fix
-- Proportional: don't nitpick style if architecture is broken
-- No overoptimization: do not report negligible performance findings with no measurable user-facing or production-facing impact
-- Honest: if unsure, say what context is missing
+- If invoked from `bill-feature-implement`, `bill-feature-verify`, `bill-kmp-code-review`, or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
+- After all P0 and P1 items are resolved, run `bill-quality-check` as final verification when the project uses a routed quality-check path and this review is being run standalone.

--- a/skills/base/bill-code-review/SKILL.md
+++ b/skills/base/bill-code-review/SKILL.md
@@ -47,6 +47,7 @@ Do not redefine stack signals here unless a route-specific exception is truly un
 - If `backend-kotlin` signals dominate, delegate to `bill-backend-kotlin-code-review`.
 - If `kotlin` signals dominate without meaningful `kmp` or `backend-kotlin` markers, delegate to `bill-kotlin-code-review`.
 - If `php` signals dominate, delegate to `bill-php-code-review`.
+- If `go` signals dominate, delegate to `bill-go-code-review`.
 - If the review scope mixes `kmp` with other Kotlin-family scope, prefer `bill-kmp-code-review` because it layers the appropriate Kotlin-family baseline internally instead of running multiple Kotlin-family orchestrators side by side.
 - If the review scope mixes `backend-kotlin` with generic `kotlin` but not `kmp`, prefer `bill-backend-kotlin-code-review` because it layers `bill-kotlin-code-review` internally instead of running both side by side.
 - If another supported stack dominates, delegate to that stack's canonical `bill-<stack>-code-review` skill when it exists in the available skill catalog.

--- a/skills/base/bill-quality-check/SKILL.md
+++ b/skills/base/bill-quality-check/SKILL.md
@@ -47,6 +47,7 @@ Do not redefine stack signals here unless a route-specific exception is truly un
 - If `backend-kotlin` signals dominate, delegate to the canonical quality-check implementation for the `backend-kotlin` package when it exists.
 - If `kotlin` signals dominate, delegate to the canonical `bill-kotlin-quality-check` skill when it exists.
 - If `php` signals dominate, delegate to the canonical `bill-php-quality-check` skill when it exists.
+- If `go` signals dominate, delegate to the canonical `bill-go-quality-check` skill when it exists.
 - Today, until separate `kmp` and `backend-kotlin` quality-check implementations exist, route `kmp`, `backend-kotlin`, and `kotlin` work to `bill-kotlin-quality-check`.
 - If another supported stack dominates, delegate to that stack's canonical `bill-<stack>-quality-check` skill when it exists in the available skill catalog.
 - If multiple supported stacks appear in one repo, run the matching stack-specific quality checks sequentially, not in parallel, so fixes stay deterministic.

--- a/skills/go/bill-go-code-review-api-contracts/SKILL.md
+++ b/skills/go/bill-go-code-review-api-contracts/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bill-go-code-review-api-contracts
+description: Use when reviewing Go backend/service API boundaries including request validation, serialization, HTTP or RPC contracts, status-code mapping, and backward compatibility.
+---
+
+# Backend API & Contract Review Specialist
+
+Review only backend/service API contract issues that can break clients, allow invalid behavior, or create hard-to-debug production regressions.
+
+## Focus
+- Request validation and boundary enforcement
+- Serialization/deserialization mismatches
+- Backward compatibility of request/response schemas
+- Status-code and error-contract correctness
+- Pagination, filtering, streaming, and idempotency semantics on public endpoints
+
+## Ignore
+- Pure style feedback
+- Internal refactors that do not change externally observable behavior
+
+## Applicability
+
+Use this specialist for Go backend/service code only. It is most relevant for HTTP APIs, gRPC/protobuf services,
+webhook handlers, and public or cross-service contracts.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-api-contracts`
+section, read that section and apply it as the highest-priority instruction for this skill. The matching section may
+refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Project-Specific Rules
+
+- Validate untrusted input at the boundary before business logic depends on it
+- Distinguish absent vs zero vs nil vs null-equivalent fields when that changes semantics; use pointers, wrapper types, or `oneof`/presence-aware fields when optionality is part of the contract
+- Do not leak internal/domain/persistence models directly as public API contracts unless that coupling is an explicit, stable decision
+- Keep request validation, transport DTO shaping, and domain behavior distinct when the project architecture expects that separation
+- Breaking contract changes require explicit versioning, coordinated migration, or a compatibility story
+- Error mapping should be stable, intentional, and not collapse distinct client outcomes into the same generic failure
+- Ensure validation failures, authentication/authorization failures, and domain/client faults map to stable and distinct API error responses
+- Mutating endpoints, commands, and webhook handlers should define idempotency clearly when retries are plausible
+- Pagination, filtering, streaming, and list endpoints should preserve deterministic ordering and bounded result sizes
+- Serialization defaults, struct tags, `omitempty`, embedded fields, protobuf field presence, and zero-value behavior must match the compatibility expectations of existing clients
+- Check enum, date/time, nullability, and default-field serialization for client-visible drift
+- Request binders, middleware, and decoder helpers must reject malformed or unknown input when the contract requires strictness instead of silently defaulting fields
+- Protobuf/gRPC changes must preserve field numbers, reserved fields, enum compatibility, `oneof` semantics, and streaming behavior expected by existing clients
+- Recover middleware, interceptors, and error translators must preserve the intended HTTP/gRPC status and error-contract shape even when handlers panic or return wrapped failures
+- Streaming, file, or `io.Reader`/`io.Writer`-style responses must define lifecycle, close, and partial-read/write behavior clearly when clients depend on them
+- If the project maintains OpenAPI, protobuf, swagger, or equivalent contract docs, check implementation drift against them
+
+## Output Rules
+- Report at most 7 findings.
+- Include client-visible consequence for each finding.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review-architecture/SKILL.md
+++ b/skills/go/bill-go-code-review-architecture/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: bill-go-code-review-architecture
+description: Use when reviewing architecture, boundaries, package design, and source-of-truth consistency in Go backend or service changes.
+---
+
+# Architecture Review Specialist
+
+Review only high-signal architectural issues.
+
+## Focus
+- Package boundaries and dependency direction
+- Module ownership and source-of-truth consistency
+- Sync/async interaction boundaries, idempotency, and data ownership
+- Separation between transport, domain, persistence, and integration concerns
+- Architectural drift introduced by convenience shortcuts
+
+## Ignore
+- Formatting/style-only comments
+- Naming preferences without architectural impact
+
+## Applicability
+
+Apply shared architecture rules to every review.
+
+If changed areas touch package design, interface placement, adapters, event ownership, or transaction boundaries, apply
+the corresponding deeper checks there as well.
+
+If different parts of the diff touch different architectural concerns, review those changed areas with the relevant
+deeper rules instead of forcing one model onto the whole change.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-architecture`
+section, read that section and apply it as the highest-priority instruction for this skill. The matching section may
+refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+If `.agents/feature-specs/<feature-name>.md` or an equivalent saved feature spec is available and contains an expected
+architecture shape, review the implementation against that saved shape as well.
+
+## Project-Specific Rules
+
+### Shared Architecture
+- Keep business logic independent from transport and storage concerns unless the project intentionally uses a simpler shape
+- Dependencies must point inward toward stable business rules, not outward toward frameworks or concrete infrastructure details
+- Preserve a single source of truth for each important piece of business state; avoid duplicated ownership across packages
+- Do not leak driver, ORM, HTTP, or protobuf-generated details across unrelated boundaries when that creates tight coupling
+- External systems (network, database, messaging, file system) should sit behind explicit adapters, repositories, clients, or gateways
+- Prefer explicit dependencies and visible wiring over hidden globals, package-level singletons, or init-driven magic that obscures ownership
+- Avoid non-trivial package-level `init()` side effects for wiring, network setup, worker startup, or registry mutation when explicit constructors or startup hooks would keep ownership visible
+
+### Go Package / Interface Checks
+- Package names should stay short, lowercase, and domain-specific; avoid catch-all packages like `util`, `common`, or `helpers`
+- Interfaces should usually live on the consuming side and stay minimal; do not introduce broad interfaces only for speculative abstraction
+- `cmd/` entrypoints should stay thin and delegate to real application packages rather than accumulating business logic
+- `internal/` boundaries should not be bypassed by moving shared logic into higher-level packages just for convenience
+- Avoid package cycles, transitive dependency tangles, and public APIs that expose internal implementation details without intent
+- Constructors and dependency wiring should make ownership explicit; avoid hiding lifecycle management in side-effect imports or init hooks
+- Exported and unexported seams should express real ownership; do not leak mutable internals through broad `any`, reflection, or callback escape hatches just to bypass package boundaries
+- Avoid `any`-heavy public boundaries and repeated type assertions/type switches when concrete types or smaller interfaces would preserve clearer package contracts and compile-time safety
+
+### Data Ownership / Coordination
+- Repository and gateway boundaries must not leak transaction handles, raw rows, or concrete driver state into higher layers unless that is an explicit architectural choice
+- Cross-package composition should happen in coordinators or use-case layers, not by reaching directly into another package's internals
+- Hot or repeated cross-boundary reads should prefer explicit read helpers, caches, or batched calls over convenience coupling
+- One business operation should have one clear orchestration owner and one clear transaction owner unless partial completion is explicitly intended
+
+### Events / Background Work / Integration Architecture
+- Background workers, subscriptions, and event handlers should converge on the same use-case boundaries instead of duplicating business logic in multiple package paths
+- Publish-after-commit flows should preserve the intended consistency model; do not blur durable state changes and side effects accidentally
+- Projectors, consumers, and rebuild flows should update derived state only and avoid quietly becoming primary business workflow owners
+- Event-triggered or job-triggered paths should not bypass validation, authorization, or domain invariants enforced by the primary path
+- Packages that start goroutines, subscription loops, or watchers should expose explicit lifecycle ownership and shutdown paths instead of relying on hidden package globals or fire-and-forget startup
+
+### Transport / Entry-Point Orchestration
+- HTTP handlers, RPC servers, and CLI entrypoints should stay thin: parse input, derive context, call a use case, map the response
+- Entry points should not become hidden composition roots for cross-package reads, transaction management, or retry-sensitive workflows when the architecture expects dedicated application boundaries
+
+## Output Rules
+- Report at most 7 findings.
+- Include the affected architectural surface for each finding when possible.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+Start with a short review summary:
+
+```text
+Shared sections applied: Shared Architecture, Go Package / Interface Checks
+Relevant deeper sections applied: Events / Background Work / Integration Architecture
+```
+
+Then include:
+
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review-performance/SKILL.md
+++ b/skills/go/bill-go-code-review-performance/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: bill-go-code-review-performance
+description: Use when reviewing performance risks in Go backend/service code, including hot-path work, blocking I/O, query-shape issues, inefficient DB/network access, marshaling overhead, buffering, goroutine churn, and resource waste.
+---
+
+# Performance Review Specialist
+
+Review only high-impact performance issues.
+
+## Focus
+- Blocking or heavy work on latency-sensitive request or worker paths
+- Expensive or repeated work in hot paths
+- Inefficient DB/network access patterns (N+1, redundant calls)
+- Retry/backoff inefficiency and CPU/network waste
+- Memory pressure, buffering, or throughput regressions users or operators would notice
+
+## Ignore — DO NOT report these
+- Micro-optimizations without measurable user-facing or production-facing impact
+- Style feedback
+- Single extra allocations with no realistic impact
+- Small collection reshaping with no hot-path evidence
+- Minor refactors that are only theoretically faster
+
+**Litmus test before reporting:** Would a user or operator ever notice this in production? Does it cause latency
+spikes, throughput collapse, memory pressure, queue backlog, or operational cost growth? If neither, skip it.
+
+## Applicability
+
+Apply shared performance rules to backend/service code. Apply the deeper DB/query-shape, marshaling, and worker-path
+checks only when the changed code uses those mechanisms.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-performance`
+section, read that section and apply it as the highest-priority instruction for this skill. The matching section may
+refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Project-Specific Rules
+
+### Shared Backend Performance
+- Avoid repeated expensive work in hot paths when inputs are unchanged
+- Watch for N+1 query/call patterns and redundant round-trips
+- Retry behavior must not amplify latency, downstream load, or CPU/network waste under failure
+- Large batch processing must avoid unbounded memory growth
+
+### Backend/Service-Specific Rules
+- Do not perform blocking or heavy work on latency-sensitive request or worker execution paths without explicit offloading or batching strategy
+- Watch for per-item downstream calls inside request handlers, consumers, schedulers, or batch loops
+- Reuse expensive clients, encoders/decoders, buffers, and parsers where construction cost is significant instead of rebuilding them per request/job
+- Bound pagination, batch sizes, queue drains, and in-memory buffering
+- Flag cache stampede or thundering-herd patterns when they can realistically spike load, latency, or infrastructure cost
+- Watch for duplicate marshaling/unmarshaling, repeated auth lookups, or repeated config parsing inside hot paths
+- Worker pools, fan-out concurrency, and batch processing must use bounded concurrency and avoid goroutine storms
+- Queue/batch processing must use bounded chunk sizes and avoid loading unbounded payloads or record sets into memory
+- Cache keys, cache cardinality, and invalidation scope must not create unbounded memory growth or low-hit-rate caches
+- Large payload paths should prefer streaming or chunked processing over whole-buffer reads/writes when buffering would materially increase memory pressure or copy cost
+- Hot loops over large data sets should pre-size slices/maps or reuse scratch buffers only when the workload is repeated enough to affect latency, throughput, or memory materially
+
+### Persistence / Query Shape
+- Query paths must not load full row sets when the hot path only needs a small slice of fields or a scalar result
+- Count, exists, and aggregate paths must not hydrate large record graphs when direct queries would preserve behavior
+- Avoid hydration-heavy loops when scalar queries, chunking, streaming, or bulk operations would preserve behavior with lower cost
+
+### Marshaling / Response Paths
+- API and event serialization paths must not repeatedly compute or re-query the same data without need
+- Response shaping must not trigger hidden repeated work on large result sets or large payloads
+- Streaming and buffering choices must stay bounded and avoid needless copies when payloads are large or repeated
+
+## Output Rules
+- Report at most 7 findings.
+- Include expected impact statement (latency, memory, throughput, queue backlog, or infrastructure cost) per finding.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review-persistence/SKILL.md
+++ b/skills/go/bill-go-code-review-persistence/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: bill-go-code-review-persistence
+description: Use when reviewing Go backend/service persistence risks including transaction boundaries, query correctness, migration safety, concurrency, and data-consistency behavior.
+---
+
+# Backend Persistence Review Specialist
+
+Review only backend persistence issues that can corrupt data, break consistency, or create high-risk operational regressions.
+
+## Focus
+- Transaction boundaries and atomicity
+- Query correctness and tenant/filter scoping
+- Lost updates, race-prone write patterns, and idempotent persistence behavior
+- Migration/schema compatibility risks
+- Driver/ORM mapping mismatches that break reads or writes
+
+## Ignore
+- Harmless query-style preferences
+- Micro-optimizations with no correctness or production impact
+
+## Applicability
+
+Use this specialist for backend/service persistence code only: repositories, `database/sql`, sqlx, sqlc, GORM, Ent,
+SQL, migrations, projections, and similar persistence layers.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-persistence`
+section, read that section and apply it as the highest-priority instruction for this skill. The matching section may
+refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Project-Specific Rules
+
+- Do not split one business write across multiple implicit transactions unless partial completion is explicitly intended
+- Avoid load-modify-save patterns that can lose concurrent updates when atomic SQL or version checks are required
+- Repository methods must apply required tenant/account/ownership filters consistently
+- Upserts, deduplication, and unique-constraint behavior should match the intended idempotency contract
+- Migrations must account for existing data, nullability transitions, indexes, and rollout compatibility
+- Rows, statements, result sets, and transactions must be closed or finalized reliably using the driver or helper equivalent; place cleanup close to acquisition so early returns, loops, or branching do not leak `Rows` or leave transactions unresolved
+- `QueryRow`/`Scan` and equivalent helpers must distinguish `ErrNoRows`, partial reads, and decode failures correctly instead of collapsing them into misleading zero-value success
+- Queries and persistence calls should use the correct `context.Context` so deadlines, cancellation, and tracing behave as intended; avoid background-context database calls in request or worker paths
+- After `BeginTx`, cleanup must make rollback-on-error explicit so failed or panicking paths do not leave transaction state ambiguous
+- Do not hold transactions open across remote I/O, event publishing, or queue dispatch unless the project explicitly requires it
+- Bulk operations should preserve correctness, not just speed; verify partial-failure behavior
+- Projection or derived-table updates must be concurrency-safe; avoid read-modify-write patterns when atomic SQL/update operations are required
+- Migration rollout must consider backfills, dual-read/dual-write windows, and replay or rebuild paths when contracts or projections change
+- Prepared statements, repository helpers, and generated query wrappers should not be recreated per item or per request when reuse is required for pool health and predictable latency
+- ORM or query-helper convenience helpers (`sqlx`, `sqlc`, GORM, Ent, builders) must not hide missing filters, accidental N+1 write patterns, implicit hooks, or silent partial updates in persistence-critical paths
+- GORM hooks/preloads, Ent eager-loading or transaction clients, and scanner/binder helpers must keep transaction scope, lock semantics, and write ordering explicit
+- Check database defaults, casts, enum storage, and timestamp behavior for write/read drift against the intended domain and API contract
+
+## Output Rules
+- Report at most 7 findings.
+- Include data-loss or consistency consequence for each Major/Blocker.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review-platform-correctness/SKILL.md
+++ b/skills/go/bill-go-code-review-platform-correctness/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: bill-go-code-review-platform-correctness
+description: Use when reviewing behavior correctness, edge cases, goroutine/channel safety, context cancellation, error handling, and concurrency-sensitive logic in Go backend/service changes.
+---
+
+# Platform-Correctness Review Specialist
+
+Review only correctness issues that change behavior or make behavior unsafe.
+
+Within the Go package, `platform-correctness` is the package-aligned correctness lane. In practice, this specialist is
+primarily about backend business-logic correctness, context/cancellation correctness, zero-value and nil handling,
+concurrency safety, and runtime-safety issues in changed Go code.
+
+## Focus
+- Race conditions, ordering bugs, and stale-state updates
+- Nil/zero-value edge cases, panic paths, and crash paths
+- Context propagation, cancellation, and timeout correctness
+- Business-rule drift in conditionals, refactors, retries, and state transitions
+- Goroutine/channel lifetime correctness and duplicate-delivery safety
+
+## Ignore
+- Style or readability feedback without correctness impact
+
+## Applicability
+
+Apply shared backend correctness rules to all backend/service code. Apply the deeper concern-specific checks only when
+the changed code uses those mechanisms.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-platform-correctness`
+section, read that section and apply it as the highest-priority instruction for this skill. The matching section may
+refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Project-Specific Rules
+
+### Shared Backend Correctness
+- Distinguish absent vs zero vs nil values when behavior changes
+- Shared mutable state must be synchronized, serialized, version-checked, or replaced with safer flow/message-driven coordination
+- Do not introduce silent fallback behavior that hides failures unless the contract explicitly requires it
+- Validate ordering guarantees where retries, duplicate delivery, schedulers, or concurrent requests can race or overwrite each other
+- Do not introduce deprecated APIs or patterns when a supported alternative exists; if usage is unavoidable, it must be narrowly scoped and explicitly justified
+- State transitions must preserve declared invariants and reject invalid intermediate states
+- Time, timezone, deadline, and clock-boundary logic must be explicit where behavior depends on them
+
+### Go Runtime / Language-Behavior Checks
+- Functions that depend on cancellation, deadlines, tracing, or auth context should accept `context.Context` explicitly and pass it through the call chain
+- Do not stash mutable request context in structs or globals when explicit parameters are required for safe propagation
+- Normal error handling should use returned errors, not `panic`, unless the contract is truly unrecoverable
+- Check returned errors instead of discarding them; avoid misleading success paths after partial failure
+- Wrapped errors should preserve actionable causes and be checked with `errors.Is`/`errors.As` or an equivalent chain-aware approach
+- Channel ownership, close behavior, and send/receive coordination must make goroutine exits obvious and safe
+- Goroutines must have clear owners, exit paths, and synchronization expectations; `WaitGroup`, semaphore, and channel usage should match the intended lifecycle exactly
+- Concurrent access to maps, slices, caches, or shared structs must be synchronized or replaced with safer ownership patterns
+- Be explicit about pointer aliasing, copying, and mutation when values cross goroutines or package boundaries
+- Loop variables captured by goroutines, callbacks, or subtests must be copied explicitly so later iterations do not corrupt behavior
+- `defer` inside loops or retry paths must not quietly accumulate cleanup, hold locks, or delay resource release longer than intended
+- Timers, tickers, and `time.After`-style resources should be stopped or drained when lifetimes outlive one call path
+
+### Backend/Server-Specific Rules
+- Worker, consumer, and scheduler code must be safe under retry/replay; acknowledge or commit only after durable success
+- Concurrent writes need atomic statements, locking, version checks, idempotency keys, or another explicit consistency mechanism
+- External side effects must happen in the intended order relative to persistence and commit boundaries
+- Retry-sensitive paths must not duplicate user-visible effects, billing effects, or event emission unless the contract explicitly permits it
+
+### Error Handling
+- Domain faults, client faults, and operational failures must not be collapsed into misleading success or generic fallback behavior
+- Wrap or classify errors in ways that preserve the caller's ability to distinguish actionable cases
+- Multi-step workflows must not report full success when only a partial effect was applied unless the contract explicitly permits partial success
+- Deferred cleanup and rollback paths must not mask the primary failure or silently convert partial failure into apparent success
+
+### Runtime / Dispatch Semantics
+- Queued/background work, subscribers, timers, and HTTP handlers must preserve the same correctness guarantees under retries and duplicate delivery
+- Shutdown, cancellation, and deadline handling must not leave orphaned goroutines or partially applied effects that callers believe succeeded
+- If a spawned goroutine must not crash silently, recovery/logging belongs inside that goroutine; caller-side recovery does not protect it
+- Build tags and platform-specific files should not hide changed production paths from CI or create inconsistent runtime behavior across the platforms the project claims to support
+
+## Output Rules
+- Report at most 7 findings.
+- Include reproducible failure scenario for Major/Blocker findings.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review-reliability/SKILL.md
+++ b/skills/go/bill-go-code-review-reliability/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: bill-go-code-review-reliability
+description: Use when reviewing Go backend/service reliability risks including timeouts, retries, background work, concurrency under load, caching, and observability-critical failures.
+---
+
+# Backend Reliability Review Specialist
+
+Review only backend/service reliability issues that can cause outages, stuck work, runaway retries, or production incidents.
+
+## Focus
+- Timeout, retry, and backoff correctness
+- Background jobs, workers, subscribers, schedulers, and replay safety
+- Blocking or heavy work on latency-sensitive request or worker execution paths
+- Cache, queue, and downstream dependency failure behavior
+- Logging/metrics/tracing gaps that hide real failures
+
+## Ignore
+- Pure style comments
+- Tiny observability niceties without incident impact
+
+## Applicability
+
+Use this specialist for backend/service code only.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-reliability`
+section, read that section and apply it as the highest-priority instruction for this skill. The matching section may
+refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Project-Specific Rules
+
+- Retries must be bounded and reserved for transient failures; include backoff and jitter where stampedes are possible
+- Circuit breakers, rate limits, and concurrency controls must avoid infinite blocks, silent drops, or retry storms
+- External calls should have explicit timeout behavior, context cancellation, and a clear cleanup story; inner client deadlines must not outlive the caller's budget accidentally
+- Message consumers, workers, and scheduled jobs must be safe under duplicate delivery and partial failure
+- Replay, rebuild, and republish flows must be bounded, observable, and safe to run more than once
+- Acknowledge, checkpoint, or commit work only after durable success, not before
+- Avoid blocking or heavy work on latency-sensitive request or worker execution paths
+- Shutdown, cancellation, and drain logic must let servers and workers exit cleanly without dropping or duplicating critical work silently
+- Server shutdown should stop accepting new work, propagate cancellation, and drain listeners/workers with an explicit bounded timeout instead of relying on process exit
+- Worker pools, channel-backed queues, and fan-out loops must use bounded concurrency with explicit backpressure or rejection behavior instead of silent drops or unbounded goroutine growth
+- Cache fill, refresh, and invalidation logic must not create obvious thundering-herd or stale-data incidents
+- Degradation and fallback behavior should fail gracefully and make partial availability explicit where clients or operators need to know
+- Logging, metrics, and tracing should include enough contextual and trace/correlation identifiers to debug failures without leaking secrets or sensitive data, and should preserve wrapped error/cancellation causes where the logging stack supports it
+- Long-running workers and consumers should emit enough progress/error context to distinguish poison messages, transient failures, and permanent contract/data issues
+- Rate limiting, backpressure, and batch sizing should protect downstream systems and avoid retry amplification under load
+- Readiness and health endpoints should not report success before required dependencies, caches, worker loops, or subscriptions are actually ready to serve traffic safely
+
+## Output Rules
+- Report at most 7 findings.
+- Include production failure scenario for each Major/Blocker.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review-security/SKILL.md
+++ b/skills/go/bill-go-code-review-security/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: bill-go-code-review-security
+description: Use when reviewing security risks in changed Go backend/service code including auth/session safety, secrets handling, trust boundaries, sensitive data exposure, injection, file handling, and output encoding.
+---
+
+# Security Review Specialist
+
+Review only exploitable or compliance-relevant issues.
+
+## Focus
+- Secret leakage (keys/tokens/credentials)
+- Auth/authz logic gaps and session/token misuse
+- Sensitive logging (PII/token leakage)
+- Insecure transport/storage assumptions
+- Security regressions from new code paths
+
+## Ignore
+- Non-security style comments
+
+## Applicability
+
+Apply shared security rules to all changed code. Apply the deeper surface-specific checks only when the changed code
+uses those mechanisms.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-security` section,
+read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or
+replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Project-Specific Rules
+
+### Shared Security
+- No secrets, tokens, passwords, or private keys in code, logs, tests, or repo config
+- Sensitive identifiers and personal data must not be logged or exposed without explicit need and protection
+- New code paths must preserve auth/authz guarantees and avoid bypassable feature-flag checks
+- Treat all external input as untrusted and validate or constrain it at the boundary
+- Watch for SSRF, command execution, path traversal, SQL injection, template injection, unsafe deserialization, and object-level access control gaps
+- Temporary debug code, bypass flags, test credentials, or relaxed verification paths must not ship
+- Cross-tenant or cross-account data access must be impossible unless the contract explicitly permits it
+
+### Backend/Server-Specific Rules
+- Enforce authn/authz at entry points; do not trust client-supplied role, tenant, actor, or ownership identifiers without server-side verification
+- Authorization must be enforced on every reachable path, including background-triggered, indirect, or alternate action paths
+- Middleware chains, route groups, and gRPC interceptors must protect every reachable handler/service; watch for direct-handler registrations or alternate muxes that bypass auth, audit, or rate-limit middleware
+- Secrets/config must come from env vars, vaults, secret-management systems, or deployment configuration, not committed config files
+- Do not expose stack traces, internal error details, or sensitive failure data in API responses
+- Verify webhook signatures, internal-service auth, signed callbacks, or mTLS assumptions when new external entry points are introduced
+- Avoid logging raw auth headers, session cookies, full request bodies, or other high-risk payloads by default
+- Session cookies and similar browser-facing tokens must set `Secure`, `HttpOnly`, and the intended `SameSite` policy when the flow depends on them
+- File upload, archive extraction, and file-path handling must not allow traversal, unsafe content execution, or unsafe trust in client-provided metadata
+- Secret material and auth context must not bleed across boundaries accidentally
+- Auth or tenant context should flow through `context.Context` or an equivalent explicit request scope, not package globals or ad hoc goroutine-local state
+- SQL construction must use parameters/placeholders instead of string interpolation in security-sensitive paths
+- `os/exec`, shell invocation, and subprocess argument construction must not allow command injection or accidental credential leakage; prefer explicit argv with `exec.CommandContext` over shell strings when possible
+- Random values used for secrets, tokens, or capability URLs must use `crypto/rand`, not predictable randomness
+- Outbound HTTP clients must constrain user-influenced targets to the intended hosts or networks and treat redirects, internal IP ranges, and metadata endpoints as SSRF-sensitive
+- TLS listener exposure, `tls.Config`, and mTLS expectations must match the intended trust boundary; do not quietly serve a weaker parallel listener or verification mode
+- HTML/template output, redirects, and generated documents must not allow unescaped user-controlled content to reach unsafe contexts
+
+## Output Rules
+- Report at most 7 findings.
+- Include abuse scenario for each Major/Blocker.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review-testing/SKILL.md
+++ b/skills/go/bill-go-code-review-testing/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: bill-go-code-review-testing
+description: Use when reviewing test coverage quality, real test value, regression protection, and test reliability risks in Go backend/service code.
+---
+
+# Testing Review Specialist
+
+Review only test gaps that create real regression risk.
+
+## Focus
+- Missing tests for changed behavior and failure paths
+- Brittle/flaky test patterns and false-confidence assertions
+- Low-value, tautological, or coverage-padding tests that do not validate real behavior
+- Contract drift between implementation and tests
+- Inadequate negative-path and concurrency coverage
+- Missing integration points where unit-only tests are insufficient
+
+## Ignore
+- Test style preferences without risk impact
+- Missing tests for trivial mappers, accessors, or glue code with no meaningful behavior
+
+## Applicability
+
+Apply shared test-risk rules to backend/service code. Apply the deeper concern-specific checks only when the changed
+code uses those mechanisms.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review-testing` section,
+read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or
+replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Project-Specific Rules
+
+### Shared Backend Testing
+- Changed behavior and failure paths should be covered at the layer where regressions would surface first
+- A test only adds value if it would fail on a meaningful regression in business behavior
+- Prefer tests that validate real behavior over tests that only mirror implementation details
+- Treat tautological tests as test gaps when they create false confidence without exercising real logic
+- Mock only true external boundaries; over-mocking internal collaborators can hide regressions
+- Time, retries, duplicate delivery, concurrency, and ordering-sensitive behavior should be tested deterministically when they matter
+- Business logic should be tested comprehensively in package-focused unit tests when the project architecture isolates domain behavior
+- Table-driven tests and subtests should keep case data explicit and copy loop variables before closures when the test body captures them
+
+### Unit Test Value Lens
+- Flag tests that only instantiate a struct, assign values, and assert the same values without logic in between
+- Flag tests that only verify a stubbed return value or a mock interaction without asserting an externally meaningful outcome
+- Flag tests that duplicate the implementation step-for-step and compare against the duplicated result
+- Flag tests that only check `not nil`, booleans, or collection size when those assertions are not tied to important behavior
+- Do not request tests for trivial mappers, accessors, or generated code unless they enforce business rules, compatibility, or invariants
+- Parsers, encoders, decoders, validators, and command handlers can still be worth testing when they validate, normalize, clamp, reject, or preserve a contract
+
+### Backend/Service-Specific Rules
+- Public boundary changes need contract or integration tests when status codes, validation, auth context, or serialization changed
+- API and boundary tests should assert the real contract shape, not only loose structure, when contract drift would matter to clients or downstream systems
+- When the local project requires exact API contracts, prefer full response/error assertions over partial structure checks
+- Persistence changes need repository or integration tests around transactions, constraints, locking, replay-sensitive behavior, and migration-sensitive behavior
+- Persistence-backed integration tests should verify actual persistence effects, not only mocked repository interactions
+- Timeout, cancellation, worker, retry, scheduler, consumer, and idempotency logic needs deterministic tests that control time, ordering, and duplicate delivery where relevant
+- Concurrency-sensitive changes should trigger race-aware or ordering-aware tests when practical, and missing `go test -race` or repo-equivalent coverage should be treated as a real gap unless the project explicitly opts out
+- Subtests using `t.Run()` and `t.Parallel()` must isolate mutable fixtures, environment overrides, and temp resources so parallelism does not create hidden races or order dependence
+- Parsers, decoders, normalizers, and security-sensitive boundary code should get fuzz coverage when malformed input could crash the process or violate a contract
+- `TestMain`, shared setup helpers, and `t.Cleanup()` usage should make failure and cleanup paths explicit so leaked goroutines, timers, sockets, or env mutations do not taint later tests
+- Prefer real request parsing, codecs, serializers, and boundary objects at API/transport tests; fake downstream systems, not the contract itself
+- Verify negative-path coverage for malformed input, forbidden access, downstream failures, duplicate delivery, and partial-failure paths where relevant
+- Boundary tests should verify persisted side effects or externally visible outcomes, not only response status or mock interactions
+- Feature-flag, permission-gated, and role-gated paths need explicit tests for both enabled and disabled or forbidden behavior when they change semantics
+
+## Output Rules
+- Report at most 7 findings.
+- Include a minimal test plan for top uncovered risks.
+- Report weak or useless tests only when they materially reduce regression confidence.
+- Include `file:line` evidence for each finding.
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Include a minimal, concrete fix, which may be to rewrite or delete the test and replace it with a behavior-focused one.
+
+## Output Table
+| Area | Severity | Confidence | Evidence | Why it matters | Minimal fix |
+|------|----------|------------|----------|----------------|-------------|

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: bill-go-code-review
+description: Use when conducting a thorough Go PR code review across backend/service projects. Classify changed areas conservatively, select the right specialist agents for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
+---
+
+# Adaptive Go PR Review
+
+You are an experienced software architect conducting a code review.
+
+This is the current Go review implementation behind the shared `bill-code-review` router.
+
+Your first job is to inspect the diff safely so the right review depth is applied.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-code-review` section, read that
+section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace
+parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass
+relevant project-wide guidance and matching per-skill overrides to all spawned sub-agents.
+
+## Setup
+
+Determine the review scope:
+
+- Specific files (list paths)
+- Git commits (hashes/range)
+- Working changes (`git diff`)
+- Entire PR
+
+Inspect the changed files and repo markers before applying review heuristics.
+
+Before applying review heuristics, read `orchestration/stack-routing/PLAYBOOK.md` and use it as the source of truth
+for Go stack signals and mixed-stack routing expectations. This skill owns the Go review depth that applies after Go
+is already in scope.
+
+---
+
+## Review Scope
+
+Inspect the changed files and changed areas.
+
+Use the routing table below to decide which additional specialist skills to run for each meaningful changed area.
+
+### Routing Table
+
+| Signal in the diff                                                                                                                                       | Agent to spawn                              |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|
+| Package boundaries, `cmd/`, `internal/`, shared libraries, interface placement, package-level `init()` side effects, dependency direction, adapters/ports, event ownership, orchestration | `bill-go-code-review-architecture`          |
+| Goroutines, channel ownership/close behavior, `sync`/`atomic` usage, context propagation, cancellation, loop-variable capture, nil/zero-value handling, wrapped error flow, time logic | `bill-go-code-review-platform-correctness`  |
+| `net/http`, chi/gin/echo/fiber handlers, gRPC/protobuf, JSON/YAML/XML struct tags, field presence/`omitempty`, request/response DTOs, validation, status codes, public contracts       | `bill-go-code-review-api-contracts`         |
+| `database/sql`, `sqlx`, `sqlc`, GORM, Ent, repositories, transactions, migrations, locking, bulk writes, schema evolution, row/statement lifecycle                                         | `bill-go-code-review-persistence`           |
+| HTTP/gRPC clients, queues/workers, retries, deadlines, shutdown logic, queue overflow/backpressure, readiness/health, caches, rate limiting, metrics/logging/tracing, background work    | `bill-go-code-review-reliability`           |
+| Auth/authz, middleware/interceptor chains, secrets, TLS/transport security, `os/exec`, file/path handling, SQL construction, template output, SSRF, token/session or cookie handling      | `bill-go-code-review-security`              |
+| Test files changed, race-sensitive tests, `t.Run`/`t.Parallel`, fuzz tests, flaky time/concurrency tests, weak assertions, missing regression proof                                          | `bill-go-code-review-testing`               |
+| Changed tests look suspiciously weak, tautological, or coverage-padding                                                                                  | `bill-unit-test-value-check`                |
+| Hot paths, repeated marshaling, per-request client creation, N+1 or repeated downstream calls, allocation churn, copy-heavy buffer use, unbounded buffers, goroutine storms                 | `bill-go-code-review-performance`           |
+
+## Dynamic Agent Selection
+
+### Step 1: Always include the baseline
+
+Always include:
+
+- `bill-go-code-review-architecture`
+- `bill-go-code-review-platform-correctness`
+
+### Step 2: Analyze the diff and select additional agents
+
+Inspect each changed file or tightly related change cluster separately and add the agents from the routing table that
+match its signals.
+
+Treat Go-specific runtime semantics as strong routing hints, not tie-breakers. If a change touches goroutine lifetime,
+loop-variable capture, wrapped error checks, struct-tag presence semantics, or `database/sql` row/transaction cleanup,
+add the matching specialist even when the diff looks small.
+
+### Step 3: Mixed diffs
+
+If different parts of the diff touch different review surfaces:
+
+- inspect those changed areas separately
+- keep the baseline specialists for the whole review
+- add the specialists needed for the relevant areas
+- do not force every file through every specialist
+
+### Step 4: Apply minimum
+
+- Minimum 2 agents (architecture + platform-correctness)
+- If tests changed materially, include `bill-go-code-review-testing`
+- Maximum 7 agents
+
+### Step 5: Launch in parallel
+
+Spawn all selected sub-agents simultaneously when the agent/runtime supports sub-agents or parallel review passes.
+
+Each sub-agent gets:
+
+- The list of changed files
+- Instructions to read its own skill file for the review rubric
+- Relevant project-wide guidance and matching per-skill overrides
+- The shared contract below
+
+---
+
+## Shared Contract For Every Specialist
+
+- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
+- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
+- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when deprecated
+  usage is broad in scope and not explicitly justified
+- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
+- Evidence is mandatory: include `file:line` + short description
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Maximum 7 findings per specialist
+- Include a minimal, concrete fix for each finding
+
+### Required Finding Schema
+
+```text
+[SEVERITY] Area: Issue title
+  Location: file:line
+  Impact: Why it matters (1 sentence)
+  Fix: Concrete fix (1-2 lines)
+  Confidence: High/Medium/Low
+```
+
+---
+
+## Orchestrator Merge Rules
+
+1. Collect all specialist findings.
+2. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
+3. Deduplicate by root cause (same evidence or same failing behavior).
+4. Keep highest severity/confidence when duplicates conflict.
+5. Prioritize: Blocker > Major > Minor, then blast radius.
+6. Produce one consolidated report.
+
+---
+
+## Review Output Format
+
+### 1. Agent Summary
+
+```text
+Detected review scope: <working tree / commit range / PR diff / files>
+Signals: goroutines, context propagation, database/sql, changed tests
+Agents spawned: bill-go-code-review-architecture, bill-go-code-review-platform-correctness, bill-go-code-review-persistence, bill-go-code-review-testing
+Reason: concurrency-sensitive state handling changed, persistence code changed, and tests changed materially
+```
+
+### 2. Risk Register
+
+Format each issue as:
+
+```text
+[IMPACT_LEVEL] Area: Issue title
+  Location: file:line
+  Impact: Description
+  Fix: Concrete action
+  Confidence: High/Medium/Low
+```
+
+Impact levels: BLOCKER | MAJOR | MINOR
+
+### 3. Action Items (Max 10, prioritized)
+
+```text
+1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
+2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
+3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
+```
+
+Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
+Effort: S (<1h) | M (1-4h) | L (>4h)
+
+### 4. Verdict
+
+`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
+
+---
+
+## Implementation Mode
+
+If invoked standalone, ask: **"Which item would you like me to fix?"**
+
+If invoked from `bill-feature-implement` or another orchestration skill, do not pause for user selection. Return
+prioritized findings so the caller can auto-fix `P0` and `P1` items and decide whether to carry `Minor` items forward.
+
+After all `P0` and `P1` items are resolved, run `bill-go-quality-check` as final verification when this review is being
+run standalone.
+
+---
+
+## Review Principles
+
+- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it
+  violates current rules
+- Evidence-based: cite `file:line`
+- Project-aware: each agent applies local `AGENTS.md` and required local docs
+- Actionable: every issue must have a concrete fix
+- Proportional: don't nitpick style if architecture, correctness, or security is broken
+- No overoptimization: do not report negligible performance findings with no measurable user-facing or production-facing
+  impact
+- Honest: if unsure, say what context is missing

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -37,6 +37,10 @@ Before applying review heuristics, read `orchestration/stack-routing/PLAYBOOK.md
 for Go stack signals and mixed-stack routing expectations. This skill owns the Go review depth that applies after Go
 is already in scope.
 
+Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use
+it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone
+behavior, and review principles used by stack-specific review orchestrators.
+
 ---
 
 ## Review Scope
@@ -101,43 +105,7 @@ Each sub-agent gets:
 - The list of changed files
 - Instructions to read its own skill file for the review rubric
 - Relevant project-wide guidance and matching per-skill overrides
-- The shared contract below
-
----
-
-## Shared Contract For Every Specialist
-
-- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
-- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
-- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when deprecated
-  usage is broad in scope and not explicitly justified
-- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
-- Evidence is mandatory: include `file:line` + short description
-- Severity: `Blocker | Major | Minor`
-- Confidence: `High | Medium | Low`
-- Maximum 7 findings per specialist
-- Include a minimal, concrete fix for each finding
-
-### Required Finding Schema
-
-```text
-[SEVERITY] Area: Issue title
-  Location: file:line
-  Impact: Why it matters (1 sentence)
-  Fix: Concrete fix (1-2 lines)
-  Confidence: High/Medium/Low
-```
-
----
-
-## Orchestrator Merge Rules
-
-1. Collect all specialist findings.
-2. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
-3. Deduplicate by root cause (same evidence or same failing behavior).
-4. Keep highest severity/confidence when duplicates conflict.
-5. Prioritize: Blocker > Major > Minor, then blast radius.
-6. Produce one consolidated report.
+- The shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
 
 ---
 
@@ -152,57 +120,13 @@ Agents spawned: bill-go-code-review-architecture, bill-go-code-review-platform-c
 Reason: concurrency-sensitive state handling changed, persistence code changed, and tests changed materially
 ```
 
-### 2. Risk Register
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow
+`orchestration/review-orchestrator/PLAYBOOK.md`.
 
-Format each issue as:
+## Implementation Mode Notes
 
-```text
-[IMPACT_LEVEL] Area: Issue title
-  Location: file:line
-  Impact: Description
-  Fix: Concrete action
-  Confidence: High/Medium/Low
-```
-
-Impact levels: BLOCKER | MAJOR | MINOR
-
-### 3. Action Items (Max 10, prioritized)
-
-```text
-1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
-2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
-3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
-```
-
-Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
-Effort: S (<1h) | M (1-4h) | L (>4h)
-
-### 4. Verdict
-
-`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
-
----
-
-## Implementation Mode
-
-If invoked standalone, ask: **"Which item would you like me to fix?"**
-
-If invoked from `bill-feature-implement` or another orchestration skill, do not pause for user selection. Return
-prioritized findings so the caller can auto-fix `P0` and `P1` items and decide whether to carry `Minor` items forward.
-
-After all `P0` and `P1` items are resolved, run `bill-go-quality-check` as final verification when this review is being
-run standalone.
-
----
-
-## Review Principles
-
-- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it
-  violates current rules
-- Evidence-based: cite `file:line`
-- Project-aware: each agent applies local `AGENTS.md` and required local docs
-- Actionable: every issue must have a concrete fix
-- Proportional: don't nitpick style if architecture, correctness, or security is broken
-- No overoptimization: do not report negligible performance findings with no measurable user-facing or production-facing
-  impact
-- Honest: if unsure, say what context is missing
+- If invoked from `bill-feature-implement` or another orchestration skill, do not pause for user selection. Return
+  prioritized findings so the caller can auto-fix `P0` and `P1` items and decide whether to carry `Minor` items
+  forward.
+- After all `P0` and `P1` items are resolved, run `bill-go-quality-check` as final verification when this review is
+  being run standalone.

--- a/skills/go/bill-go-quality-check/SKILL.md
+++ b/skills/go/bill-go-quality-check/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: bill-go-quality-check
+description: Run the project's canonical quality-check command(s) and systematically fix all issues without using suppressions. Use when running repo-defined checks, tests, linting, static analysis, formatting, or security validation in Go projects. Fixes issues properly at the root cause instead of suppressing them.
+---
+
+# Go Quality Check
+
+This is the current Go implementation behind the shared `bill-quality-check` router. Invoke it directly only when you
+already know the repo should use the Go quality-check path.
+
+Execute the project's quality-check flow and systematically fix issues **only in files changed in the current unit of
+work**. Ignore pre-existing issues in untouched files unless the change clearly exposes them.
+
+## Execution Steps
+
+1. **Determine changed files**: Use `git diff --name-only` (against the base branch or HEAD) to identify files changed in the current unit of work
+2. **Run initial check**: Execute the project's quality-check commands and capture complete output
+3. **Filter to changed files**: From the check output, only address issues in files from step 1 — skip everything else
+4. **Categorize issues**: Group by type (module/build hygiene, formatting, lint errors, static analysis, vet findings, race failures, test failures, security/audit failures, etc.)
+5. **Fix systematically**: For each issue category in priority order:
+   - Mark todo as in_progress
+   - Read affected files
+   - Implement proper fixes (never suppress)
+   - Mark todo as completed
+6. **Verify fixes**: Re-run the quality-check command(s) after all fixes
+7. **Iterate if needed**: If new issues appear, repeat the process
+
+## Fix Strategy
+
+**Always Fix, Never Suppress:**
+- Never add suppressions, baseline entries, or ignore rules as the default fix
+- Never add `// TODO` or `// FIXME` comments to defer issues
+- Never skip required project scripts silently
+- Implement proper solutions that address the root cause
+- Refactor code to eliminate warnings
+- Add missing tests or fix failing ones
+
+**Priority Order:**
+0. Module, generated-code, and build-constraint hygiene (`go mod tidy`, repo generation commands, build tags / platform files) when present
+1. Formatting and import hygiene (`gofmt`, `go fmt`, `goimports`) when present
+2. Lint / style issues (`golangci-lint`, project lint wrappers)
+3. Static analysis / vet issues (`go vet`, `staticcheck`, compiler/type errors)
+4. Test failures (`go test`, targeted package tests, example tests)
+5. Race / concurrency validation failures (`go test -race`) when the repo expects it
+6. Security or dependency audit failures (`govulncheck`, `gosec`, project wrappers)
+
+**Structural Fixes (Priority 0):**
+
+These issues often create cascading failures and should be fixed before lint/test cleanup:
+
+- **`go.mod` / `go.sum` drift**:
+  - Run `go mod tidy` or the repo's wrapper to restore the intended dependency graph
+  - Verify the resulting module changes are expected and not accidental dependency upgrades
+
+- **Generated code or schema drift**:
+  - Re-run the repo's generation command when protobuf, sqlc, mock, stringer, or other generated artifacts are expected
+  - Do not hand-edit generated files unless the repo explicitly requires it
+
+- **Build constraints / platform-specific file selection**:
+  - Verify `//go:build`, legacy build tags, and `_unix.go` / `_linux.go`-style suffixes still include the file on the intended targets
+  - Use the repo's wrapper or `go list`-style inspection when tag selection is unclear
+
+**When to Ask User:**
+- Architectural decisions (e.g., choosing between dependency shapes)
+- Breaking API changes that affect multiple packages or services
+- Test failures where business logic is unclear
+- Security-related issues requiring policy decisions
+- When multiple valid fix approaches exist with trade-offs
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-go-quality-check` section, read
+that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace
+parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Go-Specific Guidance
+
+- Prefer the project's wrapper command (`make`, `mage`, `task`, scripts, etc.) over bare tools when one exists
+- Go formatting is non-negotiable: use `gofmt` or `go fmt` and import cleanup with `goimports` when the repo expects it
+- In Go-first repos, common quality commands may include `go test ./...`, `go test -race ./...`, `go vet ./...`, `golangci-lint run`, `staticcheck ./...`, `govulncheck ./...`, or project wrappers around them
+- Keep generated artifacts, module metadata, and build tags in sync before trusting downstream lint or test failures
+- Run package-scoped commands when that preserves signal and reduces churn, but use repo-defined aggregate commands when the project expects them
+- If the repo uses goleak, leaktest, example tests, or other goroutine/example validation, treat those failures as first-class quality issues rather than optional extras
+- Fix the underlying issue rather than weakening lint, vet, race, or test coverage
+- If a required command cannot be run, report that explicitly with the reason
+
+## Output Format
+
+Provide clear progress updates:
+- Show issue count by category
+- Report each fix with file path and line number
+- Display the final quality-check result
+- Summarize all changes made
+- If a required command could not be run, report that explicitly with the reason

--- a/skills/kmp/bill-kmp-code-review/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review/SKILL.md
@@ -33,6 +33,8 @@ Inspect both the changed files and repo markers (`build.gradle*`, `settings.grad
 
 Before classifying, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for routing Android/KMP work into the `kmp` package bucket.
 
+Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
 Classify the review as one of:
 - `kmp`
 - `mixed-kmp`
@@ -94,45 +96,9 @@ Spawn all selected KMP specialists simultaneously using the `task` tool. Each ag
 - the detected project type
 - the list of changed files
 - instructions to read its own skill file for the review rubric
-- the shared contract below
+- the shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
 
 If no KMP-only triggers match but Android/KMP signals are clearly present, keep the baseline review output and state that no extra KMP-only specialist was needed for this scope.
-
----
-
-## Shared Contract For Every Specialist
-
-- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
-- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
-- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when deprecated usage is broad in scope and not explicitly justified
-- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
-- Evidence is mandatory: include `file:line` + short description
-- Severity: `Blocker | Major | Minor`
-- Confidence: `High | Medium | Low`
-- Maximum 7 findings per specialist
-- Include a minimal, concrete fix for each finding
-
-### Required Finding Schema
-
-```text
-[SEVERITY] Area: Issue title
-  Location: file:line
-  Impact: Why it matters (1 sentence)
-  Fix: Concrete fix (1-2 lines)
-  Confidence: High/Medium/Low
-```
-
----
-
-## Orchestrator Merge Rules
-
-1. Collect the baseline findings from `bill-kotlin-code-review` or `bill-backend-kotlin-code-review`.
-2. Collect all KMP-specific specialist findings.
-3. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
-4. Deduplicate by root cause (same evidence or same failing behavior).
-5. Keep highest severity/confidence when duplicates conflict.
-6. Prioritize: Blocker > Major > Minor, then blast radius.
-7. Produce one consolidated report.
 
 ---
 
@@ -147,51 +113,10 @@ KMP agents spawned: bill-kmp-code-review-ui
 Reason: Android/KMP signals were high-confidence, so the mobile layer was added on top of the baseline Kotlin-family review
 ```
 
-### 2. Risk Register
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow
+`orchestration/review-orchestrator/PLAYBOOK.md`.
 
-Format each issue as:
-```text
-[IMPACT_LEVEL] Area: Issue title
-  Location: file:line
-  Impact: Description
-  Fix: Concrete action
-```
+## Implementation Mode Notes
 
-Impact levels: BLOCKER | MAJOR | MINOR
-
-### 3. Action Items (Max 10, prioritized)
-
-```text
-1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
-2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
-3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
-```
-
-Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
-Effort: S (<1h) | M (1-4h) | L (>4h)
-
-### 4. Verdict
-
-`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
-
----
-
-## Implementation Mode
-
-If invoked standalone, ask: **"Which item would you like me to fix?"**
-
-If invoked from `bill-feature-implement`, `bill-feature-verify`, or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
-
-After all P0 and P1 items are resolved, run `bill-quality-check` as final verification when the project uses a routed quality-check path and this review is being run standalone.
-
----
-
-## Review Principles
-
-- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it violates current rules
-- Evidence-based: cite `file:line`
-- Project-aware: each agent has project-specific rules in its skill file
-- Actionable: every issue must have a concrete fix
-- Proportional: don't nitpick style if architecture is broken
-- No overoptimization: do not report negligible performance findings with no measurable user-facing or production-facing impact
-- Honest: if unsure, say what context is missing
+- If invoked from `bill-feature-implement`, `bill-feature-verify`, or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
+- After all P0 and P1 items are resolved, run `bill-quality-check` as final verification when the project uses a routed quality-check path and this review is being run standalone.

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -33,6 +33,8 @@ Inspect both the changed files and repo markers (`build.gradle*`, `settings.grad
 
 Before classifying, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for broad stack signals. This skill owns only the Kotlin-family baseline after a caller decides Kotlin is in scope.
 
+Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
 Classify the review as one of:
 - `kotlin`
 - `kmp-baseline`
@@ -91,42 +93,7 @@ Spawn all selected agents simultaneously using the `task` tool. Each agent gets:
 - the detected project type
 - the list of changed files
 - instructions to read its own skill file for the review rubric
-- the shared contract below
-
----
-
-## Shared Contract For Every Specialist
-
-- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
-- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
-- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when deprecated usage is broad in scope and not explicitly justified
-- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
-- Evidence is mandatory: include `file:line` + short description
-- Severity: `Blocker | Major | Minor`
-- Confidence: `High | Medium | Low`
-- Maximum 7 findings per specialist
-- Include a minimal, concrete fix for each finding
-
-### Required Finding Schema
-
-```text
-[SEVERITY] Area: Issue title
-  Location: file:line
-  Impact: Why it matters (1 sentence)
-  Fix: Concrete fix (1-2 lines)
-  Confidence: High/Medium/Low
-```
-
----
-
-## Orchestrator Merge Rules
-
-1. Collect all specialist findings.
-2. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
-3. Deduplicate by root cause (same evidence or same failing behavior).
-4. Keep highest severity/confidence when duplicates conflict.
-5. Prioritize: Blocker > Major > Minor, then blast radius.
-6. Produce one consolidated report.
+- the shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
 
 ---
 
@@ -140,51 +107,10 @@ Agents spawned: bill-kotlin-code-review-architecture, bill-kotlin-code-review-pl
 Reason: <why this Kotlin baseline route was selected>
 ```
 
-### 2. Risk Register
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow
+`orchestration/review-orchestrator/PLAYBOOK.md`.
 
-Format each issue as:
-```text
-[IMPACT_LEVEL] Area: Issue title
-  Location: file:line
-  Impact: Description
-  Fix: Concrete action
-```
+## Implementation Mode Notes
 
-Impact levels: BLOCKER | MAJOR | MINOR
-
-### 3. Action Items (Max 10, prioritized)
-
-```text
-1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
-2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
-3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
-```
-
-Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
-Effort: S (<1h) | M (1-4h) | L (>4h)
-
-### 4. Verdict
-
-`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
-
----
-
-## Implementation Mode
-
-If invoked standalone, ask: **"Which item would you like me to fix?"**
-
-If invoked from `bill-feature-implement`, `bill-feature-verify`, `bill-kmp-code-review`, `bill-backend-kotlin-code-review`, or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
-
-After all P0 and P1 items are resolved, run `bill-quality-check` as final verification when the project uses a routed quality-check path and this review is being run standalone.
-
----
-
-## Review Principles
-
-- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it violates current rules
-- Evidence-based: cite `file:line`
-- Project-aware: each agent has project-specific rules in its skill file
-- Actionable: every issue must have a concrete fix
-- Proportional: don't nitpick style if architecture is broken
-- No overoptimization: do not report negligible performance findings with no measurable user-facing or production-facing impact
-- Honest: if unsure, say what context is missing
+- If invoked from `bill-feature-implement`, `bill-feature-verify`, `bill-kmp-code-review`, `bill-backend-kotlin-code-review`, or another orchestration skill, do not pause for user selection. Return prioritized findings so the caller can auto-fix P0/P1 items and decide whether to carry Minor items forward.
+- After all P0 and P1 items are resolved, run `bill-quality-check` as final verification when the project uses a routed quality-check path and this review is being run standalone.

--- a/skills/php/bill-php-code-review/SKILL.md
+++ b/skills/php/bill-php-code-review/SKILL.md
@@ -37,6 +37,10 @@ Before applying review heuristics, read `orchestration/stack-routing/PLAYBOOK.md
 for PHP stack signals and mixed-stack routing expectations. This skill owns the PHP review depth that applies after PHP
 is already in scope.
 
+Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use
+it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone
+behavior, and review principles used by stack-specific review orchestrators.
+
 ---
 
 ## Review Scope
@@ -97,43 +101,7 @@ Each sub-agent gets:
 - The list of changed files
 - Instructions to read its own skill file for the review rubric
 - Relevant project-wide guidance and matching per-skill overrides
-- The shared contract below
-
----
-
-## Shared Contract For Every Specialist
-
-- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
-- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
-- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when deprecated
-  usage is broad in scope and not explicitly justified
-- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
-- Evidence is mandatory: include `file:line` + short description
-- Severity: `Blocker | Major | Minor`
-- Confidence: `High | Medium | Low`
-- Maximum 7 findings per specialist
-- Include a minimal, concrete fix for each finding
-
-### Required Finding Schema
-
-```text
-[SEVERITY] Area: Issue title
-  Location: file:line
-  Impact: Why it matters (1 sentence)
-  Fix: Concrete fix (1-2 lines)
-  Confidence: High/Medium/Low
-```
-
----
-
-## Orchestrator Merge Rules
-
-1. Collect all specialist findings.
-2. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
-3. Deduplicate by root cause (same evidence or same failing behavior).
-4. Keep highest severity/confidence when duplicates conflict.
-5. Prioritize: Blocker > Major > Minor, then blast radius.
-6. Produce one consolidated report.
+- The shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
 
 ---
 
@@ -148,57 +116,13 @@ Agents spawned: bill-php-code-review-architecture, bill-php-code-review-platform
 Reason: transaction and projection paths changed, plus tests changed materially
 ```
 
-### 2. Risk Register
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow
+`orchestration/review-orchestrator/PLAYBOOK.md`.
 
-Format each issue as:
+## Implementation Mode Notes
 
-```text
-[IMPACT_LEVEL] Area: Issue title
-  Location: file:line
-  Impact: Description
-  Fix: Concrete action
-  Confidence: High/Medium/Low
-```
-
-Impact levels: BLOCKER | MAJOR | MINOR
-
-### 3. Action Items (Max 10, prioritized)
-
-```text
-1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
-2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
-3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
-```
-
-Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
-Effort: S (<1h) | M (1-4h) | L (>4h)
-
-### 4. Verdict
-
-`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
-
----
-
-## Implementation Mode
-
-If invoked standalone, ask: **"Which item would you like me to fix?"**
-
-If invoked from `bill-feature-implement` or another orchestration skill, do not pause for user selection. Return
-prioritized findings so the caller can auto-fix `P0` and `P1` items and decide whether to carry `Minor` items forward.
-
-After all `P0` and `P1` items are resolved, run `bill-php-quality-check` as final verification when this review is being
-run standalone.
-
----
-
-## Review Principles
-
-- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it
-  violates current rules
-- Evidence-based: cite `file:line`
-- Project-aware: each agent applies local `AGENTS.md` and required local docs
-- Actionable: every issue must have a concrete fix
-- Proportional: don't nitpick style if architecture, correctness, or security is broken
-- No overoptimization: do not report negligible performance findings with no measurable user-facing or production-facing
-  impact
-- Honest: if unsure, say what context is missing
+- If invoked from `bill-feature-implement` or another orchestration skill, do not pause for user selection. Return
+  prioritized findings so the caller can auto-fix `P0` and `P1` items and decide whether to carry `Minor` items
+  forward.
+- After all `P0` and `P1` items are resolved, run `bill-php-quality-check` as final verification when this review is
+  being run standalone.

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -18,6 +18,7 @@ KOTLIN_CODE_REVIEW = read("skills/kotlin/bill-kotlin-code-review/SKILL.md")
 BACKEND_KOTLIN_CODE_REVIEW = read("skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md")
 KMP_CODE_REVIEW = read("skills/kmp/bill-kmp-code-review/SKILL.md")
 PHP_CODE_REVIEW = read("skills/php/bill-php-code-review/SKILL.md")
+GO_CODE_REVIEW = read("skills/go/bill-go-code-review/SKILL.md")
 
 
 class FeatureImplementRoutingContractTest(unittest.TestCase):
@@ -85,6 +86,20 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn(
       "read `orchestration/stack-routing/PLAYBOOK.md`",
       PHP_CODE_REVIEW,
+    )
+
+  def test_go_context_routes_to_go_review_and_quality_check(self) -> None:
+    self.assertIn(
+      "- If `go` signals dominate, delegate to `bill-go-code-review`.",
+      CODE_REVIEW,
+    )
+    self.assertIn(
+      "- If `go` signals dominate, delegate to the canonical `bill-go-quality-check` skill when it exists.",
+      QUALITY_CHECK,
+    )
+    self.assertIn(
+      "read `orchestration/stack-routing/PLAYBOOK.md`",
+      GO_CODE_REVIEW,
     )
 
   def test_kmp_plus_backend_context_uses_backend_baseline_inside_kmp_review(self) -> None:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -24,6 +24,7 @@ BACKEND_KOTLIN_SKILLS = skill_names("backend-kotlin")
 KOTLIN_SKILLS = skill_names("kotlin")
 KMP_SKILLS = skill_names("kmp")
 PHP_SKILLS = skill_names("php")
+GO_SKILLS = skill_names("go")
 
 
 class InstallScriptTest(unittest.TestCase):
@@ -56,6 +57,14 @@ class InstallScriptTest(unittest.TestCase):
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS)
 
+  def test_installs_base_and_selected_go_platform_only(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nGo\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | GO_SKILLS)
+
   def test_accepts_human_friendly_multi_platform_selection(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       result = self.run_installer(temp_home, "copilot\nKotlin backend, Kotlin, KMP\n")
@@ -73,12 +82,13 @@ class InstallScriptTest(unittest.TestCase):
       self.assertIn("Kotlin (kotlin)", result.stdout)
       self.assertIn("KMP (kmp)", result.stdout)
       self.assertIn("PHP (php)", result.stdout)
+      self.assertIn("Go (go)", result.stdout)
       self.assertIn("all (install every platform package)", result.stdout)
 
       installed = self.installed_skills(temp_home)
       self.assertEqual(
         installed,
-        BASE_SKILLS | BACKEND_KOTLIN_SKILLS | KOTLIN_SKILLS | KMP_SKILLS | PHP_SKILLS,
+        BASE_SKILLS | BACKEND_KOTLIN_SKILLS | KOTLIN_SKILLS | KMP_SKILLS | PHP_SKILLS | GO_SKILLS,
       )
 
   def test_ignores_empty_platform_tokens(self) -> None:

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -35,6 +35,16 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       result = self.run_validator(repo_root)
       self.assertEqual(result.returncode, 0, result.stdout)
 
+  def test_accepts_go_platform_override_of_dynamic_base_capability(self) -> None:
+    with self.fixture_repo(
+      [
+        ("base", "bill-ship-it"),
+        ("go", "bill-go-ship-it"),
+      ]
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 0, result.stdout)
+
   def test_rejects_platform_only_capability_name(self) -> None:
     with self.fixture_repo(
       [
@@ -59,6 +69,20 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       result = self.run_validator(repo_root)
       self.assertEqual(result.returncode, 1, result.stdout)
       self.assertIn("code-review specialization 'laravel' is not approved", result.stdout)
+
+  def test_rejects_go_platform_only_capability_name(self) -> None:
+    with self.fixture_repo(
+      [
+        ("base", "bill-ship-it"),
+        ("go", "bill-go-gin-ship-it"),
+      ]
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn(
+        "platform skill 'bill-go-gin-ship-it' must either override an approved base skill",
+        result.stdout,
+      )
 
   def test_rejects_unknown_platform_package(self) -> None:
     with self.fixture_repo(


### PR DESCRIPTION
# Summary

Add a first-class Go platform package to Skill Bill, modeled after the governed PHP platform shape and grounded in established Go guidance.

- add `skills/go/` with `bill-go-code-review`, `bill-go-quality-check`, and approved Go review specialists
- wire Go into shared routing, validator rules, installer platform selection, and README platform/catalog docs
- add Go-specific routing, validator, and installer coverage
- save the feature spec under `.feature-specs/go-platform-skills/spec.md`

## Feature Flags

N/A

# How Has This Been Tested?

1. Run `python3 -m unittest discover -s tests`.
2. Run `npx --yes agnix --strict .`.
3. Run `python3 scripts/validate_agent_configs.py`.
4. Spot-check that `install.sh` offers `Go` as a platform option and that shared routing docs and tests reference `bill-go-code-review` and `bill-go-quality-check`.
