### PR TITLE
feat: simplify installer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,10 @@ chmod +x install.sh
 ./install.sh --mode safe
 ```
 
-The installer first asks which agent targets to install to. You can choose one or more entries, including `all`, and if you choose more than one it then asks which selected agent should be primary:
+The installer first asks which agent targets to install to. You can choose one or more entries, including `all`:
 
 ```text
 all
-claude
 ```
 
 It then shows the available platform packages and asks which ones to install. Base skills in `skills/base/` are always installed; platform packages are installed only when selected.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The installer links all selected agents to the same repo so updates stay in sync
 git clone <this-repo> ~/Development/skill-bill
 cd ~/Development/skill-bill
 chmod +x install.sh
-./install.sh --mode safe
+./install.sh
 ```
 
 The installer first asks which agent targets to install to. You can choose one or more entries, including `all`:
@@ -130,15 +130,11 @@ Go
 all
 ```
 
-Re-running the installer in `safe` mode is add-only for valid platform packages, so you can install more platforms later without removing ones that were already linked.
+Each installer run replaces the existing Skill Bill links and reinstalls only the agent and platform selections from that run.
 
 Shared routing and review contracts are documented in `orchestration/` and exposed to runtimes through sibling supporting files inside each skill directory. That keeps references local to the installed skill instead of relying on repo-relative playbook paths.
 
-Modes:
-
-- `safe` — replace symlinks, migrate plugin-managed legacy installs, skip non-symlink conflicts
-- `override` — run `./uninstall.sh` first, then reinstall only the selected platforms
-- `interactive` — prompt before replacing non-symlink conflicts
+The installer always removes existing Skill Bill links before reinstalling the selected agents and platforms.
 
 If you only use Claude Code, you can also install this repo as a Claude plugin:
 
@@ -280,7 +276,7 @@ Manual path:
 
 1. create `skills/<package>/<skill-name>/SKILL.md`
 2. follow the naming rules above
-3. run `./install.sh --mode safe`
+3. run `./install.sh`
 4. update docs and validation if you intentionally add a new package or naming shape
 
 ## License

--- a/install.sh
+++ b/install.sh
@@ -300,32 +300,6 @@ format_agent_list() {
   printf '%s' "$result"
 }
 
-set_primary_agent() {
-  local target="$1"
-  local reordered_names=()
-  local reordered_paths=()
-  local idx
-
-  for idx in "${!AGENT_NAMES[@]}"; do
-    if [[ "${AGENT_NAMES[$idx]}" == "$target" ]]; then
-      reordered_names+=("${AGENT_NAMES[$idx]}")
-      reordered_paths+=("${AGENT_PATHS[$idx]}")
-    fi
-  done
-
-  for idx in "${!AGENT_NAMES[@]}"; do
-    if [[ "${AGENT_NAMES[$idx]}" != "$target" ]]; then
-      reordered_names+=("${AGENT_NAMES[$idx]}")
-      reordered_paths+=("${AGENT_PATHS[$idx]}")
-    fi
-  done
-
-  AGENT_NAMES=("${reordered_names[@]}")
-  AGENT_PATHS=("${reordered_paths[@]}")
-  PRIMARY="${AGENT_NAMES[0]}"
-  PRIMARY_DIR="${AGENT_PATHS[0]}"
-}
-
 prompt_for_agent_selection() {
   local input
   local raw_tokens=()
@@ -386,55 +360,6 @@ prompt_for_agent_selection() {
     fi
 
     return 0
-  done
-}
-
-prompt_for_primary_agent() {
-  local input
-  local normalized
-  local idx
-
-  if [[ ${#AGENT_NAMES[@]} -eq 1 ]]; then
-    PRIMARY="${AGENT_NAMES[0]}"
-    PRIMARY_DIR="${AGENT_PATHS[0]}"
-    return 0
-  fi
-
-  while true; do
-    echo ""
-    info "Selected agents: $(format_agent_list "${AGENT_NAMES[@]}")"
-    info "Choose the primary agent:"
-    for idx in "${!AGENT_NAMES[@]}"; do
-      printf "  %s. %s\n" "$((idx + 1))" "${AGENT_NAMES[$idx]}"
-    done
-    printf "${CYAN}▸${NC} Enter primary agent: "
-    read -r input
-    input="$(trim_string "$input")"
-
-    if [[ -z "$input" ]]; then
-      warn "No primary agent provided. Choose one of the selected agents."
-      continue
-    fi
-
-    if [[ "$input" =~ ^[0-9]+$ ]]; then
-      idx=$((input - 1))
-      if (( idx >= 0 && idx < ${#AGENT_NAMES[@]} )); then
-        set_primary_agent "${AGENT_NAMES[$idx]}"
-        return 0
-      fi
-      warn "Unknown primary selection: $input"
-      continue
-    fi
-
-    normalized="$(normalize_agent_token "$input")"
-    for idx in "${!AGENT_NAMES[@]}"; do
-      if [[ "$normalized" == "${AGENT_NAMES[$idx]}" ]]; then
-        set_primary_agent "${AGENT_NAMES[$idx]}"
-        return 0
-      fi
-    done
-
-    warn "Unknown primary selection: $input"
   done
 }
 
@@ -763,13 +688,11 @@ elif [[ "$MODE" == override ]]; then
   info "Override mode runs the uninstaller first, then reinstalls only the selected platforms."
 fi
 prompt_for_agent_selection
-prompt_for_primary_agent
 prompt_for_platform_selection
 build_install_skill_names
 
 echo ""
 info "Plugin:  $PLUGIN_DIR"
-info "Primary: $PRIMARY ($PRIMARY_DIR)"
 info "Agents selected: $(format_agent_list "${AGENT_NAMES[@]}")"
 info "Skills found: ${#SKILL_NAMES[@]}"
 info "Skills selected: ${#INSTALL_SKILL_NAMES[@]} (base + $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}"))"
@@ -781,35 +704,19 @@ if [[ "$MODE" == override ]]; then
   echo ""
 fi
 
-mkdir -p "$PRIMARY_DIR"
-info "Installing to primary ($PRIMARY): $PRIMARY_DIR"
-if [[ "$MODE" != override ]]; then
-  remove_legacy_skill_paths "$PRIMARY_DIR"
-fi
-for idx in "${!INSTALL_SKILL_NAMES[@]}"; do
-  skill="${INSTALL_SKILL_NAMES[$idx]}"
-  install_skill_link "$PRIMARY_DIR/$skill" "${INSTALL_SKILL_PATHS[$idx]}" "$skill → plugin"
-done
-echo ""
-
 for i in "${!AGENT_NAMES[@]}"; do
-  [[ "$i" -eq 0 ]] && continue
   agent="${AGENT_NAMES[$i]}"
   agent_dir="${AGENT_PATHS[$i]}"
 
-  if ! is_agent_available "$agent"; then
-    warn "Skipping $agent (not installed)"
-    continue
-  fi
-
   mkdir -p "$agent_dir"
-  info "Symlinking $agent: $agent_dir → $PRIMARY_DIR"
+  info "Installing to $agent: $agent_dir"
   if [[ "$MODE" != override ]]; then
     remove_legacy_skill_paths "$agent_dir"
   fi
 
-  for skill in "${INSTALL_SKILL_NAMES[@]}"; do
-    install_skill_link "$agent_dir/$skill" "$PRIMARY_DIR/$skill" "$skill"
+  for idx in "${!INSTALL_SKILL_NAMES[@]}"; do
+    skill="${INSTALL_SKILL_NAMES[$idx]}"
+    install_skill_link "$agent_dir/$skill" "${INSTALL_SKILL_PATHS[$idx]}" "$skill → plugin"
   done
   echo ""
 done
@@ -817,15 +724,11 @@ done
 printf "${GREEN}━━━ Installation complete ━━━${NC}\n"
 echo ""
 info "Source of truth: $PLUGIN_DIR/skills/"
-info "Primary agent:   $PRIMARY → $PRIMARY_DIR"
 info "Platforms:       $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}")"
 for i in "${!AGENT_NAMES[@]}"; do
-  [[ "$i" -eq 0 ]] && continue
   agent="${AGENT_NAMES[$i]}"
   agent_dir="${AGENT_PATHS[$i]}"
-  if is_agent_available "$agent"; then
-    info "Linked agent:    $agent → $agent_dir (via $PRIMARY)"
-  fi
+  info "Installed agent: $agent → $agent_dir"
 done
 
 if [[ ${#SKIPPED_TARGETS[@]} -gt 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$PLUGIN_DIR/skills"
-MODE="safe"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -18,23 +17,13 @@ err()   { printf "${RED}✗${NC} %s\n" "$1"; }
 
 usage() {
   cat <<USAGE
-Usage: ./install.sh [--mode safe|override|interactive]
-
-Modes:
-  safe         Replace existing symlinks, migrate legacy plugin installs, and skip non-symlink conflicts. (default)
-  override     Run uninstall.sh first, then reinstall only the selected platforms.
-  interactive  Prompt before replacing non-symlink conflicts.
+Usage: ./install.sh
 USAGE
 }
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --mode)
-        [[ $# -ge 2 ]] || { err "Missing value for --mode"; usage; exit 1; }
-        MODE="$2"
-        shift 2
-        ;;
       --help|-h)
         usage
         exit 0
@@ -46,15 +35,6 @@ parse_args() {
         ;;
     esac
   done
-
-  case "$MODE" in
-    safe|override|interactive) ;;
-    *)
-      err "Invalid mode: $MODE"
-      usage
-      exit 1
-      ;;
-  esac
 }
 
 get_agent_path() {
@@ -70,19 +50,6 @@ get_agent_path() {
       fi
       ;;
     *)       return 1 ;;
-  esac
-}
-
-is_agent_available() {
-  case "$1" in
-    codex)
-      [[ -d "$HOME/.codex" || -d "$HOME/.agents" ]]
-      ;;
-    *)
-      local agent_dir
-      agent_dir="$(get_agent_path "$1")"
-      [[ -d "$(dirname "$agent_dir")" ]]
-      ;;
   esac
 }
 
@@ -117,67 +84,16 @@ declare -a INSTALL_SKILL_PATHS=()
 declare -a PLATFORM_PACKAGES=()
 declare -a SELECTED_PLATFORM_PACKAGES=()
 declare -a LEGACY_SKILL_NAMES=()
-declare -a SKIPPED_TARGETS=()
-
-auto_replace_allowed() {
-  local target="$1"
-  [[ -L "$target" ]]
-}
-
-confirm_replace() {
-  local target="$1"
-  local reason="$2"
-  local answer
-
-  while true; do
-    printf "${CYAN}▸${NC} Replace '%s' (%s)? [y/N]: " "$target" "$reason"
-    read -r answer
-    case "$answer" in
-      y|Y|yes|YES) return 0 ;;
-      n|N|no|NO|'') return 1 ;;
-      *) warn "Please answer y or n." ;;
-    esac
-  done
-}
-
-should_replace_target() {
-  local target="$1"
-  local reason="$2"
-
-  if auto_replace_allowed "$target"; then
-    return 0
-  fi
-
-  case "$MODE" in
-    override)
-      return 0
-      ;;
-    interactive)
-      confirm_replace "$target" "$reason"
-      return $?
-      ;;
-    safe)
-      warn "Skipping '$target' (${reason}) because it is not a symlink. Re-run with --mode override or --mode interactive to replace it."
-      return 1
-      ;;
-  esac
-}
 
 remove_if_allowed() {
   local target="$1"
-  local reason="$2"
 
   if [[ ! -e "$target" && ! -L "$target" ]]; then
     return 0
   fi
 
-  if should_replace_target "$target" "$reason"; then
-    rm -rf "$target"
-    return 0
-  fi
-
-  SKIPPED_TARGETS+=("$target")
-  return 1
+  rm -rf "$target"
+  return 0
 }
 
 lookup_renamed_skill() {
@@ -642,7 +558,7 @@ remove_legacy_skill_paths() {
       fi
     fi
 
-    if remove_if_allowed "$legacy_target" "legacy install path"; then
+    if remove_if_allowed "$legacy_target"; then
       if [[ -e "$legacy_target" || -L "$legacy_target" ]]; then
         :
       else
@@ -662,11 +578,8 @@ install_skill_link() {
   local label="$3"
 
   if [[ -e "$target" || -L "$target" ]]; then
-    if ! remove_if_allowed "$target" "existing install target"; then
-      warn "  skipped $label"
-      return
+      remove_if_allowed "$target"
     fi
-  fi
 
   ln -s "$source" "$target"
   ok "  $label"
@@ -681,12 +594,7 @@ echo ""
 printf "${CYAN}━━━ Skill Bill Installer ━━━${NC}\n"
 echo ""
 info "Supported agents: copilot, claude, glm, codex"
-info "Install mode: $MODE"
-if [[ "$MODE" == safe ]]; then
-  info "Safe mode replaces symlinks, migrates legacy plugin installs, and skips local directory/file conflicts."
-elif [[ "$MODE" == override ]]; then
-  info "Override mode runs the uninstaller first, then reinstalls only the selected platforms."
-fi
+info "Install behavior: replace existing Skill Bill installs and reinstall the selected platforms."
 prompt_for_agent_selection
 prompt_for_platform_selection
 build_install_skill_names
@@ -698,11 +606,9 @@ info "Skills found: ${#SKILL_NAMES[@]}"
 info "Skills selected: ${#INSTALL_SKILL_NAMES[@]} (base + $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}"))"
 echo ""
 
-if [[ "$MODE" == override ]]; then
-  info "Override mode removes existing Skill Bill symlinks before reinstalling the selected platforms."
-  bash "$PLUGIN_DIR/uninstall.sh"
-  echo ""
-fi
+info "Removing existing Skill Bill symlinks before reinstalling the selected platforms."
+bash "$PLUGIN_DIR/uninstall.sh"
+echo ""
 
 for i in "${!AGENT_NAMES[@]}"; do
   agent="${AGENT_NAMES[$i]}"
@@ -710,9 +616,7 @@ for i in "${!AGENT_NAMES[@]}"; do
 
   mkdir -p "$agent_dir"
   info "Installing to $agent: $agent_dir"
-  if [[ "$MODE" != override ]]; then
-    remove_legacy_skill_paths "$agent_dir"
-  fi
+  remove_legacy_skill_paths "$agent_dir"
 
   for idx in "${!INSTALL_SKILL_NAMES[@]}"; do
     skill="${INSTALL_SKILL_NAMES[$idx]}"
@@ -731,15 +635,7 @@ for i in "${!AGENT_NAMES[@]}"; do
   info "Installed agent: $agent → $agent_dir"
 done
 
-if [[ ${#SKIPPED_TARGETS[@]} -gt 0 ]]; then
-  echo ""
-  warn "Skipped ${#SKIPPED_TARGETS[@]} existing path(s):"
-  for skipped in "${SKIPPED_TARGETS[@]}"; do
-    warn "  $skipped"
-  done
-fi
-
 echo ""
 info "Edit skills in: $PLUGIN_DIR/skills/"
-info "Run './install.sh --mode safe' again to add missing platform packages."
+info "Run './install.sh' again to reinstall with a different agent or platform selection."
 echo ""

--- a/skills/base/bill-new-skill-all-agents/SKILL.md
+++ b/skills/base/bill-new-skill-all-agents/SKILL.md
@@ -17,7 +17,7 @@ When asked to create a new skill, follow this workflow:
    - Skill name
    - One-line description
    - Full skill instructions/body
-   - Which agents to install to (comma-separated, primary first)
+   - Which agents to install to (comma-separated)
    - Whether the skill is base across stacks or specific to a stack/framework
 
 1a. Validate the proposed name against the repo naming strategy:
@@ -53,9 +53,8 @@ When asked to create a new skill, follow this workflow:
    - `$HOME/Development/skill-bill/skills/{package}/{slug}/SKILL.md`
    - This is the single source of truth — all agents point here via symlinks
 
-5. Create symlink chain (primary → canonical, secondary agents → primary):
-   a. Primary: `ln -s $HOME/Development/skill-bill/skills/{package}/{slug} {primary_path}/{slug}`
-   b. Each secondary: `ln -s {primary_path}/{slug} {secondary_path}/{slug}`
+5. Create direct symlinks from each selected agent to the canonical skill directory:
+   - `ln -s $HOME/Development/skill-bill/skills/{package}/{slug} {agent_path}/{slug}`
 
 6. Rules:
     - Never duplicate file content across agents — always use symlinks
@@ -67,6 +66,5 @@ When asked to create a new skill, follow this workflow:
 7. Return a short summary:
    - skill slug
    - canonical file path
-   - primary agent and symlink
-   - secondary symlinks created
+   - installed agent symlinks created
    - skipped agents

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -30,14 +30,15 @@ GO_SKILLS = skill_names("go")
 class InstallScriptTest(unittest.TestCase):
   maxDiff = None
 
-  def test_accepts_separate_agent_selection_and_primary_prompt(self) -> None:
+  def test_accepts_multi_agent_selection_without_primary_prompt(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       self.prepare_agent_homes(temp_home)
-      result = self.run_installer(temp_home, "all\nclaude\nPHP\n")
+      result = self.run_installer(temp_home, "all\nPHP\n")
       self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
       self.assertIn("Available agents:", result.stdout)
-      self.assertIn("Choose the primary agent:", result.stdout)
-      self.assertIn("Primary: claude", result.stdout)
+      self.assertNotIn("Choose the primary agent:", result.stdout)
+      self.assertNotIn("Primary:", result.stdout)
+      self.assertNotIn("via copilot", result.stdout)
 
       for relative_path in (
         ".copilot/skills/bill-code-review",
@@ -45,7 +46,9 @@ class InstallScriptTest(unittest.TestCase):
         ".glm/commands/bill-code-review",
         ".codex/skills/bill-code-review",
       ):
-        self.assertTrue((Path(temp_home) / relative_path).is_symlink(), relative_path)
+        path = Path(temp_home) / relative_path
+        self.assertTrue(path.is_symlink(), relative_path)
+        self.assertEqual(path.resolve(), ROOT / "skills" / "base" / "bill-code-review")
 
   def test_installs_base_and_selected_platform_only(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
@@ -59,6 +62,7 @@ class InstallScriptTest(unittest.TestCase):
       self.assertFalse((Path(temp_home) / ".copilot" / "skills" / ".bill-shared").exists())
       self.assertTrue((Path(temp_home) / ".copilot" / "skills" / "bill-code-review" / "stack-routing.md").exists())
       self.assertTrue((Path(temp_home) / ".copilot" / "skills" / "bill-php-code-review" / "review-orchestrator.md").exists())
+      self.assertIn("Installed agent: copilot", result.stdout)
 
   def test_installs_base_and_selected_go_platform_only(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -106,7 +107,7 @@ class InstallScriptTest(unittest.TestCase):
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS | BACKEND_KOTLIN_SKILLS)
 
-  def test_safe_rerun_adds_platform_without_pruning_existing_valid_one(self) -> None:
+  def test_rerun_reinstalls_only_selected_platforms(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       first = self.run_installer(temp_home, "copilot\nPHP\n")
       self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
@@ -114,21 +115,6 @@ class InstallScriptTest(unittest.TestCase):
       second = self.run_installer(
         temp_home,
         "copilot\nKotlin backend\n",
-      )
-      self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
-
-      installed = self.installed_skills(temp_home)
-      self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS | BACKEND_KOTLIN_SKILLS)
-
-  def test_override_rerun_reinstalls_only_selected_platforms_after_uninstall(self) -> None:
-    with tempfile.TemporaryDirectory() as temp_home:
-      first = self.run_installer(temp_home, "copilot\nPHP\n")
-      self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
-
-      second = self.run_installer(
-        temp_home,
-        "copilot\nKotlin backend\n",
-        mode="override",
       )
       self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
       self.assertIn("Skill Bill Uninstaller", second.stdout)
@@ -136,16 +122,33 @@ class InstallScriptTest(unittest.TestCase):
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | BACKEND_KOTLIN_SKILLS)
 
+  def test_rerun_replaces_existing_skill_directory_and_restores_sidecars(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      first = self.run_installer(temp_home, "copilot\nPHP\n")
+      self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+
+      installed_skill = Path(temp_home) / ".copilot" / "skills" / "bill-code-review"
+      self.assertTrue(installed_skill.is_symlink())
+      installed_skill.unlink()
+      shutil.copytree(ROOT / "skills" / "base" / "bill-code-review", installed_skill, symlinks=False)
+      (installed_skill / "stack-routing.md").write_text("stale sidecar", encoding="utf-8")
+
+      second = self.run_installer(temp_home, "copilot\nPHP\n")
+      self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+
+      self.assertTrue(installed_skill.is_symlink())
+      self.assertEqual(installed_skill.resolve(), ROOT / "skills" / "base" / "bill-code-review")
+      self.assertTrue((installed_skill / "stack-routing.md").exists())
+
   def run_installer(
     self,
     temp_home: str,
     user_input: str,
-    mode: str = "safe",
   ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["HOME"] = temp_home
     return subprocess.run(
-      ["bash", str(INSTALL_SCRIPT), "--mode", mode],
+      ["bash", str(INSTALL_SCRIPT)],
       cwd=ROOT,
       input=user_input,
       capture_output=True,


### PR DESCRIPTION
# Summary

Simplify the installer so it always behaves like the old override mode and remove the no-longer-useful primary-agent concept.

- remove the primary-agent prompt and reporting
- make each selected agent link directly to the repository skill directories
- remove install modes and make `./install.sh` always uninstall/reinstall the selected links
- add regression coverage that verifies reruns restore sidecar playbook symlinks correctly

## Feature Flags

N/A

# How Has This Been Tested?

1. Run `python3 -m unittest discover -s tests`
2. Run `python3 scripts/validate_agent_configs.py`
3. Run `npx --yes agnix --strict .`
4. Run `./install.sh` and choose target agents/platforms
5. Run `./install.sh` again with a different selection and confirm only the latest selection remains installed
6. Expected result: installer removes prior Skill Bill links, reinstalls the selected agent/platform set directly from the repo, and restores sidecar symlinks on rerun
