### PR TITLE
chore: simplify skill repo topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ Think of it as markdown with inheritance:
 - platform skills specialize them
 - orchestration snapshots document the shared routing, review, and delegation logic that runtime-facing skills can reference via sibling supporting files in the same skill directory
 
+## Fast mental model
+
+If you only remember four things, remember these:
+
+1. Users enter through stable skills in `skills/base/`.
+2. Platform depth lives in `skills/<platform>/`.
+3. Shared logic is documented in `orchestration/`, but runtimes consume it through sibling sidecars such as `stack-routing.md`, `review-orchestrator.md`, and `review-delegation.md`.
+4. Topology changes should start in `scripts/skill_repo_contracts.py`, then flow into skills, tests, and docs.
+
+That last file is the canonical map for:
+
+- which shared playbook snapshots exist
+- which runtime-facing skills require which sidecars
+- which review skills are governed by the shared review/delegation contract
+
 Current platform packages:
 
 - `kotlin`

--- a/scripts/skill_repo_contracts.py
+++ b/scripts/skill_repo_contracts.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ORCHESTRATION_PLAYBOOKS: dict[str, str] = {
+  "stack-routing": "orchestration/stack-routing/PLAYBOOK.md",
+  "review-orchestrator": "orchestration/review-orchestrator/PLAYBOOK.md",
+  "review-delegation": "orchestration/review-delegation/PLAYBOOK.md",
+}
+
+SUPPORTING_FILE_TARGETS: dict[str, str] = {
+  "stack-routing.md": ORCHESTRATION_PLAYBOOKS["stack-routing"],
+  "review-orchestrator.md": ORCHESTRATION_PLAYBOOKS["review-orchestrator"],
+  "review-delegation.md": ORCHESTRATION_PLAYBOOKS["review-delegation"],
+}
+
+RUNTIME_SUPPORTING_FILES: dict[str, tuple[str, ...]] = {
+  "bill-code-review": ("stack-routing.md", "review-delegation.md"),
+  "bill-quality-check": ("stack-routing.md",),
+  "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+  "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
+}
+
+REVIEW_DELEGATION_REQUIRED_SECTIONS = (
+  "## GitHub Copilot CLI",
+  "## Claude Code",
+  "## OpenAI Codex",
+  "## GLM",
+)
+
+PORTABLE_REVIEW_SKILLS = (
+  "bill-kotlin-code-review",
+  "bill-backend-kotlin-code-review",
+  "bill-kmp-code-review",
+  "bill-php-code-review",
+  "bill-go-code-review",
+)
+
+
+def skills_requiring_supporting_file(file_name: str) -> tuple[str, ...]:
+  return tuple(
+    skill_name
+    for skill_name, supporting_files in RUNTIME_SUPPORTING_FILES.items()
+    if file_name in supporting_files
+  )
+
+
+def supporting_file_targets(root: Path) -> dict[str, Path]:
+  return {
+    file_name: root / relative_path
+    for file_name, relative_path in SUPPORTING_FILE_TARGETS.items()
+  }

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -7,6 +7,13 @@ import json
 import re
 import sys
 
+from skill_repo_contracts import (
+  ORCHESTRATION_PLAYBOOKS,
+  PORTABLE_REVIEW_SKILLS,
+  REVIEW_DELEGATION_REQUIRED_SECTIONS,
+  RUNTIME_SUPPORTING_FILES,
+)
+
 
 README_TOTAL_PATTERN = re.compile(r"collection of (\d+) AI skills")
 README_SECTION_PATTERN = re.compile(r"^### (.+) \((\d+) skills\)$")
@@ -32,20 +39,6 @@ APPROVED_CODE_REVIEW_AREAS = {
   "ui",
   "ux-accessibility",
 }
-ORCHESTRATION_PLAYBOOKS: dict[str, str] = {
-  "stack-routing": "orchestration/stack-routing/PLAYBOOK.md",
-  "review-orchestrator": "orchestration/review-orchestrator/PLAYBOOK.md",
-  "review-delegation": "orchestration/review-delegation/PLAYBOOK.md",
-}
-RUNTIME_SUPPORTING_FILES: dict[str, tuple[str, ...]] = {
-  "bill-code-review": ("stack-routing.md", "review-delegation.md"),
-  "bill-quality-check": ("stack-routing.md",),
-  "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-  "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-  "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-  "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-  "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-}
 EXTERNAL_PLAYBOOK_REFERENCE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
   (
     re.compile(r"\.bill-shared/orchestration/"),
@@ -56,19 +49,6 @@ EXTERNAL_PLAYBOOK_REFERENCE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = 
     "must reference skill-local supporting files instead of repo-side playbook paths at runtime",
   ),
 )
-REVIEW_DELEGATION_REQUIRED_SECTIONS = (
-  "## GitHub Copilot CLI",
-  "## Claude Code",
-  "## OpenAI Codex",
-  "## GLM",
-)
-PORTABLE_REVIEW_SKILLS = {
-  "bill-kotlin-code-review",
-  "bill-backend-kotlin-code-review",
-  "bill-kmp-code-review",
-  "bill-php-code-review",
-  "bill-go-code-review",
-}
 NON_PORTABLE_REVIEW_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
   (
     re.compile(r"`task`"),

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from skill_repo_contracts import (  # noqa: E402
+  PORTABLE_REVIEW_SKILLS,
+  REVIEW_DELEGATION_REQUIRED_SECTIONS,
+  RUNTIME_SUPPORTING_FILES,
+  supporting_file_targets,
+  skills_requiring_supporting_file,
+)
 
 
 def read(relative_path: str) -> str:
@@ -22,37 +32,27 @@ GO_CODE_REVIEW = read("skills/go/bill-go-code-review/SKILL.md")
 STACK_ROUTING_PLAYBOOK = read("orchestration/stack-routing/PLAYBOOK.md")
 REVIEW_ORCHESTRATOR_PLAYBOOK = read("orchestration/review-orchestrator/PLAYBOOK.md")
 REVIEW_DELEGATION_PLAYBOOK = read("orchestration/review-delegation/PLAYBOOK.md")
-PORTABLE_REVIEW_SKILLS = {
+PORTABLE_REVIEW_SKILL_TEXTS = {
   "bill-kotlin-code-review": KOTLIN_CODE_REVIEW,
   "bill-backend-kotlin-code-review": BACKEND_KOTLIN_CODE_REVIEW,
   "bill-kmp-code-review": KMP_CODE_REVIEW,
   "bill-php-code-review": PHP_CODE_REVIEW,
   "bill-go-code-review": GO_CODE_REVIEW,
 }
-STACK_ROUTING_SIDECAR_SKILLS = {
-  "bill-code-review": ROOT / "skills" / "base" / "bill-code-review" / "stack-routing.md",
-  "bill-quality-check": ROOT / "skills" / "base" / "bill-quality-check" / "stack-routing.md",
-  "bill-kotlin-code-review": ROOT / "skills" / "kotlin" / "bill-kotlin-code-review" / "stack-routing.md",
-  "bill-backend-kotlin-code-review": ROOT / "skills" / "backend-kotlin" / "bill-backend-kotlin-code-review" / "stack-routing.md",
-  "bill-kmp-code-review": ROOT / "skills" / "kmp" / "bill-kmp-code-review" / "stack-routing.md",
-  "bill-php-code-review": ROOT / "skills" / "php" / "bill-php-code-review" / "stack-routing.md",
-  "bill-go-code-review": ROOT / "skills" / "go" / "bill-go-code-review" / "stack-routing.md",
-}
-REVIEW_ORCHESTRATOR_SIDECAR_SKILLS = {
-  "bill-kotlin-code-review": ROOT / "skills" / "kotlin" / "bill-kotlin-code-review" / "review-orchestrator.md",
-  "bill-backend-kotlin-code-review": ROOT / "skills" / "backend-kotlin" / "bill-backend-kotlin-code-review" / "review-orchestrator.md",
-  "bill-kmp-code-review": ROOT / "skills" / "kmp" / "bill-kmp-code-review" / "review-orchestrator.md",
-  "bill-php-code-review": ROOT / "skills" / "php" / "bill-php-code-review" / "review-orchestrator.md",
-  "bill-go-code-review": ROOT / "skills" / "go" / "bill-go-code-review" / "review-orchestrator.md",
-}
-REVIEW_DELEGATION_SIDECAR_SKILLS = {
-  "bill-code-review": ROOT / "skills" / "base" / "bill-code-review" / "review-delegation.md",
-  "bill-kotlin-code-review": ROOT / "skills" / "kotlin" / "bill-kotlin-code-review" / "review-delegation.md",
-  "bill-backend-kotlin-code-review": ROOT / "skills" / "backend-kotlin" / "bill-backend-kotlin-code-review" / "review-delegation.md",
-  "bill-kmp-code-review": ROOT / "skills" / "kmp" / "bill-kmp-code-review" / "review-delegation.md",
-  "bill-php-code-review": ROOT / "skills" / "php" / "bill-php-code-review" / "review-delegation.md",
-  "bill-go-code-review": ROOT / "skills" / "go" / "bill-go-code-review" / "review-delegation.md",
-}
+
+
+def find_skill_dir(skill_name: str) -> Path:
+  matches = list((ROOT / "skills").rglob(f"{skill_name}/SKILL.md"))
+  if len(matches) != 1:
+    raise AssertionError(f"Expected exactly one SKILL.md for {skill_name}, found {len(matches)}")
+  return matches[0].parent
+
+
+def sidecar_paths(file_name: str) -> dict[str, Path]:
+  return {
+    skill_name: find_skill_dir(skill_name) / file_name
+    for skill_name in skills_requiring_supporting_file(file_name)
+  }
 
 
 class FeatureImplementRoutingContractTest(unittest.TestCase):
@@ -65,7 +65,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertNotIn("orchestration/stack-routing/PLAYBOOK.md", CODE_REVIEW)
     self.assertNotIn("orchestration/stack-routing/PLAYBOOK.md", QUALITY_CHECK)
 
-    for skill_name, sidecar_path in STACK_ROUTING_SIDECAR_SKILLS.items():
+    for skill_name, sidecar_path in sidecar_paths("stack-routing.md").items():
       with self.subTest(skill=skill_name):
         self.assertTrue(sidecar_path.is_symlink())
         self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "stack-routing" / "PLAYBOOK.md")
@@ -80,10 +80,8 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("Do not reference this repo-relative path directly", STACK_ROUTING_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", REVIEW_DELEGATION_PLAYBOOK)
-    self.assertIn("## GitHub Copilot CLI", REVIEW_DELEGATION_PLAYBOOK)
-    self.assertIn("## Claude Code", REVIEW_DELEGATION_PLAYBOOK)
-    self.assertIn("## OpenAI Codex", REVIEW_DELEGATION_PLAYBOOK)
-    self.assertIn("## GLM", REVIEW_DELEGATION_PLAYBOOK)
+    for section in REVIEW_DELEGATION_REQUIRED_SECTIONS:
+      self.assertIn(section, REVIEW_DELEGATION_PLAYBOOK)
 
   def test_feature_implement_invokes_shared_review_and_validation_routers(self) -> None:
     self.assertIn("Run the `bill-code-review` skill", FEATURE_IMPLEMENT)
@@ -199,7 +197,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       "Agents spawned",
     )
 
-    for skill_name, skill_text in PORTABLE_REVIEW_SKILLS.items():
+    for skill_name, skill_text in PORTABLE_REVIEW_SKILL_TEXTS.items():
       with self.subTest(skill=skill_name):
         self.assertIn("specialist review", skill_text)
         self.assertIn("[review-orchestrator.md](review-orchestrator.md)", skill_text)
@@ -213,12 +211,12 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
         for forbidden_phrase in forbidden_phrases:
           self.assertNotIn(forbidden_phrase, skill_text)
 
-    for skill_name, sidecar_path in REVIEW_ORCHESTRATOR_SIDECAR_SKILLS.items():
+    for skill_name, sidecar_path in sidecar_paths("review-orchestrator.md").items():
       with self.subTest(skill=skill_name):
         self.assertTrue(sidecar_path.is_symlink())
         self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "review-orchestrator" / "PLAYBOOK.md")
 
-    for skill_name, sidecar_path in REVIEW_DELEGATION_SIDECAR_SKILLS.items():
+    for skill_name, sidecar_path in sidecar_paths("review-delegation.md").items():
       with self.subTest(skill=skill_name):
         self.assertTrue(sidecar_path.is_symlink())
         self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "review-delegation" / "PLAYBOOK.md")

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -4,9 +4,16 @@ from contextlib import contextmanager
 import json
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from skill_repo_contracts import RUNTIME_SUPPORTING_FILES, supporting_file_targets  # noqa: E402
 
 
 VALIDATOR_PATH = Path(__file__).resolve().parents[1] / "scripts" / "validate_agent_configs.py"
@@ -286,22 +293,9 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
     path.write_text(content or self.skill_markdown(skill_name), encoding="utf-8")
 
   def write_supporting_files(self, repo_root: Path, package_name: str, skill_name: str) -> None:
-    support_map = {
-      "bill-code-review": ("stack-routing.md", "review-delegation.md"),
-      "bill-quality-check": ("stack-routing.md",),
-      "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-      "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-      "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-      "bill-php-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-      "bill-go-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
-    }
-    targets = {
-      "stack-routing.md": repo_root / "orchestration" / "stack-routing" / "PLAYBOOK.md",
-      "review-orchestrator.md": repo_root / "orchestration" / "review-orchestrator" / "PLAYBOOK.md",
-      "review-delegation.md": repo_root / "orchestration" / "review-delegation" / "PLAYBOOK.md",
-    }
+    targets = supporting_file_targets(repo_root)
     skill_dir = repo_root / "skills" / package_name / skill_name
-    for file_name in support_map.get(skill_name, ()):
+    for file_name in RUNTIME_SUPPORTING_FILES.get(skill_name, ()):
       (skill_dir / file_name).symlink_to(targets[file_name])
 
   def skill_markdown(self, skill_name: str) -> str:


### PR DESCRIPTION
# Summary

This reduces the cognitive overhead of the skill repo by moving shared topology rules into a single contract module and documenting the architecture more explicitly. The goal is to make runtime sidecars, orchestration snapshots, validator rules, and tests easier to reason about without reconstructing the model from several files.

- add `scripts/skill_repo_contracts.py` as the canonical map for shared playbooks, required sidecars, and delegated-review contract sections
- refactor validator and tests to import that shared contract instead of duplicating topology constants
- add a concise README mental model section for base skills, platform skills, orchestration snapshots, and runtime sidecars

## Feature Flags

N/A

# How Has This Been Tested?

Validated that the shared contract refactor preserves existing behavior and keeps the repository green.

1. Run `python3 -m unittest discover -s tests`.
2. Run `python3 scripts/validate_agent_configs.py`.
3. Run `npx --yes agnix --strict .`.
4. Inspect `README.md` and confirm the new mental-model section points contributors to `scripts/skill_repo_contracts.py` as the topology source of truth.
5. Confirm the validator/tests still pass without reintroducing duplicated sidecar topology constants.
