### PR TITLE
refactor: streamline bill-feature-implement skill

### DIFF
--- a/skills/base/bill-feature-implement/SKILL.md
+++ b/skills/base/bill-feature-implement/SKILL.md
@@ -13,44 +13,13 @@ If an `AGENTS.md` file exists in the project root, apply it as project-wide guid
 
 Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults. When you read another skill inline, also apply that skill's matching section from `.agents/skill-overrides.md` when present.
 
-## Workflow Overview
-
-```
-Design Doc + Issue Key → Assess + Extract Criteria → [Size gate] → Create Branch →
-
-  SMALL (≤5 tasks, ≤3 boundaries):
-    Save Spec → [Read History] → Plan → Implement → bill-code-review (narrow scope, stack-routed review) → Completeness Audit → Final Validation Gate → [Write History if impactful] → Commit+Push → PR Description
-
-  MEDIUM (6-15 tasks, ≤6 boundaries):
-    Save Spec → Read History → Plan → Implement →
-    Compact → bill-code-review (stack-routed review) → Completeness Audit → Final Validation Gate → Write History → Commit+Push → PR Description
-
-  LARGE (>15 tasks or >6 boundaries):
-    Save Spec → Read History → [Rollout Control?] → Plan (phased) → Implement →
-    Compact → bill-code-review (stack-routed review) → Compact → Completeness Audit → Final Validation Gate → Write History → Commit+Push → PR Description
-```
-
 ## Step 1: Collect Design Doc + Assess Size
 
-Ask the user:
-> **Provide the feature design doc** — paste text, give me a file path, or point me to a folder with spec files.
-> Also provide the **Jira issue key** (e.g., `ME-5066`).
+Ask the user for:
+1. **Feature design doc** — inline text, file path, or directory of spec files
+2. **Issue key** (e.g., `ME-5066`)
 
-Accept any of:
-- Inline text (paste)
-- Single file path (PDF or markdown)
-- **Directory path** containing multiple spec files (PDFs, images, markdown)
-
-**Reading PDFs:** If given PDF files, use the Read tool (it supports PDFs). For large PDFs (>10 pages), read in page ranges.
-
-**Spec size limit:** If the total extracted text exceeds ~8,000 words, ask the user:
-> **The spec is very large. Which sections are most relevant for this implementation?**
-
-When given a directory:
-1. List all files and summarize what each contains
-2. Read all text-based files (PDF, markdown)
-3. Note image files as visual references (reference them by name in the plan)
-4. Synthesize into a unified understanding
+Accept PDFs (read in page ranges if >10 pages), markdown, images (note as visual references). If a directory, read all files and synthesize. If spec exceeds ~8,000 words, ask which sections matter most.
 
 ### Single-Pass Assessment
 
@@ -101,43 +70,18 @@ After the user confirms the assessment, create and switch to a new feature branc
 
 ## Step 2: Pre-Planning
 
-**All sizes:** Always **Save Spec** (the acceptance criteria serve as the contract for the completeness audit), **Read Boundary History** if history files exist near the affected module/package/area, and determine the **final validation strategy** automatically.
-**MEDIUM and LARGE only:** Also discover codebase patterns. Perform Feature Flag Setup only when the chosen rollout strategy requires a feature flag.
+**All sizes:** **Read Boundary History** if history files exist near the affected module/package/area, and determine the **final validation strategy** automatically.
+**MEDIUM and LARGE only:** Also **Save Spec** to disk, discover codebase patterns, and perform Feature Flag Setup only when the chosen rollout strategy requires a feature flag.
 
-### Save Spec
+### Save Spec (MEDIUM and LARGE only)
 
-Save the design doc to `.feature-specs/<feature-name>/spec.md`:
+Save to `.feature-specs/{ISSUE_KEY}-{feature-name}/spec.md` with: feature name, issue key, date, status (`In Progress`), sources, acceptance criteria, and consolidated spec content. Preserve code blocks, schemas, field definitions, and enums verbatim; narrative sections may be summarized.
 
-```markdown
-# Feature: <feature-name>
-Created: <date>
-Status: In Progress
-Sources: <list of original sources>
-
-## Acceptance Criteria
-1. ...
-
----
-
-<consolidated spec content>
-```
-
-**Consolidation rules for large specs:**
-- Preserve code blocks (GraphQL schemas, data models, API contracts) verbatim
-- Preserve numbered lists, field definitions, and enum values verbatim
-- Narrative/background sections can be summarized if space is needed
+For SMALL features the acceptance criteria stay in context — no spec file needed.
 
 ### Read Boundary History
 
-Look for `agent/history.md` in each module, package root, or area boundary the feature will touch. If found, use it to:
-- Read newest entries first
-- Keep scanning while entries are still relevant to the current feature, boundary, entities, or patterns
-- Stop once older entries are clearly no longer relevant or you already have enough signal; do not read the whole file by default
-- Reuse components from previous features
-- Follow the latest patterns (not outdated ones)
-- Account for recent entity changes
-
-If no history exists, skip.
+Look for `agent/history.md` in each boundary the feature touches. Read newest entries first, stop once entries are no longer relevant. Use to reuse components and follow latest patterns. Skip if none exist.
 
 ### Feature Flag Setup (only when rollout uses a feature flag)
 
@@ -153,10 +97,7 @@ Explore the codebase concurrently with planning:
 2. Find similar features referenced in the spec
 3. Identify build/runtime dependencies for affected boundaries
 4. Note reusable components
-5. Identify validation surfaces so the final gate is chosen automatically:
-   - The affected repo or boundaries use a supported stack-routed quality-check path → `bill-quality-check`
-   - Agent-config / skill repository (`SKILL.md`, `AGENTS.md`, `.agents/skill-overrides.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, installer/config files, repo-native validation scripts) → inline agent-config validation
-   - Mixed repository → run both
+5. Confirm that `bill-quality-check` can route the affected repo or boundaries (it handles all supported stacks including agent-config repos)
 6. If a repo-native validation script already exists, reuse it instead of inventing a new ad hoc checklist
 
 Do NOT present a separate "codebase patterns" section to the user — fold these findings directly into the implementation plan.
@@ -167,39 +108,16 @@ Do NOT present a separate "codebase patterns" section to the user — fold these
 - Break into **atomic tasks** — each task completable in one turn
 - Order tasks by dependency (data layer → domain → presentation)
 - Each task must reference which acceptance criteria it satisfies
-- **The final task in every plan MUST be a dedicated test task.** This task writes unit tests covering the new/changed logic. It is never optional — if there is code to implement, there are tests to write. The `Tests:` field on this task must list the specific scenarios to cover (e.g., happy path, edge cases, guard clauses). Implementation tasks may set `Tests: None` only because testing is deferred to this final task.
+- **If the plan includes testable logic, the final task must be a dedicated test task.** This task writes unit tests covering the new/changed logic. Implementation tasks may set `Tests: None` only because testing is deferred to this final task. Skip the test task only when there is genuinely nothing testable (pure config, documentation, agent-config/skill prose, or UI changes with no test infra).
 
 **Additional rules for MEDIUM/LARGE:**
 - If plan exceeds **15 tasks**, split into phases with a checkpoint between each
 - If the rollout strategy uses a feature flag, every task states how it respects that flag strategy
 - Reference relevant design artifacts by filename where relevant (for example mockups, screenshots, wireframes, API examples)
 
-**Plan format:**
-```
-## Implementation Plan: <feature-name>
+**Plan format:** Include rollout info (flag + pattern, or N/A), final validation strategy (`bill-quality-check`), then numbered tasks. Each task: description, files to create/modify, which acceptance criteria it satisfies, and test coverage (or "None" if deferred to the final test task).
 
-### Rollout
-- Flag: <name> (or N/A)
-- Pattern: <pattern> (or N/A)
-
-### Final Validation
-- Strategy: `bill-quality-check` | inline agent-config validation | both
-- Reason: <why this gate applies to the affected repo/boundaries>
-- Commands/scripts: <existing commands or repo-native scripts to run>
-
-### Tasks
-1. [ ] Task description
-   Files: list of files to create/modify
-   Criteria: #1, #3
-   Tests: what test coverage (or "None")
-
-2. [ ] ...
-```
-
-Present the plan and ask:
-> **Ready to implement?**
-
-Wait for user confirmation.
+Present the plan, then proceed to implementation. The user already confirmed the acceptance criteria — the plan is the agent's breakdown, not a second approval gate. If the plan is materially wrong, the completeness audit will catch it.
 
 ## Step 4: Execute Plan
 
@@ -214,92 +132,25 @@ Wait for user confirmation.
   - If plan has phases, pause between phases for a brief checkpoint
 - **When removing user-facing code, shared resources, or wiring:** immediately clean up orphaned artifacts (for example resource entries, assets, imports, unused mappers) in the same task — don't leave dead code for review to catch
 - **When changing agent-config or skill repositories:** update adjacent catalogs and wiring in the same task (README skill tables/counts, installer/config references, validation scripts/workflows) so the repo stays self-consistent
-- **Test gate:** Before moving to review/compaction, verify that unit tests were written. If the test task was somehow skipped or omitted from the plan, stop and write tests now. Never proceed to code review without tests.
+- **Test gate:** Before moving to review/compaction, verify that unit tests were written if the plan included testable logic. If the test task was omitted from a plan with testable code, stop and write tests now.
 
 ### Post-Implementation Compact (MEDIUM and LARGE only)
 
-Before review, summarize to free context:
-
-```
-📦 IMPLEMENTATION SUMMARY
-
-Files created:  <list>
-Files modified: <list>
-Feature flag:   <name and pattern, or N/A>
-
-Criteria coverage:
-  #1 → FileA.kt, FileB.kt
-  #2 → FileC.kt
-  ...
-
-Plan deviations: <any, or "None">
-```
-
-Then re-read `.feature-specs/<feature-name>/spec.md` to refresh acceptance criteria. Check that every criterion is mapped.
+Before review, summarize: files created/modified, feature flag info, criteria-to-file mapping, and plan deviations. Then re-read `.feature-specs/{ISSUE_KEY}-{feature-name}/spec.md` to refresh acceptance criteria and verify every criterion is mapped.
 
 ## Step 5: Code Review
 
-Run the `bill-code-review` skill and its matching `.agents/skill-overrides.md` section, then apply them inline. Treat that skill as the source of truth for:
-- Stack detection and routing
-- Stack-specific reviewer selection
-- Adaptive inline-vs-delegated review execution
-- Finding deduplication and prioritization
+Run `bill-code-review` (read its skill file and apply inline). Scope: current unit of work for SMALL, branch diff for MEDIUM/LARGE.
 
-Pass the following context from this run:
-- Review scope: current unit of work for SMALL features, current branch diff for MEDIUM/LARGE features
-- Confirmed acceptance criteria and spec path
-- Feature size
-- Feature flag name/pattern (or `N/A`)
-- The rule that newly introduced deprecated components, APIs, or patterns are not allowed when a supported alternative exists; any unavoidable usage must be explicitly justified and kept narrowly scoped
-
-### Review loop rules
-- Do not duplicate stack-specific trigger tables in this skill
-- If Blocker or Major issues are found, auto-fix them and re-run `bill-code-review` (or only the affected stack-specific reviewer if that skill supports it)
-- If only Minor issues remain, report them and continue
-- When `bill-code-review` is invoked from this skill, do not stop to ask the user which finding to fix first
-- Max **3 review iterations** — after that, report remaining issues and hand back to user
+**Review loop:** Auto-fix Blocker and Major findings, re-run review. Continue past Minor-only findings. Max **3 iterations** — after that, report remaining issues and hand back to user. Do not pause to ask the user which finding to fix.
 
 ## Step 6: Completeness Audit
 
-For **all sizes**, verify every numbered acceptance criterion against the actual code:
+**SMALL:** Quick confirmation that all acceptance criteria are satisfied. List any gaps — no formal per-criterion report needed.
 
-```
-📋 COMPLETENESS AUDIT: <feature-name>
+**MEDIUM and LARGE:** Verify every numbered acceptance criterion against actual code. For each criterion report: implemented (with file:line), missing (with reason), or partial (with what's missing). If the project targets multiple platforms, also verify platform-specific entry points and shared-vs-platform declarations.
 
-Acceptance criteria: <total>
-Implemented:         <count> ✅
-Missing:             <count> ❌
-Partial:             <count> ⚠️
-
-─────────────────────────────
-
-✅ #1: <criterion text>
-   Implemented in: FileA.kt:42, FileB.kt:88
-
-❌ #6: <criterion text>
-   Not found — <reason>
-
-⚠️ #8: <criterion text>
-   Partial — <what's missing>
-```
-
-**Platform coverage check** (only if project targets multiple platforms):
-- Verify platform-specific entry points, target configuration, and shared-vs-platform declarations where relevant (for example source sets, manifests, or `expect`/`actual` declarations when those concepts exist in the repo)
-
-### If gaps found:
-
-> **<N> requirements are missing or incomplete. Want me to implement the remaining items?**
-
-If yes: plan missing items → implement → review → re-audit. Max **2 audit iterations**.
-
-### If fully complete:
-
-```
-✅ All acceptance criteria implemented and verified.
-✅ Code review passed.
-```
-
-Update spec status to **Complete** (MEDIUM/LARGE only).
+If gaps found: ask user, then plan → implement → review → re-audit. Max **2 audit iterations**. When fully complete, update spec status to **Complete** (MEDIUM/LARGE only).
 
 ## Finalization sequence (Steps 6b → 9)
 
@@ -309,39 +160,13 @@ Once the completeness audit passes, run Steps 6b through 9 as a **continuous seq
 
 After completeness audit passes, **infer the final validation gate automatically** from the repo shape and changed files. Do not ask the user to choose.
 
-### Validation strategy
+Run `bill-quality-check` — it detects the dominant stack (including agent-config repos) and routes to the matching stack-specific quality-check skill automatically.
 
-- **Repos or affected boundaries use a supported stack-routed quality-check path:** run `bill-quality-check`
-- **Agent-config / skill repos touched:** run inline agent-config validation
-- **Both:** run both gates
-- **Neither:** run the closest existing repo-native validation command or test command already present in the project
-
-### Inline agent-config validation
-
-When the repo contains agent-config surfaces such as `SKILL.md`, `AGENTS.md`, `.agents/skill-overrides.md`, `CLAUDE.md`, `.claude/`, `.cursor/`, `.github/copilot-instructions*`, agent installer/config files, or repo-native validation scripts:
-
-1. Run `agnix` when available
-   - Prefer installed `agnix`
-   - Otherwise use `npx agnix .` if Node/npm is available
-2. Run any repo-native validation scripts and workflows already provided by the repo
-3. Fix issues at root cause in the changed files
-4. If the change created repo-wide metadata drift directly tied to the work (README tables/counts, skill references, manifest metadata, workflow wiring), fix that drift in the same pass
-
-Do **not** create a separate utility skill just for this validation path unless the repository itself is explicitly centered on validation as a product concept. `bill-feature-implement` owns this behavior.
+If `bill-quality-check` reports no supported stack for the affected repo, fall back to the closest existing repo-native validation command or test command already present in the project.
 
 ## Step 7: Write Boundary History
 
-Run the `bill-boundary-history` skill and its matching `.agents/skill-overrides.md` section, then apply them inline.
-
-Pass the required inputs from this run:
-- Feature name
-- Feature size (SMALL/MEDIUM/LARGE)
-- Primary module/package/area + affected module/package/area list
-- Feature flag name/pattern (or N/A)
-- Acceptance criteria coverage summary
-- Change summary (what changed, reusable components/patterns, breaking changes or limitations)
-
-The `bill-boundary-history` skill owns the write/skip rules, entry format, and history-file hygiene rules.
+Run `bill-boundary-history` (read its skill file and apply inline). The skill owns write/skip rules and entry format.
 
 ## Step 8: Commit and Push
 
@@ -353,12 +178,7 @@ Commit all changes and push the feature branch:
 
 ## Step 9: Generate PR Description (All sizes)
 
-Run the `bill-pr-description` skill and its matching `.agents/skill-overrides.md` section to generate a PR title, description, and QA steps.
-
-Pass along:
-- Feature name / spec path if available
-- The actual comparison base used for this feature branch (or enough git context for the skill to compute the merge-base correctly)
-- Manual verification notes from this run
+Run `bill-pr-description` (read its skill file and apply inline) to generate a PR title, description, and QA steps.
 
 ## Error Recovery
 
@@ -368,26 +188,21 @@ Pass along:
 
 ## Skills Invoked
 
-This skill orchestrates (by reading their instructions and applying inline):
-- `bill-feature-guard` — if the chosen rollout strategy requires a feature flag
-- `bill-code-review` — automatic after implementation; it detects the dominant stack and delegates to the matching stack-specific reviewer
-- `bill-quality-check` — when the affected repo/boundaries use a stack-routed quality-check path
-- `bill-boundary-history` — writes/maintains boundary-level `agent/history.md` for impactful or larger features
+Read each skill's file and apply inline when its step is reached:
+- `bill-feature-guard` — if rollout uses a feature flag
+- `bill-code-review` — after implementation
+- `bill-quality-check` — final validation gate
+- `bill-boundary-history` — after completeness audit
+- `bill-pr-description` — PR generation
 
 ## Size Reference
 
-| Indicator | SMALL | MEDIUM | LARGE |
-|-----------|-------|--------|-------|
-| Tasks | ≤5 | 6-15 | >15 |
-| Boundaries touched | ≤3 | ≤6 | >6 |
-| New boundaries/surfaces | No | Maybe | Yes |
-| Sync/migration involved | No | No | Yes |
-| Save spec to disk | Yes | Yes | Yes |
-| Read boundary history | If exists | Yes | Yes |
-| Feature flag ceremony | If required | If required | If required |
-| Codebase discovery section | Inline | Inline | Inline |
-| Compaction steps | No | Post-impl | Post-impl + post-review |
-| Review agents | Dynamic (2-6, based on diff) | Dynamic (2-6, based on diff) | Dynamic (2-6, based on diff) |
-| Final validation gate | Auto-detected | Auto-detected | Auto-detected |
-| Write boundary history | If impactful | Yes | Yes |
-| PR description | Yes | Yes | Yes |
+| | SMALL (≤5 tasks, ≤3 boundaries) | MEDIUM (6-15 tasks, ≤6 boundaries) | LARGE (>15 tasks or >6 boundaries) |
+|---|---|---|---|
+| Save spec to disk | No | Yes | Yes |
+| Compaction | No | Post-impl | Post-impl + post-review |
+| Completeness audit | Quick confirmation | Full per-criterion report | Full per-criterion report |
+| Boundary history | If impactful | Yes | Yes |
+| Codebase discovery | No | Inline | Inline |
+
+All sizes: feature flag if required, code review (dynamic 2-6 agents), `bill-quality-check`, PR description.

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -110,11 +110,10 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       self.assertIn(section, REVIEW_DELEGATION_PLAYBOOK)
 
   def test_feature_implement_invokes_shared_review_and_validation_routers(self) -> None:
-    self.assertIn("Run the `bill-code-review` skill", FEATURE_IMPLEMENT)
-    self.assertIn("run `bill-quality-check`", FEATURE_IMPLEMENT)
+    self.assertIn("Run `bill-code-review`", FEATURE_IMPLEMENT)
+    self.assertIn("Run `bill-quality-check`", FEATURE_IMPLEMENT)
     self.assertIn("`bill-code-review`", FEATURE_IMPLEMENT)
     self.assertIn("`bill-quality-check`", FEATURE_IMPLEMENT)
-    self.assertIn("Adaptive inline-vs-delegated review execution", FEATURE_IMPLEMENT)
 
   def test_pr_description_prefers_repo_native_templates(self) -> None:
     self.assertIn("## Repo-Native PR Template Preference", PR_DESCRIPTION)


### PR DESCRIPTION
## Summary

- **371 → 208 lines** (44% reduction) without losing behavioral contracts
- Delegate agent-config validation to `bill-quality-check` router instead of inline logic in Step 6b
- Remove plan confirmation gate — assessment confirmation is the only user stop before implementation
- Trim verbose format templates, workflow ASCII diagram, and invoked-skill re-explanations (trust child skills to know their own job)
- Make test task conditional on testable logic (skip for pure config, docs, skill prose)
- Lighten SMALL features: skip spec-to-disk, quick completeness check instead of formal per-criterion report
- Add issue key to spec folder naming (`{ISSUE_KEY}-{feature-name}`) for traceability
- Generalize issue tracker reference (was Jira-specific)

## Test plan

- [x] `python3 -m unittest discover -s tests` — 93 tests passing
- [x] `python3 scripts/validate_agent_configs.py` — 46 skills validated
- [ ] Run `/feature-implement` on a SMALL feature and verify reduced ceremony
- [ ] Run `/feature-implement` on a MEDIUM feature and verify full pipeline still works