### PR TITLE
Remove invalid claude plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,6 @@ Each installer run replaces the existing Skill Bill links and reinstalls only th
 
 The installer always removes existing Skill Bill links before reinstalling the selected agents and platforms.
 
-If you only use Claude Code, you can also install this repo as a Claude plugin:
-
-```bash
-claude plugin install ~/Development/skill-bill
-```
-
 ## Uninstallation
 
 To remove Skill Bill skill symlinks from the supported agent install paths:


### PR DESCRIPTION
## Summary
- Remove the `claude plugin install ~/Development/skill-bill` section from README
- This command does not exist — Claude Code uses `--plugin-dir` for local plugins or marketplace-based installation

## Test plan
- [x] `python3 scripts/validate_agent_configs.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)