### PR TITLE
feat: [SKILL-1] make review execution adaptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You interact through a handful of stable base commands. They auto-detect your st
 
 Detected stack: kotlin
 Routed to: bill-kotlin-code-review
+Execution mode: inline
 Specialist reviews: architecture, platform-correctness, testing
 
 [ARCHITECTURE]
@@ -82,15 +83,18 @@ A single `feature-implement` run chains 10-12 skill invocations:
 ├── implementation (atomic tasks)
 ├── /bill-code-review (auto-routed)
 │   └── e.g. bill-kotlin-code-review
-│       ├── architecture (subagent)
-│       ├── platform-correctness (subagent)
-│       ├── security (subagent, if applicable)
-│       └── testing (subagent, if applicable)
+│       ├── execution mode: inline or delegated
+│       ├── architecture (inline pass or subagent)
+│       ├── platform-correctness (inline pass or subagent)
+│       ├── security (inline pass or subagent, if applicable)
+│       └── testing (inline pass or subagent, if applicable)
 ├── /bill-quality-check (auto-routed)
 │   └── e.g. bill-kotlin-quality-check
 ├── completeness audit
 └── /bill-pr-description
 ```
+
+Small, low-risk review scopes may stay inline in one thread. Larger or higher-risk scopes use delegated review passes and report the chosen execution mode explicitly.
 
 Base entry points stay stable for users:
 

--- a/orchestration/review-delegation/PLAYBOOK.md
+++ b/orchestration/review-delegation/PLAYBOOK.md
@@ -11,13 +11,14 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 
 ## Shared Delegation Rules
 
-- Delegated review layers and specialist review passes must run as separate subagents on supported runtimes; do not collapse them into a single inline review.
+- Use this delegation contract only after the shared execution-mode contract selects `delegated` review.
+- Delegated review layers and specialist review passes must run as separate subagents on supported runtimes; do not collapse a delegated-required scope into a single inline review.
 - Launch one delegated worker per routed stack-specific review skill or selected specialist review pass unless the current agent-specific section explicitly says otherwise.
 - When the runtime supports delegated-worker model inheritance, delegated workers should use the same model as the parent thread by default. Do not override the delegated-worker model unless the current runtime-specific section explicitly requires it.
 - Every delegated worker must receive the exact review scope, changed files or diff source, relevant project guidance, the delegated skill file path, and the shared contract from `review-orchestrator.md`.
 - Wait for all delegated workers to finish, then merge and deduplicate findings by root cause, severity, and confidence.
-- If a supported runtime refuses or cannot start delegated workers, stop and report a delegation failure instead of silently falling back to inline review.
-- If the current runtime is not documented below, stop and say guaranteed delegated review execution is unsupported.
+- If delegated review is required for the current scope and a supported runtime refuses or cannot start delegated workers, stop and report that delegated review is required for this scope but unavailable on the current runtime.
+- If the current runtime is not documented below, stop and say delegated review is unsupported for delegated-required scopes.
 
 ## GitHub Copilot CLI
 

--- a/orchestration/review-delegation/PLAYBOOK.md
+++ b/orchestration/review-delegation/PLAYBOOK.md
@@ -14,9 +14,11 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Use this delegation contract only after the shared execution-mode contract selects `delegated` review.
 - Delegated review layers and specialist review passes must run as separate subagents on supported runtimes; do not collapse a delegated-required scope into a single inline review.
 - Launch one delegated worker per routed stack-specific review skill or selected specialist review pass unless the current agent-specific section explicitly says otherwise.
+- The parent review owns only the delegated workers it launched itself. If a delegated child review launches more workers internally, treat those nested workers as opaque implementation detail and consume only the child review's final merged result.
 - When the runtime supports delegated-worker model inheritance, delegated workers should use the same model as the parent thread by default. Do not override the delegated-worker model unless the current runtime-specific section explicitly requires it.
 - Every delegated worker must receive the exact review scope, changed files or diff source, relevant project guidance, the delegated skill file path, and the shared contract from `review-orchestrator.md`.
 - Wait for all delegated workers to finish, then merge and deduplicate findings by root cause, severity, and confidence.
+- Track delegated workers by the ids returned when they are launched. Do not discover or poll delegated workers through broad global listing in the normal review path.
 - If delegated review is required for the current scope and a supported runtime refuses or cannot start delegated workers, stop and report that delegated review is required for this scope but unavailable on the current runtime.
 - If the current runtime is not documented below, stop and say delegated review is unsupported for delegated-required scopes.
 
@@ -25,7 +27,9 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Use the `task` tool.
 - Launch one `code-review` agent per delegated review skill or specialist review pass.
 - Use prompts that tell each subagent to read the delegated skill's `SKILL.md` as the primary rubric and apply `review-orchestrator.md` for shared output structure.
-- Use background mode for parallel delegated passes, then read all results and merge them in the parent review.
+- Use background mode for parallel delegated passes, capture every returned `agent_id`, then wait on and read only those tracked ids before merging results in the parent review.
+- Do not use `list_agents` to discover delegated workers during normal review execution. Reserve it for explicit recovery/debugging only.
+- Do not call `read_agent` on nested workers launched by a delegated child review. Read only the child review agent you launched and let that child return its own merged result.
 - For a single delegated pass, still use a subagent instead of reviewing inline.
 
 ## Claude Code

--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -21,16 +21,39 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Keep each specialist review pass to at most 7 findings
 - Include a minimal concrete fix for each finding
 
+## Shared Scope Contract
+
+- Resolve the exact review source before routing, classifying, or selecting specialist review passes
+- Supported scope labels are `staged changes`, `unstaged changes`, `working tree`, `commit range`, `PR diff`, and `files`
+- When the caller asks for staged changes, inspect only the staged/index diff and treat unstaged working tree edits as out of scope, except for repo markers needed for stack detection
+- When the caller asks for unstaged changes, inspect only the unstaged working tree diff and do not fold in staged-only hunks unless the caller explicitly asks for all local changes
+- Use `working tree` only when the caller explicitly wants both staged and unstaged local changes reviewed together
+- State the resolved scope in Section 1 as `Detected review scope: ...`
+
+## Shared Execution Mode Contract
+
+- Review skills must choose an execution mode of `inline` or `delegated` before running routed review layers or specialist review passes
+- `inline` is allowed only when the review scope is small and low-risk; treat a scope as inline-eligible only when all of the following are true:
+  - one routed stack-specific review skill is sufficient
+  - the diff is small enough to inspect in one thread without losing coverage
+  - no mixed-stack or mixed KMP/backend layering requires multiple routed review layers
+  - no high-risk signals dominate the diff, such as auth/security/secrets changes, public API or schema changes, persistence or migration changes, concurrency/lifecycle/threading changes, retries/timeouts/caching/observability changes, rollout/feature-flag changes, or broad config/infra changes
+- If any inline-eligibility condition is false or unclear, choose `delegated`
+- Inline mode must still run the selected baseline or specialist review passes deliberately, using each reviewer's own rubric and the shared specialist contract; do not collapse the review into a generic skim
+
 ## Shared Delegation Contract
 
 - Runtime-facing review skills must read `review-delegation.md` before delegating routed review layers or specialist review passes
-- On supported runtimes, delegated review layers and specialist review passes run as separate subagents; do not silently inline them
-- If a supported runtime cannot start the required delegated workers, stop and report the delegation failure instead of pretending the delegated review ran
+- When execution mode is `delegated`, routed review layers and specialist review passes run as separate subagents on supported runtimes
+- If delegated review is required for the current scope and a supported runtime cannot start the required workers, stop and report that delegated review is required for this scope but unavailable on the current runtime
 - If a specialist review pass fails or returns no output, note it in the summary and continue with available results when the parent skill contract permits it
 - When multiple review passes produce overlapping findings, deduplicate by root cause and keep the highest severity/confidence version
 - Prioritize final findings as `Blocker > Major > Minor`, then by blast radius
 
 ## Shared Report Structure
+
+Section 1 summary must include `Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>`.
+Section 1 summary must include `Execution mode: inline | delegated`.
 
 After Section 1 in a stack-specific review skill, use:
 

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
@@ -22,8 +22,12 @@ Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGEN
 Determine the review scope:
 - Specific files (list paths)
 - Git commits (hashes/range)
-- Working changes (`git diff`)
+- Staged changes (`git diff --cached`; index only)
+- Unstaged changes (`git diff`; working tree only)
+- Combined working tree (`git diff --cached` + `git diff`) only when the caller explicitly asks for all local changes
 - Entire PR
+
+Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
 
 ---
 
@@ -68,18 +72,29 @@ Classify the review as one of:
 
 ## Layered Review Plan
 
-### Step 1: Run `bill-kotlin-code-review` as the baseline review
+### Step 1: Choose execution mode
 
-Run `bill-kotlin-code-review` against the same scope first as a delegated subagent. That skill owns:
+Select `inline` or `delegated` using [review-orchestrator.md](review-orchestrator.md).
+
+- Use `inline` only when the backend review scope stays small and low-risk under the shared execution-mode contract
+- Use `delegated` when the diff is large, backend-only specialist risk is present, multiple layers are meaningfully involved, or the safest choice is unclear
+
+### Step 2: Run `bill-kotlin-code-review` as the baseline review
+
+Run `bill-kotlin-code-review` against the same scope first. That skill owns:
 - shared Kotlin architecture, correctness, security, performance, and testing review
 - the baseline Kotlin findings that every backend/server review should inherit
 
-When invoking it from this skill:
+When invoking it from this skill in either execution mode:
 - tell it that backend/server scope is valid and should be treated as `backend-kotlin-baseline`
 - tell it to keep backend-only review concerns out of scope
 - pass the same diff source, changed files, and relevant override guidance
 
-### Step 2: Analyze the diff and select backend-specific specialist reviews
+If execution mode is `inline`, apply `bill-kotlin-code-review` inline in the current thread.
+
+If execution mode is `delegated`, run `bill-kotlin-code-review` as a delegated subagent and use the runtime-specific delegation contract from [review-delegation.md](review-delegation.md).
+
+### Step 3: Analyze the diff and select backend-specific specialist reviews
 
 | Signal in the diff | Specialist review to run |
 |---------------------|--------------------------|
@@ -87,16 +102,18 @@ When invoking it from this skill:
 | Repositories/DAOs, SQL, ORM mappings, transactions, migrations, optimistic locking, upserts, bulk writes | `bill-backend-kotlin-code-review-persistence` |
 | Timeouts, retries, circuit breakers, queues, schedulers, idempotency, caching, metrics, tracing, startup/shutdown lifecycle | `bill-backend-kotlin-code-review-reliability` |
 
-### Step 3: Run backend specialist reviews
+### Step 4: Run backend specialist reviews
 
-Run one delegated subagent per selected backend specialist review pass. For supported runtimes, do not inline backend specialist review passes or collapse them into the parent review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
+If execution mode is `inline`:
+- run the selected backend specialist review passes sequentially in the current thread
+- read each backend specialist skill file as the primary rubric for that pass
+- apply the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- keep findings attributed to each layer before merging and deduplicating them for the final report
 
-Each backend specialist review pass uses:
-- the detected project type
-- the list of changed files
-- instructions to read its own skill file for the review rubric
-- the parent thread's model when the runtime supports delegated-worker model inheritance
-- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+If execution mode is `delegated`:
+- run one delegated subagent per selected backend specialist review pass
+- pass the detected project type, list of changed files, instructions to read the backend specialist skill file, the parent thread's model when the runtime supports delegated-worker model inheritance, and the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- if delegated review is required for this scope but the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that delegated review is required for this scope but unavailable on the current runtime
 
 If no backend-only triggers match but backend/server signals are clearly present, keep the baseline Kotlin review output and state that no extra backend-specific specialist was needed for this scope.
 
@@ -106,8 +123,10 @@ If no backend-only triggers match but backend/server signals are clearly present
 
 ### 1. Classification & Layer Summary
 ```text
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Detected stack: backend-kotlin | mixed-backend-kotlin
 Signals: application.yml, @RestController, Exposed
+Execution mode: inline | delegated
 Baseline review: bill-kotlin-code-review
 Backend specialist reviews: bill-backend-kotlin-code-review-api-contracts
 Reason: backend/server signals were high-confidence, so the backend layer was added on top of the baseline Kotlin review

--- a/skills/base/bill-code-review/SKILL.md
+++ b/skills/base/bill-code-review/SKILL.md
@@ -26,10 +26,14 @@ Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGEN
 Determine the review scope:
 - Specific files (list paths)
 - Git commits (hashes/range)
-- Working changes (`git diff`)
+- Staged changes (`git diff --cached`; index only)
+- Unstaged changes (`git diff`; working tree only)
+- Combined working tree (`git diff --cached` + `git diff`) only when the caller explicitly asks for all local changes
 - Entire PR
 
 Inspect both the changed files and repo markers before routing.
+
+Resolve the scope before routing. If the caller asks for staged changes, route and review only the staged diff; do not let unstaged edits expand the findings beyond repo-marker stack detection.
 
 ## Additional Resources
 
@@ -58,15 +62,26 @@ Do not redefine stack signals here unless a route-specific exception is truly un
 - If the review scope mixes `kmp` with other Kotlin-family scope, prefer `bill-kmp-code-review` because it layers the appropriate Kotlin-family baseline internally instead of running multiple Kotlin-family orchestrators side by side.
 - If the review scope mixes `backend-kotlin` with generic `kotlin` but not `kmp`, prefer `bill-backend-kotlin-code-review` because it layers `bill-kotlin-code-review` internally instead of running both side by side.
 - If another supported stack dominates, delegate to that stack's canonical `bill-<stack>-code-review` skill when it exists in the available skill catalog.
-- If multiple supported stacks appear in one review scope, route to each matching stack-specific skill and merge the results.
+- If multiple supported stacks appear in one review scope, route to each matching stack-specific skill and merge the results using delegated execution.
 - If the required stack-specific skill does not exist yet, say so explicitly and stop instead of pretending coverage exists.
-- The delegated stack-specific skill is the source of truth for classification details, specialist selection, and review heuristics.
+- The routed stack-specific skill is the source of truth for classification details, specialist selection, review heuristics, and single-stack execution mode.
 
-## Delegation Contract
+## Execution Contract
 
-Before delegating to another skill, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific delegated execution of routed stack-specific review skills.
+Before running delegated routed reviews, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific delegated execution of routed stack-specific review skills.
+
+For a single routed stack-specific review skill:
+- Let the routed stack-specific reviewer choose `inline` or `delegated` using its own `review-orchestrator.md` contract
+- If the routed skill selects `inline`, run it inline in the current thread instead of spawning an extra routed worker just for indirection
+- If the routed skill selects `delegated`, use `review-delegation.md` and pass along the routed skill file path plus the required review context
+
+For multiple routed stack-specific review skills:
+- Use delegated workers for each routed stack-specific review skill and merge the results in the parent review
+- Use parallel delegated workers only when multiple supported stacks are clearly in scope
+- If delegated review is required for the current scope and the runtime lacks a documented delegation path or cannot start the required worker(s), stop and report that delegated review is required for this scope but unavailable on the current runtime
 
 When routing to another skill, pass along:
+- the exact resolved review scope label
 - the exact review scope
 - the changed files or diff source
 - the detected stack and key signals
@@ -76,30 +91,30 @@ When routing to another skill, pass along:
 - the rule that the delegated skill must follow its own `SKILL.md` as the primary rubric
 - the delegated skill's `review-orchestrator.md` contract when the routed skill is a stack review orchestrator
 
-For supported runtimes, execute routed stack-specific reviews as delegated subagents rather than reviewing inline in this router. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
-
-Use parallel delegated subagents only when multiple supported stacks are clearly in scope.
-
 ## Output Format
 
-For a single delegated skill:
+For a single routed skill:
 
 ```text
 Routed to: <skill-name>
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Detected stack: <stack>
 Signals: <markers>
-Reason: <why this stack-specific reviewer was selected>
+Execution mode: inline | delegated
+Reason: <why this stack-specific reviewer was selected and why this execution mode was used>
 
-<delegated review output>
+<review output>
 ```
 
 For multiple delegated skills:
 
 ```text
 Routed to: <skill-a>, <skill-b>
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Detected stack: Mixed
 Signals: <markers>
-Reason: <why multiple stack-specific reviewers were selected>
+Execution mode: delegated
+Reason: <why multiple stack-specific reviewers were selected and why delegated routing was required>
 
 <merged delegated review output>
 ```
@@ -107,6 +122,7 @@ Reason: <why multiple stack-specific reviewers were selected>
 For unsupported stacks:
 
 ```text
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Detected stack: Unknown/Unsupported
 Signals: <markers>
 Result: No matching stack-specific code-review skill is available yet.

--- a/skills/base/bill-feature-implement/SKILL.md
+++ b/skills/base/bill-feature-implement/SKILL.md
@@ -242,7 +242,7 @@ Then re-read `.feature-specs/<feature-name>/spec.md` to refresh acceptance crite
 Run the `bill-code-review` skill and its matching `.agents/skill-overrides.md` section, then apply them inline. Treat that skill as the source of truth for:
 - Stack detection and routing
 - Stack-specific reviewer selection
-- Parallel review execution
+- Adaptive inline-vs-delegated review execution
 - Finding deduplication and prioritization
 
 Pass the following context from this run:

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -28,10 +28,14 @@ Determine the review scope:
 
 - Specific files (list paths)
 - Git commits (hashes/range)
-- Working changes (`git diff`)
+- Staged changes (`git diff --cached`; index only)
+- Unstaged changes (`git diff`; working tree only)
+- Combined working tree (`git diff --cached` + `git diff`) only when the caller explicitly asks for all local changes
 - Entire PR
 
 Inspect the changed files and repo markers before applying review heuristics.
+
+Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
 
 ## Additional Resources
 
@@ -101,17 +105,27 @@ If different parts of the diff touch different review surfaces:
 - If tests changed materially, include `bill-go-code-review-testing`
 - Maximum 7 specialist reviews
 
-### Step 5: Run selected specialist reviews
+### Step 5: Choose execution mode
 
-Run one delegated subagent per selected specialist review pass. For supported runtimes, do not inline specialist review passes or collapse multiple specialists into a single combined review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
+Select `inline` or `delegated` using [review-orchestrator.md](review-orchestrator.md).
 
-Each specialist review pass uses:
+- Use `inline` only when the Go review scope stays small and low-risk under the shared execution-mode contract
+- Use `delegated` when the diff is large, the risk profile is high, multiple review surfaces are meaningfully involved, or the safest choice is unclear
 
-- The list of changed files
-- Instructions to read its own skill file for the review rubric
-- Relevant project-wide guidance and matching per-skill overrides
-- the parent thread's model when the runtime supports delegated-worker model inheritance
-- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+### Step 6: Run selected specialist reviews
+
+If execution mode is `inline`:
+
+- run the selected specialist review passes sequentially in the current thread
+- read each specialist skill file as the primary rubric for that pass
+- apply the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- keep findings attributed to each specialist before merging and deduplicating them for the final report
+
+If execution mode is `delegated`:
+
+- run one delegated subagent per selected specialist review pass
+- pass the list of changed files, instructions to read the specialist skill file, relevant project-wide guidance and matching per-skill overrides, the parent thread's model when the runtime supports delegated-worker model inheritance, and the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- if delegated review is required for this scope but the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that delegated review is required for this scope but unavailable on the current runtime
 
 ---
 
@@ -120,8 +134,9 @@ Each specialist review pass uses:
 ### 1. Specialist Summary
 
 ```text
-Detected review scope: <working tree / commit range / PR diff / files>
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Signals: goroutines, context propagation, database/sql, changed tests
+Execution mode: inline | delegated
 Specialist reviews: bill-go-code-review-architecture, bill-go-code-review-platform-correctness, bill-go-code-review-persistence, bill-go-code-review-testing
 Reason: concurrency-sensitive state handling changed, persistence code changed, and tests changed materially
 ```

--- a/skills/kmp/bill-kmp-code-review/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review/SKILL.md
@@ -22,8 +22,12 @@ Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGEN
 Determine the review scope:
 - Specific files (list paths)
 - Git commits (hashes/range)
-- Working changes (`git diff`)
+- Staged changes (`git diff --cached`; index only)
+- Unstaged changes (`git diff`; working tree only)
+- Combined working tree (`git diff --cached` + `git diff`) only when the caller explicitly asks for all local changes
 - Entire PR
+
+Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
 
 ---
 
@@ -68,9 +72,16 @@ Classify the review as one of:
 
 ## Layered Review Plan
 
-### Step 1: Choose and run the baseline Kotlin-family review
+### Step 1: Choose execution mode
 
-Use the same scope to run exactly one baseline review layer as a delegated subagent:
+Select `inline` or `delegated` using [review-orchestrator.md](review-orchestrator.md).
+
+- Use `inline` only when the Android/KMP review scope stays small and low-risk under the shared execution-mode contract
+- Use `delegated` when the diff is large, mobile or backend specialist risk is present, mixed scope is meaningfully involved, or the safest choice is unclear
+
+### Step 2: Choose and run the baseline Kotlin-family review
+
+Use the same scope to run exactly one baseline review layer:
 - Use `bill-backend-kotlin-code-review` when backend/server files or markers are meaningfully in scope
 - Otherwise use `bill-kotlin-code-review`
 
@@ -79,12 +90,16 @@ That baseline review layer owns:
 - backend/server specialist selection when backend signals are present
 - the baseline Kotlin findings that every Android/KMP review should inherit
 
-When invoking the baseline review:
+When invoking the baseline review in either execution mode:
 - tell it that Android/KMP scope is valid
 - tell it to keep KMP-only review concerns out of scope
 - pass the same diff source, changed files, and relevant override guidance
 
-### Step 2: Analyze the diff and select KMP-specific agents
+If execution mode is `inline`, apply the selected baseline review inline in the current thread.
+
+If execution mode is `delegated`, run the selected baseline review as a delegated subagent and use the runtime-specific delegation contract from [review-delegation.md](review-delegation.md).
+
+### Step 3: Analyze the diff and select KMP-specific agents
 
 - Preserve Android/KMP specialists for any Android/KMP files even when backend files are changed in the same PR
 - A single PR may spawn both the baseline review and KMP-only specialists, but keep the KMP-specific specialist count at 2 or fewer
@@ -98,16 +113,18 @@ Keep the mobile triggers focused on what the baseline review does not cover:
 | `@Composable` functions, UI state classes, Modifier chains, `remember`, `LaunchedEffect` | `bill-kmp-code-review-ui` |
 | User-facing UI changes, `stringResource`, accessibility attributes, navigation, error states, localization files | `bill-kmp-code-review-ux-accessibility` |
 
-### Step 3: Run KMP specialist reviews
+### Step 4: Run KMP specialist reviews
 
-Run one delegated subagent per selected KMP specialist review pass. For supported runtimes, do not inline KMP specialist review passes or collapse them into the parent review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
+If execution mode is `inline`:
+- run the selected KMP specialist review passes sequentially in the current thread
+- read each KMP specialist skill file as the primary rubric for that pass
+- apply the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- keep findings attributed to each layer before merging and deduplicating them for the final report
 
-Each KMP specialist review pass uses:
-- the detected project type
-- the list of changed files
-- instructions to read its own skill file for the review rubric
-- the parent thread's model when the runtime supports delegated-worker model inheritance
-- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+If execution mode is `delegated`:
+- run one delegated subagent per selected KMP specialist review pass
+- pass the detected project type, list of changed files, instructions to read the KMP specialist skill file, the parent thread's model when the runtime supports delegated-worker model inheritance, and the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- if delegated review is required for this scope but the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that delegated review is required for this scope but unavailable on the current runtime
 
 If no KMP-only triggers match but Android/KMP signals are clearly present, keep the baseline review output and state that no extra KMP-only specialist was needed for this scope.
 
@@ -117,8 +134,10 @@ If no KMP-only triggers match but Android/KMP signals are clearly present, keep 
 
 ### 1. Classification & Layer Summary
 ```text
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Detected stack: kmp | mixed-kmp
 Signals: @Composable, AndroidManifest.xml, ViewModel
+Execution mode: inline | delegated
 Baseline review: bill-kotlin-code-review | bill-backend-kotlin-code-review
 KMP specialist reviews: bill-kmp-code-review-ui
 Reason: Android/KMP signals were high-confidence, so the mobile layer was added on top of the baseline Kotlin-family review

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -22,8 +22,12 @@ Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGEN
 Determine the review scope:
 - Specific files (list paths)
 - Git commits (hashes/range)
-- Working changes (`git diff`)
+- Staged changes (`git diff --cached`; index only)
+- Unstaged changes (`git diff`; working tree only)
+- Combined working tree (`git diff --cached` + `git diff`) only when the caller explicitly asks for all local changes
 - Entire PR
+
+Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
 
 ---
 
@@ -95,16 +99,25 @@ Architecture review is relevant for every non-trivial change.
 - Maximum 5 agents
 - Do not run KMP-only specialists or backend-only specialists from this skill; leave those to the platform-specific override that owns them
 
-### Step 5: Run selected specialist reviews
+### Step 5: Choose execution mode
 
-Run one delegated subagent per selected specialist review pass. For supported runtimes, do not inline specialist review passes or collapse multiple specialists into a single combined review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
+Select `inline` or `delegated` using [review-orchestrator.md](review-orchestrator.md).
 
-Each specialist review pass uses:
-- the detected project type
-- the list of changed files
-- instructions to read its own skill file for the review rubric
-- the parent thread's model when the runtime supports delegated-worker model inheritance
-- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- Use `inline` only when the Kotlin review scope stays small and low-risk under the shared execution-mode contract
+- Use `delegated` when the diff is large, the risk profile is high, multiple layers are meaningfully involved, or the safest choice is unclear
+
+### Step 6: Run selected specialist reviews
+
+If execution mode is `inline`:
+- run the selected specialist review passes sequentially in the current thread
+- read each specialist skill file as the primary rubric for that pass
+- apply the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- keep findings attributed to each specialist before merging and deduplicating them for the final report
+
+If execution mode is `delegated`:
+- run one delegated subagent per selected specialist review pass
+- pass the detected project type, list of changed files, instructions to read the specialist skill file, the parent thread's model when the runtime supports delegated-worker model inheritance, and the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- if delegated review is required for this scope but the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that delegated review is required for this scope but unavailable on the current runtime
 
 ---
 
@@ -112,8 +125,10 @@ Each specialist review pass uses:
 
 ### 1. Classification & Specialist Summary
 ```text
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Detected stack: kotlin | kmp-baseline | backend-kotlin-baseline
 Signals: <markers>
+Execution mode: inline | delegated
 Specialist reviews: bill-kotlin-code-review-architecture, bill-kotlin-code-review-platform-correctness
 Reason: <why this Kotlin baseline route was selected>
 ```

--- a/skills/php/bill-php-code-review/SKILL.md
+++ b/skills/php/bill-php-code-review/SKILL.md
@@ -28,10 +28,14 @@ Determine the review scope:
 
 - Specific files (list paths)
 - Git commits (hashes/range)
-- Working changes (`git diff`)
+- Staged changes (`git diff --cached`; index only)
+- Unstaged changes (`git diff`; working tree only)
+- Combined working tree (`git diff --cached` + `git diff`) only when the caller explicitly asks for all local changes
 - Entire PR
 
 Inspect the changed files and repo markers before applying review heuristics.
+
+Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
 
 ## Additional Resources
 
@@ -96,17 +100,27 @@ If different parts of the diff touch different review surfaces:
 - If tests changed materially, include `bill-php-code-review-testing`
 - Maximum 7 specialist reviews
 
-### Step 5: Run selected specialist reviews
+### Step 5: Choose execution mode
 
-Run one delegated subagent per selected specialist review pass. For supported runtimes, do not inline specialist review passes or collapse multiple specialists into a single combined review. If the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that guaranteed delegated review execution is unavailable.
+Select `inline` or `delegated` using [review-orchestrator.md](review-orchestrator.md).
 
-Each specialist review pass uses:
+- Use `inline` only when the PHP review scope stays small and low-risk under the shared execution-mode contract
+- Use `delegated` when the diff is large, the risk profile is high, multiple review surfaces are meaningfully involved, or the safest choice is unclear
 
-- The list of changed files
-- Instructions to read its own skill file for the review rubric
-- Relevant project-wide guidance and matching per-skill overrides
-- the parent thread's model when the runtime supports delegated-worker model inheritance
-- the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+### Step 6: Run selected specialist reviews
+
+If execution mode is `inline`:
+
+- run the selected specialist review passes sequentially in the current thread
+- read each specialist skill file as the primary rubric for that pass
+- apply the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- keep findings attributed to each specialist before merging and deduplicating them for the final report
+
+If execution mode is `delegated`:
+
+- run one delegated subagent per selected specialist review pass
+- pass the list of changed files, instructions to read the specialist skill file, relevant project-wide guidance and matching per-skill overrides, the parent thread's model when the runtime supports delegated-worker model inheritance, and the shared specialist contract in [review-orchestrator.md](review-orchestrator.md)
+- if delegated review is required for this scope but the current runtime lacks a documented delegation path or cannot start the required subagent(s), stop and report that delegated review is required for this scope but unavailable on the current runtime
 
 ---
 
@@ -115,8 +129,9 @@ Each specialist review pass uses:
 ### 1. Specialist Summary
 
 ```text
-Detected review scope: <working tree / commit range / PR diff / files>
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
 Signals: transactions, projections, changed tests
+Execution mode: inline | delegated
 Specialist reviews: bill-php-code-review-architecture, bill-php-code-review-platform-correctness, bill-php-code-review-persistence, bill-php-code-review-testing
 Reason: transaction and projection paths changed, plus tests changed materially
 ```

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -83,6 +83,9 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("Supported scope labels are `staged changes`, `unstaged changes`, `working tree`, `commit range`, `PR diff`, and `files`", REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn("When the caller asks for staged changes, inspect only the staged/index diff", REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn("Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("The parent review owns only the delegated workers it launched itself.", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("Track delegated workers by the ids returned when they are launched.", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("Do not use `list_agents` to discover delegated workers during normal review execution.", REVIEW_DELEGATION_PLAYBOOK)
     for section in REVIEW_DELEGATION_REQUIRED_SECTIONS:
       self.assertIn(section, REVIEW_DELEGATION_PLAYBOOK)
 

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -80,6 +80,9 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("Do not reference this repo-relative path directly", STACK_ROUTING_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("Supported scope labels are `staged changes`, `unstaged changes`, `working tree`, `commit range`, `PR diff`, and `files`", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("When the caller asks for staged changes, inspect only the staged/index diff", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>", REVIEW_ORCHESTRATOR_PLAYBOOK)
     for section in REVIEW_DELEGATION_REQUIRED_SECTIONS:
       self.assertIn(section, REVIEW_DELEGATION_PLAYBOOK)
 
@@ -88,6 +91,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("run `bill-quality-check`", FEATURE_IMPLEMENT)
     self.assertIn("`bill-code-review`", FEATURE_IMPLEMENT)
     self.assertIn("`bill-quality-check`", FEATURE_IMPLEMENT)
+    self.assertIn("Adaptive inline-vs-delegated review execution", FEATURE_IMPLEMENT)
 
   def test_kotlin_context_routes_to_kotlin_review_and_quality_check(self) -> None:
     self.assertIn(
@@ -113,7 +117,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       QUALITY_CHECK,
     )
     self.assertIn(
-      "### Step 1: Run `bill-kotlin-code-review` as the baseline review",
+      "### Step 2: Run `bill-kotlin-code-review` as the baseline review",
       BACKEND_KOTLIN_CODE_REVIEW,
     )
 
@@ -187,7 +191,26 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       KOTLIN_CODE_REVIEW,
     )
 
-  def test_stack_review_skills_require_delegated_subagent_execution(self) -> None:
+  def test_router_uses_adaptive_execution_contract(self) -> None:
+    self.assertIn(
+      "Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>",
+      CODE_REVIEW,
+    )
+    self.assertIn("Execution mode: inline | delegated", CODE_REVIEW)
+    self.assertIn(
+      "If the caller asks for staged changes, route and review only the staged diff",
+      CODE_REVIEW,
+    )
+    self.assertIn(
+      "If the routed skill selects `inline`, run it inline in the current thread instead of spawning an extra routed worker just for indirection",
+      CODE_REVIEW,
+    )
+    self.assertIn(
+      "If delegated review is required for the current scope and the runtime lacks a documented delegation path or cannot start the required worker(s), stop and report that delegated review is required for this scope but unavailable on the current runtime",
+      CODE_REVIEW,
+    )
+
+  def test_stack_review_skills_define_adaptive_execution_modes(self) -> None:
     forbidden_phrases = (
       "`task`",
       "spawn_agent",
@@ -202,8 +225,25 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
         self.assertIn("specialist review", skill_text)
         self.assertIn("[review-orchestrator.md](review-orchestrator.md)", skill_text)
         self.assertIn("[review-delegation.md](review-delegation.md)", skill_text)
-        self.assertIn("delegated subagent", skill_text)
-        self.assertIn("guaranteed delegated review execution is unavailable", skill_text)
+        self.assertIn(
+          "Staged changes (`git diff --cached`; index only)",
+          skill_text,
+        )
+        self.assertIn(
+          "Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff",
+          skill_text,
+        )
+        self.assertIn(
+          "Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>",
+          skill_text,
+        )
+        self.assertIn("Execution mode: inline | delegated", skill_text)
+        self.assertIn("Use `inline` only", skill_text)
+        self.assertIn("If execution mode is `delegated`", skill_text)
+        self.assertIn(
+          "delegated review is required for this scope but unavailable on the current runtime",
+          skill_text,
+        )
         self.assertNotIn(".bill-shared/orchestration/", skill_text)
         self.assertNotIn("orchestration/stack-routing/PLAYBOOK.md", skill_text)
         self.assertNotIn("orchestration/review-orchestrator/PLAYBOOK.md", skill_text)


### PR DESCRIPTION
# Summary

This changes the review contract from always-delegated execution to adaptive execution based on scope and risk, so small low-risk reviews can stay inline while larger or riskier reviews still use delegated specialist passes.

It also makes review scope explicit in the output and tightens the staged-vs-unstaged guidance so staged-only reviews do not drift into unrelated working tree changes.

- update the shared review orchestration and delegation contracts
- teach the base and stack-specific review skills to label scope and execution mode explicitly
- document the adaptive behavior in the feature flow and README, and lock it in with routing-contract tests

## Feature Flags

N/A

# How Has This Been Tested?

Ran the repo validation suite and verified the review-contract assertions that cover adaptive execution mode and explicit scope labeling.

1. Run `python3 -m unittest discover -s tests`
2. Run `npx --yes agnix --strict .`
3. Run `python3 scripts/validate_agent_configs.py`
4. Run the code-review flow on staged-only and unstaged-only local changes and confirm the output reports the correct `Detected review scope` and `Execution mode`
