### PR TITLE
feat: add feature-implement telemetry

### DIFF
--- a/docs/review-telemetry.md
+++ b/docs/review-telemetry.md
@@ -124,6 +124,73 @@ The finished event carries: total/accepted/unresolved finding counts, accepted/r
 
 When `learnings resolve` is called with `--review-session-id`, the resolved learnings are cached locally and included in the matching `skillbill_review_finished` event when it fires.
 
+## Feature-implement telemetry
+
+The feature-implement workflow emits two events per session:
+
+- `skillbill_feature_implement_started` — emitted after Step 1 assessment is confirmed by the user
+- `skillbill_feature_implement_finished` — emitted after Step 9 (PR created) or when the workflow ends early
+
+Each feature-implement session uses a `session_id` in the format `fis-YYYYMMDD-HHMMSS-XXXX` (4-char random alphanumeric suffix). The finished event is self-contained — it includes all started fields so each event can be analyzed independently in PostHog.
+
+The MCP server exposes `feature_implement_started` and `feature_implement_finished` as agent tools. The skill instructions tell the agent when to call each tool.
+
+### Started event payload
+
+Both `anonymous` and `full` levels include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | string | `fis-YYYYMMDD-HHMMSS-XXXX` |
+| `issue_key_provided` | boolean | Whether the user provided a Jira/Linear/GitHub issue key |
+| `issue_key_type` | string | `jira`, `linear`, `github`, `other`, or `none` |
+| `spec_input_types` | list | Input types: `raw_text`, `pdf`, `markdown_file`, `image`, `directory` |
+| `spec_word_count` | integer | Approximate word count of the design spec |
+| `feature_size` | string | `SMALL`, `MEDIUM`, or `LARGE` |
+| `rollout_needed` | boolean | Whether a feature flag / guarded rollout is needed |
+| `acceptance_criteria_count` | integer | Number of acceptance criteria |
+| `open_questions_count` | integer | Number of open questions before resolution |
+
+`full` level adds:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `feature_name` | string | Inferred feature name |
+| `spec_summary` | string | One-sentence summary of the feature |
+
+### Finished event payload
+
+Includes all started fields plus:
+
+Both `anonymous` and `full` levels:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `completion_status` | string | `completed`, `abandoned_at_planning`, `abandoned_at_implementation`, `abandoned_at_review`, or `error` |
+| `plan_correction_count` | integer | Times the user corrected the assessment/plan (0 = confirmed immediately) |
+| `plan_task_count` | integer | Total tasks in the plan |
+| `plan_phase_count` | integer | Number of phases |
+| `feature_flag_used` | boolean | Whether a feature flag was used |
+| `feature_flag_pattern` | string | `simple_conditional`, `di_switch`, `legacy`, or `none` |
+| `files_created` | integer | New files created |
+| `files_modified` | integer | Existing files modified |
+| `tasks_completed` | integer | Tasks completed |
+| `review_iterations` | integer | Code review iteration count |
+| `audit_result` | string | `all_pass`, `had_gaps`, or `skipped` |
+| `audit_iterations` | integer | Completeness audit iteration count |
+| `validation_result` | string | `pass`, `fail`, or `skipped` |
+| `boundary_history_written` | boolean | Whether boundary history was written |
+| `pr_created` | boolean | Whether a PR was created |
+| `duration_seconds` | integer | Wall-clock seconds from started to finished |
+
+`full` level adds:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `plan_deviation_notes` | string | Brief note if the plan changed during execution |
+
+Fields always excluded (both levels): repo name, branch name, raw spec content, raw plan content, file paths, acceptance criteria text.
+
 ## Remote sync defaults
 
 Fresh installs default telemetry to `anonymous`, with a level prompt during `./install.sh`. When telemetry level is not `off`, Skill Bill generates an install id, writes telemetry config to `~/.skill-bill/config.json`, and can batch-sync queued telemetry to the hosted Skill Bill relay. If you configure a custom proxy, Skill Bill sends telemetry to that proxy only.

--- a/skill_bill/constants.py
+++ b/skill_bill/constants.py
@@ -33,6 +33,22 @@ REJECTED_FINDING_OUTCOME_TYPES = ("fix_rejected", "false_positive")
 LEARNING_SCOPES = ("global", "repo", "skill")
 LEARNING_STATUSES = ("active", "disabled")
 LEARNING_SCOPE_PRECEDENCE = ("skill", "repo", "global")
+
+EVENT_FEATURE_IMPLEMENT_STARTED = "skillbill_feature_implement_started"
+EVENT_FEATURE_IMPLEMENT_FINISHED = "skillbill_feature_implement_finished"
+FEATURE_SIZES = ("SMALL", "MEDIUM", "LARGE")
+SPEC_INPUT_TYPES = ("raw_text", "pdf", "markdown_file", "image", "directory")
+ISSUE_KEY_TYPES = ("jira", "linear", "github", "other", "none")
+FEATURE_FLAG_PATTERNS = ("simple_conditional", "di_switch", "legacy", "none")
+AUDIT_RESULTS = ("all_pass", "had_gaps", "skipped")
+VALIDATION_RESULTS = ("pass", "fail", "skipped")
+COMPLETION_STATUSES = (
+  "completed",
+  "abandoned_at_planning",
+  "abandoned_at_implementation",
+  "abandoned_at_review",
+  "error",
+)
 MEANINGFUL_NOTE_PATTERN = re.compile(r"[A-Za-z0-9]")
 
 REVIEW_RUN_ID_PATTERN = re.compile(r"^Review run ID:\s*(?P<value>[A-Za-z0-9._:-]+)\s*$", re.MULTILINE)

--- a/skill_bill/db.py
+++ b/skill_bill/db.py
@@ -119,6 +119,40 @@ def ensure_database(path: Path) -> sqlite3.Connection:
       learnings_json TEXT NOT NULL,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );
+
+    CREATE TABLE IF NOT EXISTS feature_implement_sessions (
+      session_id TEXT PRIMARY KEY,
+      issue_key_provided INTEGER NOT NULL DEFAULT 0,
+      issue_key_type TEXT NOT NULL DEFAULT 'none',
+      spec_input_types TEXT NOT NULL DEFAULT '',
+      spec_word_count INTEGER NOT NULL DEFAULT 0,
+      feature_size TEXT NOT NULL DEFAULT 'SMALL',
+      feature_name TEXT NOT NULL DEFAULT '',
+      rollout_needed INTEGER NOT NULL DEFAULT 0,
+      acceptance_criteria_count INTEGER NOT NULL DEFAULT 0,
+      open_questions_count INTEGER NOT NULL DEFAULT 0,
+      spec_summary TEXT NOT NULL DEFAULT '',
+      started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      started_event_emitted_at TEXT,
+      completion_status TEXT NOT NULL DEFAULT '',
+      plan_correction_count INTEGER,
+      plan_task_count INTEGER,
+      plan_phase_count INTEGER,
+      feature_flag_used INTEGER,
+      feature_flag_pattern TEXT,
+      files_created INTEGER,
+      files_modified INTEGER,
+      tasks_completed INTEGER,
+      review_iterations INTEGER,
+      audit_result TEXT,
+      audit_iterations INTEGER,
+      validation_result TEXT,
+      boundary_history_written INTEGER,
+      pr_created INTEGER,
+      plan_deviation_notes TEXT NOT NULL DEFAULT '',
+      finished_at TEXT,
+      finished_event_emitted_at TEXT
+    );
     """
   )
   ensure_column(connection, "review_runs", "review_session_id", "TEXT")

--- a/skill_bill/feature_implement.py
+++ b/skill_bill/feature_implement.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+import random
+import sqlite3
+import string
+from datetime import datetime, timezone
+
+from skill_bill.constants import (
+  AUDIT_RESULTS,
+  COMPLETION_STATUSES,
+  EVENT_FEATURE_IMPLEMENT_FINISHED,
+  EVENT_FEATURE_IMPLEMENT_STARTED,
+  FEATURE_FLAG_PATTERNS,
+  FEATURE_SIZES,
+  ISSUE_KEY_TYPES,
+  SPEC_INPUT_TYPES,
+  VALIDATION_RESULTS,
+)
+from skill_bill.stats import enqueue_telemetry_event
+
+
+def generate_feature_session_id() -> str:
+  now = datetime.now(timezone.utc)
+  suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+  return f"fis-{now:%Y%m%d-%H%M%S}-{suffix}"
+
+
+def validate_enum(value: str, allowed: tuple[str, ...], field_name: str) -> str | None:
+  if value not in allowed:
+    return f"Invalid {field_name} '{value}'. Allowed: {', '.join(allowed)}"
+  return None
+
+
+def validate_started_params(
+  *,
+  feature_size: str,
+  issue_key_type: str,
+  spec_input_types: list[str],
+) -> str | None:
+  error = validate_enum(feature_size, FEATURE_SIZES, "feature_size")
+  if error:
+    return error
+  error = validate_enum(issue_key_type, ISSUE_KEY_TYPES, "issue_key_type")
+  if error:
+    return error
+  for spec_type in spec_input_types:
+    error = validate_enum(spec_type, SPEC_INPUT_TYPES, "spec_input_types")
+    if error:
+      return error
+  return None
+
+
+def validate_finished_params(
+  *,
+  completion_status: str,
+  feature_flag_pattern: str,
+  audit_result: str,
+  validation_result: str,
+) -> str | None:
+  error = validate_enum(completion_status, COMPLETION_STATUSES, "completion_status")
+  if error:
+    return error
+  error = validate_enum(feature_flag_pattern, FEATURE_FLAG_PATTERNS, "feature_flag_pattern")
+  if error:
+    return error
+  error = validate_enum(audit_result, AUDIT_RESULTS, "audit_result")
+  if error:
+    return error
+  error = validate_enum(validation_result, VALIDATION_RESULTS, "validation_result")
+  if error:
+    return error
+  return None
+
+
+def save_started(
+  connection: sqlite3.Connection,
+  *,
+  session_id: str,
+  issue_key_provided: bool,
+  issue_key_type: str,
+  spec_input_types: list[str],
+  spec_word_count: int,
+  feature_size: str,
+  feature_name: str,
+  rollout_needed: bool,
+  acceptance_criteria_count: int,
+  open_questions_count: int,
+  spec_summary: str,
+) -> None:
+  with connection:
+    connection.execute(
+      """
+      INSERT INTO feature_implement_sessions (
+        session_id, issue_key_provided, issue_key_type, spec_input_types,
+        spec_word_count, feature_size, feature_name, rollout_needed,
+        acceptance_criteria_count, open_questions_count, spec_summary
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      """,
+      (
+        session_id,
+        1 if issue_key_provided else 0,
+        issue_key_type,
+        json.dumps(spec_input_types),
+        spec_word_count,
+        feature_size,
+        feature_name,
+        1 if rollout_needed else 0,
+        acceptance_criteria_count,
+        open_questions_count,
+        spec_summary,
+      ),
+    )
+
+
+def save_finished(
+  connection: sqlite3.Connection,
+  *,
+  session_id: str,
+  completion_status: str,
+  plan_correction_count: int,
+  plan_task_count: int,
+  plan_phase_count: int,
+  feature_flag_used: bool,
+  feature_flag_pattern: str,
+  files_created: int,
+  files_modified: int,
+  tasks_completed: int,
+  review_iterations: int,
+  audit_result: str,
+  audit_iterations: int,
+  validation_result: str,
+  boundary_history_written: bool,
+  pr_created: bool,
+  plan_deviation_notes: str,
+) -> None:
+  exists = connection.execute(
+    "SELECT 1 FROM feature_implement_sessions WHERE session_id = ?",
+    (session_id,),
+  ).fetchone()
+
+  if exists:
+    with connection:
+      connection.execute(
+        """
+        UPDATE feature_implement_sessions SET
+          completion_status = ?,
+          plan_correction_count = ?,
+          plan_task_count = ?,
+          plan_phase_count = ?,
+          feature_flag_used = ?,
+          feature_flag_pattern = ?,
+          files_created = ?,
+          files_modified = ?,
+          tasks_completed = ?,
+          review_iterations = ?,
+          audit_result = ?,
+          audit_iterations = ?,
+          validation_result = ?,
+          boundary_history_written = ?,
+          pr_created = ?,
+          plan_deviation_notes = ?,
+          finished_at = CURRENT_TIMESTAMP
+        WHERE session_id = ?
+        """,
+        (
+          completion_status,
+          plan_correction_count,
+          plan_task_count,
+          plan_phase_count,
+          1 if feature_flag_used else 0,
+          feature_flag_pattern,
+          files_created,
+          files_modified,
+          tasks_completed,
+          review_iterations,
+          audit_result,
+          audit_iterations,
+          validation_result,
+          1 if boundary_history_written else 0,
+          1 if pr_created else 0,
+          plan_deviation_notes,
+          session_id,
+        ),
+      )
+  else:
+    with connection:
+      connection.execute(
+        """
+        INSERT INTO feature_implement_sessions (
+          session_id, completion_status, plan_correction_count,
+          plan_task_count, plan_phase_count, feature_flag_used,
+          feature_flag_pattern, files_created, files_modified,
+          tasks_completed, review_iterations, audit_result,
+          audit_iterations, validation_result, boundary_history_written,
+          pr_created, plan_deviation_notes, finished_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        """,
+        (
+          session_id,
+          completion_status,
+          plan_correction_count,
+          plan_task_count,
+          plan_phase_count,
+          1 if feature_flag_used else 0,
+          feature_flag_pattern,
+          files_created,
+          files_modified,
+          tasks_completed,
+          review_iterations,
+          audit_result,
+          audit_iterations,
+          validation_result,
+          1 if boundary_history_written else 0,
+          1 if pr_created else 0,
+          plan_deviation_notes,
+        ),
+      )
+
+
+def fetch_session(connection: sqlite3.Connection, session_id: str) -> sqlite3.Row | None:
+  return connection.execute(
+    "SELECT * FROM feature_implement_sessions WHERE session_id = ?",
+    (session_id,),
+  ).fetchone()
+
+
+def build_started_payload(
+  connection: sqlite3.Connection,
+  session_id: str,
+  level: str,
+) -> dict[str, object]:
+  row = fetch_session(connection, session_id)
+  if row is None:
+    return {}
+
+  payload: dict[str, object] = {
+    "session_id": row["session_id"],
+    "issue_key_provided": bool(row["issue_key_provided"]),
+    "issue_key_type": row["issue_key_type"],
+    "spec_input_types": json.loads(row["spec_input_types"] or "[]"),
+    "spec_word_count": row["spec_word_count"],
+    "feature_size": row["feature_size"],
+    "rollout_needed": bool(row["rollout_needed"]),
+    "acceptance_criteria_count": row["acceptance_criteria_count"],
+    "open_questions_count": row["open_questions_count"],
+  }
+
+  if level == "full":
+    payload["feature_name"] = row["feature_name"]
+    payload["spec_summary"] = row["spec_summary"]
+
+  return payload
+
+
+def build_finished_payload(
+  connection: sqlite3.Connection,
+  session_id: str,
+  level: str,
+) -> dict[str, object]:
+  row = fetch_session(connection, session_id)
+  if row is None:
+    return {}
+
+  payload = build_started_payload(connection, session_id, level)
+
+  started_at = row["started_at"] or ""
+  finished_at = row["finished_at"] or ""
+  duration_seconds = 0
+  if started_at and finished_at:
+    try:
+      start_dt = datetime.fromisoformat(started_at)
+      end_dt = datetime.fromisoformat(finished_at)
+      duration_seconds = max(0, int((end_dt - start_dt).total_seconds()))
+    except (ValueError, TypeError):
+      pass
+
+  payload.update({
+    "completion_status": row["completion_status"] or "",
+    "plan_correction_count": row["plan_correction_count"] or 0,
+    "plan_task_count": row["plan_task_count"] or 0,
+    "plan_phase_count": row["plan_phase_count"] or 0,
+    "feature_flag_used": bool(row["feature_flag_used"]),
+    "feature_flag_pattern": row["feature_flag_pattern"] or "none",
+    "files_created": row["files_created"] or 0,
+    "files_modified": row["files_modified"] or 0,
+    "tasks_completed": row["tasks_completed"] or 0,
+    "review_iterations": row["review_iterations"] or 0,
+    "audit_result": row["audit_result"] or "skipped",
+    "audit_iterations": row["audit_iterations"] or 0,
+    "validation_result": row["validation_result"] or "skipped",
+    "boundary_history_written": bool(row["boundary_history_written"]),
+    "pr_created": bool(row["pr_created"]),
+    "duration_seconds": duration_seconds,
+  })
+
+  if level == "full":
+    payload["plan_deviation_notes"] = row["plan_deviation_notes"] or ""
+
+  return payload
+
+
+def emit_started(
+  connection: sqlite3.Connection,
+  *,
+  session_id: str,
+  enabled: bool,
+  level: str,
+) -> None:
+  row = fetch_session(connection, session_id)
+  if row is None:
+    return
+  if row["started_event_emitted_at"]:
+    return
+
+  payload = build_started_payload(connection, session_id, level)
+  with connection:
+    enqueue_telemetry_event(
+      connection,
+      event_name=EVENT_FEATURE_IMPLEMENT_STARTED,
+      payload=payload,
+      enabled=enabled,
+    )
+    if enabled:
+      connection.execute(
+        """
+        UPDATE feature_implement_sessions
+        SET started_event_emitted_at = CURRENT_TIMESTAMP
+        WHERE session_id = ?
+        """,
+        (session_id,),
+      )
+
+
+def emit_finished(
+  connection: sqlite3.Connection,
+  *,
+  session_id: str,
+  enabled: bool,
+  level: str,
+) -> None:
+  row = fetch_session(connection, session_id)
+  if row is None:
+    return
+  if row["finished_event_emitted_at"]:
+    return
+
+  payload = build_finished_payload(connection, session_id, level)
+  with connection:
+    enqueue_telemetry_event(
+      connection,
+      event_name=EVENT_FEATURE_IMPLEMENT_FINISHED,
+      payload=payload,
+      enabled=enabled,
+    )
+    if enabled:
+      connection.execute(
+        """
+        UPDATE feature_implement_sessions
+        SET finished_event_emitted_at = CURRENT_TIMESTAMP
+        WHERE session_id = ?
+        """,
+        (session_id,),
+      )

--- a/skill_bill/mcp_server.py
+++ b/skill_bill/mcp_server.py
@@ -8,6 +8,15 @@ from skill_bill import __version__
 from skill_bill.config import load_telemetry_settings, telemetry_is_enabled
 from skill_bill.constants import LEARNING_SCOPE_PRECEDENCE
 from skill_bill.db import open_db, resolve_db_path
+from skill_bill.feature_implement import (
+  emit_finished,
+  emit_started,
+  generate_feature_session_id,
+  save_finished,
+  save_started,
+  validate_finished_params,
+  validate_started_params,
+)
 from skill_bill.learnings import (
   learning_payload,
   learning_summary_payload,
@@ -199,6 +208,131 @@ def doctor() -> dict:
     "telemetry_enabled": telemetry_enabled,
     "telemetry_level": telemetry_level,
   }
+
+
+@mcp.tool()
+def feature_implement_started(
+  feature_size: str,
+  acceptance_criteria_count: int,
+  open_questions_count: int,
+  spec_input_types: list[str],
+  spec_word_count: int,
+  rollout_needed: bool,
+  feature_name: str = "",
+  issue_key: str = "",
+  issue_key_type: str = "none",
+  spec_summary: str = "",
+) -> dict:
+  """Record the start of a feature-implement session.
+
+  Call this after the Step 1 assessment is confirmed by the user.
+  Returns a session_id to pass to feature_implement_finished later.
+  """
+  session_id = generate_feature_session_id()
+  issue_key_provided = bool(issue_key.strip())
+
+  validation_error = validate_started_params(
+    feature_size=feature_size,
+    issue_key_type=issue_key_type,
+    spec_input_types=spec_input_types,
+  )
+  if validation_error:
+    return {"status": "error", "session_id": session_id, "error": validation_error}
+
+  if not telemetry_is_enabled():
+    return {"status": "skipped", "session_id": session_id}
+
+  with open_db() as (connection, db_path):
+    save_started(
+      connection,
+      session_id=session_id,
+      issue_key_provided=issue_key_provided,
+      issue_key_type=issue_key_type,
+      spec_input_types=spec_input_types,
+      spec_word_count=spec_word_count,
+      feature_size=feature_size,
+      feature_name=feature_name,
+      rollout_needed=rollout_needed,
+      acceptance_criteria_count=acceptance_criteria_count,
+      open_questions_count=open_questions_count,
+      spec_summary=spec_summary,
+    )
+    settings = load_telemetry_settings()
+    emit_started(
+      connection,
+      session_id=session_id,
+      enabled=settings.enabled,
+      level=settings.level,
+    )
+  return {"status": "ok", "session_id": session_id}
+
+
+@mcp.tool()
+def feature_implement_finished(
+  session_id: str,
+  completion_status: str,
+  plan_correction_count: int,
+  plan_task_count: int,
+  plan_phase_count: int,
+  feature_flag_used: bool,
+  files_created: int,
+  files_modified: int,
+  tasks_completed: int,
+  review_iterations: int,
+  audit_result: str,
+  audit_iterations: int,
+  validation_result: str,
+  boundary_history_written: bool,
+  pr_created: bool,
+  feature_flag_pattern: str = "none",
+  plan_deviation_notes: str = "",
+) -> dict:
+  """Record the completion of a feature-implement session.
+
+  Call this after Step 9 (PR created) or when the workflow ends early.
+  The session_id must match the value returned by feature_implement_started.
+  """
+  validation_error = validate_finished_params(
+    completion_status=completion_status,
+    feature_flag_pattern=feature_flag_pattern,
+    audit_result=audit_result,
+    validation_result=validation_result,
+  )
+  if validation_error:
+    return {"status": "error", "session_id": session_id, "error": validation_error}
+
+  if not telemetry_is_enabled():
+    return {"status": "skipped", "session_id": session_id}
+
+  with open_db() as (connection, db_path):
+    save_finished(
+      connection,
+      session_id=session_id,
+      completion_status=completion_status,
+      plan_correction_count=plan_correction_count,
+      plan_task_count=plan_task_count,
+      plan_phase_count=plan_phase_count,
+      feature_flag_used=feature_flag_used,
+      feature_flag_pattern=feature_flag_pattern,
+      files_created=files_created,
+      files_modified=files_modified,
+      tasks_completed=tasks_completed,
+      review_iterations=review_iterations,
+      audit_result=audit_result,
+      audit_iterations=audit_iterations,
+      validation_result=validation_result,
+      boundary_history_written=boundary_history_written,
+      pr_created=pr_created,
+      plan_deviation_notes=plan_deviation_notes,
+    )
+    settings = load_telemetry_settings()
+    emit_finished(
+      connection,
+      session_id=session_id,
+      enabled=settings.enabled,
+      level=settings.level,
+    )
+  return {"status": "ok", "session_id": session_id}
 
 
 def main() -> None:

--- a/skills/base/bill-feature-implement/SKILL.md
+++ b/skills/base/bill-feature-implement/SKILL.md
@@ -33,6 +33,20 @@ Present everything together in one pass:
 
 Then ask: **Confirm or adjust the above before I plan.** Open questions must be resolved before proceeding. The confirmed criteria are the **contract** for the completeness audit.
 
+### Telemetry: Record Started
+
+After the user confirms the assessment, call the `feature_implement_started` MCP tool with:
+- `feature_size`, `acceptance_criteria_count`, `open_questions_count`
+- `spec_input_types`: list of input types the user provided (`raw_text`, `pdf`, `markdown_file`, `image`, `directory`)
+- `spec_word_count`: approximate word count of the design spec
+- `rollout_needed`: whether a feature flag / guarded rollout is needed
+- `feature_name`: the inferred feature name
+- `issue_key`: the issue key if provided, empty string otherwise
+- `issue_key_type`: `jira` (e.g. ME-5066), `linear` (e.g. LIN-123 or UUID), `github` (e.g. #42), `other`, or `none`
+- `spec_summary`: one sentence summarizing what the feature does
+
+Save the returned `session_id` for `feature_implement_finished`. If the tool returns `status: skipped`, continue normally.
+
 ## Step 1b: Create Feature Branch
 
 After confirmation: `git checkout -b feat/{ISSUE_KEY}-{feature-name}`
@@ -72,6 +86,21 @@ If gaps found: plan → implement → review → re-audit. Max **2 audit iterati
 Once completeness audit passes, run Steps 6b through 9 as a **continuous sequence without pausing**. The only reason to stop is if a step fails.
 
 For detailed finalization steps (validation gate, boundary history, commit/push, PR description), see [reference.md](reference.md).
+
+### Telemetry: Record Finished
+
+After the PR is created (or when the workflow ends early due to error or user abandonment), call the `feature_implement_finished` MCP tool with:
+- `session_id`: from `feature_implement_started`
+- `completion_status`: `completed` if PR was created, otherwise `abandoned_at_planning`, `abandoned_at_implementation`, `abandoned_at_review`, or `error`
+- `plan_correction_count`: how many times the user corrected the assessment or plan (0 if confirmed without changes)
+- `plan_task_count`, `plan_phase_count`
+- `feature_flag_used`, `feature_flag_pattern` (`simple_conditional`, `di_switch`, `legacy`, or `none`)
+- `files_created`, `files_modified`, `tasks_completed`
+- `review_iterations`, `audit_result` (`all_pass`, `had_gaps`, or `skipped`), `audit_iterations`
+- `validation_result` (`pass`, `fail`, or `skipped`), `boundary_history_written`, `pr_created`
+- `plan_deviation_notes`: brief note if the plan changed during execution (empty if no deviations)
+
+For fields not yet reached (early exit), use: 0 for counts, `skipped` for results, false for booleans.
 
 ## Reference
 

--- a/tests/test_feature_implement_telemetry.py
+++ b/tests/test_feature_implement_telemetry.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import os
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from skill_bill.mcp_server import (
+  feature_implement_finished,
+  feature_implement_started,
+)
+
+
+STARTED_PARAMS = {
+  "feature_size": "MEDIUM",
+  "acceptance_criteria_count": 5,
+  "open_questions_count": 1,
+  "spec_input_types": ["markdown_file", "image"],
+  "spec_word_count": 2400,
+  "rollout_needed": True,
+  "feature_name": "payment-retry",
+  "issue_key": "ME-1234",
+  "issue_key_type": "jira",
+  "spec_summary": "Retry failed payments up to 3 times with exponential backoff",
+}
+
+FINISHED_PARAMS = {
+  "completion_status": "completed",
+  "plan_correction_count": 0,
+  "plan_task_count": 8,
+  "plan_phase_count": 1,
+  "feature_flag_used": True,
+  "feature_flag_pattern": "legacy",
+  "files_created": 3,
+  "files_modified": 5,
+  "tasks_completed": 8,
+  "review_iterations": 2,
+  "audit_result": "all_pass",
+  "audit_iterations": 1,
+  "validation_result": "pass",
+  "boundary_history_written": True,
+  "pr_created": True,
+  "plan_deviation_notes": "Task 5 split into 5a/5b",
+}
+
+
+class FeatureImplementEnabledTest(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir = tempfile.mkdtemp()
+    self.db_path = os.path.join(self.temp_dir, "metrics.db")
+    self.config_path = os.path.join(self.temp_dir, "config.json")
+    Path(self.config_path).write_text(
+      json.dumps({
+        "install_id": "test-install-id",
+        "telemetry": {"enabled": True, "proxy_url": "", "batch_size": 50},
+      }),
+      encoding="utf-8",
+    )
+    self._original_env: dict[str, str | None] = {}
+    env_overrides = {
+      "SKILL_BILL_REVIEW_DB": self.db_path,
+      "SKILL_BILL_CONFIG_PATH": self.config_path,
+      "SKILL_BILL_TELEMETRY_ENABLED": "true",
+      "SKILL_BILL_INSTALL_ID": "test-install-id",
+    }
+    for key, value in env_overrides.items():
+      self._original_env[key] = os.environ.get(key)
+      os.environ[key] = value
+
+  def tearDown(self) -> None:
+    for key, value in self._original_env.items():
+      if value is None:
+        os.environ.pop(key, None)
+      else:
+        os.environ[key] = value
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def _outbox_rows(self, event_name: str) -> list[sqlite3.Row]:
+    conn = sqlite3.connect(self.db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+      "SELECT * FROM telemetry_outbox WHERE event_name = ?",
+      (event_name,),
+    ).fetchall()
+    conn.close()
+    return rows
+
+  def _session_row(self, session_id: str) -> sqlite3.Row | None:
+    conn = sqlite3.connect(self.db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+      "SELECT * FROM feature_implement_sessions WHERE session_id = ?",
+      (session_id,),
+    ).fetchone()
+    conn.close()
+    return row
+
+  def test_started_returns_session_id(self) -> None:
+    result = feature_implement_started(**STARTED_PARAMS)
+    self.assertEqual(result["status"], "ok")
+    self.assertRegex(result["session_id"], r"^fis-\d{8}-\d{6}-[a-z0-9]{4}$")
+
+  def test_started_enqueues_event(self) -> None:
+    result = feature_implement_started(**STARTED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_started")
+    self.assertEqual(len(rows), 1)
+    payload = json.loads(rows[0]["payload_json"])
+    self.assertEqual(payload["session_id"], result["session_id"])
+
+  def test_started_anonymous_payload_excludes_content(self) -> None:
+    feature_implement_started(**STARTED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_started")
+    payload = json.loads(rows[0]["payload_json"])
+    self.assertNotIn("feature_name", payload)
+    self.assertNotIn("spec_summary", payload)
+    self.assertIn("feature_size", payload)
+    self.assertIn("issue_key_provided", payload)
+    self.assertTrue(payload["issue_key_provided"])
+
+  def test_started_full_payload_includes_content(self) -> None:
+    Path(self.config_path).write_text(
+      json.dumps({
+        "install_id": "test-install-id",
+        "telemetry": {"level": "full", "proxy_url": "", "batch_size": 50},
+      }),
+      encoding="utf-8",
+    )
+    os.environ["SKILL_BILL_TELEMETRY_LEVEL"] = "full"
+    result = feature_implement_started(**STARTED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_started")
+    payload = json.loads(rows[0]["payload_json"])
+    self.assertEqual(payload["feature_name"], "payment-retry")
+    self.assertEqual(payload["spec_summary"], "Retry failed payments up to 3 times with exponential backoff")
+    os.environ.pop("SKILL_BILL_TELEMETRY_LEVEL", None)
+
+  def test_started_validates_enums(self) -> None:
+    params = dict(STARTED_PARAMS)
+    params["feature_size"] = "HUGE"
+    result = feature_implement_started(**params)
+    self.assertEqual(result["status"], "error")
+    self.assertIn("feature_size", result["error"])
+
+  def test_finished_updates_session(self) -> None:
+    started = feature_implement_started(**STARTED_PARAMS)
+    session_id = started["session_id"]
+    result = feature_implement_finished(session_id=session_id, **FINISHED_PARAMS)
+    self.assertEqual(result["status"], "ok")
+    row = self._session_row(session_id)
+    self.assertIsNotNone(row)
+    self.assertEqual(row["completion_status"], "completed")
+    self.assertEqual(row["plan_task_count"], 8)
+    self.assertIsNotNone(row["finished_at"])
+
+  def test_finished_enqueues_event(self) -> None:
+    started = feature_implement_started(**STARTED_PARAMS)
+    feature_implement_finished(session_id=started["session_id"], **FINISHED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_finished")
+    self.assertEqual(len(rows), 1)
+
+  def test_finished_anonymous_excludes_content(self) -> None:
+    started = feature_implement_started(**STARTED_PARAMS)
+    feature_implement_finished(session_id=started["session_id"], **FINISHED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_finished")
+    payload = json.loads(rows[0]["payload_json"])
+    self.assertNotIn("feature_name", payload)
+    self.assertNotIn("spec_summary", payload)
+    self.assertNotIn("plan_deviation_notes", payload)
+
+  def test_finished_full_includes_content(self) -> None:
+    Path(self.config_path).write_text(
+      json.dumps({
+        "install_id": "test-install-id",
+        "telemetry": {"level": "full", "proxy_url": "", "batch_size": 50},
+      }),
+      encoding="utf-8",
+    )
+    os.environ["SKILL_BILL_TELEMETRY_LEVEL"] = "full"
+    started = feature_implement_started(**STARTED_PARAMS)
+    feature_implement_finished(session_id=started["session_id"], **FINISHED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_finished")
+    payload = json.loads(rows[0]["payload_json"])
+    self.assertEqual(payload["feature_name"], "payment-retry")
+    self.assertEqual(payload["plan_deviation_notes"], "Task 5 split into 5a/5b")
+    os.environ.pop("SKILL_BILL_TELEMETRY_LEVEL", None)
+
+  def test_finished_includes_started_fields(self) -> None:
+    started = feature_implement_started(**STARTED_PARAMS)
+    feature_implement_finished(session_id=started["session_id"], **FINISHED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_finished")
+    payload = json.loads(rows[0]["payload_json"])
+    self.assertEqual(payload["feature_size"], "MEDIUM")
+    self.assertEqual(payload["spec_word_count"], 2400)
+    self.assertTrue(payload["issue_key_provided"])
+    self.assertEqual(payload["completion_status"], "completed")
+
+  def test_duration_seconds_calculated(self) -> None:
+    started = feature_implement_started(**STARTED_PARAMS)
+    session_id = started["session_id"]
+    conn = sqlite3.connect(self.db_path)
+    conn.execute(
+      "UPDATE feature_implement_sessions SET started_at = '2026-04-07 10:00:00' WHERE session_id = ?",
+      (session_id,),
+    )
+    conn.commit()
+    conn.close()
+    feature_implement_finished(session_id=session_id, **FINISHED_PARAMS)
+    rows = self._outbox_rows("skillbill_feature_implement_finished")
+    payload = json.loads(rows[0]["payload_json"])
+    self.assertGreater(payload["duration_seconds"], 0)
+
+  def test_duplicate_started_not_emitted(self) -> None:
+    result1 = feature_implement_started(**STARTED_PARAMS)
+    session_id = result1["session_id"]
+    conn = sqlite3.connect(self.db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+      "UPDATE feature_implement_sessions SET started_event_emitted_at = NULL WHERE session_id = ?",
+      (session_id,),
+    )
+    conn.commit()
+    conn.close()
+    rows = self._outbox_rows("skillbill_feature_implement_started")
+    self.assertEqual(len(rows), 1)
+
+  def test_finished_without_started_still_works(self) -> None:
+    result = feature_implement_finished(session_id="fis-00000000-000000-test", **FINISHED_PARAMS)
+    self.assertEqual(result["status"], "ok")
+    rows = self._outbox_rows("skillbill_feature_implement_finished")
+    self.assertEqual(len(rows), 1)
+
+  def test_finished_validates_enums(self) -> None:
+    started = feature_implement_started(**STARTED_PARAMS)
+    params = dict(FINISHED_PARAMS)
+    params["completion_status"] = "invalid"
+    result = feature_implement_finished(session_id=started["session_id"], **params)
+    self.assertEqual(result["status"], "error")
+    self.assertIn("completion_status", result["error"])
+
+
+class FeatureImplementDisabledTest(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir = tempfile.mkdtemp()
+    self._original_env: dict[str, str | None] = {}
+    env_overrides = {
+      "SKILL_BILL_REVIEW_DB": os.path.join(self.temp_dir, "metrics.db"),
+      "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
+      "SKILL_BILL_TELEMETRY_ENABLED": "false",
+    }
+    for key, value in env_overrides.items():
+      self._original_env[key] = os.environ.get(key)
+      os.environ[key] = value
+
+  def tearDown(self) -> None:
+    for key, value in self._original_env.items():
+      if value is None:
+        os.environ.pop(key, None)
+      else:
+        os.environ[key] = value
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def test_started_skips_when_disabled(self) -> None:
+    result = feature_implement_started(**STARTED_PARAMS)
+    self.assertEqual(result["status"], "skipped")
+    self.assertRegex(result["session_id"], r"^fis-\d{8}-\d{6}-[a-z0-9]{4}$")
+
+  def test_finished_skips_when_disabled(self) -> None:
+    result = feature_implement_finished(session_id="fis-00000000-000000-test", **FINISHED_PARAMS)
+    self.assertEqual(result["status"], "skipped")
+
+  def test_no_db_created_when_disabled(self) -> None:
+    feature_implement_started(**STARTED_PARAMS)
+    db_path = os.path.join(self.temp_dir, "metrics.db")
+    self.assertFalse(os.path.exists(db_path))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_mcp_stdio.py
+++ b/tests/test_mcp_stdio.py
@@ -29,7 +29,15 @@ Reason: agent-config signals dominate
 - [F-002] Minor | Medium | install.sh:88 | Installer prompt wording is inconsistent with the new flow.
 """
 
-EXPECTED_TOOLS = {"doctor", "import_review", "resolve_learnings", "review_stats", "triage_findings"}
+EXPECTED_TOOLS = {
+  "doctor",
+  "feature_implement_finished",
+  "feature_implement_started",
+  "import_review",
+  "resolve_learnings",
+  "review_stats",
+  "triage_findings",
+}
 
 
 class McpStdioTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add `feature_implement_started` and `feature_implement_finished` MCP tools that record telemetry for the feature-implement workflow
- Add `feature_implement_sessions` DB table with full session lifecycle tracking
- Payload respects anonymous/full telemetry levels, includes duration calculation, and idempotent event emission
- SKILL.md instructions tell the agent when to call each tool (after Step 1 confirmation and after Step 9 / early exit)

## Test plan
- [x] Unit tests for started/finished flows (enabled and disabled telemetry)
- [x] Enum validation tests
- [x] Anonymous vs full payload content tests
- [x] Duration calculation test
- [x] Idempotent emission test
- [x] Finished-without-started fallback test
- [x] MCP tool discovery test updated