### PR TITLE
Add GitHub release plumbing

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  categories:
+    - title: Breaking and migration-sensitive changes
+      labels:
+        - breaking-change
+        - migration
+    - title: New skills and platform coverage
+      labels:
+        - skill
+        - platform
+        - routing
+    - title: Tooling and validation
+      labels:
+        - tooling
+        - validation
+        - ci
+    - title: Documentation
+      labels:
+        - docs
+  exclude:
+    labels:
+      - skip-changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run validator e2e tests
+        run: python3 -m unittest discover -s tests
+
+      - name: Run agnix
+        run: npx --yes agnix --strict .
+
+      - name: Run repo-native validation
+        run: python3 scripts/validate_agent_configs.py
+
+      - name: Validate release tag
+        id: release_meta
+        run: python3 scripts/validate_release_ref.py "$GITHUB_REF_NAME" --github-output "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.release_meta.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release ${{ steps.release_meta.outputs.tag }} already exists; skipping publish."
+            exit 0
+          fi
+
+          args=(
+            "${{ steps.release_meta.outputs.tag }}"
+            --repo "${{ github.repository }}"
+            --title "${{ steps.release_meta.outputs.tag }}"
+            --generate-notes
+            --verify-tag
+          )
+
+          if [[ "${{ steps.release_meta.outputs.prerelease }}" == "true" ]]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ chmod +x install.sh
 ./install.sh
 ```
 
+If you want a stable install target instead of tracking `main`, clone a release tag and install from that checkout:
+
+```bash
+TAG=v0.x.y
+git clone --branch "$TAG" --depth 1 <this-repo> ~/Development/skill-bill
+cd ~/Development/skill-bill
+./install.sh
+```
+
 The installer first asks which agent targets to install to. You can choose one or more entries, including `all`:
 
 ```text
@@ -271,6 +280,16 @@ python3 scripts/validate_agent_configs.py
 ```
 
 CI runs the same checks.
+
+## Versioning and releases
+
+Skill Bill uses tag-driven GitHub Releases.
+
+- stable releases use SemVer tags such as `v0.4.0`
+- prereleases use SemVer prerelease tags such as `v0.5.0-rc.1`
+- pushing a release tag reruns validation and publishes a GitHub Release with generated notes
+
+See `RELEASING.md` for the maintainer checklist and versioning policy.
 
 The validator enforces:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,56 @@
+# Releasing Skill Bill
+
+Skill Bill uses tag-driven GitHub Releases.
+
+The release contract is:
+
+- create an annotated SemVer tag such as `v0.4.0`
+- push the tag to GitHub
+- let the `Release` workflow rerun validation and publish the GitHub Release
+
+Pre-release tags such as `v0.5.0-rc.1` are also supported and publish GitHub prereleases.
+
+## Versioning policy
+
+Skill Bill should stay on pre-1.0 SemVer until the install surface, taxonomy, and stable entry points feel settled.
+
+- bump `patch` for docs-only work, validator fixes, and non-breaking tooling or installer fixes
+- bump `minor` for new skills, new platform coverage, new routing behavior, or other user-visible capability additions
+- reserve `major` for intentional breaking changes to taxonomy, install behavior, or stable entry points
+
+## Release checklist
+
+1. Make sure the release commit is on `main`.
+2. Run the local checks:
+
+   ```bash
+   python3 -m unittest discover -s tests
+   npx --yes agnix --strict .
+   python3 scripts/validate_agent_configs.py
+   ```
+
+3. Pick the next version tag.
+4. Create an annotated tag:
+
+   ```bash
+   git tag -a v0.x.y -m "Release v0.x.y"
+   ```
+
+5. Push the tag:
+
+   ```bash
+   git push origin v0.x.y
+   ```
+
+6. Confirm the `Release` workflow succeeds and the GitHub Release appears with generated notes.
+
+## Installing from a release
+
+If you want a stable install target instead of following `main`, clone the repo at a tag and run the normal installer:
+
+```bash
+TAG=v0.x.y
+git clone --branch "$TAG" --depth 1 <this-repo> ~/Development/skill-bill
+cd ~/Development/skill-bill
+./install.sh
+```

--- a/scripts/validate_release_ref.py
+++ b/scripts/validate_release_ref.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import argparse
+import json
+import os
+import re
+import sys
+
+
+SEMVER_TAG_PATTERN = re.compile(
+  r"^v"
+  r"(?P<major>0|[1-9]\d*)\."
+  r"(?P<minor>0|[1-9]\d*)\."
+  r"(?P<patch>0|[1-9]\d*)"
+  r"(?:-(?P<prerelease>"
+  r"(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+  r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*"
+  r"))?"
+  r"(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+@dataclass(frozen=True)
+class ReleaseRef:
+  tag: str
+  version: str
+  prerelease: bool
+
+
+def normalize_ref(value: str) -> str:
+  candidate = value.strip()
+  if candidate.startswith("refs/tags/"):
+    return candidate.removeprefix("refs/tags/")
+  return candidate
+
+
+def parse_release_ref(value: str) -> ReleaseRef:
+  candidate = normalize_ref(value)
+  match = SEMVER_TAG_PATTERN.fullmatch(candidate)
+  if not match:
+    raise ValueError(
+      "Release tag must match vMAJOR.MINOR.PATCH with optional SemVer prerelease/build metadata."
+    )
+
+  return ReleaseRef(
+    tag=candidate,
+    version=candidate.removeprefix("v"),
+    prerelease=bool(match.group("prerelease")),
+  )
+
+
+def resolve_ref(cli_value: str | None) -> str:
+  if cli_value:
+    return cli_value
+
+  for environment_key in ("GITHUB_REF_NAME", "GITHUB_REF"):
+    value = os.environ.get(environment_key)
+    if value:
+      return value
+
+  raise ValueError("No release ref supplied. Pass a tag or set GITHUB_REF_NAME.")
+
+
+def write_github_output(path: str, release_ref: ReleaseRef) -> None:
+  with open(path, "a", encoding="utf-8") as handle:
+    handle.write(f"tag={release_ref.tag}\n")
+    handle.write(f"version={release_ref.version}\n")
+    handle.write(f"prerelease={'true' if release_ref.prerelease else 'false'}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = argparse.ArgumentParser(
+    description="Validate a release tag and emit metadata for GitHub Actions."
+  )
+  parser.add_argument("ref", nargs="?", help="Tag or refs/tags/... reference to validate.")
+  parser.add_argument(
+    "--github-output",
+    help="Optional file path where GitHub Actions step outputs should be appended.",
+  )
+  args = parser.parse_args(argv)
+
+  try:
+    release_ref = parse_release_ref(resolve_ref(args.ref))
+  except ValueError as error:
+    print(str(error), file=sys.stderr)
+    return 1
+
+  if args.github_output:
+    write_github_output(args.github_output, release_ref)
+
+  print(
+    json.dumps(
+      {
+        "tag": release_ref.tag,
+        "version": release_ref.version,
+        "prerelease": release_ref.prerelease,
+      },
+      indent=2,
+    )
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/tests/test_validate_release_ref.py
+++ b/tests/test_validate_release_ref.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "validate_release_ref.py"
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from validate_release_ref import parse_release_ref  # noqa: E402
+
+
+class ValidateReleaseRefTest(unittest.TestCase):
+  def test_accepts_stable_semver_tag(self) -> None:
+    release_ref = parse_release_ref("v0.4.0")
+
+    self.assertEqual(release_ref.tag, "v0.4.0")
+    self.assertEqual(release_ref.version, "0.4.0")
+    self.assertFalse(release_ref.prerelease)
+
+  def test_accepts_tag_ref_and_marks_prerelease(self) -> None:
+    release_ref = parse_release_ref("refs/tags/v0.5.0-rc.1")
+
+    self.assertEqual(release_ref.tag, "v0.5.0-rc.1")
+    self.assertEqual(release_ref.version, "0.5.0-rc.1")
+    self.assertTrue(release_ref.prerelease)
+
+  def test_rejects_invalid_tag(self) -> None:
+    with self.assertRaisesRegex(ValueError, "Release tag must match"):
+      parse_release_ref("release-0.4.0")
+
+  def test_cli_writes_github_output(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+      github_output = Path(temp_dir) / "github-output.txt"
+      result = subprocess.run(
+        [
+          "python3",
+          str(SCRIPT_PATH),
+          "v1.2.3-rc.1",
+          "--github-output",
+          str(github_output),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+      )
+
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+      self.assertEqual(
+        json.loads(result.stdout),
+        {
+          "tag": "v1.2.3-rc.1",
+          "version": "1.2.3-rc.1",
+          "prerelease": True,
+        },
+      )
+      self.assertEqual(
+        github_output.read_text(encoding="utf-8"),
+        "tag=v1.2.3-rc.1\nversion=1.2.3-rc.1\nprerelease=true\n",
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Summary

Add the missing plumbing for stable GitHub releases so Skill Bill can publish validated, tag-driven versions instead of relying on ad hoc release steps.

- add a release workflow that validates the repo on pushed `vX.Y.Z` tags and publishes a GitHub Release
- add SemVer tag validation plus test coverage for release-tag parsing and prerelease handling
- document the release contract and how to install from a pinned release tag

## Feature Flags

N/A

# How Has This Been Tested?

Ran the existing validation suite plus the new release-tag validator locally.

1. Run `python3 scripts/validate_release_ref.py v0.1.0`.
2. Run `python3 -m unittest discover -s tests`.
3. Run `npx --yes agnix --strict .` and `python3 scripts/validate_agent_configs.py`.
4. Confirm all checks pass and the repo now contains `RELEASING.md`, `.github/workflows/release.yml`, and `.github/release.yml`.
