### PR TITLE
feat: add boundary_history_value telemetry to feature-implement

### DIFF
--- a/skill_bill/constants.py
+++ b/skill_bill/constants.py
@@ -40,6 +40,7 @@ FEATURE_SIZES = ("SMALL", "MEDIUM", "LARGE")
 SPEC_INPUT_TYPES = ("raw_text", "pdf", "markdown_file", "image", "directory")
 ISSUE_KEY_TYPES = ("jira", "linear", "github", "other", "none")
 FEATURE_FLAG_PATTERNS = ("simple_conditional", "di_switch", "legacy", "none")
+BOUNDARY_HISTORY_VALUES = ("none", "irrelevant", "low", "medium", "high")
 AUDIT_RESULTS = ("all_pass", "had_gaps", "skipped")
 VALIDATION_RESULTS = ("pass", "fail", "skipped")
 COMPLETION_STATUSES = (

--- a/skill_bill/db.py
+++ b/skill_bill/db.py
@@ -148,6 +148,7 @@ def ensure_database(path: Path) -> sqlite3.Connection:
       audit_iterations INTEGER,
       validation_result TEXT,
       boundary_history_written INTEGER,
+      boundary_history_value TEXT NOT NULL DEFAULT 'none',
       pr_created INTEGER,
       plan_deviation_notes TEXT NOT NULL DEFAULT '',
       finished_at TEXT,
@@ -160,6 +161,12 @@ def ensure_database(path: Path) -> sqlite3.Connection:
   ensure_column(connection, "review_runs", "review_finished_event_emitted_at", "TEXT")
   ensure_column(connection, "review_runs", "specialist_reviews", "TEXT NOT NULL DEFAULT ''")
   backfill_review_session_ids(connection)
+  ensure_column(
+    connection,
+    "feature_implement_sessions",
+    "boundary_history_value",
+    "TEXT NOT NULL DEFAULT 'none'",
+  )
   migrate_feedback_events_schema(connection)
   return connection
 

--- a/skill_bill/feature_implement.py
+++ b/skill_bill/feature_implement.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 from skill_bill.constants import (
   AUDIT_RESULTS,
+  BOUNDARY_HISTORY_VALUES,
   COMPLETION_STATUSES,
   EVENT_FEATURE_IMPLEMENT_FINISHED,
   EVENT_FEATURE_IMPLEMENT_STARTED,
@@ -57,6 +58,7 @@ def validate_finished_params(
   feature_flag_pattern: str,
   audit_result: str,
   validation_result: str,
+  boundary_history_value: str,
 ) -> str | None:
   error = validate_enum(completion_status, COMPLETION_STATUSES, "completion_status")
   if error:
@@ -68,6 +70,9 @@ def validate_finished_params(
   if error:
     return error
   error = validate_enum(validation_result, VALIDATION_RESULTS, "validation_result")
+  if error:
+    return error
+  error = validate_enum(boundary_history_value, BOUNDARY_HISTORY_VALUES, "boundary_history_value")
   if error:
     return error
   return None
@@ -131,6 +136,7 @@ def save_finished(
   audit_iterations: int,
   validation_result: str,
   boundary_history_written: bool,
+  boundary_history_value: str,
   pr_created: bool,
   plan_deviation_notes: str,
 ) -> None:
@@ -158,6 +164,7 @@ def save_finished(
           audit_iterations = ?,
           validation_result = ?,
           boundary_history_written = ?,
+          boundary_history_value = ?,
           pr_created = ?,
           plan_deviation_notes = ?,
           finished_at = CURRENT_TIMESTAMP
@@ -178,6 +185,7 @@ def save_finished(
           audit_iterations,
           validation_result,
           1 if boundary_history_written else 0,
+          boundary_history_value,
           1 if pr_created else 0,
           plan_deviation_notes,
           session_id,
@@ -193,8 +201,9 @@ def save_finished(
           feature_flag_pattern, files_created, files_modified,
           tasks_completed, review_iterations, audit_result,
           audit_iterations, validation_result, boundary_history_written,
-          pr_created, plan_deviation_notes, finished_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+          boundary_history_value, pr_created, plan_deviation_notes,
+          finished_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
         """,
         (
           session_id,
@@ -212,6 +221,7 @@ def save_finished(
           audit_iterations,
           validation_result,
           1 if boundary_history_written else 0,
+          boundary_history_value,
           1 if pr_created else 0,
           plan_deviation_notes,
         ),
@@ -290,6 +300,7 @@ def build_finished_payload(
     "audit_iterations": row["audit_iterations"] or 0,
     "validation_result": row["validation_result"] or "skipped",
     "boundary_history_written": bool(row["boundary_history_written"]),
+    "boundary_history_value": row["boundary_history_value"] or "none",
     "pr_created": bool(row["pr_created"]),
     "duration_seconds": duration_seconds,
   })

--- a/skill_bill/mcp_server.py
+++ b/skill_bill/mcp_server.py
@@ -285,6 +285,7 @@ def feature_implement_finished(
   boundary_history_written: bool,
   pr_created: bool,
   feature_flag_pattern: str = "none",
+  boundary_history_value: str = "none",
   plan_deviation_notes: str = "",
 ) -> dict:
   """Record the completion of a feature-implement session.
@@ -297,6 +298,7 @@ def feature_implement_finished(
     feature_flag_pattern=feature_flag_pattern,
     audit_result=audit_result,
     validation_result=validation_result,
+    boundary_history_value=boundary_history_value,
   )
   if validation_error:
     return {"status": "error", "session_id": session_id, "error": validation_error}
@@ -322,6 +324,7 @@ def feature_implement_finished(
       audit_iterations=audit_iterations,
       validation_result=validation_result,
       boundary_history_written=boundary_history_written,
+      boundary_history_value=boundary_history_value,
       pr_created=pr_created,
       plan_deviation_notes=plan_deviation_notes,
     )

--- a/skills/base/bill-feature-implement/SKILL.md
+++ b/skills/base/bill-feature-implement/SKILL.md
@@ -98,6 +98,7 @@ After the PR is created (or when the workflow ends early due to error or user ab
 - `files_created`, `files_modified`, `tasks_completed`
 - `review_iterations`, `audit_result` (`all_pass`, `had_gaps`, or `skipped`), `audit_iterations`
 - `validation_result` (`pass`, `fail`, or `skipped`), `boundary_history_written`, `pr_created`
+- `boundary_history_value`: how useful the boundary history was during pre-planning (`none` if no history existed, `irrelevant`, `low`, `medium`, or `high`)
 - `plan_deviation_notes`: brief note if the plan changed during execution (empty if no deviations)
 
 For fields not yet reached (early exit), use: 0 for counts, `skipped` for results, false for booleans.

--- a/skills/base/bill-feature-implement/reference.md
+++ b/skills/base/bill-feature-implement/reference.md
@@ -12,6 +12,8 @@ For SMALL features the acceptance criteria stay in context — no spec file need
 
 Look for `agent/history.md` in each boundary the feature touches. Read newest entries first, stop once entries are no longer relevant. Use to reuse components and follow latest patterns. Skip if none exist.
 
+After reading, assess how useful the history was for this feature: `irrelevant` (nothing applied), `low` (minor context), `medium` (reused patterns or avoided pitfalls), `high` (directly shaped the approach). Use `none` if no history files existed. Report this as `boundary_history_value` in the finished telemetry.
+
 ### Read Boundary Decisions
 
 Look for `agent/decisions.md` in each boundary the feature touches. If the file exists, scan only the `## [date] title` header lines first. Read full entries only for decisions whose titles are relevant to the boundaries, patterns, or interfaces this feature will touch. Skip if none exist.

--- a/tests/test_feature_implement_telemetry.py
+++ b/tests/test_feature_implement_telemetry.py
@@ -47,6 +47,7 @@ FINISHED_PARAMS = {
   "audit_iterations": 1,
   "validation_result": "pass",
   "boundary_history_written": True,
+  "boundary_history_value": "medium",
   "pr_created": True,
   "plan_deviation_notes": "Task 5 split into 5a/5b",
 }


### PR DESCRIPTION
## Summary
- Adds `boundary_history_value` property (`none | irrelevant | low | medium | high`) to the `feature_implement_finished` MCP tool
- Tracks whether reading boundary history during pre-planning was useful for that run
- Includes DB schema, migration for existing databases, enum validation, payload building, skill instructions, and test updates

## Test plan
- [x] All 17 existing telemetry tests pass
- [ ] Verify `boundary_history_value` is persisted in DB and included in telemetry payload
- [ ] Verify enum validation rejects invalid values
- [ ] Verify default `none` works when parameter is omitted