### PR TITLE
feat: [SKILL-2] add install-time skill prefixes

### DIFF
--- a/.feature-specs/install-prefix-aliases/spec.md
+++ b/.feature-specs/install-prefix-aliases/spec.md
@@ -1,0 +1,36 @@
+# Feature: install-prefix-aliases
+Created: 2026-04-02
+Status: In Progress
+Sources: chat discussion for SKILL-2 about install-time user-facing skill prefixes
+
+## Acceptance Criteria
+1. The installer prompts for a user-facing skill prefix.
+2. Pressing Enter keeps the default prefix `bill`.
+3. A custom prefix changes the installed command names without changing the repo's canonical `bill-*` taxonomy.
+4. Installed aliased skills keep working for routing and cross-skill references.
+5. Reinstalling or uninstalling removes previously installed aliases cleanly.
+6. Installer docs and tests are updated.
+
+## Non-Goals
+- Changing canonical in-repo skill names
+- Redesigning the taxonomy
+- Changing review behavior unrelated to install-time naming
+
+## Open Questions
+None
+
+---
+
+## Consolidated Spec
+
+Add install-time support for a user-facing skill prefix so teams can invoke Skill Bill commands under their own namespace while leaving the repository's canonical skill names unchanged.
+
+The default behavior should remain the current `bill-*` namespace. If the user presses Enter at the new prefix prompt, installation should proceed with the canonical `bill` prefix and preserve existing behavior.
+
+If the user provides a custom prefix, the installed command names should use that prefix instead of `bill`, but the repository itself must continue using canonical `bill-*` names. This should be treated as an install-time alias layer only, not a taxonomy rewrite.
+
+Aliased installs must continue to work for routed and delegated workflows. That means cross-skill references inside installed skill files and supporting markdown contracts need to resolve under the chosen prefix rather than pointing at canonical command names that are not installed under that namespace.
+
+Reinstall and uninstall behavior must remain clean. Existing installs under a previous prefix should be removed safely before reinstalling with a new prefix, and uninstall should clean up generated alias installs as well as canonical symlink installs.
+
+The installer and related documentation should explain the prefix behavior clearly enough that teams understand the difference between canonical repository names and installed command aliases.

--- a/.feature-specs/pr-template-preference/spec.md
+++ b/.feature-specs/pr-template-preference/spec.md
@@ -1,0 +1,33 @@
+# Feature: pr-template-preference
+Created: 2026-04-02
+Status: In Progress
+Sources: chat discussion for SKILL-2 about preferring repo-native PR templates in `bill-pr-description`
+
+## Acceptance Criteria
+1. `bill-pr-description` checks whether the target repository has its own PR description template before using Skill Bill's built-in template.
+2. If a single default repo-native template exists, the skill uses that template shape first.
+3. If no repo-native template exists, the skill falls back to the current built-in Skill Bill PR description template.
+4. If multiple repo-native templates exist and there is no obvious default, the skill does not guess silently; it asks the user which template to use.
+5. The skill documentation and tests are updated to describe and enforce this behavior.
+
+## Non-Goals
+- Changing the canonical built-in fallback template
+- Redesigning GitHub's template semantics
+- Adding repo-specific hardcoded paths beyond standard PR template locations
+
+## Open Questions
+None
+
+---
+
+## Consolidated Spec
+
+Update `bill-pr-description` so it first checks whether the target repository already defines a PR description template. If a clear repo-native template exists, the skill should use that template structure instead of always emitting Skill Bill's built-in PR description format.
+
+The preferred search space should stay within standard repository template locations such as `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, root-level `pull_request_template.md`, root-level `PULL_REQUEST_TEMPLATE.md`, and `.github/PULL_REQUEST_TEMPLATE/*.md`.
+
+If there is no repo-native template, the current built-in Skill Bill PR description template remains the fallback and should continue to work as it does today.
+
+If multiple repo-native templates exist and there is no clear default, the skill should not silently pick one. It should ask the user which template to use so the output remains faithful to the repository's actual process instead of inventing a heuristic that may be wrong.
+
+The skill instructions and repository tests should be updated so this behavior is explicit, documented, and resistant to regression.

--- a/README.md
+++ b/README.md
@@ -137,42 +137,52 @@ The installer first asks which agent targets to install to. You can choose one o
 all
 ```
 
-It then shows the available platform packages and asks which ones to install. Base skills in `skills/base/` are always installed; platform packages are installed only when selected.
+It then shows the available platform packages and asks which ones to install. Base skills in `skills/base/` are always installed; platform packages are installed only when selected. The primary input path is **comma-separated numbers**, though platform names still work too.
 
 Available options are shown as separate entries:
 
 ```text
-Kotlin backend
-Kotlin
-KMP
-PHP
-Go
-all
+1. Kotlin backend
+2. Kotlin
+3. KMP
+4. PHP
+5. Go
+6. all
 ```
 
 Example platform selections:
 
 ```text
-Kotlin backend, Kotlin, KMP
-PHP
-Go
-all
+1,2,3
+4
+5
+6
 ```
 
-Each installer run replaces the existing Skill Bill links and reinstalls only the agent and platform selections from that run.
+Finally, the installer asks for the **user-facing command prefix**. Press Enter to keep the default `bill` prefix, or enter your own team/org prefix:
 
-The installer always removes existing Skill Bill links before reinstalling the selected agents and platforms.
+```text
+bill
+acme
+platform
+```
+
+Canonical in-repo skill names stay `bill-*`. A custom prefix changes only the installed command names (for example `acme-code-review`) and rewrites installed skill references so routed workflows still resolve under that namespace.
+
+Each installer run replaces the existing Skill Bill installs and reinstalls only the agent and platform selections from that run.
+
+The installer always removes existing Skill Bill installs before reinstalling the selected agents and platforms. The default `bill` prefix keeps the current symlink-based install behavior. Custom prefixes install generated alias copies, so re-run `./install.sh` after editing skills in the repo.
 
 ## Uninstallation
 
-To remove Skill Bill skill symlinks from the supported agent install paths:
+To remove Skill Bill skill installs from the supported agent install paths:
 
 ```bash
 chmod +x uninstall.sh
 ./uninstall.sh
 ```
 
-The uninstaller is idempotent. It removes current Skill Bill skill names plus known legacy install names when they are present as symlinks, and skips non-symlink paths.
+The uninstaller is idempotent. It removes current Skill Bill installs, generated alias installs, and known legacy install names when they are present, and skips unrelated non-symlink paths.
 
 ## Skills Included
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The uninstaller is idempotent. It removes current Skill Bill installs, generated
 | `/bill-go-quality-check` | Go quality-check implementation |
 | `/bill-boundary-history` | Maintain `agent/history.md` at module/package/area boundaries |
 | `/bill-unit-test-value-check` | Audit unit tests for real value |
-| `/bill-pr-description` | Generate PR title, description, and QA steps |
+| `/bill-pr-description` | Generate PR title, description, and QA steps, preferring repo PR templates when present |
 | `/bill-new-skill-all-agents` | Create a new skill and sync it to all agents |
 
 ## Project customization

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,381 @@
+# Skill Bill Roadmap
+
+## Why this document exists
+
+Skill Bill can look deceptively simple because most of the repository is Markdown rather than application code. But the project is not just a prompt collection. It is a governed behavior system: a portable layer of routing, orchestration, review depth, safety rules, and team-facing contracts for AI-assisted engineering.
+
+That means the project needs a clear long-term direction. Without one, it risks drifting into "more skills, more stacks, more prompts" without becoming meaningfully more reliable or more useful to teams.
+
+This roadmap exists to keep the bigger picture visible while the repository grows.
+
+## North star
+
+**Make AI-assisted engineering feel like a reliable team capability, not a bag of prompts.**
+
+In practical terms, that means a team should be able to adopt stable commands such as `/bill-code-review`, `/bill-feature-implement`, and `/bill-quality-check` and trust:
+
+- what behavior they will get
+- how scope will be interpreted
+- how depth will be chosen
+- what review guarantees and failure modes exist
+- how platform-specific behavior stays consistent with shared entry points
+
+The long-term goal is not only broader stack coverage. The goal is to become the policy and orchestration layer that makes AI behavior portable, governed, and dependable across agents and teams.
+
+## Product thesis
+
+Skill Bill is most valuable when it behaves like infrastructure rather than a prompt dump.
+
+The repository should continue to optimize for:
+
+- **stable user-facing entry points** instead of proliferating ad hoc commands
+- **platform depth behind the router** instead of stack-specific sprawl leaking into the base layer
+- **validator-backed rules** instead of tribal knowledge
+- **portable behavior across agents** instead of one runtime getting all the quality
+- **explicit contracts** instead of implicit prompt folklore
+- **predictable failure handling** instead of silent fallback or "best effort" ambiguity
+
+## What success looks like
+
+Skill Bill is succeeding when most of the following are true:
+
+1. Teams can install it once and get consistent behavior across supported agents.
+2. Shared entry points stay stable even as platform depth grows behind them.
+3. Reviews are high-signal, scope-faithful, and understandable enough to influence merge decisions.
+4. Feature workflows reliably move from spec to implementation to validation with clear contracts at each step.
+5. Project-specific customization is possible without degrading the shared taxonomy.
+6. New skills and edits are constrained by tests and validators, not only maintainer judgment.
+7. Teams start treating Skill Bill as part of engineering process, not as an experimental side tool.
+
+## Current position
+
+Today, Skill Bill is strongest in these areas:
+
+- governed naming and package taxonomy
+- portable installation across multiple agent environments
+- stack-aware routing for code review and quality-check flows
+- layered review orchestration with shared and platform-specific contracts
+- validation coverage that prevents many forms of repository drift
+
+Today, Skill Bill is still relatively early in these areas:
+
+- reliability under real-world runtime behavior
+- organization-level rollout and override strategy
+- measurement of review quality and usefulness
+- deeper process routing beyond stack detection
+- broader team adoption patterns, documentation, and change management
+
+## Strategic priorities
+
+The roadmap below is ordered by importance, not by date.
+
+### 1. Reliability first
+
+The first responsibility of a governed AI workflow repo is to behave predictably.
+
+This means continuing to reduce:
+
+- scope drift between staged, unstaged, PR, and file-based review modes
+- orchestration noise such as background-agent bookkeeping failures
+- review-mode ambiguity such as unclear inline vs delegated behavior
+- false confidence caused by unsupported or partially supported execution paths
+- hidden fallbacks that make output look stronger than the actual guarantees
+
+Key outcome:
+
+**A user should be able to trust that the reported behavior matches what actually happened.**
+
+### 2. Make existing workflows truly strong
+
+Adding new languages is useful, but deepening the main workflows matters more.
+
+The highest-leverage flows today are:
+
+- `/bill-code-review`
+- `/bill-feature-implement`
+- `/bill-feature-verify`
+- `/bill-quality-check`
+- `/bill-pr-description`
+
+The next phase of maturity is making these workflows feel complete and dependable enough for daily team use.
+
+That means improving:
+
+- signal quality of reviews
+- consistency of outputs across agents
+- risk classification and prioritization
+- completeness checks against specs and acceptance criteria
+- end-to-end handoff quality into PRs and team review process
+
+Key outcome:
+
+**A small set of stable commands should cover a meaningful portion of normal engineering work without feeling shallow or flaky.**
+
+### 3. Deepen governance
+
+Skill Bill already has a strong taxonomy bias. The next step is turning that into a fuller operating model.
+
+This includes:
+
+- stronger validation of routing and orchestration contracts
+- clearer portability boundaries between runtime-facing skill files and maintainer playbooks
+- better rules for overrides, versioning, migration, and deprecation
+- explicit support for what is guaranteed vs best effort
+- clearer contracts for how stack-specific packages are allowed to diverge
+
+Key outcome:
+
+**Maintainers should be able to evolve the repository without slowly eroding consistency.**
+
+### 4. Support team and org adoption
+
+The project becomes meaningfully more valuable when teams can adopt it as process infrastructure.
+
+That requires more than good skill text. It requires:
+
+- team-friendly documentation
+- rollout guidance
+- conventions for repository-local overrides
+- clear guidance for when to trust, verify, or escalate outputs
+- easier onboarding for EMs, tech leads, and senior ICs
+- patterns for introducing Skill Bill into code review, feature work, and quality gates
+
+Key outcome:
+
+**Teams should be able to operationalize Skill Bill without each team inventing its own model from scratch.**
+
+### 5. Add measurement and feedback loops
+
+A governed behavior system needs evidence, not only intuition.
+
+Over time, Skill Bill should develop lightweight ways to evaluate:
+
+- review usefulness
+- false-positive rate
+- missed-issue rate
+- scope-faithfulness
+- workflow completion quality
+- team adoption and repeated use
+
+This does not need to begin as heavy analytics. Even structured manual evaluation can create a much stronger improvement loop than anecdotal memory alone.
+
+Key outcome:
+
+**The project should learn from real usage patterns and improve on purpose.**
+
+### 6. Expand from stack routing to process routing
+
+Right now, Skill Bill is strong at answering:
+
+- what stack is this?
+- which specialist review layers should run?
+
+Its next level is being able to answer:
+
+- what kind of change is this?
+- what process should apply?
+
+Examples:
+
+- migration or schema change
+- risky auth/session change
+- rollout or feature-flag change
+- incident fix
+- refactor with behavior-preservation expectations
+- design-heavy UI work
+- reliability-sensitive infra change
+
+This is a major strategic shift because it moves Skill Bill from stack-aware prompting to workflow-aware engineering policy.
+
+Key outcome:
+
+**Routing should eventually reflect both technical stack and work type.**
+
+### 7. Build reusable organizational memory
+
+One of the most promising directions for Skill Bill is encoding engineering judgment once and reusing it everywhere.
+
+That includes:
+
+- architecture rules
+- review heuristics
+- rollout practices
+- security expectations
+- testing standards
+- change-management norms
+- boundary history and feature history
+
+The goal is not just to ship prompts. The goal is to make team knowledge durable and portable across agent runtimes.
+
+Key outcome:
+
+**Skill Bill should become a reusable container for engineering standards, not only a skill catalog.**
+
+## Roadmap themes
+
+The next set of improvements should cluster around a few durable themes.
+
+### Theme A: Execution reliability
+
+Focus:
+
+- explicit scope contracts
+- deterministic execution mode selection
+- safer delegated worker tracking
+- clearer unsupported-runtime behavior
+- less noisy failure handling
+
+Examples of work:
+
+- tighten orchestration rules for parent/child delegated reviews
+- add contract tests for common runtime failure patterns
+- require more explicit reporting when guarantees are weakened
+- reduce accidental broadening of review scope
+
+### Theme B: Review quality and trust
+
+Focus:
+
+- higher signal-to-noise
+- better actionability
+- fewer speculative findings
+- more consistent prioritization
+
+Examples of work:
+
+- improve evidence and minimal-fix expectations
+- refine severity guidance
+- add more comparison-based evaluation of review outputs
+- standardize verdict wording so teams can act on it
+
+### Theme C: Workflow completeness
+
+Focus:
+
+- stronger end-to-end feature implementation flow
+- better verification against specs
+- cleaner PR handoff
+- less manual glue between steps
+
+Examples of work:
+
+- improve feature-to-review-to-quality-check sequencing
+- strengthen acceptance-criteria completeness checks
+- improve PR summary generation based on actual branch diff
+- make "done" states more explicit and less optimistic
+
+### Theme D: Team adoption
+
+Focus:
+
+- easier setup
+- clearer documentation
+- better organizational customization
+- practical team rollout patterns
+
+Examples of work:
+
+- write team adoption docs and examples
+- define recommended repo-local override strategy
+- document a minimal process integration model for reviews and PRs
+- make install/update flows friendlier for non-maintainers
+
+### Theme E: Governance and maintainability
+
+Focus:
+
+- preserve taxonomy clarity
+- keep playbooks and runtime-facing files aligned
+- make allowed divergence explicit
+- protect the project from entropy
+
+Examples of work:
+
+- extend validator coverage
+- add more contract tests around routing and sidecar references
+- document deprecation and migration policy for skills
+- formalize what belongs in base vs platform packages
+
+## Suggested sequencing
+
+This is a recommended sequence of emphasis, not a date-based plan.
+
+### Horizon 1: Stabilize the core
+
+Prioritize:
+
+- review reliability
+- scope fidelity
+- execution-mode clarity
+- delegated orchestration correctness
+- stronger tests for existing review flows
+
+This horizon is about making the current system trustworthy enough that adoption does not outpace quality.
+
+### Horizon 2: Make the core workflows excellent
+
+Prioritize:
+
+- stronger review quality
+- stronger feature implementation and verification flows
+- cleaner PR generation
+- better consistency across supported agents
+
+This horizon is about turning the current stable commands into genuinely strong daily tools.
+
+### Horizon 3: Operationalize for teams
+
+Prioritize:
+
+- team adoption documentation
+- project-specific customization patterns
+- org memory and boundary-history workflows
+- process routing for different change types
+
+This horizon is about moving from "useful to an advanced individual" to "safe and valuable for a team."
+
+### Horizon 4: Expand carefully
+
+Prioritize:
+
+- new platforms only when they fit the governance model
+- new workflows only when they strengthen the stable command surface
+- measurement loops that justify what should be built next
+
+This horizon is about growth without losing coherence.
+
+## What not to optimize for
+
+Skill Bill should resist several attractive but dangerous directions:
+
+- adding stacks faster than the current workflows become trustworthy
+- creating many narrow one-off skills without stable base entry points
+- hiding runtime limitations behind optimistic language
+- overfitting to one agent runtime at the expense of portability
+- turning governance into ceremony that slows down useful improvement
+- treating every user preference as a new top-level capability
+
+## Open questions worth revisiting
+
+These questions do not need immediate answers, but they should stay visible.
+
+1. How much of Skill Bill should be shared portable contract vs agent-specific runtime behavior?
+2. What is the right override model for teams that want local standards without breaking the shared taxonomy?
+3. How should review quality be measured in a lightweight but honest way?
+4. Which workflows should become first-class after review, implementation, verification, and quality-check?
+5. How should Skill Bill communicate levels of confidence and support across different runtimes?
+6. At what point should process routing become a first-class concept in the taxonomy?
+
+## Summary
+
+Skill Bill's future is not primarily about becoming a larger collection of skills.
+
+Its future is about becoming a **reliable, portable, governed engineering behavior layer**:
+
+- stable for users
+- deep behind the router
+- explicit about guarantees
+- adaptable across agents
+- useful enough for teams to operationalize
+
+That is the bigger picture this roadmap is meant to preserve.

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$PLUGIN_DIR/skills"
+MANAGED_INSTALL_MARKER=".skill-bill-install"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -81,9 +82,11 @@ declare -a SKILL_NAMES=()
 declare -a SKILL_PATHS=()
 declare -a INSTALL_SKILL_NAMES=()
 declare -a INSTALL_SKILL_PATHS=()
+declare -a INSTALL_TARGET_NAMES=()
 declare -a PLATFORM_PACKAGES=()
 declare -a SELECTED_PLATFORM_PACKAGES=()
 declare -a LEGACY_SKILL_NAMES=()
+INSTALL_PREFIX="bill"
 
 remove_if_allowed() {
   local target="$1"
@@ -92,8 +95,20 @@ remove_if_allowed() {
     return 0
   fi
 
-  rm -rf "$target"
-  return 0
+  if [[ -L "$target" ]]; then
+    rm -f "$target"
+    return 0
+  fi
+
+  if [[ -d "$target" ]]; then
+    if [[ -f "$target/$MANAGED_INSTALL_MARKER" ]] || path_has_matching_skill_name "$target"; then
+      rm -rf "$target"
+      return 0
+    fi
+  fi
+
+  err "Refusing to overwrite existing non-Skill-Bill path: $target"
+  return 1
 }
 
 lookup_renamed_skill() {
@@ -145,12 +160,38 @@ trim_string() {
   printf '%s' "$value"
 }
 
+normalize_prefix_token() {
+  local value
+  value="$(trim_string "$1")"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  value="${value#/}"
+  while [[ "$value" == *- ]]; do
+    value="${value%-}"
+  done
+  printf '%s' "$value"
+}
+
 normalize_platform_token() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]_/-'
 }
 
 normalize_agent_token() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]'
+}
+
+is_valid_prefix() {
+  [[ "$1" =~ ^[a-z][a-z0-9-]*$ ]]
+}
+
+alias_skill_name() {
+  local canonical_name="$1"
+
+  if [[ "$INSTALL_PREFIX" == "bill" ]] || [[ "$canonical_name" != bill-* ]]; then
+    printf '%s' "$canonical_name"
+    return 0
+  fi
+
+  printf '%s-%s' "$INSTALL_PREFIX" "${canonical_name#bill-}"
 }
 
 add_agent_selection() {
@@ -420,8 +461,8 @@ prompt_for_platform_selection() {
     option_number=$(( ${#PLATFORM_PACKAGES[@]} + 1 ))
     printf "  %s. all (install every platform package)\n" "$option_number"
     info "Base skills are always installed."
-    info "Choose one or more platform options (comma-separated)."
-    printf "${CYAN}▸${NC} Enter platforms (e.g. Kotlin backend, Kotlin, KMP or PHP): "
+    info "Choose one or more platform numbers (comma-separated). Names still work if you prefer them."
+    printf "${CYAN}▸${NC} Enter platforms (e.g. 1,3 or %s): " "$option_number"
     read -r input
 
     if [[ -z "$(trim_string "$input")" ]]; then
@@ -464,6 +505,35 @@ prompt_for_platform_selection() {
   done
 }
 
+prompt_for_skill_prefix() {
+  local input
+  local normalized
+
+  while true; do
+    echo ""
+    info "Choose the user-facing skill prefix."
+    info "Press Enter to keep the default prefix: bill"
+    printf "${CYAN}▸${NC} Enter prefix: "
+    if ! read -r input; then
+      input=""
+    fi
+
+    normalized="$(normalize_prefix_token "$input")"
+    if [[ -z "$normalized" ]]; then
+      INSTALL_PREFIX="bill"
+      return 0
+    fi
+
+    if ! is_valid_prefix "$normalized"; then
+      warn "Prefix must start with a letter and use only lowercase letters, digits, or hyphens."
+      continue
+    fi
+
+    INSTALL_PREFIX="$normalized"
+    return 0
+  done
+}
+
 build_skill_names() {
   local skill_file skill_dir skill_name
   local existing_idx
@@ -491,17 +561,21 @@ build_install_skill_names() {
   local idx
   local skill_dir
   local package_name
+  local canonical_name
 
   INSTALL_SKILL_NAMES=()
   INSTALL_SKILL_PATHS=()
+  INSTALL_TARGET_NAMES=()
 
   for idx in "${!SKILL_NAMES[@]}"; do
     skill_dir="${SKILL_PATHS[$idx]}"
     package_name="$(basename "$(dirname "$skill_dir")")"
+    canonical_name="${SKILL_NAMES[$idx]}"
 
     if [[ "$package_name" == "base" ]] || array_contains "$package_name" "${SELECTED_PLATFORM_PACKAGES[@]:-}"; then
-      INSTALL_SKILL_NAMES+=("${SKILL_NAMES[$idx]}")
+      INSTALL_SKILL_NAMES+=("$canonical_name")
       INSTALL_SKILL_PATHS+=("$skill_dir")
+      INSTALL_TARGET_NAMES+=("$(alias_skill_name "$canonical_name")")
     fi
   done
 }
@@ -585,6 +659,86 @@ install_skill_link() {
   ok "  $label"
 }
 
+path_has_matching_skill_name() {
+  local target="$1"
+  local skill_file="$target/SKILL.md"
+  local declared_name=""
+  local expected_name
+
+  [[ -d "$target" ]] || return 1
+  [[ -f "$skill_file" ]] || return 1
+
+  expected_name="$(basename "$target")"
+  declared_name="$(sed -n 's/^name:[[:space:]]*//p' "$skill_file" | head -n 1)"
+  [[ "$declared_name" == "$expected_name" ]]
+}
+
+rewrite_markdown_file() {
+  local source_file="$1"
+  local target_file="$2"
+
+  if [[ "$INSTALL_PREFIX" == "bill" ]]; then
+    cp "$source_file" "$target_file"
+    return 0
+  fi
+
+  SKILL_BILL_INSTALL_PREFIX="$INSTALL_PREFIX" perl -0pe \
+    's/\bbill-([a-z0-9-]+)/$ENV{"SKILL_BILL_INSTALL_PREFIX"} . "-" . $1/ge' \
+    "$source_file" > "$target_file"
+}
+
+install_generated_skill_dir() {
+  local target="$1"
+  local source="$2"
+  local label="$3"
+  local source_path
+  local relative_path
+  local target_path
+
+  if [[ -e "$target" || -L "$target" ]]; then
+    remove_if_allowed "$target"
+  fi
+
+  mkdir -p "$target"
+  {
+    printf 'managed_by=skill-bill\n'
+    printf 'canonical_name=%s\n' "$(basename "$source")"
+    printf 'installed_name=%s\n' "$(basename "$target")"
+    printf 'prefix=%s\n' "$INSTALL_PREFIX"
+  } > "$target/$MANAGED_INSTALL_MARKER"
+
+  while IFS= read -r source_path; do
+    relative_path="${source_path#$source/}"
+    target_path="$target/$relative_path"
+
+    if [[ -d "$source_path" ]]; then
+      mkdir -p "$target_path"
+      continue
+    fi
+
+    mkdir -p "$(dirname "$target_path")"
+    if [[ "$source_path" == *.md ]]; then
+      rewrite_markdown_file "$source_path" "$target_path"
+    else
+      cp "$source_path" "$target_path"
+    fi
+  done < <(find "$source" -mindepth 1 | sort)
+
+  ok "  $label"
+}
+
+install_skill() {
+  local target="$1"
+  local source="$2"
+  local label="$3"
+
+  if [[ "$INSTALL_PREFIX" == "bill" ]]; then
+    install_skill_link "$target" "$source" "$label"
+  else
+    install_generated_skill_dir "$target" "$source" "$label"
+  fi
+}
+
 parse_args "$@"
 build_skill_names
 build_legacy_skill_names
@@ -597,6 +751,7 @@ info "Supported agents: copilot, claude, glm, codex"
 info "Install behavior: replace existing Skill Bill installs and reinstall the selected platforms."
 prompt_for_agent_selection
 prompt_for_platform_selection
+prompt_for_skill_prefix
 build_install_skill_names
 
 echo ""
@@ -604,9 +759,10 @@ info "Plugin:  $PLUGIN_DIR"
 info "Agents selected: $(format_agent_list "${AGENT_NAMES[@]}")"
 info "Skills found: ${#SKILL_NAMES[@]}"
 info "Skills selected: ${#INSTALL_SKILL_NAMES[@]} (base + $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}"))"
+info "Command prefix: ${INSTALL_PREFIX}-"
 echo ""
 
-info "Removing existing Skill Bill symlinks before reinstalling the selected platforms."
+info "Removing existing Skill Bill installs before reinstalling the selected platforms."
 bash "$PLUGIN_DIR/uninstall.sh"
 echo ""
 
@@ -620,7 +776,8 @@ for i in "${!AGENT_NAMES[@]}"; do
 
   for idx in "${!INSTALL_SKILL_NAMES[@]}"; do
     skill="${INSTALL_SKILL_NAMES[$idx]}"
-    install_skill_link "$agent_dir/$skill" "${INSTALL_SKILL_PATHS[$idx]}" "$skill → plugin"
+    target_skill="${INSTALL_TARGET_NAMES[$idx]}"
+    install_skill "$agent_dir/$target_skill" "${INSTALL_SKILL_PATHS[$idx]}" "$target_skill → plugin ($skill)"
   done
   echo ""
 done
@@ -629,6 +786,7 @@ printf "${GREEN}━━━ Installation complete ━━━${NC}\n"
 echo ""
 info "Source of truth: $PLUGIN_DIR/skills/"
 info "Platforms:       $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}")"
+info "Command prefix:  ${INSTALL_PREFIX}-"
 for i in "${!AGENT_NAMES[@]}"; do
   agent="${AGENT_NAMES[$i]}"
   agent_dir="${AGENT_PATHS[$i]}"
@@ -637,5 +795,8 @@ done
 
 echo ""
 info "Edit skills in: $PLUGIN_DIR/skills/"
+if [[ "$INSTALL_PREFIX" != "bill" ]]; then
+  info "Custom prefixes install generated alias copies. Re-run './install.sh' after editing skills."
+fi
 info "Run './install.sh' again to reinstall with a different agent or platform selection."
 echo ""

--- a/skills/base/bill-pr-description/SKILL.md
+++ b/skills/base/bill-pr-description/SKILL.md
@@ -20,8 +20,29 @@ Generate a PR title, description, and QA/test steps ready to paste. Present the 
 1. **Determine the comparison base** — use the branch this feature branch was created from when known, otherwise compute the best available merge-base from git context. Never assume `main`.
 2. **Gather context** — read the git diff from that merge-base to `HEAD`, along with the commit log and branch name
 3. **Read project guidelines** — check `CLAUDE.md`, `AGENTS.md`, and the matching `bill-pr-description` section in `.agents/skill-overrides.md` when present
-4. **Generate** the title and description using the template below
-5. **Present** the result to the user for review and adjustment
+4. **Prefer a repo-native PR template when available** — check standard repository template locations before falling back to the built-in template
+5. **Generate** the title and description using the selected template
+6. **Present** the result to the user for review and adjustment
+
+## Repo-Native PR Template Preference
+
+Before using the built-in Skill Bill template, inspect the target repository for PR templates in these standard locations:
+
+1. `.github/pull_request_template.md`
+2. `.github/PULL_REQUEST_TEMPLATE.md`
+3. `pull_request_template.md`
+4. `PULL_REQUEST_TEMPLATE.md`
+5. `.github/pull_request_template/*.md`
+6. `.github/PULL_REQUEST_TEMPLATE/*.md`
+
+Apply the following rules:
+
+- If exactly one template exists in the default single-file locations above, use it.
+- If no default single-file template exists but exactly one directory-based template exists, use it.
+- If multiple templates exist and there is no obvious default, do not guess silently; ask the user which template to use.
+- If no repo-native template exists, fall back to the built-in Skill Bill template below.
+- When using a repo-native template, preserve its headings, checklist structure, and section order rather than reshaping it into the Skill Bill fallback format.
+- Still use the gathered git/spec context to fill the chosen template with concise, reviewer-friendly content.
 
 ## PR Title
 
@@ -58,5 +79,6 @@ Use this exact template, filling in the sections:
 - Test instructions should be concrete enough for a reviewer to reproduce
 - If the feature is behind a flag, mention how to enable it for testing
 - Keep it concise — reviewers appreciate brevity
+- Use this built-in template only when no repo-native PR template is available
 - If invoked from `bill-feature-implement`, check `.feature-specs/<feature-name>/spec.md` for additional context (this file only exists when bill-feature-implement created it)
 - If the caller provides an explicit comparison base or merge-base, use it instead of inferring one

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -24,6 +24,7 @@ def read(relative_path: str) -> str:
 FEATURE_IMPLEMENT = read("skills/base/bill-feature-implement/SKILL.md")
 CODE_REVIEW = read("skills/base/bill-code-review/SKILL.md")
 QUALITY_CHECK = read("skills/base/bill-quality-check/SKILL.md")
+PR_DESCRIPTION = read("skills/base/bill-pr-description/SKILL.md")
 KOTLIN_CODE_REVIEW = read("skills/kotlin/bill-kotlin-code-review/SKILL.md")
 BACKEND_KOTLIN_CODE_REVIEW = read("skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md")
 KMP_CODE_REVIEW = read("skills/kmp/bill-kmp-code-review/SKILL.md")
@@ -95,6 +96,18 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("`bill-code-review`", FEATURE_IMPLEMENT)
     self.assertIn("`bill-quality-check`", FEATURE_IMPLEMENT)
     self.assertIn("Adaptive inline-vs-delegated review execution", FEATURE_IMPLEMENT)
+
+  def test_pr_description_prefers_repo_native_templates(self) -> None:
+    self.assertIn("## Repo-Native PR Template Preference", PR_DESCRIPTION)
+    self.assertIn("`.github/pull_request_template.md`", PR_DESCRIPTION)
+    self.assertIn("`.github/PULL_REQUEST_TEMPLATE.md`", PR_DESCRIPTION)
+    self.assertIn("`pull_request_template.md`", PR_DESCRIPTION)
+    self.assertIn("`PULL_REQUEST_TEMPLATE.md`", PR_DESCRIPTION)
+    self.assertIn("`.github/pull_request_template/*.md`", PR_DESCRIPTION)
+    self.assertIn("`.github/PULL_REQUEST_TEMPLATE/*.md`", PR_DESCRIPTION)
+    self.assertIn("If multiple templates exist and there is no obvious default, do not guess silently; ask the user which template to use.", PR_DESCRIPTION)
+    self.assertIn("If no repo-native template exists, fall back to the built-in Skill Bill template below.", PR_DESCRIPTION)
+    self.assertIn("Use this built-in template only when no repo-native PR template is available", PR_DESCRIPTION)
 
   def test_kotlin_context_routes_to_kotlin_review_and_quality_check(self) -> None:
     self.assertIn(

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -20,6 +20,18 @@ def skill_names(package_name: str) -> set[str]:
   }
 
 
+def alias_skill_names(skills: set[str], prefix: str) -> set[str]:
+  if prefix == "bill":
+    return set(skills)
+
+  return {
+    f"{prefix}-{skill.removeprefix('bill-')}"
+    if skill.startswith("bill-")
+    else skill
+    for skill in skills
+  }
+
+
 BASE_SKILLS = skill_names("base")
 BACKEND_KOTLIN_SKILLS = skill_names("backend-kotlin")
 KOTLIN_SKILLS = skill_names("kotlin")
@@ -40,6 +52,7 @@ class InstallScriptTest(unittest.TestCase):
       self.assertNotIn("Choose the primary agent:", result.stdout)
       self.assertNotIn("Primary:", result.stdout)
       self.assertNotIn("via copilot", result.stdout)
+      self.assertIn("Choose the user-facing skill prefix.", result.stdout)
 
       for relative_path in (
         ".copilot/skills/bill-code-review",
@@ -57,6 +70,8 @@ class InstallScriptTest(unittest.TestCase):
       self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
       self.assertIn("Available platforms:", result.stdout)
       self.assertIn("Base skills are always installed.", result.stdout)
+      self.assertIn("Choose one or more platform numbers (comma-separated).", result.stdout)
+      self.assertIn("Command prefix: bill-", result.stdout)
 
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS)
@@ -72,6 +87,34 @@ class InstallScriptTest(unittest.TestCase):
 
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | GO_SKILLS)
+
+  def test_installs_custom_prefix_aliases_and_rewrites_skill_names(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nPHP\nacme\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+      self.assertIn("Command prefix: acme-", result.stdout)
+      self.assertIn("Custom prefixes install generated alias copies.", result.stdout)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, alias_skill_names(BASE_SKILLS | PHP_SKILLS, "acme"))
+      self.assertFalse((Path(temp_home) / ".copilot" / "skills" / "bill-code-review").exists())
+
+      installed_skill = Path(temp_home) / ".copilot" / "skills" / "acme-code-review"
+      self.assertTrue(installed_skill.is_dir())
+      self.assertTrue((installed_skill / ".skill-bill-install").exists())
+      skill_text = (installed_skill / "SKILL.md").read_text(encoding="utf-8")
+      self.assertIn("name: acme-code-review", skill_text)
+      self.assertIn("delegate to `acme-php-code-review`.", skill_text)
+      self.assertNotIn("name: bill-code-review", skill_text)
+
+  def test_accepts_numeric_multi_platform_selection(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\n1,2,3\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | BACKEND_KOTLIN_SKILLS | KOTLIN_SKILLS | KMP_SKILLS)
+      self.assertTrue(PHP_SKILLS.isdisjoint(installed))
 
   def test_accepts_human_friendly_multi_platform_selection(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
@@ -122,6 +165,22 @@ class InstallScriptTest(unittest.TestCase):
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | BACKEND_KOTLIN_SKILLS)
 
+  def test_rerun_replaces_previous_custom_prefix_aliases(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      first = self.run_installer(temp_home, "copilot\nPHP\nacme\n")
+      self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+
+      second = self.run_installer(temp_home, "copilot\nPHP\nplatform\n")
+      self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+
+      install_dir = Path(temp_home) / ".copilot" / "skills"
+      self.assertFalse((install_dir / "acme-code-review").exists())
+      self.assertTrue((install_dir / "platform-code-review").exists())
+      self.assertEqual(
+        self.installed_skills(temp_home),
+        alias_skill_names(BASE_SKILLS | PHP_SKILLS, "platform"),
+      )
+
   def test_rerun_replaces_existing_skill_directory_and_restores_sidecars(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       first = self.run_installer(temp_home, "copilot\nPHP\n")
@@ -161,7 +220,7 @@ class InstallScriptTest(unittest.TestCase):
     install_dir = Path(temp_home) / ".copilot" / "skills"
     if not install_dir.exists():
       return set()
-    return {path.name for path in install_dir.iterdir() if path.name.startswith("bill-")}
+    return {path.name for path in install_dir.iterdir() if not path.name.startswith(".")}
 
   def prepare_agent_homes(self, temp_home: str) -> None:
     for relative_dir in (

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -25,10 +25,22 @@ class UninstallScriptTest(unittest.TestCase):
 
       uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
       self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)
-      self.assertIn("Removed symlinks:", uninstall.stdout)
+      self.assertIn("Removed installs:", uninstall.stdout)
       self.assertFalse((Path(temp_home) / ".copilot" / "skills" / "bill-code-review").exists())
       self.assertFalse((Path(temp_home) / ".claude" / "commands" / "bill-code-review").exists())
       self.assertFalse((Path(temp_home) / ".copilot" / "skills" / ".bill-shared").exists())
+
+  def test_uninstall_removes_generated_alias_installs(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      install = self.run_script(INSTALL_SCRIPT, temp_home, "copilot\nPHP\nacme\n")
+      self.assertEqual(install.returncode, 0, install.stdout + install.stderr)
+      self.assertTrue((Path(temp_home) / ".copilot" / "skills" / "acme-code-review").is_dir())
+
+      uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
+      self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)
+      self.assertFalse((Path(temp_home) / ".copilot" / "skills" / "acme-code-review").exists())
+      self.assertIn("Removed installs:", uninstall.stdout)
 
   def test_uninstall_removes_legacy_skill_symlinks_and_is_idempotent(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
@@ -44,7 +56,7 @@ class UninstallScriptTest(unittest.TestCase):
 
       second = self.run_script(UNINSTALL_SCRIPT, temp_home)
       self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
-      self.assertIn("Removed symlinks: 0", second.stdout)
+      self.assertIn("Removed installs: 0", second.stdout)
 
   def prepare_agent_homes(self, temp_home: str) -> None:
     for relative_dir in (

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$PLUGIN_DIR/skills"
+MANAGED_INSTALL_MARKER=".skill-bill-install"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -109,6 +110,13 @@ remove_skill_target() {
     return
   fi
 
+  if [[ -d "$target" && -f "$target/$MANAGED_INSTALL_MARKER" ]]; then
+    rm -rf "$target"
+    REMOVED_TARGETS+=("$target")
+    ok "  removed $(basename "$target")"
+    return
+  fi
+
   if [[ -e "$target" ]]; then
     SKIPPED_TARGETS+=("$target")
     warn "  skipped $(basename "$target") (not a symlink)"
@@ -130,6 +138,13 @@ remove_from_agent_dir() {
   before_skipped=${#SKIPPED_TARGETS[@]}
 
   info "Checking $label: $target_dir"
+  shopt -s nullglob
+  for managed_target in "$target_dir"/*; do
+    if [[ -d "$managed_target" && -f "$managed_target/$MANAGED_INSTALL_MARKER" ]]; then
+      remove_skill_target "$managed_target"
+    fi
+  done
+  shopt -u nullglob
   for skill_name in "${SKILL_NAMES[@]}"; do
     remove_skill_target "$target_dir/$skill_name"
   done
@@ -148,7 +163,7 @@ build_legacy_skill_names
 echo ""
 printf "${CYAN}━━━ Skill Bill Uninstaller ━━━${NC}\n"
 echo ""
-info "Removing Skill Bill symlinks from supported agent paths."
+info "Removing Skill Bill installs from supported agent paths."
 
 remove_from_agent_dir "copilot" "$HOME/.copilot/skills"
 remove_from_agent_dir "claude" "$HOME/.claude/commands"
@@ -159,7 +174,7 @@ remove_from_agent_dir "codex" "$HOME/.agents/skills"
 echo ""
 printf "${GREEN}━━━ Uninstall complete ━━━${NC}\n"
 echo ""
-info "Removed symlinks: ${#REMOVED_TARGETS[@]}"
+info "Removed installs: ${#REMOVED_TARGETS[@]}"
 if [[ ${#SKIPPED_TARGETS[@]} -gt 0 ]]; then
   warn "Skipped non-symlink paths: ${#SKIPPED_TARGETS[@]}"
 fi


### PR DESCRIPTION
# Summary

This adds install-time support for custom user-facing skill prefixes while keeping the repository's canonical `bill-*` taxonomy unchanged. Teams can now install commands like `acme-code-review` or `platform-feature-implement` without changing the underlying skill graph, and the installer rewrites installed references so routed workflows still resolve correctly.

It also improves the installer UX by making numbered platform selection the primary input path, updates uninstall behavior to clean up generated alias installs, and adds a roadmap document to capture the project's longer-term direction.

- add installer support for custom install-time skill prefixes with generated alias installs
- keep the default `bill` path on symlink-based installs while preserving canonical in-repo names
- teach uninstall to remove generated alias installs and update docs/tests for the new installer flow

## Feature Flags

N/A

# How Has This Been Tested?

Ran the repository validation suite and exercised the installer/uninstaller flows covered by the new test cases.

1. Run `python3 -m unittest discover -s tests`
2. Run `npx --yes agnix --strict .`
3. Run `python3 scripts/validate_agent_configs.py`
4. Run `./install.sh`, select platform numbers, then enter either `bill` or a custom prefix such as `acme`
5. Verify the installed skill names use the chosen prefix and that `./uninstall.sh` removes both canonical and generated installs cleanly
