### PR TITLE
feat: [SKILL-3] add agent-config support

### DIFF
--- a/.feature-specs/agent-config-review/spec.md
+++ b/.feature-specs/agent-config-review/spec.md
@@ -1,0 +1,34 @@
+# Feature: agent-config-review
+Created: 2026-04-02
+Status: In Progress
+Sources: chat discussion for SKILL-3 about making Skill Bill able to review and quality-check its own repository type
+
+## Acceptance Criteria
+1. Add a first-class `agent-config` package under `skills/`.
+2. Add `bill-agent-config-code-review` that reviews this repository type honestly instead of routing to Unknown/Unsupported.
+3. Add `bill-agent-config-quality-check` and route quality-check requests for this repo type to it.
+4. Update shared routers so repos dominated by skill/agent-config signals route to the new package.
+5. Update validator, installer/docs/catalogs, and tests so the new package follows the existing governance contract fully.
+6. Keep canonical base entry points stable while making Skill Bill able to review and validate its own repository type.
+
+## Non-Goals
+- Inventing a special bypass path outside the contract
+- Adding unapproved taxonomy shapes
+- Faking support by routing this repo type to an unrelated stack
+
+## Open Questions
+None
+
+---
+
+## Consolidated Spec
+
+Add first-class support for Skill Bill's own repository type by introducing an `agent-config` package under `skills/`. This package should let the shared `bill-code-review` and `bill-quality-check` routers recognize skill/agent-configuration repositories and delegate to governed stack-specific implementations instead of returning Unknown/Unsupported.
+
+The new package must follow the existing project contract completely. That means it should use the approved platform override naming shape, be recognized by the validator as an allowed package, be installed like other platform packages, and be represented in docs and tests just like existing supported stacks.
+
+The first pass should include both `bill-agent-config-code-review` and `bill-agent-config-quality-check`.
+
+The new review support should focus on the kinds of changes that dominate this repository: skill contracts, routing playbooks, installer/uninstaller behavior, override mechanics, validator rules, README/catalog drift, and similar agent-configuration infrastructure. The quality-check support should focus on the repository's existing validation commands and fix issues only in the current unit of work.
+
+This feature should preserve the stable base entry points. Users should still enter through `bill-code-review` and `bill-quality-check`; the shared routers should simply gain the ability to classify this repository type and delegate to the new `agent-config` implementations.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Treat your AI skills like software — with stable interfaces, platform overrides, and validation that prevents the repo from rotting.
 
-sKill Bill is a portable collection of 44 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, and Go backends/services.
+sKill Bill is a portable collection of 46 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
 
 ## Why this exists
 
@@ -98,7 +98,7 @@ Small, low-risk review scopes may stay inline in one thread. Larger or higher-ri
 
 Base entry points stay stable for users:
 
-- `/bill-code-review` routes to `bill-kotlin-code-review` | `bill-backend-kotlin-code-review` | `bill-kmp-code-review` | `bill-php-code-review` | `bill-go-code-review`
+- `/bill-code-review` routes to `bill-agent-config-code-review` | `bill-kotlin-code-review` | `bill-backend-kotlin-code-review` | `bill-kmp-code-review` | `bill-php-code-review` | `bill-go-code-review`
 - `/bill-quality-check` routes to the matching stack-specific quality checker
 - `/bill-feature-implement` orchestrates the full workflow
 
@@ -147,7 +147,8 @@ Available options are shown as separate entries:
 3. KMP
 4. PHP
 5. Go
-6. all
+6. Agent config
+7. all
 ```
 
 Example platform selections:
@@ -157,6 +158,7 @@ Example platform selections:
 4
 5
 6
+7
 ```
 
 Finally, the installer asks for the **user-facing command prefix**. Press Enter to keep the default `bill` prefix, or enter your own team/org prefix:
@@ -186,11 +188,12 @@ The uninstaller is idempotent. It removes current Skill Bill installs, generated
 
 ## Skills Included
 
-### Code Review (32 skills)
+### Code Review (33 skills)
 
 | Skill | Purpose |
 |-------|---------|
 | `/bill-code-review` | Shared review router |
+| `/bill-agent-config-code-review` | Review skill/agent-config repositories |
 | `/bill-kotlin-code-review` | Kotlin baseline review orchestrator |
 | `/bill-backend-kotlin-code-review` | Backend Kotlin review override |
 | `/bill-kmp-code-review` | Android/KMP review override |
@@ -232,11 +235,12 @@ The uninstaller is idempotent. It removes current Skill Bill installs, generated
 | `/bill-feature-guard` | Add feature-flag rollout safety |
 | `/bill-feature-guard-cleanup` | Remove feature flags after rollout |
 
-### Utilities (8 skills)
+### Utilities (9 skills)
 
 | Skill | Purpose |
 |-------|---------|
 | `/bill-quality-check` | Shared quality-check router |
+| `/bill-agent-config-quality-check` | Agent-config repository quality-check implementation |
 | `/bill-kotlin-quality-check` | Gradle/Kotlin quality-check implementation |
 | `/bill-php-quality-check` | PHP quality-check implementation |
 | `/bill-go-quality-check` | Go quality-check implementation |
@@ -307,6 +311,7 @@ That last file is the canonical map for:
 
 Current platform packages:
 
+- `agent-config`
 - `kotlin`
 - `backend-kotlin`
 - `kmp`

--- a/install.sh
+++ b/install.sh
@@ -322,6 +322,7 @@ prompt_for_agent_selection() {
 
 display_platform_name() {
   case "$1" in
+    agent-config) printf 'Agent config' ;;
     backend-kotlin) printf 'Kotlin backend' ;;
     kotlin) printf 'Kotlin' ;;
     kmp) printf 'KMP' ;;
@@ -344,7 +345,7 @@ build_platform_packages() {
   done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
 
   PLATFORM_PACKAGES=()
-  for package in backend-kotlin kotlin kmp php go; do
+  for package in backend-kotlin kotlin kmp php go agent-config; do
     if array_contains "$package" "${discovered[@]:-}"; then
       PLATFORM_PACKAGES+=("$package")
     fi
@@ -389,6 +390,10 @@ resolve_platform_selection() {
       ;;
     backendkotlin|kotlinbackend)
       printf 'backend-kotlin\n'
+      return 0
+      ;;
+    agentconfig|skillrepo|skillsinfra)
+      printf 'agent-config\n'
       return 0
       ;;
     kotlin)

--- a/orchestration/stack-routing/PLAYBOOK.md
+++ b/orchestration/stack-routing/PLAYBOOK.md
@@ -21,6 +21,7 @@ When classifying stack or platform:
 ## Stack Taxonomy
 
 Classify work as one of:
+- `agent-config`
 - `kmp`
 - `backend-kotlin`
 - `kotlin`
@@ -29,6 +30,13 @@ Classify work as one of:
 - `Unknown/Unsupported`
 
 ## Strong Stack Signals
+
+### agent-config
+
+- `SKILL.md`, `AGENTS.md`, `CLAUDE.md`
+- `install.sh`, `uninstall.sh`, `config.yaml`, `.claude-plugin/plugin.json`
+- `orchestration/`, `skills/`, `scripts/validate_agent_configs.py`, `scripts/skill_repo_contracts.py`
+- tests or docs that primarily govern skill contracts, routing, installer behavior, or catalog validation
 
 ### kmp
 
@@ -58,6 +66,7 @@ Classify work as one of:
 
 ## Tie-Breakers
 
+- If skill/agent-config repository markers dominate, route to `agent-config`
 - If Android/KMP markers are strong, route to `kmp`
 - Treat Android-only scope as `kmp` because that is the package-aligned Android/KMP bucket
 - If backend/server markers are strong without meaningful `kmp` markers, route to `backend-kotlin`

--- a/scripts/skill_repo_contracts.py
+++ b/scripts/skill_repo_contracts.py
@@ -18,6 +18,7 @@ SUPPORTING_FILE_TARGETS: dict[str, str] = {
 RUNTIME_SUPPORTING_FILES: dict[str, tuple[str, ...]] = {
   "bill-code-review": ("stack-routing.md", "review-delegation.md"),
   "bill-quality-check": ("stack-routing.md",),
+  "bill-agent-config-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
   "bill-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
   "bill-backend-kotlin-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
   "bill-kmp-code-review": ("stack-routing.md", "review-orchestrator.md", "review-delegation.md"),
@@ -33,6 +34,7 @@ REVIEW_DELEGATION_REQUIRED_SECTIONS = (
 )
 
 PORTABLE_REVIEW_SKILLS = (
+  "bill-agent-config-code-review",
   "bill-kotlin-code-review",
   "bill-backend-kotlin-code-review",
   "bill-kmp-code-review",

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -26,7 +26,7 @@ SKILL_OVERRIDE_FILE = ".agents/skill-overrides.md"
 SKILL_OVERRIDE_EXAMPLE_FILE = ".agents/skill-overrides.example.md"
 SKILL_OVERRIDE_TITLE = "# Skill Overrides"
 SKILL_OVERRIDE_SECTION_PATTERN = re.compile(r"^## (bill-[a-z0-9-]+)$")
-ALLOWED_PACKAGES = ("base", "kotlin", "kmp", "backend-kotlin", "php", "go")
+ALLOWED_PACKAGES = ("base", "agent-config", "kotlin", "kmp", "backend-kotlin", "php", "go")
 APPROVED_CODE_REVIEW_AREAS = {
   "api-contracts",
   "architecture",
@@ -266,7 +266,7 @@ def validate_skill_location(skill_name: str, skill_file: Path, issues: list[str]
 
   expected_prefixes = expected_prefixes_for_package(package_name)
   if package_name == "base":
-    if any(skill_name.startswith(prefix) for prefix in ("bill-kotlin-", "bill-kmp-", "bill-backend-kotlin-", "bill-php-", "bill-go-", "bill-gradle-")):
+    if any(skill_name.startswith(prefix) for prefix in ("bill-agent-config-", "bill-kotlin-", "bill-kmp-", "bill-backend-kotlin-", "bill-php-", "bill-go-", "bill-gradle-")):
       issues.append(
         f"{skill_file}: base skills must use neutral names; move '{skill_name}' to the matching package"
       )

--- a/skills/agent-config/bill-agent-config-code-review/SKILL.md
+++ b/skills/agent-config/bill-agent-config-code-review/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: bill-agent-config-code-review
+description: Use when conducting a thorough code review for governed skill, prompt, and agent-configuration repositories. Focus on routing correctness, contract drift, installer safety, portability, and docs/tests/catalog consistency. Produces a structured review with risk register and prioritized action items.
+---
+
+# Agent-Config Repository Review
+
+You are an experienced maintainer reviewing a governed skill or agent-configuration repository.
+
+This skill owns review depth for repositories where the primary unit of work is AI skill contracts, routing playbooks, installer/configuration wiring, and validation logic rather than application code in a single programming language.
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-agent-config-code-review` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. Pass relevant project-wide guidance and matching per-skill overrides to every delegated or inline review pass.
+
+## Setup
+
+Determine the review scope:
+- Specific files (list paths)
+- Git commits (hashes/range)
+- Staged changes (`git diff --cached`; index only)
+- Unstaged changes (`git diff`; working tree only)
+- Combined working tree (`git diff --cached` + `git diff`) only when the caller explicitly asks for all local changes
+- Entire PR
+
+Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
+
+Inspect both the changed files and repo markers for skill/agent-config signals.
+
+## Additional Resources
+
+- For shared stack-routing signals and tie-breakers, see [stack-routing.md](stack-routing.md).
+- For shared review-orchestration rules, see [review-orchestrator.md](review-orchestrator.md).
+- For agent-specific delegated review execution, see [review-delegation.md](review-delegation.md).
+
+Before classifying, read [stack-routing.md](stack-routing.md). Use it as the source of truth for `agent-config` signals and mixed-stack routing expectations.
+
+Before selecting review depth or formatting the final report, read [review-orchestrator.md](review-orchestrator.md). Use it as the source of truth for the shared specialist review contract, merge rules, common output sections, and review principles used by stack-specific review orchestrators.
+
+Before delegating review execution, read [review-delegation.md](review-delegation.md). Use it as the source of truth for agent-specific delegated execution.
+
+## Review Focus
+
+Review this scope against the kinds of failures that matter in governed skill repositories:
+
+- routing correctness and stack-signal drift
+- skill references, naming, and package-taxonomy violations
+- runtime/supporting-file contract mismatches
+- installer/uninstaller safety, migration handling, and alias behavior
+- override precedence, fallback honesty, and unsupported-path clarity
+- README/catalog/docs/test mismatch against actual repository behavior
+
+Treat these review focus areas as the specialist review surfaces for this skill. Apply them directly in the chosen execution mode; this package does not need deeper `agent-config` review subskills yet.
+
+## Execution Mode
+
+Select `inline` or `delegated` using [review-orchestrator.md](review-orchestrator.md).
+
+- Use `inline` only when the agent-config review scope stays small and low-risk under the shared execution-mode contract
+- Use `delegated` when the diff is large, routing/installer/validation risk is high, multiple repository contracts are changing at once, or the safest choice is unclear
+
+If execution mode is `inline`, review the scope directly in the current thread using the focus areas above and the shared specialist review contract in [review-orchestrator.md](review-orchestrator.md).
+
+If execution mode is `delegated`, run this same review in delegated execution using [review-delegation.md](review-delegation.md). If delegated review is required for this scope but unavailable on the current runtime, stop and report that explicitly. Do not invent deeper nested `agent-config` review passes unless the package grows approved specializations later.
+
+## Review Output Format
+
+### 1. Classification & Review Summary
+```text
+Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>
+Detected stack: agent-config
+Signals: SKILL.md, AGENTS.md, install.sh, orchestration/, validator tests
+Execution mode: inline | delegated
+Review focus: routing/contracts, installer/runtime safety, docs/tests/catalog consistency
+Reason: skill/agent-config repository signals dominate, so the governed repo review layer was selected
+```
+
+For the shared risk register, action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).

--- a/skills/agent-config/bill-agent-config-code-review/review-delegation.md
+++ b/skills/agent-config/bill-agent-config-code-review/review-delegation.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-delegation/PLAYBOOK.md

--- a/skills/agent-config/bill-agent-config-code-review/review-orchestrator.md
+++ b/skills/agent-config/bill-agent-config-code-review/review-orchestrator.md
@@ -1,0 +1,1 @@
+../../../orchestration/review-orchestrator/PLAYBOOK.md

--- a/skills/agent-config/bill-agent-config-code-review/stack-routing.md
+++ b/skills/agent-config/bill-agent-config-code-review/stack-routing.md
@@ -1,0 +1,1 @@
+../../../orchestration/stack-routing/PLAYBOOK.md

--- a/skills/agent-config/bill-agent-config-quality-check/SKILL.md
+++ b/skills/agent-config/bill-agent-config-quality-check/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: bill-agent-config-quality-check
+description: Run the repository's canonical validation commands for governed skill and agent-configuration repositories, then fix issues in the current unit of work without using suppressions. Use when validating skill contracts, routing docs, installers, catalogs, and repo-native validator scripts.
+---
+
+# Agent-Config Repository Quality Check
+
+This is the current `agent-config` implementation behind the shared `bill-quality-check` router. Invoke it directly only when you already know the repo should use the `agent-config` quality-check path.
+
+Execute the repository's validation flow and systematically fix issues **only in files changed in the current unit of work**. Ignore pre-existing issues in untouched files unless the change clearly exposes them.
+
+## Execution Steps
+
+1. **Determine changed files**: Use `git diff --name-only` (against the base branch or HEAD) to identify files changed in the current unit of work
+2. **Run initial validation**: Execute the repository's canonical validation commands and capture complete output
+3. **Filter to changed files**: From the command output, only address issues in files from step 1 — skip everything else
+4. **Categorize issues**: Group by type (skill contract drift, validator/test failures, installer/script failures, docs/catalog mismatch, formatting/lint failures, etc.)
+5. **Fix systematically**: For each issue category in priority order:
+   - Mark todo as in_progress
+   - Read affected files
+   - Implement proper fixes (never suppress)
+   - Mark todo as completed
+6. **Verify fixes**: Re-run the validation commands after all fixes
+7. **Iterate if needed**: If new issues appear, repeat the process
+
+## Fix Strategy
+
+**Always Fix, Never Suppress:**
+- Never add suppressions, ignore rules, or fake passing output as the default fix
+- Never weaken validator rules just to make the repository pass
+- Never skip required project scripts silently
+- Implement proper solutions that address the root cause
+- Keep docs, tests, installer behavior, and catalogs aligned with the actual repository contract
+
+**Priority Order:**
+1. Structural repository contract issues (broken skill references, invalid package names, missing required sidecars, install/uninstall breakage)
+2. Validation script or test failures
+3. README/catalog/docs mismatch against the actual repository behavior
+4. Formatting or lint failures
+5. Remaining repo-native quality issues surfaced by the configured validation commands
+
+**Typical Commands In This Repo Type:**
+- `python3 -m unittest discover -s tests`
+- `npx --yes agnix --strict .`
+- `python3 scripts/validate_agent_configs.py`
+
+If the current repository defines different repo-native validator commands, use those instead of hardcoding the examples above.
+
+## When to Ask User
+
+- Taxonomy decisions that materially change the package model
+- Breaking changes to stable user-facing command names
+- Cases where multiple valid governance directions exist and the repository guidance does not decide between them
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-agent-config-quality-check` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Agent-Config-Specific Guidance
+
+- Prefer the repository's existing validation commands over ad hoc checks
+- Treat catalog drift, installer behavior drift, and validator/test drift as first-class quality issues
+- When a change affects runtime-facing skills, ensure supporting-file references, README catalog entries, installer behavior, and validation tests stay consistent in the same unit of work
+- If a required command cannot be run, report that explicitly with the reason
+
+## Output Format
+
+Provide clear progress updates:
+- Show issue count by category
+- Report each fix with file path and line number
+- Display the final validation result
+- Summarize all changes made
+- If a required command could not be run, report that explicitly with the reason

--- a/skills/base/bill-code-review/SKILL.md
+++ b/skills/base/bill-code-review/SKILL.md
@@ -57,6 +57,7 @@ Do not redefine stack signals here unless a route-specific exception is truly un
 - If `kmp` signals dominate, delegate to `bill-kmp-code-review`.
 - If `backend-kotlin` signals dominate, delegate to `bill-backend-kotlin-code-review`.
 - If `kotlin` signals dominate without meaningful `kmp` or `backend-kotlin` markers, delegate to `bill-kotlin-code-review`.
+- If `agent-config` signals dominate, delegate to `bill-agent-config-code-review`.
 - If `php` signals dominate, delegate to `bill-php-code-review`.
 - If `go` signals dominate, delegate to `bill-go-code-review`.
 - If the review scope mixes `kmp` with other Kotlin-family scope, prefer `bill-kmp-code-review` because it layers the appropriate Kotlin-family baseline internally instead of running multiple Kotlin-family orchestrators side by side.

--- a/skills/base/bill-quality-check/SKILL.md
+++ b/skills/base/bill-quality-check/SKILL.md
@@ -52,6 +52,7 @@ Do not redefine stack signals here unless a route-specific exception is truly un
 - If `kmp` signals dominate, delegate to the canonical quality-check implementation for the `kmp` package when it exists.
 - If `backend-kotlin` signals dominate, delegate to the canonical quality-check implementation for the `backend-kotlin` package when it exists.
 - If `kotlin` signals dominate, delegate to the canonical `bill-kotlin-quality-check` skill when it exists.
+- If `agent-config` signals dominate, delegate to the canonical `bill-agent-config-quality-check` skill when it exists.
 - If `php` signals dominate, delegate to the canonical `bill-php-quality-check` skill when it exists.
 - If `go` signals dominate, delegate to the canonical `bill-go-quality-check` skill when it exists.
 - Today, until separate `kmp` and `backend-kotlin` quality-check implementations exist, route `kmp`, `backend-kotlin`, and `kotlin` work to `bill-kotlin-quality-check`.

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -25,6 +25,8 @@ FEATURE_IMPLEMENT = read("skills/base/bill-feature-implement/SKILL.md")
 CODE_REVIEW = read("skills/base/bill-code-review/SKILL.md")
 QUALITY_CHECK = read("skills/base/bill-quality-check/SKILL.md")
 PR_DESCRIPTION = read("skills/base/bill-pr-description/SKILL.md")
+AGENT_CONFIG_CODE_REVIEW = read("skills/agent-config/bill-agent-config-code-review/SKILL.md")
+AGENT_CONFIG_QUALITY_CHECK = read("skills/agent-config/bill-agent-config-quality-check/SKILL.md")
 KOTLIN_CODE_REVIEW = read("skills/kotlin/bill-kotlin-code-review/SKILL.md")
 BACKEND_KOTLIN_CODE_REVIEW = read("skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md")
 KMP_CODE_REVIEW = read("skills/kmp/bill-kmp-code-review/SKILL.md")
@@ -34,6 +36,7 @@ STACK_ROUTING_PLAYBOOK = read("orchestration/stack-routing/PLAYBOOK.md")
 REVIEW_ORCHESTRATOR_PLAYBOOK = read("orchestration/review-orchestrator/PLAYBOOK.md")
 REVIEW_DELEGATION_PLAYBOOK = read("orchestration/review-delegation/PLAYBOOK.md")
 PORTABLE_REVIEW_SKILL_TEXTS = {
+  "bill-agent-config-code-review": AGENT_CONFIG_CODE_REVIEW,
   "bill-kotlin-code-review": KOTLIN_CODE_REVIEW,
   "bill-backend-kotlin-code-review": BACKEND_KOTLIN_CODE_REVIEW,
   "bill-kmp-code-review": KMP_CODE_REVIEW,
@@ -118,6 +121,20 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       "- If `kotlin` signals dominate, delegate to the canonical `bill-kotlin-quality-check` skill when it exists.",
       QUALITY_CHECK,
     )
+
+  def test_agent_config_context_routes_to_agent_config_review_and_quality_check(self) -> None:
+    self.assertIn(
+      "- If `agent-config` signals dominate, delegate to `bill-agent-config-code-review`.",
+      CODE_REVIEW,
+    )
+    self.assertIn(
+      "- If `agent-config` signals dominate, delegate to the canonical `bill-agent-config-quality-check` skill when it exists.",
+      QUALITY_CHECK,
+    )
+    self.assertIn("[stack-routing.md](stack-routing.md)", AGENT_CONFIG_CODE_REVIEW)
+    self.assertIn("[review-orchestrator.md](review-orchestrator.md)", AGENT_CONFIG_CODE_REVIEW)
+    self.assertIn("[review-delegation.md](review-delegation.md)", AGENT_CONFIG_CODE_REVIEW)
+    self.assertIn("Typical Commands In This Repo Type:", AGENT_CONFIG_QUALITY_CHECK)
 
   def test_backend_kotlin_context_routes_to_backend_review_and_current_quality_check(self) -> None:
     self.assertIn(

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -38,6 +38,7 @@ KOTLIN_SKILLS = skill_names("kotlin")
 KMP_SKILLS = skill_names("kmp")
 PHP_SKILLS = skill_names("php")
 GO_SKILLS = skill_names("go")
+AGENT_CONFIG_SKILLS = skill_names("agent-config")
 
 
 class InstallScriptTest(unittest.TestCase):
@@ -88,6 +89,14 @@ class InstallScriptTest(unittest.TestCase):
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | GO_SKILLS)
 
+  def test_installs_base_and_selected_agent_config_platform_only(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nAgent config\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      installed = self.installed_skills(temp_home)
+      self.assertEqual(installed, BASE_SKILLS | AGENT_CONFIG_SKILLS)
+
   def test_installs_custom_prefix_aliases_and_rewrites_skill_names(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       result = self.run_installer(temp_home, "copilot\nPHP\nacme\n")
@@ -134,12 +143,13 @@ class InstallScriptTest(unittest.TestCase):
       self.assertIn("KMP (kmp)", result.stdout)
       self.assertIn("PHP (php)", result.stdout)
       self.assertIn("Go (go)", result.stdout)
+      self.assertIn("Agent config (agent-config)", result.stdout)
       self.assertIn("all (install every platform package)", result.stdout)
 
       installed = self.installed_skills(temp_home)
       self.assertEqual(
         installed,
-        BASE_SKILLS | BACKEND_KOTLIN_SKILLS | KOTLIN_SKILLS | KMP_SKILLS | PHP_SKILLS | GO_SKILLS,
+        BASE_SKILLS | BACKEND_KOTLIN_SKILLS | KOTLIN_SKILLS | KMP_SKILLS | PHP_SKILLS | GO_SKILLS | AGENT_CONFIG_SKILLS,
       )
 
   def test_ignores_empty_platform_tokens(self) -> None:

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -52,6 +52,16 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       result = self.run_validator(repo_root)
       self.assertEqual(result.returncode, 0, result.stdout)
 
+  def test_accepts_agent_config_platform_override_of_dynamic_base_capability(self) -> None:
+    with self.fixture_repo(
+      [
+        ("base", "bill-ship-it"),
+        ("agent-config", "bill-agent-config-ship-it"),
+      ]
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 0, result.stdout)
+
   def test_rejects_platform_only_capability_name(self) -> None:
     with self.fixture_repo(
       [


### PR DESCRIPTION
# Summary

Add first-class `agent-config` platform support so Skill Bill can route code review and quality-check requests for governed skill and agent-configuration repositories instead of falling back to `Unknown/Unsupported`.

- add `bill-agent-config-code-review` and `bill-agent-config-quality-check`
- route base review and quality-check entry points plus shared stack taxonomy to `agent-config`
- wire installer, validator, README/catalog, and tests so `agent-config` behaves like every other supported platform package

## Feature Flags

N/A

# How Has This Been Tested?

Ran the repository's canonical validation commands after the routing, installer, validator, and docs/test updates.

1. `python3 -m unittest discover -s tests`
2. `npx --yes agnix --strict .`
3. `python3 scripts/validate_agent_configs.py`
4. Reinstall the skills with the `Agent config` platform selected and confirm the installed catalog includes `readian-agent-config-code-review` and `readian-agent-config-quality-check`
