### PR TITLE
feat: add bill-boundary-decisions skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Treat your AI skills like software — with stable interfaces, platform overrides, and validation that prevents the repo from rotting.
 
-sKill Bill is a portable collection of 47 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
+sKill Bill is a portable collection of 48 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
 
 ## Why this exists
 
@@ -236,7 +236,7 @@ The uninstaller is idempotent. It removes current Skill Bill installs, generated
 | `/bill-feature-guard` | Add feature-flag rollout safety |
 | `/bill-feature-guard-cleanup` | Remove feature flags after rollout |
 
-### Utilities (10 skills)
+### Utilities (11 skills)
 
 | Skill | Purpose |
 |-------|---------|
@@ -246,6 +246,7 @@ The uninstaller is idempotent. It removes current Skill Bill installs, generated
 | `/bill-php-quality-check` | PHP quality-check implementation |
 | `/bill-go-quality-check` | Go quality-check implementation |
 | `/bill-boundary-history` | Maintain `agent/history.md` at module/package/area boundaries |
+| `/bill-boundary-decisions` | Record architectural/implementation decisions in `agent/decisions.md` |
 | `/bill-unit-test-value-check` | Audit unit tests for real value |
 | `/bill-pr-description` | Generate PR title, description, and QA steps, preferring repo PR templates when present |
 | `/bill-grill-plan` | Stress-test a plan or design by walking every decision branch |

--- a/skills/base/bill-boundary-decisions/SKILL.md
+++ b/skills/base/bill-boundary-decisions/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: bill-boundary-decisions
+description: Use when recording architectural or implementation decisions in a module/package/area agent/decisions.md file. Use when user mentions record decision, boundary decision, why we chose, decision log, or remember this decision.
+---
+
+# Boundary Decisions
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-boundary-decisions` section, read that section and apply it as the highest-priority instruction for this skill. The matching section may refine or replace parts of the default workflow below.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+Precedence for this skill: matching `.agents/skill-overrides.md` section > `AGENTS.md` > built-in defaults.
+
+## Purpose
+
+Record **why** something was done a certain way — not what changed (that belongs in `history.md`), but the reasoning behind non-obvious choices, special cases, constraints, and trade-offs that future contributors need to understand before modifying the code.
+
+## Inputs Required
+
+- Decision title (short, descriptive)
+- Primary module/package/area where the decision applies
+- User explanation of the decision (the agent captures and structures it, not invents it)
+
+## Input Recovery
+
+- If the user omits the primary boundary, infer it from the files most recently changed in the current diff
+- If the user gives a free-form explanation, the agent structures it into the entry format below — preserving the user's reasoning faithfully without adding interpretation
+
+## Entry Format
+
+```markdown
+## [<date>] <short decision title>
+Context: <what situation or requirement prompted this decision — 1-2 lines>
+Decision: <what was chosen — 1-2 lines>
+Reason: <why this approach over alternatives — 1-3 lines>
+```
+
+Optional trailing lines (include only when relevant):
+- `Alternatives considered: <what was rejected and why — 1 line>`
+- `Revisit when: <condition that would make this decision worth re-evaluating>`
+
+## Format Rules
+
+- Max **10 lines** per entry
+- Newest entry first (reverse chronological)
+- No code snippets; describe patterns and choices in plain language
+- One decision per entry — if the user describes multiple decisions, write separate entries
+
+## File Rules
+
+- File path: `<primary-boundary>/agent/decisions.md`
+- If the file does not exist, create it along with any missing parent directories
+- Newest entry first
+- No fixed entry cap
+- Keep older entries when they still provide useful context for understanding the boundary's design
+- Prune entries only when the decision has been fully reversed or the context no longer applies
+
+## Distinguishing from History
+
+- **history.md**: *what* changed, reusable patterns, feature scope — written after feature completion
+- **decisions.md**: *why* something was done this way — written whenever the user wants to capture reasoning
+
+If the user describes something that is purely a "what changed" summary with no reasoning, suggest `bill-boundary-history` instead.
+
+## Output
+
+Report one concise result:
+- Written (with entry count) or skipped (with reason)
+- Target file path
+- Decision title(s) recorded

--- a/skills/base/bill-feature-implement/reference.md
+++ b/skills/base/bill-feature-implement/reference.md
@@ -12,6 +12,10 @@ For SMALL features the acceptance criteria stay in context — no spec file need
 
 Look for `agent/history.md` in each boundary the feature touches. Read newest entries first, stop once entries are no longer relevant. Use to reuse components and follow latest patterns. Skip if none exist.
 
+### Read Boundary Decisions
+
+Look for `agent/decisions.md` in each boundary the feature touches. If the file exists, scan only the `## [date] title` header lines first. Read full entries only for decisions whose titles are relevant to the boundaries, patterns, or interfaces this feature will touch. Skip if none exist.
+
 ### Feature Flag Setup (only when rollout uses a feature flag)
 
 - Read the `bill-feature-guard` skill instructions and its matching `.agents/skill-overrides.md` section, then apply them inline
@@ -105,6 +109,8 @@ All sizes: feature flag if required, code review (dynamic 2-6 agents), `bill-qua
 - Implementation fails mid-plan: stop, report which task failed and why, ask user
 - Review enters fix loop (>3 iterations): stop, report remaining issues, hand to user
 - Completeness audit loops (>2 iterations): report remaining gaps, let user decide
+
+In all early-exit cases, call `feature_implement_finished` with the appropriate `completion_status` (`abandoned_at_planning`, `abandoned_at_implementation`, `abandoned_at_review`, or `error`) so the telemetry session is closed.
 
 ## Skills Invoked
 


### PR DESCRIPTION
## Summary
- New `bill-boundary-decisions` skill that records architectural and implementation decisions in `<boundary>/agent/decisions.md`
- Complements `bill-boundary-history` (what changed) with reasoning capture (why it was done this way)
- Integrates with `bill-feature-implement` planning phase via header-scan pattern — reads only `## [date] title` lines first, then selectively expands relevant entries to minimize context pollution

## Test plan
- [x] `python3 -m unittest discover -s tests` — 121 tests pass
- [x] `npx --yes agnix --strict .` — 0 errors, 0 warnings
- [x] `python3 scripts/validate_agent_configs.py` — 48 skills validated
- [ ] Manual: invoke `/bill-boundary-decisions` in a project, verify it creates `agent/decisions.md` with correct entry format
- [ ] Manual: run `/bill-feature-implement` on a boundary with existing decisions, verify header-scan reads only relevant entries