### PR TITLE
feat: use skill-local sidecars for shared review contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,7 @@ The repository uses a strict three-layer model:
 
 - `skills/base/` — canonical, user-facing capabilities
 - `skills/<platform>/` — platform-specific overrides and approved platform-owned subskills
-- `orchestration/` — shared internal routing and decision logic; not user-facing slash commands
-
-Keep shared contracts in `skills/base/`, stack-specific behavior in `skills/<platform>/`, and reusable routing logic in `orchestration/`.
+- `orchestration/` — maintainer-facing reference snapshots for shared routing and review contracts; not a runtime dependency for installed skills
 
 ## Naming rules
 
@@ -58,7 +56,9 @@ Use only these two platform naming patterns unless the taxonomy itself is intent
 
 - Add platform capabilities only as base-capability overrides or approved `code-review-<area>` specializations.
 - Add a new package only when behavior is materially different from existing packages.
-- Put shared routing logic in `orchestration/`, not in installable skills.
+- Runtime-facing skills may reference sibling supporting files inside the same skill directory.
+- Use sibling supporting files for runtime-shared contracts instead of repo-relative or install-root-relative playbook paths.
+- Keep `orchestration/` snapshots aligned with the sibling supporting-file contracts when shared routing or review behavior changes.
 - Preserve stable base entry points even when a platform needs more depth behind the router.
 - Keep README skill counts and catalog entries accurate whenever skills change.
 - Update `install.sh` migration rules in the same change when renaming stack-bound skills.
@@ -87,10 +87,9 @@ When adding a new platform or language package:
    - `ALLOWED_PACKAGES`
    - any package-specific validation logic
    - any tests or assumptions tied to current package names
-4. Update `orchestration/stack-routing/PLAYBOOK.md`:
-   - add the platform to taxonomy
-   - add stack signals
-   - add routing decision rules
+4. Update maintainer reference snapshots when shared routing or review behavior changes:
+   - `orchestration/stack-routing/PLAYBOOK.md`
+   - `orchestration/review-orchestrator/PLAYBOOK.md`
 5. Update base routers if needed:
    - `skills/base/bill-code-review/SKILL.md`
    - `skills/base/bill-quality-check/SKILL.md`

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ The repo is organized around a strict three-layer model:
 
 - `skills/base/` — canonical, user-facing capabilities such as `bill-code-review`, `bill-quality-check`, and `bill-feature-implement`
 - `skills/<platform>/` — platform-specific overrides and approved subskills
-- `orchestration/` — internal playbooks used for shared routing and decision logic
+- `orchestration/` — maintainer-facing reference snapshots for shared routing and review contracts
 
 Think of it as markdown with inheritance:
 
 - base skills define the stable contracts
 - platform skills specialize them
-- orchestration decides which specialization to use
+- orchestration snapshots document the shared logic that runtime-facing skills can reference via sibling supporting files in the same skill directory
 
 Current platform packages:
 
@@ -91,7 +91,7 @@ Today, `backend-kotlin` and `kmp` both fall back to `bill-kotlin-quality-check` 
 | GLM | `~/.glm/commands/` |
 | OpenAI Codex | `~/.codex/skills/` or `~/.agents/skills/` |
 
-The installer links all selected agents to the same repo so updates stay in sync.
+The installer links all selected agents to the same repo so updates stay in sync. Runtime-facing skills reference supporting files that live beside `SKILL.md` inside each skill directory rather than depending on repo-relative playbook paths.
 
 ## Installation
 
@@ -132,6 +132,8 @@ all
 ```
 
 Re-running the installer in `safe` mode is add-only for valid platform packages, so you can install more platforms later without removing ones that were already linked.
+
+Shared routing and review contracts are documented in `orchestration/` and exposed to runtimes through sibling supporting files inside each skill directory. That keeps references local to the installed skill instead of relying on repo-relative playbook paths.
 
 Modes:
 

--- a/install.sh
+++ b/install.sh
@@ -678,6 +678,7 @@ add_legacy_name() {
 
 build_legacy_skill_names() {
   LEGACY_SKILL_NAMES=()
+  add_legacy_name ".bill-shared"
 
   local skill pair old_name
   for skill in "${SKILL_NAMES[@]}"; do

--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -1,105 +1,39 @@
 ---
 name: review-orchestrator
-description: Internal playbook for shared stack-specific code-review orchestrator contracts, merge rules, output structure, and baseline review behavior.
+description: Maintainer-facing reference snapshot for shared stack-specific code-review orchestration contracts, merge rules, and output structure.
 ---
 
-# Shared Code Review Orchestrator Playbook
+# Shared Code Review Orchestrator Snapshot
 
-Use this playbook when a stack-specific `*-code-review` orchestrator needs a shared contract for spawned specialists and
-a consistent final report shape.
+This maintainer-facing reference snapshot documents the shared review-orchestration contract used when authoring or updating installable skills.
 
-This playbook is only for shared review-orchestration behavior. Keep stack-specific routing heuristics, signal tables,
-layering examples, caller-specific notes, and final quality-check command choices in the calling skill.
-
-## Project Guidance
-
-If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance when using this playbook.
-
-This playbook supplements, but does not replace, each skill's own `## Project Overrides` section and per-skill override
-precedence.
+Runtime-facing skills consume this contract through sibling supporting files such as `review-orchestrator.md` inside each skill directory. Do not reference this repo-relative path directly from installable skills.
 
 ## Shared Contract For Every Specialist
 
-- Scope: review only the changes in the current PR/unit of work — do not flag pre-existing issues in unchanged code
-- Review only meaningful issues (bug, logic flaw, security risk, regression risk, architectural breakage)
-- Flag newly introduced deprecated components, APIs, or patterns when a supported alternative exists, or when
-  deprecated usage is broad in scope and not explicitly justified
-- Ignore style, formatting, naming bikeshedding, and pure refactor preferences
-- Evidence is mandatory: include `file:line` + short description
+- Review only changed code in the current PR or unit of work
+- Surface only meaningful issues such as bugs, logic flaws, security risks, regression risks, or architectural breakage
+- Flag newly introduced deprecated APIs or patterns when a supported alternative exists, or when deprecated usage is broad and unjustified
+- Ignore style-only nits, formatting preferences, and naming bikeshedding
+- Evidence is mandatory: include `file:line` and a short description
 - Severity: `Blocker | Major | Minor`
 - Confidence: `High | Medium | Low`
-- Maximum 7 findings per specialist
-- Include a minimal, concrete fix for each finding
+- Keep each specialist review pass to at most 7 findings
+- Include a minimal concrete fix for each finding
 
-### Required Finding Schema
+## Delegation Portability Contract
 
-```text
-[SEVERITY] Area: Issue title
-  Location: file:line
-  Impact: Why it matters (1 sentence)
-  Fix: Concrete fix (1-2 lines)
-  Confidence: High/Medium/Low
-```
+- Use the runtime's available delegation mechanism for parallel specialist review passes when delegation is supported and permitted
+- Shared installable skills must not hardcode agent-specific delegation tool names such as `task` or `spawn_agent`
+- If delegation is unavailable, perform the same specialist review passes inline and say so in the summary
+- If a specialist review pass fails or returns no output, note it in the summary and continue with available results
+- When multiple review passes produce overlapping findings, deduplicate by root cause and keep the highest severity/confidence version
+- Prioritize final findings as `Blocker > Major > Minor`, then by blast radius
 
-## Orchestrator Merge Rules
+## Shared Report Structure
 
-1. Collect results from every selected review layer. If the orchestrator also runs a baseline review layer, merge those
-   findings first.
-2. If a specialist agent fails or returns no output, note it in the summary and continue with available results.
-3. Deduplicate by root cause (same evidence or same failing behavior).
-4. Keep highest severity/confidence when duplicates conflict.
-5. Prioritize: Blocker > Major > Minor, then blast radius.
-6. Produce one consolidated report.
+After Section 1 in a stack-specific review skill, use:
 
-## Shared Output Format
-
-Stack-specific orchestrator skills should keep their own Section 1 summary example. The rest of the output should use
-the shared structure below.
-
-### 2. Risk Register
-
-Format each issue as:
-
-```text
-[IMPACT_LEVEL] Area: Issue title
-  Location: file:line
-  Impact: Description
-  Fix: Concrete action
-  Confidence: High/Medium/Low
-```
-
-Impact levels: BLOCKER | MAJOR | MINOR
-
-### 3. Action Items (Max 10, prioritized)
-
-```text
-1. [P0 BLOCKER] Fix issue (Effort: S, Impact: High)
-2. [P1 MAJOR] Fix issue (Effort: M, Impact: Medium)
-3. [P2 MINOR] Fix issue (Effort: S, Impact: Low)
-```
-
-Priority: P0 (blocker) | P1 (critical) | P2 (important) | P3 (nice-to-have)
-Effort: S (<1h) | M (1-4h) | L (>4h)
-
-### 4. Verdict
-
-`Ship` | `Ship with fixes [list P0/P1 items]` | `Block until [list blockers]`
-
-## Shared Implementation Baseline
-
-- If invoked standalone, ask: **"Which item would you like me to fix?"**
-- If invoked from another orchestration skill, do not pause for user selection unless the caller explicitly wants
-  interactive triage
-- Let the calling skill specify any stack-specific caller list and the final quality-check command or router
-
-## Review Principles
-
-- Changed code only: review what was added or modified in this PR — do not report issues in untouched code, even if it
-  violates current rules
-- Evidence-based: cite `file:line`
-- Project-aware: each agent applies local `AGENTS.md` and required local docs
-- Actionable: every issue must have a concrete fix
-- Proportional: do not nitpick style when architecture, correctness, or security problems are more important
-- No overoptimization: do not report negligible performance findings with no measurable user-facing or
-  production-facing impact
-- Honest: if unsure, say what context is missing
+- `### 2. Risk Register`
+- `### 3. Action Items (Max 10, prioritized)`
+- `### 4. Verdict`

--- a/orchestration/stack-routing/PLAYBOOK.md
+++ b/orchestration/stack-routing/PLAYBOOK.md
@@ -1,21 +1,13 @@
 ---
 name: stack-routing
-description: Internal playbook for stack detection, dominant-signal tie-breakers, and router delegation decisions.
+description: Maintainer-facing reference snapshot for shared stack detection, dominant-signal tie-breakers, and router delegation decisions.
 ---
 
-# Shared Stack Routing Playbook
+# Shared Stack Routing Snapshot
 
-Use this playbook when another skill needs to decide which stack-specific skill should handle the current repo, diff, or validation scope.
+This maintainer-facing reference snapshot documents the shared stack-routing contract used when authoring or updating installable skills.
 
-This is not the place for stack-specific review heuristics or build commands. Keep it focused on:
-- stack taxonomy
-- signal collection order
-- dominant-stack tie-breakers
-- mixed-stack delegation rules
-
-## Project Guidance
-
-If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance when using this playbook.
+Runtime-facing skills consume this contract through sibling supporting files such as `stack-routing.md` inside each skill directory. Do not reference this repo-relative path directly from installable skills.
 
 ## Signal Collection Order
 
@@ -36,56 +28,39 @@ Classify work as one of:
 - `go`
 - `Unknown/Unsupported`
 
-## Stack Signals
+## Strong Stack Signals
 
-### kmp Signals
+### kmp
 
-- `.kt`, `.kts`, `build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`
 - `kotlin("multiplatform")`, `org.jetbrains.kotlin.multiplatform`, `expect` / `actual`
-- `androidx`, `AndroidManifest.xml`, `androidMain`, `iosMain`, `commonMain`
-- Compose, Activities, Fragments, resources, platform source sets
+- `androidMain`, `iosMain`, `commonMain`, `AndroidManifest.xml`
+- Compose Multiplatform, Android resources, platform source sets
 
-### backend-kotlin Signals
+### backend-kotlin
 
-- `.kt`, `.kts`, `build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`, `pom.xml`
-- Kotlin backend/server modules or services without strong Android/KMP markers
-- `io.ktor.server`, Spring, Micronaut, Quarkus, http4k
-- Exposed, jOOQ, Flyway, Liquibase, Hibernate/JPA, JDBC, R2DBC
+- Kotlin files/builds plus server markers such as `io.ktor.server`, Spring, Micronaut, Quarkus, http4k
 - `application.yml`, `application.yaml`, `application.conf`
+- Exposed, jOOQ, Flyway, Liquibase, Hibernate/JPA, JDBC, R2DBC
 
-### kotlin Signals
+### kotlin
 
-- `.kt`, `.kts`, `build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`, `pom.xml`
 - Kotlin/JVM libraries, CLIs, or shared utilities without strong `kmp` or `backend-kotlin` markers
 
-### php Signals
+### php
 
-- `composer.json`, `composer.lock`, `phpunit.xml`, `phpunit.xml.dist`
-- `.php`, `artisan`, `routes/web.php`, `routes/api.php`, `bootstrap/app.php`
+- `composer.json`, `composer.lock`, `phpunit.xml*`, `.php`
 - Laravel, Symfony, Slim, Doctrine, Eloquent, PHPUnit, Pest, Blade, Twig
 
-### go Signals
+### go
 
-- `go.mod`, `go.sum`, `go.work`, `go.work.sum`
-- `.go`, `cmd/`, `internal/`, `pkg/`, `vendor/`
-- `net/http`, `google.golang.org/grpc`, chi, gin, echo, fiber, cobra
-- `database/sql`, sqlx, `gorm.io`, `entgo.io`, migration tooling, worker or service packages using `context.Context`
+- `go.mod`, `go.sum`, `go.work*`, `.go`, `cmd/`, `internal/`, `pkg/`
+- `net/http`, gRPC, chi, gin, echo, fiber, `database/sql`, sqlx, GORM, Ent
 
-## Decision Rules
+## Tie-Breakers
 
-- If Android/KMP markers are strong, classify as `kmp`.
-- Treat Android-only scope as `kmp` too; `kmp` is the package-aligned bucket for Android/KMP work.
-- If backend/server markers are strong without meaningful `kmp` markers, classify as `backend-kotlin`.
-- If generic Kotlin markers are present without meaningful `kmp` or `backend-kotlin` markers, classify as `kotlin`.
-- If PHP markers are strong, classify as `php`.
-- If Go markers are strong, classify as `go`.
-- If multiple supported stacks are present in one unit of work, classify as `Mixed` for routing purposes and delegate to each matching package-aligned stack-specific skill when the caller supports multi-route execution.
-- If no supported stack has clear evidence, classify as `Unknown/Unsupported` and say so explicitly.
-
-## Router Contract
-
-Skills that use this playbook should:
-- cite the detected stack
-- cite the key signals that drove the choice
-- explain whether they routed to one skill or multiple skills
-- keep stack-specific heuristics in the delegated skill, not here
+- If Android/KMP markers are strong, route to `kmp`
+- Treat Android-only scope as `kmp` because that is the package-aligned Android/KMP bucket
+- If backend/server markers are strong without meaningful `kmp` markers, route to `backend-kotlin`
+- If generic Kotlin markers appear without meaningful `kmp` or `backend-kotlin` markers, route to `kotlin`
+- If multiple supported stacks are clearly present, treat the scope as mixed and route to each matching stack-specific skill when the caller supports it
+- If no supported stack has clear evidence, stop and say the stack is unsupported instead of pretending coverage exists

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -11,7 +11,7 @@ import sys
 README_TOTAL_PATTERN = re.compile(r"collection of (\d+) AI skills")
 README_SECTION_PATTERN = re.compile(r"^### (.+) \((\d+) skills\)$")
 README_SKILL_ROW_PATTERN = re.compile(r"^\| `/(bill-[a-z0-9-]+)` \|")
-SKILL_REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9-])(bill-[a-z0-9-]+)(?![A-Za-z0-9-])")
+SKILL_REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9.-])(bill-[a-z0-9-]+)(?![A-Za-z0-9-])")
 FRONTMATTER_PATTERN = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
 SKILL_NAME_PATTERN = re.compile(r"^bill-[a-z0-9-]+$")
 PROJECT_OVERRIDES_HEADING = "## Project Overrides"
@@ -34,16 +34,56 @@ APPROVED_CODE_REVIEW_AREAS = {
 }
 ORCHESTRATION_PLAYBOOKS: dict[str, str] = {
   "stack-routing": "orchestration/stack-routing/PLAYBOOK.md",
+  "review-orchestrator": "orchestration/review-orchestrator/PLAYBOOK.md",
 }
-REQUIRED_PLAYBOOK_REFERENCES: dict[str, tuple[str, ...]] = {
-  "bill-code-review": ("stack-routing",),
-  "bill-quality-check": ("stack-routing",),
-  "bill-kotlin-code-review": ("stack-routing",),
-  "bill-backend-kotlin-code-review": ("stack-routing",),
-  "bill-kmp-code-review": ("stack-routing",),
-  "bill-php-code-review": ("stack-routing",),
-  "bill-go-code-review": ("stack-routing",),
+RUNTIME_SUPPORTING_FILES: dict[str, tuple[str, ...]] = {
+  "bill-code-review": ("stack-routing.md",),
+  "bill-quality-check": ("stack-routing.md",),
+  "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
+  "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
+  "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md"),
+  "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md"),
+  "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md"),
 }
+EXTERNAL_PLAYBOOK_REFERENCE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+  (
+    re.compile(r"\.bill-shared/orchestration/"),
+    "must reference skill-local supporting files instead of install-local playbook paths",
+  ),
+  (
+    re.compile(r"orchestration/(?:stack-routing|review-orchestrator)/PLAYBOOK\.md"),
+    "must reference skill-local supporting files instead of repo-side playbook paths at runtime",
+  ),
+)
+PORTABLE_REVIEW_SKILLS = {
+  "bill-kotlin-code-review",
+  "bill-backend-kotlin-code-review",
+  "bill-kmp-code-review",
+  "bill-php-code-review",
+  "bill-go-code-review",
+}
+NON_PORTABLE_REVIEW_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+  (
+    re.compile(r"`task`"),
+    "must not hardcode the `task` tool in shared review orchestration",
+  ),
+  (
+    re.compile(r"\bspawn_agent\b"),
+    "must not hardcode the `spawn_agent` tool in shared review orchestration",
+  ),
+  (
+    re.compile(r"\bsub-agent(s)?\b"),
+    "must not describe review delegation as sub-agents; use specialist review passes instead",
+  ),
+  (
+    re.compile(r"\bAgent to spawn\b"),
+    "must use portable routing-table wording such as 'Specialist review to run'",
+  ),
+  (
+    re.compile(r"\bAgents spawned\b"),
+    "must use portable summary wording such as 'Specialist reviews'",
+  ),
+)
 
 
 def main() -> int:
@@ -144,26 +184,52 @@ def validate_skill_file(skill_name: str, skill_file: Path, issues: list[str]) ->
   if SKILL_OVERRIDE_FILE not in text:
     issues.append(f"{skill_file}: missing reference to '{SKILL_OVERRIDE_FILE}'")
 
-  validate_required_playbook_references(skill_name, text, skill_file, issues)
+  validate_runtime_supporting_files(skill_name, text, skill_file, issues)
+  validate_portable_review_wording(skill_name, text, skill_file, issues)
 
 
-def validate_required_playbook_references(
+def validate_runtime_supporting_files(
   skill_name: str,
   text: str,
   skill_file: Path,
   issues: list[str],
 ) -> None:
-  required_references = REQUIRED_PLAYBOOK_REFERENCES.get(skill_name, ())
-  for required_reference in required_references:
-    playbook_path = ORCHESTRATION_PLAYBOOKS[required_reference]
-    if required_reference not in text and playbook_path not in text:
-      issues.append(
-        f"{skill_file}: must reference '{playbook_path}' as the shared routing playbook"
-      )
+  required_files = RUNTIME_SUPPORTING_FILES.get(skill_name)
+  if not required_files:
+    return
+
+  for pattern, message in EXTERNAL_PLAYBOOK_REFERENCE_PATTERNS:
+    match = pattern.search(text)
+    if match:
+      issues.append(f"{skill_file}: {message}; found '{match.group(0)}'")
+
+  for file_name in required_files:
+    supporting_file = skill_file.parent / file_name
+    if file_name not in text:
+      issues.append(f"{skill_file}: must reference local supporting file '{file_name}'")
+    if not supporting_file.exists():
+      issues.append(f"{skill_file}: supporting file '{file_name}' is missing")
+    elif not supporting_file.is_symlink():
+      issues.append(f"{skill_file}: supporting file '{file_name}' must be a symlink to the shared snapshot")
+
+
+def validate_portable_review_wording(
+  skill_name: str,
+  text: str,
+  skill_file: Path,
+  issues: list[str],
+) -> None:
+  if skill_name not in PORTABLE_REVIEW_SKILLS:
+    return
+
+  for pattern, message in NON_PORTABLE_REVIEW_PATTERNS:
+    match = pattern.search(text)
+    if match:
+      issues.append(f"{skill_file}: {message}; found '{match.group(0)}'")
 
 
 def validate_orchestration_playbooks(root: Path, issues: list[str]) -> None:
-  for playbook_name, relative_path in ORCHESTRATION_PLAYBOOKS.items():
+  for relative_path in ORCHESTRATION_PLAYBOOKS.values():
     playbook_path = root / relative_path
     if not playbook_path.is_file():
       issues.append(f"{relative_path} is missing")

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
@@ -15,7 +15,7 @@ If `.agents/skill-overrides.md` exists in the project root and contains a `## bi
 
 If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
 
-Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to all spawned sub-agents.
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to every delegated or inline specialist review pass.
 
 ## Setup
 
@@ -31,9 +31,14 @@ Determine the review scope:
 
 Inspect both the changed files and repo markers (`build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`, `pom.xml`, `application.yml`, `application.conf`, source layout, module names, imports).
 
-Before classifying, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for broad stack signals. This skill owns only the backend/server override that happens after Kotlin is already in scope.
+## Additional Resources
 
-Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+- For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+
+Before classifying, read [stack-routing.md](stack-routing.md). Use it as the source of truth for broad stack signals. This skill owns only the backend/server override that happens after Kotlin is already in scope.
+
+Before selecting backend specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
 
 Classify the review as one of:
 - `backend-kotlin`
@@ -71,21 +76,23 @@ When invoking it from this skill:
 - tell it to keep backend-only review concerns out of scope
 - pass the same diff source, changed files, and relevant override guidance
 
-### Step 2: Analyze the diff and select backend-specific agents
+### Step 2: Analyze the diff and select backend-specific specialist reviews
 
-| Signal in the diff | Agent to spawn |
-|---------------------|----------------|
+| Signal in the diff | Specialist review to run |
+|---------------------|--------------------------|
 | Routes/controllers, request/response DTOs, serializers, content negotiation, validation, status-code mapping, OpenAPI/schema changes | `bill-backend-kotlin-code-review-api-contracts` |
 | Repositories/DAOs, SQL, ORM mappings, transactions, migrations, optimistic locking, upserts, bulk writes | `bill-backend-kotlin-code-review-persistence` |
 | Timeouts, retries, circuit breakers, queues, schedulers, idempotency, caching, metrics, tracing, startup/shutdown lifecycle | `bill-backend-kotlin-code-review-reliability` |
 
-### Step 3: Launch backend specialists in parallel
+### Step 3: Run backend specialist reviews
 
-Spawn all selected backend specialists simultaneously using the `task` tool. Each agent gets:
+Run all selected backend specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same backend specialist review passes inline and say so in the summary.
+
+Each backend specialist review pass uses:
 - the detected project type
 - the list of changed files
 - instructions to read its own skill file for the review rubric
-- the shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
+- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
 
 If no backend-only triggers match but backend/server signals are clearly present, keep the baseline Kotlin review output and state that no extra backend-specific specialist was needed for this scope.
 
@@ -98,12 +105,11 @@ If no backend-only triggers match but backend/server signals are clearly present
 Detected stack: backend-kotlin | mixed-backend-kotlin
 Signals: application.yml, @RestController, Exposed
 Baseline review: bill-kotlin-code-review
-Backend agents spawned: bill-backend-kotlin-code-review-api-contracts
+Backend specialist reviews: bill-backend-kotlin-code-review-api-contracts
 Reason: backend/server signals were high-confidence, so the backend layer was added on top of the baseline Kotlin review
 ```
 
-For the shared risk register, action items, verdict format, merge rules, and review principles, follow
-`orchestration/review-orchestrator/PLAYBOOK.md`.
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 
 ## Implementation Mode Notes
 

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/review-orchestrator.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/review-orchestrator.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-orchestrator/PLAYBOOK.md

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/stack-routing.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/skills/base/bill-code-review/SKILL.md
+++ b/skills/base/bill-code-review/SKILL.md
@@ -31,13 +31,19 @@ Determine the review scope:
 
 Inspect both the changed files and repo markers before routing.
 
+## Additional Resources
+
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+
 ## Shared Stack Detection
 
-Before routing, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for:
+Before routing, read [stack-routing.md](stack-routing.md). Use it as the source of truth for:
 - stack taxonomy
 - signal collection order
 - dominant-stack tie-breakers
 - mixed-stack routing rules
+
+This supporting file lives beside `SKILL.md`; keep the routing rules in this skill aligned with it.
 
 Do not redefine stack signals here unless a route-specific exception is truly unique to code review.
 

--- a/skills/base/bill-code-review/stack-routing.md
+++ b/skills/base/bill-code-review/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/skills/base/bill-quality-check/SKILL.md
+++ b/skills/base/bill-quality-check/SKILL.md
@@ -31,13 +31,19 @@ Determine the current unit of work:
 
 Inspect the changed files and repo markers before routing.
 
+## Additional Resources
+
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+
 ## Shared Stack Detection
 
-Before routing, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for:
+Before routing, read [stack-routing.md](stack-routing.md). Use it as the source of truth for:
 - stack taxonomy
 - signal collection order
 - dominant-stack tie-breakers
 - mixed-stack routing rules
+
+This supporting file lives beside `SKILL.md`; keep the routing rules in this skill aligned with it.
 
 Do not redefine stack signals here unless a route-specific exception is truly unique to quality-check behavior.
 

--- a/skills/base/bill-quality-check/stack-routing.md
+++ b/skills/base/bill-quality-check/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-go-code-review
-description: Use when conducting a thorough Go PR code review across backend/service projects. Classify changed areas conservatively, select the right specialist agents for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
+description: Use when conducting a thorough Go PR code review across backend/service projects. Classify changed areas conservatively, select the right specialist review passes for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
 ---
 
 # Adaptive Go PR Review
@@ -20,7 +20,7 @@ parts of the default workflow below.
 If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
 
 Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass
-relevant project-wide guidance and matching per-skill overrides to all spawned sub-agents.
+relevant project-wide guidance and matching per-skill overrides to every delegated or inline specialist review pass.
 
 ## Setup
 
@@ -33,13 +33,14 @@ Determine the review scope:
 
 Inspect the changed files and repo markers before applying review heuristics.
 
-Before applying review heuristics, read `orchestration/stack-routing/PLAYBOOK.md` and use it as the source of truth
-for Go stack signals and mixed-stack routing expectations. This skill owns the Go review depth that applies after Go
-is already in scope.
+## Additional Resources
 
-Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use
-it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone
-behavior, and review principles used by stack-specific review orchestrators.
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+- For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+
+Before applying review heuristics, read [stack-routing.md](stack-routing.md) and use it as the source of truth for Go stack signals and mixed-stack routing expectations. This skill owns the Go review depth that applies after Go is already in scope.
+
+Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
 
 ---
 
@@ -51,7 +52,7 @@ Use the routing table below to decide which additional specialist skills to run 
 
 ### Routing Table
 
-| Signal in the diff                                                                                                                                       | Agent to spawn                              |
+| Signal in the diff                                                                                                                                       | Specialist review to run                    |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|
 | Package boundaries, `cmd/`, `internal/`, shared libraries, interface placement, package-level `init()` side effects, dependency direction, adapters/ports, event ownership, orchestration | `bill-go-code-review-architecture`          |
 | Goroutines, channel ownership/close behavior, `sync`/`atomic` usage, context propagation, cancellation, loop-variable capture, nil/zero-value handling, wrapped error flow, time logic | `bill-go-code-review-platform-correctness`  |
@@ -63,7 +64,7 @@ Use the routing table below to decide which additional specialist skills to run 
 | Changed tests look suspiciously weak, tautological, or coverage-padding                                                                                  | `bill-unit-test-value-check`                |
 | Hot paths, repeated marshaling, per-request client creation, N+1 or repeated downstream calls, allocation churn, copy-heavy buffer use, unbounded buffers, goroutine storms                 | `bill-go-code-review-performance`           |
 
-## Dynamic Agent Selection
+## Dynamic Specialist Selection
 
 ### Step 1: Always include the baseline
 
@@ -72,9 +73,10 @@ Always include:
 - `bill-go-code-review-architecture`
 - `bill-go-code-review-platform-correctness`
 
-### Step 2: Analyze the diff and select additional agents
+### Step 2: Analyze the diff and select additional specialist reviews
 
-Inspect each changed file or tightly related change cluster separately and add the agents from the routing table that
+Inspect each changed file or tightly related change cluster separately and add the specialist reviews from the routing
+table that
 match its signals.
 
 Treat Go-specific runtime semantics as strong routing hints, not tie-breakers. If a change touches goroutine lifetime,
@@ -92,36 +94,37 @@ If different parts of the diff touch different review surfaces:
 
 ### Step 4: Apply minimum
 
-- Minimum 2 agents (architecture + platform-correctness)
+- Minimum 2 specialist reviews (architecture + platform-correctness)
 - If tests changed materially, include `bill-go-code-review-testing`
-- Maximum 7 agents
+- Maximum 7 specialist reviews
 
-### Step 5: Launch in parallel
+### Step 5: Run selected specialist reviews
 
-Spawn all selected sub-agents simultaneously when the agent/runtime supports sub-agents or parallel review passes.
+Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it.
+Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable,
+perform the same specialist review passes inline and say so in the summary.
 
-Each sub-agent gets:
+Each specialist review pass uses:
 
 - The list of changed files
 - Instructions to read its own skill file for the review rubric
 - Relevant project-wide guidance and matching per-skill overrides
-- The shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
+- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
 
 ---
 
 ## Review Output Format
 
-### 1. Agent Summary
+### 1. Specialist Summary
 
 ```text
 Detected review scope: <working tree / commit range / PR diff / files>
 Signals: goroutines, context propagation, database/sql, changed tests
-Agents spawned: bill-go-code-review-architecture, bill-go-code-review-platform-correctness, bill-go-code-review-persistence, bill-go-code-review-testing
+Specialist reviews: bill-go-code-review-architecture, bill-go-code-review-platform-correctness, bill-go-code-review-persistence, bill-go-code-review-testing
 Reason: concurrency-sensitive state handling changed, persistence code changed, and tests changed materially
 ```
 
-For the shared risk register, action items, verdict format, merge rules, and review principles, follow
-`orchestration/review-orchestrator/PLAYBOOK.md`.
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 
 ## Implementation Mode Notes
 

--- a/skills/go/bill-go-code-review/review-orchestrator.md
+++ b/skills/go/bill-go-code-review/review-orchestrator.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-orchestrator/PLAYBOOK.md

--- a/skills/go/bill-go-code-review/stack-routing.md
+++ b/skills/go/bill-go-code-review/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/skills/kmp/bill-kmp-code-review/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review/SKILL.md
@@ -15,7 +15,7 @@ If `.agents/skill-overrides.md` exists in the project root and contains a `## bi
 
 If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
 
-Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to all spawned sub-agents.
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to every delegated or inline specialist review pass.
 
 ## Setup
 
@@ -31,9 +31,14 @@ Determine the review scope:
 
 Inspect both the changed files and repo markers (`build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`, `pom.xml`, source set layout, module names, imports).
 
-Before classifying, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for routing Android/KMP work into the `kmp` package bucket.
+## Additional Resources
 
-Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+- For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+
+Before classifying, read [stack-routing.md](stack-routing.md). Use it as the source of truth for routing Android/KMP work into the `kmp` package bucket.
+
+Before selecting KMP specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
 
 Classify the review as one of:
 - `kmp`
@@ -85,18 +90,20 @@ When invoking the baseline review:
 
 Keep the mobile triggers focused on what the baseline review does not cover:
 
-| Signal in the diff | Agent to spawn |
-|---------------------|----------------|
+| Signal in the diff | Specialist review to run |
+|---------------------|--------------------------|
 | `@Composable` functions, UI state classes, Modifier chains, `remember`, `LaunchedEffect` | `bill-kmp-code-review-ui` |
 | User-facing UI changes, `stringResource`, accessibility attributes, navigation, error states, localization files | `bill-kmp-code-review-ux-accessibility` |
 
-### Step 3: Launch KMP specialists in parallel
+### Step 3: Run KMP specialist reviews
 
-Spawn all selected KMP specialists simultaneously using the `task` tool. Each agent gets:
+Run all selected KMP specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same KMP specialist review passes inline and say so in the summary.
+
+Each KMP specialist review pass uses:
 - the detected project type
 - the list of changed files
 - instructions to read its own skill file for the review rubric
-- the shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
+- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
 
 If no KMP-only triggers match but Android/KMP signals are clearly present, keep the baseline review output and state that no extra KMP-only specialist was needed for this scope.
 
@@ -109,12 +116,11 @@ If no KMP-only triggers match but Android/KMP signals are clearly present, keep 
 Detected stack: kmp | mixed-kmp
 Signals: @Composable, AndroidManifest.xml, ViewModel
 Baseline review: bill-kotlin-code-review | bill-backend-kotlin-code-review
-KMP agents spawned: bill-kmp-code-review-ui
+KMP specialist reviews: bill-kmp-code-review-ui
 Reason: Android/KMP signals were high-confidence, so the mobile layer was added on top of the baseline Kotlin-family review
 ```
 
-For the shared risk register, action items, verdict format, merge rules, and review principles, follow
-`orchestration/review-orchestrator/PLAYBOOK.md`.
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 
 ## Implementation Mode Notes
 

--- a/skills/kmp/bill-kmp-code-review/review-orchestrator.md
+++ b/skills/kmp/bill-kmp-code-review/review-orchestrator.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-orchestrator/PLAYBOOK.md

--- a/skills/kmp/bill-kmp-code-review/stack-routing.md
+++ b/skills/kmp/bill-kmp-code-review/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -15,7 +15,7 @@ If `.agents/skill-overrides.md` exists in the project root and contains a `## bi
 
 If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
 
-Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to all spawned sub-agents.
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to every delegated or inline specialist review pass.
 
 ## Setup
 
@@ -31,9 +31,14 @@ Determine the review scope:
 
 Inspect both the changed files and repo markers (`build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`, `pom.xml`, `application.yml`, `application.conf`, source layout, module names, imports).
 
-Before classifying, read `orchestration/stack-routing/PLAYBOOK.md`. Use it as the source of truth for broad stack signals. This skill owns only the Kotlin-family baseline after a caller decides Kotlin is in scope.
+## Additional Resources
 
-Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+- For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+
+Before classifying, read [stack-routing.md](stack-routing.md). Use it as the source of truth for broad stack signals. This skill owns only the Kotlin-family baseline after a caller decides Kotlin is in scope.
+
+Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
 
 Classify the review as one of:
 - `kotlin`
@@ -59,9 +64,9 @@ Classify the review as one of:
 
 ---
 
-## Dynamic Agent Selection
+## Dynamic Specialist Selection
 
-### Step 1: Always spawn `bill-kotlin-code-review-architecture`
+### Step 1: Always include `bill-kotlin-code-review-architecture`
 
 Architecture review is relevant for every non-trivial change.
 
@@ -71,10 +76,10 @@ Architecture review is relevant for every non-trivial change.
 - `kmp-baseline`: baseline is `architecture` + `bill-kotlin-code-review-platform-correctness`
 - `backend-kotlin-baseline`: baseline is `architecture` + `bill-kotlin-code-review-platform-correctness`
 
-### Step 3: Analyze the diff and select additional agents
+### Step 3: Analyze the diff and select additional specialist reviews
 
-| Signal in the diff | Agent to spawn |
-|---------------------|----------------|
+| Signal in the diff | Specialist review to run |
+|---------------------|--------------------------|
 | `launch`, `Flow`, `StateFlow`, `viewModelScope`, `LifecycleOwner`, `DispatcherProvider`, `Mutex`, `Semaphore`, `suspend fun`, coroutine scopes, concurrent mutation | `bill-kotlin-code-review-platform-correctness` |
 | Auth, tokens, keys, passwords, encryption, HTTP clients, interceptors, sensitive data | `bill-kotlin-code-review-security` |
 | Heavy computation, blocking I/O, retry/polling loops, bulk data processing, redundant I/O | `bill-kotlin-code-review-performance` |
@@ -83,32 +88,33 @@ Architecture review is relevant for every non-trivial change.
 ### Step 4: Apply minimum
 
 - Minimum 2 agents (architecture + at least one other)
-- If no additional triggers match, spawn `bill-kotlin-code-review-platform-correctness` as the default second agent
+- If no additional triggers match, include `bill-kotlin-code-review-platform-correctness` as the default second specialist review
 - Maximum 5 agents
-- Do not spawn KMP-only specialists or backend-only specialists from this skill; leave those to the platform-specific override that owns them
+- Do not run KMP-only specialists or backend-only specialists from this skill; leave those to the platform-specific override that owns them
 
-### Step 5: Launch in parallel
+### Step 5: Run selected specialist reviews
 
-Spawn all selected agents simultaneously using the `task` tool. Each agent gets:
+Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same specialist review passes inline and say so in the summary.
+
+Each specialist review pass uses:
 - the detected project type
 - the list of changed files
 - instructions to read its own skill file for the review rubric
-- the shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
+- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
 
 ---
 
 ## Review Output Format
 
-### 1. Classification & Agent Summary
+### 1. Classification & Specialist Summary
 ```text
 Detected stack: kotlin | kmp-baseline | backend-kotlin-baseline
 Signals: <markers>
-Agents spawned: bill-kotlin-code-review-architecture, bill-kotlin-code-review-platform-correctness
+Specialist reviews: bill-kotlin-code-review-architecture, bill-kotlin-code-review-platform-correctness
 Reason: <why this Kotlin baseline route was selected>
 ```
 
-For the shared risk register, action items, verdict format, merge rules, and review principles, follow
-`orchestration/review-orchestrator/PLAYBOOK.md`.
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 
 ## Implementation Mode Notes
 

--- a/skills/kotlin/bill-kotlin-code-review/review-orchestrator.md
+++ b/skills/kotlin/bill-kotlin-code-review/review-orchestrator.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-orchestrator/PLAYBOOK.md

--- a/skills/kotlin/bill-kotlin-code-review/stack-routing.md
+++ b/skills/kotlin/bill-kotlin-code-review/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/skills/php/bill-php-code-review/SKILL.md
+++ b/skills/php/bill-php-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-php-code-review
-description: Use when conducting a thorough PHP PR code review across backend/server projects. Classify changed areas conservatively, select the right specialist agents for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
+description: Use when conducting a thorough PHP PR code review across backend/server projects. Classify changed areas conservatively, select the right specialist review passes for the diff, including real test-value review when tests change. Produces a structured review with risk register and prioritized action items.
 ---
 
 # Adaptive PHP PR Review
@@ -20,7 +20,7 @@ parts of the default workflow below.
 If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
 
 Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass
-relevant project-wide guidance and matching per-skill overrides to all spawned sub-agents.
+relevant project-wide guidance and matching per-skill overrides to every delegated or inline specialist review pass.
 
 ## Setup
 
@@ -33,13 +33,14 @@ Determine the review scope:
 
 Inspect the changed files and repo markers before applying review heuristics.
 
-Before applying review heuristics, read `orchestration/stack-routing/PLAYBOOK.md` and use it as the source of truth
-for PHP stack signals and mixed-stack routing expectations. This skill owns the PHP review depth that applies after PHP
-is already in scope.
+## Additional Resources
 
-Before spawning specialists or formatting the final report, read `orchestration/review-orchestrator/PLAYBOOK.md`. Use
-it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone
-behavior, and review principles used by stack-specific review orchestrators.
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+- For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+
+Before applying review heuristics, read [stack-routing.md](stack-routing.md) and use it as the source of truth for PHP stack signals and mixed-stack routing expectations. This skill owns the PHP review depth that applies after PHP is already in scope.
+
+Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
 
 ---
 
@@ -51,7 +52,7 @@ Use the routing table below to decide which additional specialist skills to run 
 
 ### Routing Table
 
-| Signal in the diff                                                                                                                                                                     | Agent to spawn                                |
+| Signal in the diff                                                                                                                                                                     | Specialist review to run                      |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
 | Layering changes, module ownership, ports/adapters, read gateways, outbox, listeners, projectors, boundary-crossing composition                                                        | `bill-php-code-review-architecture`           |
 | Conditional logic, state transitions, retry-sensitive logic, time/date logic, nullability, behavior drift in refactors                                                                 | `bill-php-code-review-platform-correctness`   |
@@ -63,7 +64,7 @@ Use the routing table below to decide which additional specialist skills to run 
 | Changed tests look suspiciously weak, tautological, or coverage-padding                                                                                                                | `bill-unit-test-value-check`                  |
 | Hot paths, N+1, repeated downstream calls, serialization waste, feed/backfill loops, rendering waste, unbounded buffers or batch work                                                  | `bill-php-code-review-performance`            |
 
-## Dynamic Agent Selection
+## Dynamic Specialist Selection
 
 ### Step 1: Always include the baseline
 
@@ -72,7 +73,7 @@ Always include:
 - `bill-php-code-review-architecture`
 - `bill-php-code-review-platform-correctness`
 
-### Step 2: Analyze the diff and select additional agents
+### Step 2: Analyze the diff and select additional specialist reviews
 
 Inspect each changed file or tightly related change cluster separately and add the agents from the routing table that
 match its signals.
@@ -88,36 +89,37 @@ If different parts of the diff touch different review surfaces:
 
 ### Step 4: Apply minimum
 
-- Minimum 2 agents (architecture + platform-correctness)
+- Minimum 2 specialist reviews (architecture + platform-correctness)
 - If tests changed materially, include `bill-php-code-review-testing`
-- Maximum 7 agents
+- Maximum 7 specialist reviews
 
-### Step 5: Launch in parallel
+### Step 5: Run selected specialist reviews
 
-Spawn all selected sub-agents simultaneously when the agent/runtime supports sub-agents or parallel review passes.
+Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it.
+Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable,
+perform the same specialist review passes inline and say so in the summary.
 
-Each sub-agent gets:
+Each specialist review pass uses:
 
 - The list of changed files
 - Instructions to read its own skill file for the review rubric
 - Relevant project-wide guidance and matching per-skill overrides
-- The shared specialist contract in `orchestration/review-orchestrator/PLAYBOOK.md`
+- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
 
 ---
 
 ## Review Output Format
 
-### 1. Agent Summary
+### 1. Specialist Summary
 
 ```text
 Detected review scope: <working tree / commit range / PR diff / files>
 Signals: transactions, projections, changed tests
-Agents spawned: bill-php-code-review-architecture, bill-php-code-review-platform-correctness, bill-php-code-review-persistence, bill-php-code-review-testing
+Specialist reviews: bill-php-code-review-architecture, bill-php-code-review-platform-correctness, bill-php-code-review-persistence, bill-php-code-review-testing
 Reason: transaction and projection paths changed, plus tests changed materially
 ```
 
-For the shared risk register, action items, verdict format, merge rules, and review principles, follow
-`orchestration/review-orchestrator/PLAYBOOK.md`.
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 
 ## Implementation Mode Notes
 

--- a/skills/php/bill-php-code-review/review-orchestrator.md
+++ b/skills/php/bill-php-code-review/review-orchestrator.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-orchestrator/PLAYBOOK.md

--- a/skills/php/bill-php-code-review/stack-routing.md
+++ b/skills/php/bill-php-code-review/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -19,9 +19,55 @@ BACKEND_KOTLIN_CODE_REVIEW = read("skills/backend-kotlin/bill-backend-kotlin-cod
 KMP_CODE_REVIEW = read("skills/kmp/bill-kmp-code-review/SKILL.md")
 PHP_CODE_REVIEW = read("skills/php/bill-php-code-review/SKILL.md")
 GO_CODE_REVIEW = read("skills/go/bill-go-code-review/SKILL.md")
+STACK_ROUTING_PLAYBOOK = read("orchestration/stack-routing/PLAYBOOK.md")
+REVIEW_ORCHESTRATOR_PLAYBOOK = read("orchestration/review-orchestrator/PLAYBOOK.md")
+PORTABLE_REVIEW_SKILLS = {
+  "bill-kotlin-code-review": KOTLIN_CODE_REVIEW,
+  "bill-backend-kotlin-code-review": BACKEND_KOTLIN_CODE_REVIEW,
+  "bill-kmp-code-review": KMP_CODE_REVIEW,
+  "bill-php-code-review": PHP_CODE_REVIEW,
+  "bill-go-code-review": GO_CODE_REVIEW,
+}
+STACK_ROUTING_SIDECAR_SKILLS = {
+  "bill-code-review": ROOT / "skills" / "base" / "bill-code-review" / "stack-routing.md",
+  "bill-quality-check": ROOT / "skills" / "base" / "bill-quality-check" / "stack-routing.md",
+  "bill-kotlin-code-review": ROOT / "skills" / "kotlin" / "bill-kotlin-code-review" / "stack-routing.md",
+  "bill-backend-kotlin-code-review": ROOT / "skills" / "backend-kotlin" / "bill-backend-kotlin-code-review" / "stack-routing.md",
+  "bill-kmp-code-review": ROOT / "skills" / "kmp" / "bill-kmp-code-review" / "stack-routing.md",
+  "bill-php-code-review": ROOT / "skills" / "php" / "bill-php-code-review" / "stack-routing.md",
+  "bill-go-code-review": ROOT / "skills" / "go" / "bill-go-code-review" / "stack-routing.md",
+}
+REVIEW_ORCHESTRATOR_SIDECAR_SKILLS = {
+  "bill-kotlin-code-review": ROOT / "skills" / "kotlin" / "bill-kotlin-code-review" / "review-orchestrator.md",
+  "bill-backend-kotlin-code-review": ROOT / "skills" / "backend-kotlin" / "bill-backend-kotlin-code-review" / "review-orchestrator.md",
+  "bill-kmp-code-review": ROOT / "skills" / "kmp" / "bill-kmp-code-review" / "review-orchestrator.md",
+  "bill-php-code-review": ROOT / "skills" / "php" / "bill-php-code-review" / "review-orchestrator.md",
+  "bill-go-code-review": ROOT / "skills" / "go" / "bill-go-code-review" / "review-orchestrator.md",
+}
 
 
 class FeatureImplementRoutingContractTest(unittest.TestCase):
+  def test_shared_router_skills_reference_local_stack_routing_sidecars(self) -> None:
+    self.assertIn("[stack-routing.md](stack-routing.md)", CODE_REVIEW)
+    self.assertIn("[stack-routing.md](stack-routing.md)", QUALITY_CHECK)
+    self.assertNotIn(".bill-shared/orchestration/", CODE_REVIEW)
+    self.assertNotIn(".bill-shared/orchestration/", QUALITY_CHECK)
+    self.assertNotIn("orchestration/stack-routing/PLAYBOOK.md", CODE_REVIEW)
+    self.assertNotIn("orchestration/stack-routing/PLAYBOOK.md", QUALITY_CHECK)
+
+    for skill_name, sidecar_path in STACK_ROUTING_SIDECAR_SKILLS.items():
+      with self.subTest(skill=skill_name):
+        self.assertTrue(sidecar_path.is_symlink())
+        self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "stack-routing" / "PLAYBOOK.md")
+
+  def test_reference_playbooks_remain_available_for_maintainers(self) -> None:
+    self.assertIn("maintainer-facing reference snapshot", STACK_ROUTING_PLAYBOOK)
+    self.assertIn("maintainer-facing reference snapshot", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("sibling supporting files", STACK_ROUTING_PLAYBOOK)
+    self.assertIn("sibling supporting files", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("Do not reference this repo-relative path directly", STACK_ROUTING_PLAYBOOK)
+    self.assertIn("Do not reference this repo-relative path directly", REVIEW_ORCHESTRATOR_PLAYBOOK)
+
   def test_feature_implement_invokes_shared_review_and_validation_routers(self) -> None:
     self.assertIn("Run the `bill-code-review` skill", FEATURE_IMPLEMENT)
     self.assertIn("run `bill-quality-check`", FEATURE_IMPLEMENT)
@@ -84,7 +130,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       QUALITY_CHECK,
     )
     self.assertIn(
-      "read `orchestration/stack-routing/PLAYBOOK.md`",
+      "[stack-routing.md](stack-routing.md)",
       PHP_CODE_REVIEW,
     )
 
@@ -98,7 +144,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       QUALITY_CHECK,
     )
     self.assertIn(
-      "read `orchestration/stack-routing/PLAYBOOK.md`",
+      "[stack-routing.md](stack-routing.md)",
       GO_CODE_REVIEW,
     )
 
@@ -125,6 +171,34 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       "- If backend/server signals clearly dominate and this skill is invoked standalone, delegate to `bill-backend-kotlin-code-review` and stop instead of pretending this baseline layer is the full backend review.",
       KOTLIN_CODE_REVIEW,
     )
+
+  def test_stack_review_skills_use_portable_specialist_review_wording(self) -> None:
+    forbidden_phrases = (
+      "`task`",
+      "spawn_agent",
+      "sub-agent",
+      "sub-agents",
+      "Agent to spawn",
+      "Agents spawned",
+    )
+
+    for skill_name, skill_text in PORTABLE_REVIEW_SKILLS.items():
+      with self.subTest(skill=skill_name):
+        self.assertIn("specialist review", skill_text)
+        self.assertIn("delegation mechanism", skill_text)
+        self.assertIn("perform the same", skill_text)
+        self.assertIn("inline and say so in the summary", skill_text)
+        self.assertIn("[review-orchestrator.md](review-orchestrator.md)", skill_text)
+        self.assertNotIn(".bill-shared/orchestration/", skill_text)
+        self.assertNotIn("orchestration/stack-routing/PLAYBOOK.md", skill_text)
+        self.assertNotIn("orchestration/review-orchestrator/PLAYBOOK.md", skill_text)
+        for forbidden_phrase in forbidden_phrases:
+          self.assertNotIn(forbidden_phrase, skill_text)
+
+    for skill_name, sidecar_path in REVIEW_ORCHESTRATOR_SIDECAR_SKILLS.items():
+      with self.subTest(skill=skill_name):
+        self.assertTrue(sidecar_path.is_symlink())
+        self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "review-orchestrator" / "PLAYBOOK.md")
 
 
 if __name__ == "__main__":

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -56,6 +56,9 @@ class InstallScriptTest(unittest.TestCase):
 
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS)
+      self.assertFalse((Path(temp_home) / ".copilot" / "skills" / ".bill-shared").exists())
+      self.assertTrue((Path(temp_home) / ".copilot" / "skills" / "bill-code-review" / "stack-routing.md").exists())
+      self.assertTrue((Path(temp_home) / ".copilot" / "skills" / "bill-php-code-review" / "review-orchestrator.md").exists())
 
   def test_installs_base_and_selected_go_platform_only(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
@@ -151,7 +154,7 @@ class InstallScriptTest(unittest.TestCase):
     install_dir = Path(temp_home) / ".copilot" / "skills"
     if not install_dir.exists():
       return set()
-    return {path.name for path in install_dir.iterdir()}
+    return {path.name for path in install_dir.iterdir() if path.name.startswith("bill-")}
 
   def prepare_agent_homes(self, temp_home: str) -> None:
     for relative_dir in (

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -28,6 +28,7 @@ class UninstallScriptTest(unittest.TestCase):
       self.assertIn("Removed symlinks:", uninstall.stdout)
       self.assertFalse((Path(temp_home) / ".copilot" / "skills" / "bill-code-review").exists())
       self.assertFalse((Path(temp_home) / ".claude" / "commands" / "bill-code-review").exists())
+      self.assertFalse((Path(temp_home) / ".copilot" / "skills" / ".bill-shared").exists())
 
   def test_uninstall_removes_legacy_skill_symlinks_and_is_idempotent(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -95,6 +95,38 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       self.assertEqual(result.returncode, 1, result.stdout)
       self.assertIn("package 'laravel' is not allowed", result.stdout)
 
+  def test_rejects_runtime_playbook_references(self) -> None:
+    with self.fixture_repo(
+      [
+        ("base", "bill-code-review"),
+      ],
+      skill_contents={
+        "bill-code-review": self.skill_with_runtime_playbook_reference("bill-code-review"),
+      },
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn("must reference skill-local supporting files", result.stdout)
+
+  def test_rejects_non_portable_review_orchestration_wording(self) -> None:
+    with self.fixture_repo(
+      [
+        ("base", "bill-code-review"),
+        ("php", "bill-php-code-review"),
+      ],
+      skill_contents={
+        "bill-php-code-review": self.portable_review_fixture_with_forbidden_wording(
+          "bill-php-code-review"
+        ),
+      },
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn("must not hardcode the `task` tool", result.stdout)
+      self.assertIn("must not describe review delegation as sub-agents", result.stdout)
+      self.assertIn("must use portable routing-table wording", result.stdout)
+      self.assertIn("must use portable summary wording", result.stdout)
+
   def run_validator(self, repo_root: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
       ["python3", str(VALIDATOR_PATH), str(repo_root)],
@@ -104,16 +136,28 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
     )
 
   @contextmanager
-  def fixture_repo(self, skills: list[tuple[str, str]]):
+  def fixture_repo(
+    self,
+    skills: list[tuple[str, str]],
+    *,
+    skill_contents: dict[str, str] | None = None,
+  ):
     with tempfile.TemporaryDirectory() as temp_dir:
       repo_root = Path(temp_dir)
       self.write_readme(repo_root, [skill_name for _, skill_name in skills])
       self.write_skill_overrides_example(repo_root, skills[0][1])
       self.write_plugin_manifest(repo_root)
       self.write_stack_routing_playbook(repo_root)
+      self.write_review_orchestrator_playbook(repo_root)
 
       for package_name, skill_name in skills:
-        self.write_skill(repo_root, package_name, skill_name)
+        self.write_skill(
+          repo_root,
+          package_name,
+          skill_name,
+          content=(skill_contents or {}).get(skill_name),
+        )
+        self.write_supporting_files(repo_root, package_name, skill_name)
 
       yield repo_root
 
@@ -171,21 +215,67 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
         """\
         ---
         name: stack-routing
-        description: Fixture routing playbook used for validator end-to-end coverage.
+        description: Maintainer-facing reference snapshot for shared stack routing behavior.
         ---
 
-        # Fixture Stack Routing
+        # Shared Stack Routing Snapshot
 
-        This fixture playbook exists so the validator can confirm orchestration files are present.
+        This maintainer-facing reference snapshot exists to document the shared routing contract.
+        It is not a runtime dependency for installed skills.
         """
       ),
       encoding="utf-8",
     )
 
-  def write_skill(self, repo_root: Path, package_name: str, skill_name: str) -> None:
+  def write_review_orchestrator_playbook(self, repo_root: Path) -> None:
+    path = repo_root / "orchestration" / "review-orchestrator" / "PLAYBOOK.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+      textwrap.dedent(
+        """\
+        ---
+        name: review-orchestrator
+        description: Maintainer-facing reference snapshot for shared review orchestration behavior.
+        ---
+
+        # Shared Review Orchestrator Snapshot
+
+        This maintainer-facing reference snapshot exists to document the shared review contract.
+        It is not a runtime dependency for installed skills.
+        """
+      ),
+      encoding="utf-8",
+    )
+
+  def write_skill(
+    self,
+    repo_root: Path,
+    package_name: str,
+    skill_name: str,
+    *,
+    content: str | None = None,
+  ) -> None:
     path = repo_root / "skills" / package_name / skill_name / "SKILL.md"
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(self.skill_markdown(skill_name), encoding="utf-8")
+    path.write_text(content or self.skill_markdown(skill_name), encoding="utf-8")
+
+  def write_supporting_files(self, repo_root: Path, package_name: str, skill_name: str) -> None:
+    support_map = {
+      "bill-code-review": ("stack-routing.md",),
+      "bill-quality-check": ("stack-routing.md",),
+      "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
+      "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
+      "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md"),
+      "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md"),
+      "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md"),
+    }
+    targets = {
+      "stack-routing.md": repo_root / "orchestration" / "stack-routing" / "PLAYBOOK.md",
+      "review-orchestrator.md": repo_root / "orchestration" / "review-orchestrator" / "PLAYBOOK.md",
+    }
+    skill_dir = repo_root / "skills" / package_name / skill_name
+    for file_name in support_map.get(skill_name, ()):
+      (skill_dir / file_name).symlink_to(targets[file_name])
 
   def skill_markdown(self, skill_name: str) -> str:
     return textwrap.dedent(
@@ -202,6 +292,48 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       If `.agents/skill-overrides.md` exists in the project root and contains a `## {skill_name}` section, read that section and apply it as the highest-priority instruction for this skill.
 
       Use this fixture skill for validator end-to-end coverage.
+      """
+    )
+
+  def skill_with_runtime_playbook_reference(self, skill_name: str) -> str:
+    return textwrap.dedent(
+      f"""\
+      ---
+      name: {skill_name}
+      description: Fixture review skill used for validator portability coverage.
+      ---
+
+      # {skill_name}
+
+      ## Project Overrides
+
+      If `.agents/skill-overrides.md` exists in the project root and contains a `## {skill_name}` section, read that section and apply it as the highest-priority instruction for this skill.
+
+      Read `.bill-shared/orchestration/stack-routing/PLAYBOOK.md` before routing.
+      """
+    )
+
+  def portable_review_fixture_with_forbidden_wording(self, skill_name: str) -> str:
+    return textwrap.dedent(
+      f"""\
+      ---
+      name: {skill_name}
+      description: Fixture review skill used for validator portability coverage.
+      ---
+
+      # {skill_name}
+
+      ## Project Overrides
+
+      If `.agents/skill-overrides.md` exists in the project root and contains a `## {skill_name}` section, read that section and apply it as the highest-priority instruction for this skill.
+
+      | Signal | Agent to spawn |
+      | --- | --- |
+      | fixture | `bill-php-code-review-security` |
+
+      Spawn all selected sub-agents simultaneously using the `task` tool.
+
+      Agents spawned: bill-php-code-review-security
       """
     )
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -84,6 +84,7 @@ build_legacy_skill_names() {
   local old_name
 
   LEGACY_SKILL_NAMES=()
+  add_legacy_name ".bill-shared"
 
   for skill in "${SKILL_NAMES[@]}"; do
     if [[ "$skill" == bill-* ]]; then


### PR DESCRIPTION
# Summary

Switch shared routing and review-orchestration contracts from inlined skill text to skill-local sidecar files so installed skills can reuse the same snapshots without repo-relative paths. This keeps runtime skills local-file-based, preserves maintainer snapshots in `orchestration/`, and validates the behavior across Copilot, Claude, GLM, and Codex installs.

- add `stack-routing.md` and `review-orchestrator.md` sidecars beside the relevant runtime-facing skills
- update skill docs, validator rules, tests, installer expectations, and maintainer snapshots to enforce the sidecar model
- verify runtime behavior with real `bill-code-review` runs against `ZeroAccount`, including post-install and all-agent checks

## Feature Flags

N/A

# How Has This Been Tested?

Ran repo validation plus installation and runtime verification for the sidecar workflow.

1. Run `python3 -m unittest discover -s tests`
2. Run `python3 scripts/validate_agent_configs.py`
3. Run `npx --yes agnix --strict .`
4. Run `./install.sh --mode safe` for Copilot with all platforms, then `./install.sh --mode override`, then `./install.sh --mode safe` for all agents
5. Verify `stack-routing.md` and `review-orchestrator.md` resolve from Copilot, Claude, GLM, and Codex install paths
6. Run `bill-code-review` against the latest `ZeroAccount` commit and confirm KMP routing, sidecar access, and specialist execution
7. Expected result: installs succeed, sidecar files resolve through installed skill paths, validation stays green, and the review flow reports the sidecars were used during routing and specialist execution
