### PR TITLE
feat: require delegated subagent code reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ The repository uses a strict three-layer model:
 
 - `skills/base/` — canonical, user-facing capabilities
 - `skills/<platform>/` — platform-specific overrides and approved platform-owned subskills
-- `orchestration/` — maintainer-facing reference snapshots for shared routing and review contracts; not a runtime dependency for installed skills
+- `orchestration/` — maintainer-facing reference snapshots for shared routing, review, and delegation contracts; not a runtime dependency for installed skills
 
 ## Naming rules
 
@@ -57,8 +57,8 @@ Use only these two platform naming patterns unless the taxonomy itself is intent
 - Add platform capabilities only as base-capability overrides or approved `code-review-<area>` specializations.
 - Add a new package only when behavior is materially different from existing packages.
 - Runtime-facing skills may reference sibling supporting files inside the same skill directory.
-- Use sibling supporting files for runtime-shared contracts instead of repo-relative or install-root-relative playbook paths.
-- Keep `orchestration/` snapshots aligned with the sibling supporting-file contracts when shared routing or review behavior changes.
+- Use sibling supporting files for runtime-shared routing, review, and delegation contracts instead of repo-relative or install-root-relative playbook paths.
+- Keep `orchestration/` snapshots aligned with the sibling supporting-file contracts when shared routing, review, or delegation behavior changes.
 - Preserve stable base entry points even when a platform needs more depth behind the router.
 - Keep README skill counts and catalog entries accurate whenever skills change.
 - Update `install.sh` migration rules in the same change when renaming stack-bound skills.
@@ -90,6 +90,7 @@ When adding a new platform or language package:
 4. Update maintainer reference snapshots when shared routing or review behavior changes:
    - `orchestration/stack-routing/PLAYBOOK.md`
    - `orchestration/review-orchestrator/PLAYBOOK.md`
+   - `orchestration/review-delegation/PLAYBOOK.md`
 5. Update base routers if needed:
    - `skills/base/bill-code-review/SKILL.md`
    - `skills/base/bill-quality-check/SKILL.md`

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ The repo is organized around a strict three-layer model:
 
 - `skills/base/` — canonical, user-facing capabilities such as `bill-code-review`, `bill-quality-check`, and `bill-feature-implement`
 - `skills/<platform>/` — platform-specific overrides and approved subskills
-- `orchestration/` — maintainer-facing reference snapshots for shared routing and review contracts
+- `orchestration/` — maintainer-facing reference snapshots for shared routing, review, and delegation contracts
 
 Think of it as markdown with inheritance:
 
 - base skills define the stable contracts
 - platform skills specialize them
-- orchestration snapshots document the shared logic that runtime-facing skills can reference via sibling supporting files in the same skill directory
+- orchestration snapshots document the shared routing, review, and delegation logic that runtime-facing skills can reference via sibling supporting files in the same skill directory
 
 Current platform packages:
 
@@ -132,7 +132,7 @@ all
 
 Each installer run replaces the existing Skill Bill links and reinstalls only the agent and platform selections from that run.
 
-Shared routing and review contracts are documented in `orchestration/` and exposed to runtimes through sibling supporting files inside each skill directory. That keeps references local to the installed skill instead of relying on repo-relative playbook paths.
+Shared routing, review, and delegation contracts are documented in `orchestration/` and exposed to runtimes through sibling supporting files inside each skill directory. That keeps references local to the installed skill instead of relying on repo-relative playbook paths.
 
 The installer always removes existing Skill Bill links before reinstalling the selected agents and platforms.
 

--- a/orchestration/review-delegation/PLAYBOOK.md
+++ b/orchestration/review-delegation/PLAYBOOK.md
@@ -1,0 +1,51 @@
+---
+name: review-delegation
+description: Maintainer-facing reference snapshot for agent-specific delegated code-review execution.
+---
+
+# Shared Review Delegation Snapshot
+
+This maintainer-facing reference snapshot documents the agent-specific delegation contract used when authoring or updating installable code-review skills.
+
+Runtime-facing skills consume this contract through sibling supporting files such as `review-delegation.md` inside each skill directory. Do not reference this repo-relative path directly from installable skills.
+
+## Shared Delegation Rules
+
+- Delegated review layers and specialist review passes must run as separate subagents on supported runtimes; do not collapse them into a single inline review.
+- Launch one delegated worker per routed stack-specific review skill or selected specialist review pass unless the current agent-specific section explicitly says otherwise.
+- Every delegated worker must receive the exact review scope, changed files or diff source, relevant project guidance, the delegated skill file path, and the shared contract from `review-orchestrator.md`.
+- Wait for all delegated workers to finish, then merge and deduplicate findings by root cause, severity, and confidence.
+- If a supported runtime refuses or cannot start delegated workers, stop and report a delegation failure instead of silently falling back to inline review.
+- If the current runtime is not documented below, stop and say guaranteed delegated review execution is unsupported.
+
+## GitHub Copilot CLI
+
+- Use the `task` tool.
+- Launch one `code-review` agent per delegated review skill or specialist review pass.
+- Use prompts that tell each subagent to read the delegated skill's `SKILL.md` as the primary rubric and apply `review-orchestrator.md` for shared output structure.
+- Use background mode for parallel delegated passes, then read all results and merge them in the parent review.
+- For a single delegated pass, still use a subagent instead of reviewing inline.
+
+## Claude Code
+
+- Use the `Task` tool / subagent mechanism.
+- Launch one subagent per delegated review skill or specialist review pass.
+- Tell each subagent to read the delegated skill file as the primary rubric and return only meaningful findings.
+- Run eligible delegated passes in parallel and merge the results in the parent review.
+- Do not inline delegated review logic on Claude when Task/subagents are available.
+
+## OpenAI Codex
+
+- Explicitly request subagents.
+- Spawn one subagent per delegated review skill or specialist review pass.
+- Tell each subagent to read the delegated skill file and return structured review findings only.
+- Wait for all subagents and merge their results in the parent review.
+- Do not run delegated review passes inline.
+
+## GLM
+
+- Use the Task/subagent mechanism.
+- Spawn one subagent per delegated review skill or specialist review pass.
+- Provide the delegated skill file and `review-orchestrator.md` contract to each subagent.
+- Run delegated passes in parallel when possible and merge the results in the parent review.
+- Do not inline delegated review passes.

--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -21,12 +21,12 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Keep each specialist review pass to at most 7 findings
 - Include a minimal concrete fix for each finding
 
-## Delegation Portability Contract
+## Shared Delegation Contract
 
-- Use the runtime's available delegation mechanism for parallel specialist review passes when delegation is supported and permitted
-- Shared installable skills must not hardcode agent-specific delegation tool names such as `task` or `spawn_agent`
-- If delegation is unavailable, perform the same specialist review passes inline and say so in the summary
-- If a specialist review pass fails or returns no output, note it in the summary and continue with available results
+- Runtime-facing review skills must read `review-delegation.md` before delegating routed review layers or specialist review passes
+- On supported runtimes, delegated review layers and specialist review passes run as separate subagents; do not silently inline them
+- If a supported runtime cannot start the required delegated workers, stop and report the delegation failure instead of pretending the delegated review ran
+- If a specialist review pass fails or returns no output, note it in the summary and continue with available results when the parent skill contract permits it
 - When multiple review passes produce overlapping findings, deduplicate by root cause and keep the highest severity/confidence version
 - Prioritize final findings as `Blocker > Major > Minor`, then by blast radius
 

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -35,15 +35,16 @@ APPROVED_CODE_REVIEW_AREAS = {
 ORCHESTRATION_PLAYBOOKS: dict[str, str] = {
   "stack-routing": "orchestration/stack-routing/PLAYBOOK.md",
   "review-orchestrator": "orchestration/review-orchestrator/PLAYBOOK.md",
+  "review-delegation": "orchestration/review-delegation/PLAYBOOK.md",
 }
 RUNTIME_SUPPORTING_FILES: dict[str, tuple[str, ...]] = {
-  "bill-code-review": ("stack-routing.md",),
+  "bill-code-review": ("stack-routing.md", "review-delegation.md"),
   "bill-quality-check": ("stack-routing.md",),
-  "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
-  "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
-  "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md"),
-  "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md"),
-  "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md"),
+  "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
 }
 EXTERNAL_PLAYBOOK_REFERENCE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
   (
@@ -51,9 +52,15 @@ EXTERNAL_PLAYBOOK_REFERENCE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = 
     "must reference skill-local supporting files instead of install-local playbook paths",
   ),
   (
-    re.compile(r"orchestration/(?:stack-routing|review-orchestrator)/PLAYBOOK\.md"),
+    re.compile(r"orchestration/(?:stack-routing|review-orchestrator|review-delegation)/PLAYBOOK\.md"),
     "must reference skill-local supporting files instead of repo-side playbook paths at runtime",
   ),
+)
+REVIEW_DELEGATION_REQUIRED_SECTIONS = (
+  "## GitHub Copilot CLI",
+  "## Claude Code",
+  "## OpenAI Codex",
+  "## GLM",
 )
 PORTABLE_REVIEW_SKILLS = {
   "bill-kotlin-code-review",
@@ -229,7 +236,7 @@ def validate_portable_review_wording(
 
 
 def validate_orchestration_playbooks(root: Path, issues: list[str]) -> None:
-  for relative_path in ORCHESTRATION_PLAYBOOKS.values():
+  for playbook_name, relative_path in ORCHESTRATION_PLAYBOOKS.items():
     playbook_path = root / relative_path
     if not playbook_path.is_file():
       issues.append(f"{relative_path} is missing")
@@ -240,6 +247,10 @@ def validate_orchestration_playbooks(root: Path, issues: list[str]) -> None:
       issues.append(f"{relative_path}: missing YAML frontmatter block")
     if SKILL_OVERRIDE_FILE in text:
       issues.append(f"{relative_path}: orchestration playbooks must not reference '{SKILL_OVERRIDE_FILE}'")
+    if playbook_name == "review-delegation":
+      for section in REVIEW_DELEGATION_REQUIRED_SECTIONS:
+        if section not in text:
+          issues.append(f"{relative_path}: missing required delegation section '{section}'")
 
 
 def validate_skill_location(skill_name: str, skill_file: Path, issues: list[str]) -> None:

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
@@ -35,10 +35,13 @@ Inspect both the changed files and repo markers (`build.gradle*`, `settings.grad
 
 - For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
 - For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+- For agent-specific delegated review execution, see [review-delegation.md](review-delegation.md).
 
 Before classifying, read [stack-routing.md](stack-routing.md). Use it as the source of truth for broad stack signals. This skill owns only the backend/server override that happens after Kotlin is already in scope.
 
-Before selecting backend specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
+Before selecting backend specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
+Before delegating baseline or backend specialist review passes, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific subagent execution.
 
 Classify the review as one of:
 - `backend-kotlin`
@@ -67,7 +70,7 @@ Classify the review as one of:
 
 ### Step 1: Run `bill-kotlin-code-review` as the baseline review
 
-Run `bill-kotlin-code-review` against the same scope first. That skill owns:
+Run `bill-kotlin-code-review` against the same scope first as a delegated subagent. That skill owns:
 - shared Kotlin architecture, correctness, security, performance, and testing review
 - the baseline Kotlin findings that every backend/server review should inherit
 
@@ -86,7 +89,7 @@ When invoking it from this skill:
 
 ### Step 3: Run backend specialist reviews
 
-Run all selected backend specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same backend specialist review passes inline and say so in the summary.
+Run one delegated subagent per selected backend specialist review pass. For supported runtimes, do not inline backend specialist review passes or collapse them into the parent review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
 
 Each backend specialist review pass uses:
 - the detected project type

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/review-delegation.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/review-delegation.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-delegation/PLAYBOOK.md

--- a/skills/base/bill-code-review/SKILL.md
+++ b/skills/base/bill-code-review/SKILL.md
@@ -34,6 +34,7 @@ Inspect both the changed files and repo markers before routing.
 ## Additional Resources
 
 - For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+- For agent-specific delegated review execution, see [review-delegation.md](review-delegation.md).
 
 ## Shared Stack Detection
 
@@ -63,14 +64,20 @@ Do not redefine stack signals here unless a route-specific exception is truly un
 
 ## Delegation Contract
 
+Before delegating to another skill, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific delegated execution of routed stack-specific review skills.
+
 When routing to another skill, pass along:
 - the exact review scope
 - the changed files or diff source
 - the detected stack and key signals
 - relevant `AGENTS.md` guidance and matching `.agents/skill-overrides.md` sections
+- the delegated skill file path
 - the rule that the delegated skill must follow its own `SKILL.md` as the primary rubric
+- the delegated skill's `review-orchestrator.md` contract when the routed skill is a stack review orchestrator
 
-Use parallel delegation only when multiple supported stacks are clearly in scope.
+For supported runtimes, execute routed stack-specific reviews as delegated subagents rather than reviewing inline in this router. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
+
+Use parallel delegated subagents only when multiple supported stacks are clearly in scope.
 
 ## Output Format
 

--- a/skills/base/bill-code-review/review-delegation.md
+++ b/skills/base/bill-code-review/review-delegation.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-delegation/PLAYBOOK.md

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -37,10 +37,13 @@ Inspect the changed files and repo markers before applying review heuristics.
 
 - For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
 - For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+- For agent-specific delegated review execution, see [review-delegation.md](review-delegation.md).
 
 Before applying review heuristics, read [stack-routing.md](stack-routing.md) and use it as the source of truth for Go stack signals and mixed-stack routing expectations. This skill owns the Go review depth that applies after Go is already in scope.
 
-Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
+Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
+Before delegating specialist review passes, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific subagent execution.
 
 ---
 
@@ -100,9 +103,7 @@ If different parts of the diff touch different review surfaces:
 
 ### Step 5: Run selected specialist reviews
 
-Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it.
-Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable,
-perform the same specialist review passes inline and say so in the summary.
+Run one delegated subagent per selected specialist review pass. For supported runtimes, do not inline specialist review passes or collapse multiple specialists into a single combined review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
 
 Each specialist review pass uses:
 

--- a/skills/go/bill-go-code-review/review-delegation.md
+++ b/skills/go/bill-go-code-review/review-delegation.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-delegation/PLAYBOOK.md

--- a/skills/kmp/bill-kmp-code-review/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review/SKILL.md
@@ -35,10 +35,13 @@ Inspect both the changed files and repo markers (`build.gradle*`, `settings.grad
 
 - For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
 - For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+- For agent-specific delegated review execution, see [review-delegation.md](review-delegation.md).
 
 Before classifying, read [stack-routing.md](stack-routing.md). Use it as the source of truth for routing Android/KMP work into the `kmp` package bucket.
 
-Before selecting KMP specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
+Before selecting KMP specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
+Before delegating baseline or KMP specialist review passes, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific subagent execution.
 
 Classify the review as one of:
 - `kmp`
@@ -67,7 +70,7 @@ Classify the review as one of:
 
 ### Step 1: Choose and run the baseline Kotlin-family review
 
-Use the same scope to run exactly one baseline review layer:
+Use the same scope to run exactly one baseline review layer as a delegated subagent:
 - Use `bill-backend-kotlin-code-review` when backend/server files or markers are meaningfully in scope
 - Otherwise use `bill-kotlin-code-review`
 
@@ -97,7 +100,7 @@ Keep the mobile triggers focused on what the baseline review does not cover:
 
 ### Step 3: Run KMP specialist reviews
 
-Run all selected KMP specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same KMP specialist review passes inline and say so in the summary.
+Run one delegated subagent per selected KMP specialist review pass. For supported runtimes, do not inline KMP specialist review passes or collapse them into the parent review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
 
 Each KMP specialist review pass uses:
 - the detected project type

--- a/skills/kmp/bill-kmp-code-review/review-delegation.md
+++ b/skills/kmp/bill-kmp-code-review/review-delegation.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-delegation/PLAYBOOK.md

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -35,10 +35,13 @@ Inspect both the changed files and repo markers (`build.gradle*`, `settings.grad
 
 - For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
 - For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+- For agent-specific delegated review execution, see [review-delegation.md](review-delegation.md).
 
 Before classifying, read [stack-routing.md](stack-routing.md). Use it as the source of truth for broad stack signals. This skill owns only the Kotlin-family baseline after a caller decides Kotlin is in scope.
 
-Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
+Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
+Before delegating specialist review passes, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific subagent execution.
 
 Classify the review as one of:
 - `kotlin`
@@ -94,7 +97,7 @@ Architecture review is relevant for every non-trivial change.
 
 ### Step 5: Run selected specialist reviews
 
-Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same specialist review passes inline and say so in the summary.
+Run one delegated subagent per selected specialist review pass. For supported runtimes, do not inline specialist review passes or collapse multiple specialists into a single combined review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
 
 Each specialist review pass uses:
 - the detected project type

--- a/skills/kotlin/bill-kotlin-code-review/review-delegation.md
+++ b/skills/kotlin/bill-kotlin-code-review/review-delegation.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-delegation/PLAYBOOK.md

--- a/skills/php/bill-php-code-review/SKILL.md
+++ b/skills/php/bill-php-code-review/SKILL.md
@@ -37,10 +37,13 @@ Inspect the changed files and repo markers before applying review heuristics.
 
 - For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
 - For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+- For agent-specific delegated review execution, see [review-delegation.md](review-delegation.md).
 
 Before applying review heuristics, read [stack-routing.md](stack-routing.md) and use it as the source of truth for PHP stack signals and mixed-stack routing expectations. This skill owns the PHP review depth that applies after PHP is already in scope.
 
-Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, review principles, and delegation portability used by stack-specific review orchestrators.
+Before selecting specialist review passes or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist contract, merge rules, common output sections, shared standalone behavior, and review principles used by stack-specific review orchestrators.
+
+Before delegating specialist review passes, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific subagent execution.
 
 ---
 
@@ -95,9 +98,7 @@ If different parts of the diff touch different review surfaces:
 
 ### Step 5: Run selected specialist reviews
 
-Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it.
-Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable,
-perform the same specialist review passes inline and say so in the summary.
+Run one delegated subagent per selected specialist review pass. For supported runtimes, do not inline specialist review passes or collapse multiple specialists into a single combined review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
 
 Each specialist review pass uses:
 

--- a/skills/php/bill-php-code-review/review-delegation.md
+++ b/skills/php/bill-php-code-review/review-delegation.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-delegation/PLAYBOOK.md

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -21,6 +21,7 @@ PHP_CODE_REVIEW = read("skills/php/bill-php-code-review/SKILL.md")
 GO_CODE_REVIEW = read("skills/go/bill-go-code-review/SKILL.md")
 STACK_ROUTING_PLAYBOOK = read("orchestration/stack-routing/PLAYBOOK.md")
 REVIEW_ORCHESTRATOR_PLAYBOOK = read("orchestration/review-orchestrator/PLAYBOOK.md")
+REVIEW_DELEGATION_PLAYBOOK = read("orchestration/review-delegation/PLAYBOOK.md")
 PORTABLE_REVIEW_SKILLS = {
   "bill-kotlin-code-review": KOTLIN_CODE_REVIEW,
   "bill-backend-kotlin-code-review": BACKEND_KOTLIN_CODE_REVIEW,
@@ -44,11 +45,20 @@ REVIEW_ORCHESTRATOR_SIDECAR_SKILLS = {
   "bill-php-code-review": ROOT / "skills" / "php" / "bill-php-code-review" / "review-orchestrator.md",
   "bill-go-code-review": ROOT / "skills" / "go" / "bill-go-code-review" / "review-orchestrator.md",
 }
+REVIEW_DELEGATION_SIDECAR_SKILLS = {
+  "bill-code-review": ROOT / "skills" / "base" / "bill-code-review" / "review-delegation.md",
+  "bill-kotlin-code-review": ROOT / "skills" / "kotlin" / "bill-kotlin-code-review" / "review-delegation.md",
+  "bill-backend-kotlin-code-review": ROOT / "skills" / "backend-kotlin" / "bill-backend-kotlin-code-review" / "review-delegation.md",
+  "bill-kmp-code-review": ROOT / "skills" / "kmp" / "bill-kmp-code-review" / "review-delegation.md",
+  "bill-php-code-review": ROOT / "skills" / "php" / "bill-php-code-review" / "review-delegation.md",
+  "bill-go-code-review": ROOT / "skills" / "go" / "bill-go-code-review" / "review-delegation.md",
+}
 
 
 class FeatureImplementRoutingContractTest(unittest.TestCase):
   def test_shared_router_skills_reference_local_stack_routing_sidecars(self) -> None:
     self.assertIn("[stack-routing.md](stack-routing.md)", CODE_REVIEW)
+    self.assertIn("[review-delegation.md](review-delegation.md)", CODE_REVIEW)
     self.assertIn("[stack-routing.md](stack-routing.md)", QUALITY_CHECK)
     self.assertNotIn(".bill-shared/orchestration/", CODE_REVIEW)
     self.assertNotIn(".bill-shared/orchestration/", QUALITY_CHECK)
@@ -63,10 +73,17 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
   def test_reference_playbooks_remain_available_for_maintainers(self) -> None:
     self.assertIn("maintainer-facing reference snapshot", STACK_ROUTING_PLAYBOOK)
     self.assertIn("maintainer-facing reference snapshot", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("maintainer-facing reference snapshot", REVIEW_DELEGATION_PLAYBOOK)
     self.assertIn("sibling supporting files", STACK_ROUTING_PLAYBOOK)
     self.assertIn("sibling supporting files", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("sibling supporting files", REVIEW_DELEGATION_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", STACK_ROUTING_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("Do not reference this repo-relative path directly", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("## GitHub Copilot CLI", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("## Claude Code", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("## OpenAI Codex", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("## GLM", REVIEW_DELEGATION_PLAYBOOK)
 
   def test_feature_implement_invokes_shared_review_and_validation_routers(self) -> None:
     self.assertIn("Run the `bill-code-review` skill", FEATURE_IMPLEMENT)
@@ -172,7 +189,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       KOTLIN_CODE_REVIEW,
     )
 
-  def test_stack_review_skills_use_portable_specialist_review_wording(self) -> None:
+  def test_stack_review_skills_require_delegated_subagent_execution(self) -> None:
     forbidden_phrases = (
       "`task`",
       "spawn_agent",
@@ -185,13 +202,14 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     for skill_name, skill_text in PORTABLE_REVIEW_SKILLS.items():
       with self.subTest(skill=skill_name):
         self.assertIn("specialist review", skill_text)
-        self.assertIn("delegation mechanism", skill_text)
-        self.assertIn("perform the same", skill_text)
-        self.assertIn("inline and say so in the summary", skill_text)
         self.assertIn("[review-orchestrator.md](review-orchestrator.md)", skill_text)
+        self.assertIn("[review-delegation.md](review-delegation.md)", skill_text)
+        self.assertIn("delegated subagent", skill_text)
+        self.assertIn("guaranteed delegated review execution is unavailable", skill_text)
         self.assertNotIn(".bill-shared/orchestration/", skill_text)
         self.assertNotIn("orchestration/stack-routing/PLAYBOOK.md", skill_text)
         self.assertNotIn("orchestration/review-orchestrator/PLAYBOOK.md", skill_text)
+        self.assertNotIn("orchestration/review-delegation/PLAYBOOK.md", skill_text)
         for forbidden_phrase in forbidden_phrases:
           self.assertNotIn(forbidden_phrase, skill_text)
 
@@ -199,6 +217,11 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       with self.subTest(skill=skill_name):
         self.assertTrue(sidecar_path.is_symlink())
         self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "review-orchestrator" / "PLAYBOOK.md")
+
+    for skill_name, sidecar_path in REVIEW_DELEGATION_SIDECAR_SKILLS.items():
+      with self.subTest(skill=skill_name):
+        self.assertTrue(sidecar_path.is_symlink())
+        self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "review-delegation" / "PLAYBOOK.md")
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -149,6 +149,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       self.write_plugin_manifest(repo_root)
       self.write_stack_routing_playbook(repo_root)
       self.write_review_orchestrator_playbook(repo_root)
+      self.write_review_delegation_playbook(repo_root)
 
       for package_name, skill_name in skills:
         self.write_skill(
@@ -247,6 +248,31 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       encoding="utf-8",
     )
 
+  def write_review_delegation_playbook(self, repo_root: Path) -> None:
+    path = repo_root / "orchestration" / "review-delegation" / "PLAYBOOK.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+      textwrap.dedent(
+        """\
+        ---
+        name: review-delegation
+        description: Maintainer-facing reference snapshot for agent-specific delegated review execution.
+        ---
+
+        # Shared Review Delegation Snapshot
+
+        This maintainer-facing reference snapshot exists to document the shared delegation contract.
+        Runtime-facing skills consume it through sibling supporting files.
+
+        ## GitHub Copilot CLI
+        ## Claude Code
+        ## OpenAI Codex
+        ## GLM
+        """
+      ),
+      encoding="utf-8",
+    )
+
   def write_skill(
     self,
     repo_root: Path,
@@ -261,17 +287,18 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
 
   def write_supporting_files(self, repo_root: Path, package_name: str, skill_name: str) -> None:
     support_map = {
-      "bill-code-review": ("stack-routing.md",),
+      "bill-code-review": ("stack-routing.md", "review-delegation.md"),
       "bill-quality-check": ("stack-routing.md",),
-      "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
-      "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md"),
-      "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md"),
-      "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md"),
-      "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md"),
+      "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+      "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+      "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+      "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+      "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
     }
     targets = {
       "stack-routing.md": repo_root / "orchestration" / "stack-routing" / "PLAYBOOK.md",
       "review-orchestrator.md": repo_root / "orchestration" / "review-orchestrator" / "PLAYBOOK.md",
+      "review-delegation.md": repo_root / "orchestration" / "review-delegation" / "PLAYBOOK.md",
     }
     skill_dir = repo_root / "skills" / package_name / skill_name
     for file_name in support_map.get(skill_name, ()):


### PR DESCRIPTION
# Summary

This updates the code-review skill stack so routed stack reviews and specialist passes run as delegated subagents on supported runtimes instead of silently falling back to inline execution. It adds a shared `review-delegation` contract beside the existing routing/orchestration sidecars so delegation stays explicit, portable, and validator-backed.

- add `orchestration/review-delegation/PLAYBOOK.md` and `review-delegation.md` sidecars for the base router and stack review orchestrators
- require delegated execution in `bill-code-review` plus Kotlin/backend-Kotlin/KMP/PHP/Go review skills
- extend validator, contract tests, and docs to enforce and document the new delegation model

## Feature Flags

N/A

# How Has This Been Tested?

Ran the repo validation suite and a real end-to-end `bill-code-review` runtime check against `ZeroAccount` to verify that routed reviews now spawn delegated review agents.

1. Run `python3 -m unittest discover -s tests`.
2. Run `python3 scripts/validate_agent_configs.py`.
3. Run `npx --yes agnix --strict .`.
4. Invoke `bill-code-review` against a KMP-heavy review scope (for example the latest `ZeroAccount` QR approval MFA commit) from an installed Copilot skill setup.
5. Confirm the review routes to `bill-kmp-code-review` and that delegated reviewers are spawned for the routed KMP pass plus its baseline/specialist reviews instead of running inline.
