### PR TITLE
docs: clarify native delegation preference for review passes

### DIFF
--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -23,9 +23,9 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 
 ## Delegation Portability Contract
 
-- Use the runtime's available delegation mechanism for parallel specialist review passes when delegation is supported and permitted
+- When the runtime provides native subagents or an equivalent native delegation mechanism, use it for parallel specialist review passes. Only fall back to inline review when delegation is unavailable or disallowed.
 - Shared installable skills must not hardcode agent-specific delegation tool names such as `task` or `spawn_agent`
-- If delegation is unavailable, perform the same specialist review passes inline and say so in the summary
+- If delegation is unavailable or disallowed, perform the same specialist review passes inline and say so in the summary
 - If a specialist review pass fails or returns no output, note it in the summary and continue with available results
 - When multiple review passes produce overlapping findings, deduplicate by root cause and keep the highest severity/confidence version
 - Prioritize final findings as `Blocker > Major > Minor`, then by blast radius

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
@@ -86,7 +86,7 @@ When invoking it from this skill:
 
 ### Step 3: Run backend specialist reviews
 
-Run all selected backend specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same backend specialist review passes inline and say so in the summary.
+Run all selected backend specialist review passes in parallel through the runtime's native subagents or equivalent native delegation mechanism when it is supported and permitted. If native delegation is unavailable or disallowed, perform the same backend specialist review passes inline and say so in the summary. Do not hardcode agent-specific delegation tool names in the skill text.
 
 Each backend specialist review pass uses:
 - the detected project type

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -100,9 +100,10 @@ If different parts of the diff touch different review surfaces:
 
 ### Step 5: Run selected specialist reviews
 
-Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it.
-Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable,
-perform the same specialist review passes inline and say so in the summary.
+Run all selected specialist review passes in parallel through the runtime's native subagents or equivalent native
+delegation mechanism when it is supported and permitted. If native delegation is unavailable or disallowed, perform
+the same specialist review passes inline and say so in the summary. Do not hardcode agent-specific delegation tool
+names in the skill text.
 
 Each specialist review pass uses:
 

--- a/skills/kmp/bill-kmp-code-review/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review/SKILL.md
@@ -97,7 +97,7 @@ Keep the mobile triggers focused on what the baseline review does not cover:
 
 ### Step 3: Run KMP specialist reviews
 
-Run all selected KMP specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same KMP specialist review passes inline and say so in the summary.
+Run all selected KMP specialist review passes in parallel through the runtime's native subagents or equivalent native delegation mechanism when it is supported and permitted. If native delegation is unavailable or disallowed, perform the same KMP specialist review passes inline and say so in the summary. Do not hardcode agent-specific delegation tool names in the skill text.
 
 Each KMP specialist review pass uses:
 - the detected project type

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -94,7 +94,7 @@ Architecture review is relevant for every non-trivial change.
 
 ### Step 5: Run selected specialist reviews
 
-Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it. Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable, perform the same specialist review passes inline and say so in the summary.
+Run all selected specialist review passes in parallel through the runtime's native subagents or equivalent native delegation mechanism when it is supported and permitted. If native delegation is unavailable or disallowed, perform the same specialist review passes inline and say so in the summary. Do not hardcode agent-specific delegation tool names in the skill text.
 
 Each specialist review pass uses:
 - the detected project type

--- a/skills/php/bill-php-code-review/SKILL.md
+++ b/skills/php/bill-php-code-review/SKILL.md
@@ -95,9 +95,10 @@ If different parts of the diff touch different review surfaces:
 
 ### Step 5: Run selected specialist reviews
 
-Run all selected specialist review passes in parallel when the runtime supports delegation and current policy allows it.
-Use the runtime's available delegation mechanism rather than naming a specific tool. If delegation is unavailable,
-perform the same specialist review passes inline and say so in the summary.
+Run all selected specialist review passes in parallel through the runtime's native subagents or equivalent native
+delegation mechanism when it is supported and permitted. If native delegation is unavailable or disallowed, perform
+the same specialist review passes inline and say so in the summary. Do not hardcode agent-specific delegation tool
+names in the skill text.
 
 Each specialist review pass uses:
 


### PR DESCRIPTION
# Summary

Clarify the review-pass delegation contract so installable skills state more explicitly that native subagents are the preferred parallel execution mode when the runtime supports them.

## Changes

- make the shared review-orchestrator contract prefer native subagents or equivalent native delegation
- keep inline specialist review as the explicit fallback when delegation is unavailable or disallowed
- align the PHP, Kotlin, backend-Kotlin, KMP, and Go review skills with the shared wording

## Testing

- not run (wording-only skill updates)
