### PR TITLE
feat: add Copilot custom agent support with sub-agent delegation

### DIFF
--- a/.github/agents/bill-code-review-resolve.agent.md
+++ b/.github/agents/bill-code-review-resolve.agent.md
@@ -1,0 +1,28 @@
+---
+name: bill-code-review-resolve
+description: Applies fixes for findings produced by the Skill Bill code review agent.
+tools: ["read", "search", "edit", "execute"]
+---
+
+You are the Skill Bill code review resolve agent.
+
+You receive findings from the code review agent. Each finding includes a severity, file path, line number, description, context explaining why it is a problem, and a suggested fix.
+
+## Execution
+
+1. For each finding, read the referenced file and apply the suggested fix. Use the context to understand the intent — do not apply fixes mechanically if the suggestion does not match the actual code.
+2. Apply the minimal correct fix. Do not refactor surrounding code or make unrelated changes.
+3. If a suggested fix is wrong or outdated (code has changed), apply the correct fix based on the finding's context and description.
+
+## Required output format
+
+```
+## Fixes applied
+- [F-001] <file:line> — <what was changed>
+- [F-002] <file:line> — <what was changed>
+
+## Fixes skipped
+- [F-003] <file:line> — <why it could not be fixed>
+```
+
+Do not re-review the code. Do not add new findings.

--- a/.github/agents/bill-finalize.agent.md
+++ b/.github/agents/bill-finalize.agent.md
@@ -1,0 +1,21 @@
+---
+name: bill-finalize
+description: Finalization agent that writes boundary history, commits, pushes, and generates a PR description.
+tools: ["read", "search", "edit", "execute"]
+---
+
+You are the Skill Bill finalization agent. You wrap up a completed feature for shipping.
+
+You receive a finalization handoff containing the feature name, issue key, acceptance criteria, and a summary of all changes made.
+
+Execute these steps in order:
+
+1. **Boundary history** — Run the `bill-boundary-history` skill. Look for `agent/history.md` files in affected modules and update them with a reusable entry about this feature. Skip if no history files exist in the affected paths.
+2. **Commit** — Stage all new and modified files from the feature (do not use `git add -A`). Commit with message format: `feat: [<ISSUE_KEY>] <concise description>`.
+3. **Push** — Push the branch to remote with `-u` to set upstream tracking.
+4. **PR description** — Run the `bill-pr-description` skill to generate the PR title, description, and QA steps.
+
+Return a summary containing:
+- Whether boundary history was written or skipped
+- The commit hash and message
+- The PR URL or PR description output

--- a/.github/agents/bill-implement.agent.md
+++ b/.github/agents/bill-implement.agent.md
@@ -1,0 +1,39 @@
+---
+name: bill-implement
+description: Implementation agent that executes a plan by making code changes.
+tools: ["read", "search", "edit", "execute"]
+---
+
+You are the Skill Bill implementation agent.
+
+You receive an implementation handoff containing the plan (with tasks, file targets, rationale per step, and acceptance criteria mapping) and relevant project conventions.
+
+## Execution
+
+1. Follow the plan step by step. Do not skip steps or reorder without good reason.
+2. Read each file before modifying it.
+3. Use the rationale provided per task to guide your approach — it reflects codebase patterns and conventions discovered during planning.
+4. Make complete, production-grade changes — no TODOs, no placeholders, no partial implementations.
+5. If a plan step is ambiguous or impossible, note it in your summary instead of guessing.
+6. Print progress after each task: `[3/10] Task description`
+
+## Required output format
+
+```
+## Changes made
+1. [Task] <description> — criteria: <numbers satisfied>
+   Files modified: <paths>
+   Files created: <paths>
+   What was done: <concise description of the actual change>
+
+## Decisions made during implementation
+- <any deviations from the plan and why>
+- <any ambiguities resolved and how>
+
+## Acceptance criteria coverage
+- Criteria 1: covered by task <N> in <file>
+- Criteria 2: covered by task <N> in <file>
+- ...
+```
+
+Do not review your own changes. Do not run quality checks. Those are handled by separate agents.

--- a/.github/agents/bill-plan.agent.md
+++ b/.github/agents/bill-plan.agent.md
@@ -1,0 +1,49 @@
+---
+name: bill-plan
+description: Planning agent that explores the codebase and produces a structured implementation plan from a feature spec.
+tools: ["read", "search"]
+---
+
+You are the Skill Bill planning agent. You are read-only — you cannot edit files or execute commands.
+
+You receive a planning handoff containing the feature spec, acceptance criteria, size classification, and issue key.
+
+## Pre-planning
+
+Before creating the plan, explore the codebase:
+
+1. Read `CLAUDE.md`, `AGENTS.md`, and any `.agents/skill-overrides.md` for project conventions.
+2. Look for `agent/history.md` files in modules relevant to the change. Note reusable patterns or past decisions that inform this feature.
+3. Look for `agent/decisions.md` files in relevant modules. Note active architectural constraints.
+4. Find similar features or patterns in the codebase that this implementation should follow.
+5. Identify dependencies, shared components, and boundaries the change will touch.
+
+## Plan creation
+
+Produce a step-by-step implementation plan:
+
+1. Break the work into atomic, dependency-ordered tasks.
+2. Each task must reference which acceptance criteria it satisfies.
+3. If testable logic exists, include a dedicated test task.
+4. If the plan exceeds 15 tasks, split into phases with checkpoints.
+
+## Required output format
+
+```
+## Pre-planning context
+- Project conventions: <key conventions from CLAUDE.md/AGENTS.md>
+- Relevant history: <patterns or decisions from agent/history.md, agent/decisions.md>
+- Similar patterns found: <existing code this feature should follow>
+- Boundaries touched: <modules, packages, or APIs affected>
+
+## Implementation plan
+1. [Task] <description> — satisfies criteria: <numbers>
+   Files: <files to create or modify>
+   Rationale: <why this approach, referencing conventions or patterns found>
+2. ...
+
+## Risks and open questions
+- <anything ambiguous, risky, or requiring a decision>
+```
+
+Do not make any code changes.

--- a/.github/agents/bill-quality-check.agent.md
+++ b/.github/agents/bill-quality-check.agent.md
@@ -1,0 +1,16 @@
+---
+name: bill-quality-check
+description: Validation agent that runs the Skill Bill quality-check workflow for the current stack.
+tools: ["read", "search", "edit", "execute"]
+---
+
+You are the Skill Bill quality-check agent.
+
+Run validation through the stable Skill Bill quality gate:
+
+1. Prefer the `bill-quality-check` skill as the primary validation contract.
+2. Let Skill Bill route to the correct stack-specific checker instead of inventing a repo-specific validation flow.
+3. Fix root causes in the current unit of work without suppressions.
+4. Keep documentation, installer behavior, catalogs, and tests aligned when validation reveals drift in a governed skill repository.
+
+This agent can be invoked standalone from the Copilot Agents tab or as a sub-agent by the `bill-feature-implement-copilot` skill during its quality-check step.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Treat your AI skills like software — with stable interfaces, platform overrides, and validation that prevents the repo from rotting.
 
-sKill Bill is a portable collection of 49 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
+sKill Bill is a portable collection of 50 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
 
 ## Why this exists
 
@@ -229,11 +229,12 @@ The uninstaller is idempotent. It removes current Skill Bill installs, generated
 | `/bill-go-code-review-performance` | Go performance review |
 | `/bill-go-code-review-testing` | Go test quality review |
 
-### Feature Lifecycle (5 skills)
+### Feature Lifecycle (6 skills)
 
 | Skill | Purpose |
 |-------|---------|
 | `/bill-feature-implement` | Spec-to-verified implementation workflow |
+| `/bill-feature-implement-agentic` | Runtime-agnostic orchestrator with subagent delegation |
 | `/bill-feature-implement-copilot` | Copilot-optimized orchestrator with sub-agent delegation |
 | `/bill-feature-verify` | Verify a PR against a task spec |
 | `/bill-feature-guard` | Add feature-flag rollout safety |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Treat your AI skills like software — with stable interfaces, platform overrides, and validation that prevents the repo from rotting.
 
-sKill Bill is a portable collection of 48 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
+sKill Bill is a portable collection of 49 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
 
 ## Why this exists
 
@@ -109,12 +109,12 @@ Skill Bill records review acceptance metrics locally in SQLite and can optionall
 
 | Agent | Install path |
 |-------|--------------|
-| GitHub Copilot | `~/.copilot/skills/` |
+| GitHub Copilot | `~/.copilot/skills/` and `~/.copilot/agents/` |
 | Claude Code | `~/.claude/commands/` |
 | GLM | `~/.glm/commands/` |
 | OpenAI Codex | `~/.codex/skills/` or `~/.agents/skills/` |
 
-The installer links all selected agents to the same repo so updates stay in sync.
+The installer links all selected agents to the same repo so updates stay in sync. Copilot keeps the portable skill install plus an additive custom-agent layer sourced from `.github/agents/`.
 
 ## Installation
 
@@ -176,6 +176,8 @@ Each installer run replaces the existing Skill Bill installs and reinstalls only
 
 The installer always removes existing Skill Bill installs before reinstalling the selected agents and platforms. The default `bill` prefix keeps the current symlink-based install behavior. Custom prefixes install generated alias copies, so re-run `./install.sh` after editing skills in the repo.
 
+For Copilot installs, Skill Bill also installs managed custom agents into `~/.copilot/agents/` from the repo-owned templates in `.github/agents/`. The feature-implement agent orchestrates a full pipeline — planning, implementation, code review, fix resolution, quality check, and finalization — by delegating each stage to a dedicated sub-agent with isolated context, using Copilot's native agent-spawning capability without changing the portable skill model used by other agent targets.
+
 ## Uninstallation
 
 To remove Skill Bill skill installs from the supported agent install paths:
@@ -185,7 +187,7 @@ chmod +x uninstall.sh
 ./uninstall.sh
 ```
 
-The uninstaller is idempotent. It removes current Skill Bill installs, generated alias installs, and known legacy install names when they are present, and skips unrelated non-symlink paths.
+The uninstaller is idempotent. It removes current Skill Bill installs, generated alias installs, managed Copilot custom agents, and known legacy install names when they are present, and skips unrelated non-symlink paths.
 
 ## Skills Included
 
@@ -227,11 +229,12 @@ The uninstaller is idempotent. It removes current Skill Bill installs, generated
 | `/bill-go-code-review-performance` | Go performance review |
 | `/bill-go-code-review-testing` | Go test quality review |
 
-### Feature Lifecycle (4 skills)
+### Feature Lifecycle (5 skills)
 
 | Skill | Purpose |
 |-------|---------|
 | `/bill-feature-implement` | Spec-to-verified implementation workflow |
+| `/bill-feature-implement-copilot` | Copilot-optimized orchestrator with sub-agent delegation |
 | `/bill-feature-verify` | Verify a PR against a task spec |
 | `/bill-feature-guard` | Add feature-flag rollout safety |
 | `/bill-feature-guard-cleanup` | Remove feature flags after rollout |

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$PLUGIN_DIR/skills"
+CUSTOM_AGENT_SOURCE_DIR="$PLUGIN_DIR/.github/agents"
 MANAGED_INSTALL_MARKER=".skill-bill-install"
+MANAGED_AGENT_FILE_MARKER="<!-- managed_by=skill-bill-agent -->"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -83,6 +85,8 @@ declare -a SKILL_PATHS=()
 declare -a INSTALL_SKILL_NAMES=()
 declare -a INSTALL_SKILL_PATHS=()
 declare -a INSTALL_TARGET_NAMES=()
+declare -a CUSTOM_AGENT_FILE_NAMES=()
+declare -a CUSTOM_AGENT_FILE_PATHS=()
 declare -a PLATFORM_PACKAGES=()
 declare -a REQUIRED_PLATFORM_PACKAGES=(agent-config)
 declare -a SELECTED_PLATFORM_PACKAGES=()
@@ -179,6 +183,13 @@ normalize_platform_token() {
 
 normalize_agent_token() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]'
+}
+
+get_custom_agent_path() {
+  case "$1" in
+    copilot) echo "$HOME/.copilot/agents" ;;
+    *)       return 1 ;;
+  esac
 }
 
 is_valid_prefix() {
@@ -623,6 +634,23 @@ build_skill_names() {
   done < <(find "$SKILLS_DIR" -type f -name 'SKILL.md' | sort)
 }
 
+build_custom_agent_files() {
+  local agent_file agent_name
+
+  CUSTOM_AGENT_FILE_NAMES=()
+  CUSTOM_AGENT_FILE_PATHS=()
+
+  if [[ ! -d "$CUSTOM_AGENT_SOURCE_DIR" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r agent_file; do
+    agent_name="$(basename "$agent_file")"
+    CUSTOM_AGENT_FILE_NAMES+=("$agent_name")
+    CUSTOM_AGENT_FILE_PATHS+=("$agent_file")
+  done < <(find "$CUSTOM_AGENT_SOURCE_DIR" -type f -name '*.agent.md' | sort)
+}
+
 build_install_skill_names() {
   local idx
   local skill_dir
@@ -753,6 +781,33 @@ rewrite_markdown_file() {
     "$source_file" > "$target_file"
 }
 
+custom_agent_file_is_managed() {
+  local target="$1"
+  [[ -f "$target" ]] || return 1
+  grep -Fqx "$MANAGED_AGENT_FILE_MARKER" "$target"
+}
+
+remove_custom_agent_target_if_allowed() {
+  local target="$1"
+
+  if [[ ! -e "$target" && ! -L "$target" ]]; then
+    return 0
+  fi
+
+  if [[ -L "$target" ]]; then
+    rm -f "$target"
+    return 0
+  fi
+
+  if custom_agent_file_is_managed "$target"; then
+    rm -f "$target"
+    return 0
+  fi
+
+  err "Refusing to overwrite existing non-Skill-Bill path: $target"
+  return 1
+}
+
 install_generated_skill_dir() {
   local target="$1"
   local source="$2"
@@ -805,8 +860,32 @@ install_skill() {
   fi
 }
 
+install_generated_custom_agent_file() {
+  local target="$1"
+  local source="$2"
+  local label="$3"
+
+  if [[ -e "$target" || -L "$target" ]]; then
+    remove_custom_agent_target_if_allowed "$target"
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  rewrite_markdown_file "$source" "$target"
+  printf '%s\n' "$MANAGED_AGENT_FILE_MARKER" >> "$target"
+  ok "  $label"
+}
+
+install_custom_agent() {
+  local target="$1"
+  local source="$2"
+  local label="$3"
+
+  install_generated_custom_agent_file "$target" "$source" "$label"
+}
+
 parse_args "$@"
 build_skill_names
+build_custom_agent_files
 build_legacy_skill_names
 build_platform_packages
 
@@ -847,6 +926,20 @@ for i in "${!AGENT_NAMES[@]}"; do
     target_skill="${INSTALL_TARGET_NAMES[$idx]}"
     install_skill "$agent_dir/$target_skill" "${INSTALL_SKILL_PATHS[$idx]}" "$target_skill → plugin ($skill)"
   done
+
+  if [[ "$agent" == "copilot" && ${#CUSTOM_AGENT_FILE_NAMES[@]} -gt 0 ]]; then
+    custom_agent_dir="$(get_custom_agent_path "$agent")"
+    mkdir -p "$custom_agent_dir"
+    info "Installing Copilot custom agents: $custom_agent_dir"
+    for idx in "${!CUSTOM_AGENT_FILE_NAMES[@]}"; do
+      source_agent_name="${CUSTOM_AGENT_FILE_NAMES[$idx]}"
+      target_agent_name="$(echo "$source_agent_name" | sed "s/^bill-/${INSTALL_PREFIX}-/")"
+      install_custom_agent \
+        "$custom_agent_dir/$target_agent_name" \
+        "${CUSTOM_AGENT_FILE_PATHS[$idx]}" \
+        "$target_agent_name → copilot agent"
+    done
+  fi
   echo ""
 done
 
@@ -947,6 +1040,9 @@ fi
 printf "${GREEN}━━━ Installation complete ━━━${NC}\n"
 echo ""
 info "Source of truth: $PLUGIN_DIR/skills/"
+if [[ ${#CUSTOM_AGENT_FILE_NAMES[@]} -gt 0 ]]; then
+  info "Copilot agents:  $CUSTOM_AGENT_SOURCE_DIR"
+fi
 info "Platforms:       $(format_platform_list "${SELECTED_PLATFORM_PACKAGES[@]}")"
 info "Command prefix:  ${INSTALL_PREFIX}-"
 if [[ "$TELEMETRY_LEVEL" == "setup_failed" ]]; then

--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -114,7 +114,7 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
 
 ## Specialist Contract Subset
 

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -82,7 +82,7 @@ PORTABLE_REVIEW_LIFECYCLE_REQUIREMENTS: tuple[tuple[str, str], ...] = (
   ("Call the `import_review` MCP tool:", "portable review skills must describe the import_review lifecycle handoff"),
   ("## Auto-Triage", "portable review skills must define the inline auto-triage section"),
   ("Call the `triage_findings` MCP tool:", "portable review skills must describe the triage_findings lifecycle handoff"),
-  ("Skip auto-triage when the review produced no findings.", "portable review skills must define the no-findings auto-triage rule"),
+  ("When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.", "portable review skills must define the no-findings auto-triage rule"),
 )
 
 
@@ -459,16 +459,28 @@ def validate_readme(readme_path: Path, skill_names: list[str], issues: list[str]
     )
 
 
+def discover_copilot_agent_names(root: Path) -> set[str]:
+  agents_dir = root / ".github" / "agents"
+  if not agents_dir.is_dir():
+    return set()
+  names: set[str] = set()
+  for agent_file in agents_dir.glob("*.agent.md"):
+    name = agent_file.stem.removesuffix(".agent")
+    if name:
+      names.add(name)
+  return names
+
+
 def validate_skill_references(root: Path, skill_names: list[str], issues: list[str]) -> None:
-  known_skills = set(skill_names)
+  known_names = set(skill_names) | discover_copilot_agent_names(root)
   files_to_scan = sorted((root / "skills").rglob("SKILL.md"))
 
   for file_path in files_to_scan:
     text = file_path.read_text(encoding="utf-8")
     for reference in sorted(set(SKILL_REFERENCE_PATTERN.findall(text))):
-      if reference not in known_skills:
+      if reference not in known_names:
         relative_path = file_path.relative_to(root)
-        issues.append(f"{relative_path}: references unknown skill '{reference}'")
+        issues.append(f"{relative_path}: references unknown skill or agent '{reference}'")
 
 
 def validate_skill_override_markdown(

--- a/skills/agent-config/bill-agent-config-code-review/SKILL.md
+++ b/skills/agent-config/bill-agent-config-code-review/SKILL.md
@@ -113,7 +113,7 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
@@ -175,7 +175,7 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/base/bill-code-review/SKILL.md
+++ b/skills/base/bill-code-review/SKILL.md
@@ -176,4 +176,4 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.

--- a/skills/base/bill-feature-implement-agentic/SKILL.md
+++ b/skills/base/bill-feature-implement-agentic/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: bill-feature-implement-agentic
+description: Agentic feature orchestrator that runs inline and delegates heavy stages to subagents for context isolation and token savings. Each subagent loads the respective portable skill. Works across all agent runtimes that support subagent spawning (Claude Code, GLM, Codex). Use when implementing features and you want the agent-delegated pipeline instead of the standard inline flow.
+---
+
+# Agentic Feature Implement Orchestrator
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-feature-implement-agentic` section, read that section and apply it as the highest-priority instruction for this skill.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+## Overview
+
+This skill runs inline in the main thread and selectively delegates heavy stages to subagents for context isolation. It follows the same workflow as `bill-feature-implement` but uses subagents for plan, implement, code review, quality-check, resolve, and finalize stages to keep context lean and save tokens.
+
+Each subagent loads and follows the respective portable skill as its primary rubric. This keeps the orchestrator runtime-agnostic — it works on any runtime that supports subagent spawning (Claude Code Task/Agent, GLM Task, Codex subagents).
+
+## Subagent Delegation Model
+
+When spawning a subagent, always include:
+- The skill to load: tell the subagent to read the specified `SKILL.md` and follow it as the primary rubric
+- The handoff context specific to the stage
+- Relevant `AGENTS.md` and `.agents/skill-overrides.md` guidance
+- The instruction to return a structured summary, not raw output
+
+If a subagent is interrupted or fails, retry once. If it fails again, run the stage inline in this thread instead.
+
+## Step 1: Spec and assessment
+
+Collect the feature specification from the user. Extract:
+- Numbered acceptance criteria
+- Non-goals (out of scope)
+- Open questions
+- Size classification: SMALL (< 5 files), MEDIUM (5-15 files), LARGE (> 15 files)
+- Feature name and issue key (if provided)
+
+Clarify any ambiguities. Get user confirmation before proceeding.
+
+After confirmation, call the `feature_implement_started` MCP tool with:
+- `feature_size`, `acceptance_criteria_count`, `open_questions_count`
+- `spec_input_types`: list of input types (`raw_text`, `pdf`, `markdown_file`, `image`, `directory`)
+- `spec_word_count`: approximate word count of the spec
+- `rollout_needed`: whether a feature flag / guarded rollout is needed
+- `feature_name`, `issue_key`
+- `issue_key_type`: `jira`, `linear`, `github`, `other`, or `none`
+- `spec_summary`: one sentence summarizing the feature
+
+Save the returned `session_id` for the finished event. If the tool returns `status: skipped`, continue normally.
+
+Create the feature branch: `git checkout -b feat/{ISSUE_KEY}-{feature-name}`
+
+## Step 2: Plan (subagent)
+
+Spawn a subagent with this handoff:
+- **Skill to load**: read `bill-feature-implement` skill's `reference.md` — follow the Pre-Planning Details and Planning Rules sections
+- The full feature spec
+- Acceptance criteria (numbered)
+- Size classification
+- Issue key
+- Project conventions from `CLAUDE.md` / `AGENTS.md`
+
+The subagent should explore the codebase (boundary history, boundary decisions, codebase patterns) and return:
+- Pre-planning context (conventions, history, patterns found)
+- Implementation plan (tasks with file targets, rationale, and criteria mapping)
+- Risks and open questions
+
+Present the plan to the user for approval before continuing.
+
+## Step 3: Implement (subagent)
+
+Spawn a subagent with this handoff:
+- **Skill to load**: follow the Execution Rules from `bill-feature-implement` skill's `reference.md`
+- The approved plan (tasks, file targets, rationale per step, criteria mapping)
+- Key project conventions from the plan's pre-planning context
+
+The subagent returns:
+- Changes made per task with criteria mapping
+- Decisions made during implementation
+- Acceptance criteria coverage mapping
+
+## Step 4: Completeness audit
+
+Compare the implement summary's criteria coverage against the original acceptance criteria. If any criteria are not covered:
+- List the gaps
+- Spawn a subagent with: the missing criteria, files already modified, and relevant plan context
+- Repeat review after re-implementation
+
+Max 2 audit iterations.
+
+## Step 5: Review (subagent or inline)
+
+The code review skill triggers deep nested delegation (stack routing, specialist subagents). This works on runtimes that support nested subagent spawning (e.g. Claude Code). On runtimes where nested delegation is unavailable or hits runtime limits, run this step inline in the current thread instead of spawning a subagent.
+
+When delegating, spawn a subagent with this handoff:
+- **Skill to load**: read `bill-code-review` skill's `SKILL.md` and follow it as the primary rubric
+- The branch diff (scope the review to the branch diff)
+- Decisions made during implementation (so the reviewer understands intent)
+- Key project conventions
+
+The subagent runs the full code review flow — stack detection, routing, specialist delegation — and returns findings with severity, file paths, and descriptions.
+
+After the review output is produced, call the `import_review` MCP tool with the complete review text (Sections 1 through 4). After findings are resolved (via the resolve subagent or skipped), call the `triage_findings` MCP tool with the `review_run_id` and decisions. When the review produced no findings, still call `triage_findings` with an empty decisions list to close the review lifecycle.
+
+## Step 6: Resolve (subagent)
+
+If there are Blocker or Major findings, spawn a subagent with:
+- All findings including their context and suggested fixes
+- The instruction to apply the minimal correct fix for each finding
+
+The subagent returns: which findings were fixed and which were skipped.
+
+If fixes were applied, spawn a new review subagent (Step 5) to verify. Max 3 review iterations.
+
+Continue past Minor-only findings.
+
+## Step 7: Quality check (subagent)
+
+Spawn a subagent with this handoff:
+- **Skill to load**: read `bill-quality-check` skill's `SKILL.md` and follow it as the primary rubric
+- The repo path and changed files
+
+The subagent returns pass or fail.
+
+If it fails, spawn an implement subagent with the failures to fix, then re-run quality check. Max 2 quality iterations.
+
+## Step 8: Finalize (subagent)
+
+Spawn a subagent with this handoff:
+- **Skill to load**: follow the Finalization Steps from `bill-feature-implement` skill's `reference.md`
+- Feature name and issue key
+- Acceptance criteria
+- Summary of all changes made across all implementation passes
+- Branch name
+
+The subagent:
+1. Writes boundary history using `bill-boundary-history`
+2. Stages and commits with format `feat: [<ISSUE_KEY>] <concise description>`
+3. Pushes with `-u` to set upstream tracking
+4. Generates PR description using `bill-pr-description`
+
+Returns: whether history was written, the commit hash, and the PR description output.
+
+## Telemetry: Record Finished
+
+After finalize completes (or when the workflow ends early due to error or user abandonment), call the `feature_implement_finished` MCP tool with:
+- `session_id`: from `feature_implement_started`
+- `completion_status`: `completed` if PR was created, otherwise `abandoned_at_planning`, `abandoned_at_implementation`, `abandoned_at_review`, or `error`
+- `plan_correction_count`, `plan_task_count`, `plan_phase_count`
+- `feature_flag_used`, `feature_flag_pattern` (`simple_conditional`, `di_switch`, `legacy`, or `none`)
+- `files_created`, `files_modified`, `tasks_completed`
+- `review_iterations`, `audit_result` (`all_pass`, `had_gaps`, or `skipped`), `audit_iterations`
+- `validation_result` (`pass`, `fail`, or `skipped`), `boundary_history_written`, `pr_created`
+- `boundary_history_value` (`none`, `irrelevant`, `low`, `medium`, or `high`)
+- `plan_deviation_notes`: brief note if plan changed (empty if no deviations)
+
+For fields not yet reached (early exit), use: 0 for counts, `skipped` for results, false for booleans.
+
+## Handoff principles
+
+- Each subagent starts with a clean context. Pass only what it needs for its stage.
+- Always include rationale and decisions context — not just file lists. This prevents the next subagent from misunderstanding intentional choices.
+- Hold subagent summaries in your context, not their raw outputs.
+- When re-running a stage (audit loop, review loop), include what changed since the last run so the subagent can focus on the delta.
+- If a delegated stage is interrupted twice, continue inline instead of retrying the subagent chain.

--- a/skills/base/bill-feature-implement-copilot/SKILL.md
+++ b/skills/base/bill-feature-implement-copilot/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: bill-feature-implement-copilot
+description: Copilot-optimized feature orchestrator that runs inline and delegates heavy stages to sub-agents for context isolation and token savings. Use when implementing features on Copilot and you want the agent-delegated pipeline instead of the standard inline flow.
+---
+
+# Copilot Feature Implement Orchestrator
+
+## Project Overrides
+
+If `.agents/skill-overrides.md` exists in the project root and contains a `## bill-feature-implement-copilot` section, read that section and apply it as the highest-priority instruction for this skill.
+
+If an `AGENTS.md` file exists in the project root, apply it as project-wide guidance.
+
+## Overview
+
+This skill runs inline in the main thread and selectively delegates heavy stages to Copilot custom agents for context isolation. It follows the same workflow as `bill-feature-implement` but uses sub-agents for plan, implement, quality-check, resolve, and finalize stages to keep context lean and save tokens.
+
+Code review runs inline because the `bill-code-review` skill triggers deep nested delegation that exceeds Copilot's runtime limits when spawned as a sub-agent.
+
+## Step 1: Spec and assessment
+
+Collect the feature specification from the user. Extract:
+- Numbered acceptance criteria
+- Non-goals (out of scope)
+- Open questions
+- Size classification: SMALL (< 5 files), MEDIUM (5-15 files), LARGE (> 15 files)
+- Feature name and issue key (if provided)
+
+Clarify any ambiguities. Get user confirmation before proceeding.
+
+After confirmation, call the `feature_implement_started` MCP tool with:
+- `feature_size`, `acceptance_criteria_count`, `open_questions_count`
+- `spec_input_types`: list of input types (`raw_text`, `pdf`, `markdown_file`, `image`, `directory`)
+- `spec_word_count`: approximate word count of the spec
+- `rollout_needed`: whether a feature flag / guarded rollout is needed
+- `feature_name`, `issue_key`
+- `issue_key_type`: `jira`, `linear`, `github`, `other`, or `none`
+- `spec_summary`: one sentence summarizing the feature
+
+Save the returned `session_id` for the finished event. If the tool returns `status: skipped`, continue normally.
+
+Create the feature branch: `git checkout -b feat/{ISSUE_KEY}-{feature-name}`
+
+## Step 2: Plan (sub-agent)
+
+Delegate to the `bill-plan` agent with this handoff:
+- The full feature spec
+- Acceptance criteria (numbered)
+- Size classification
+- Issue key
+
+It returns: pre-planning context (conventions, history, patterns found), implementation plan (tasks with file targets, rationale, and criteria mapping), and risks.
+
+Present the plan to the user for approval before continuing.
+
+If the sub-agent is interrupted, retry once. If it fails again, run the planning step inline in this thread instead.
+
+## Step 3: Implement (sub-agent)
+
+Delegate to the `bill-implement` agent with this handoff:
+- The approved plan (tasks, file targets, rationale per step, criteria mapping)
+- Key project conventions from the plan's pre-planning context
+
+It returns: changes made per task, decisions made during implementation, and acceptance criteria coverage mapping.
+
+If the sub-agent is interrupted, retry once. If it fails again, run the implementation step inline in this thread instead.
+
+## Step 4: Completeness audit
+
+Compare the implement summary's criteria coverage against the original acceptance criteria. If any criteria are not covered:
+- List the gaps
+- Delegate to `bill-implement` agent with: the missing criteria, files already modified, and relevant plan context
+- Repeat review after re-implementation
+
+Max 2 audit iterations.
+
+## Step 5: Review (inline)
+
+Run the `bill-code-review` skill directly in this thread — do NOT delegate to a sub-agent. Code review triggers deep nested delegation that exceeds Copilot's runtime limits when spawned as a sub-agent.
+
+Scope the review to the branch diff. Use the implementation decisions context to understand intent behind choices.
+
+The skill produces findings with severity, file paths, and descriptions.
+
+After the review output is produced, call the `import_review` MCP tool with the complete review text (Sections 1 through 4). After findings are resolved (via the resolve agent or skipped), call the `triage_findings` MCP tool with the `review_run_id` and decisions. When the review produced no findings, still call `triage_findings` with an empty decisions list to close the review lifecycle.
+
+## Step 6: Resolve (sub-agent)
+
+If there are Blocker or Major findings, delegate to the `bill-code-review-resolve` agent with:
+- All findings including their context and suggested fixes
+
+It returns: which findings were fixed and which were skipped.
+
+If fixes were applied, run `bill-code-review` inline again to verify. Max 3 review iterations.
+
+Continue past Minor-only findings.
+
+## Step 7: Quality check (sub-agent)
+
+Delegate to the `bill-quality-check` agent. It returns pass or fail.
+
+If it fails, delegate to `bill-implement` agent with the failures to fix, then re-run quality check. Max 2 quality iterations.
+
+## Step 8: Finalize (sub-agent)
+
+Delegate to the `bill-finalize` agent with this handoff:
+- Feature name and issue key
+- Acceptance criteria
+- Summary of all changes made across all implementation passes
+- Branch name
+
+It returns: whether history was written, the commit hash, and the PR description output.
+
+## Telemetry: Record Finished
+
+After finalize completes (or when the workflow ends early due to error or user abandonment), call the `feature_implement_finished` MCP tool with:
+- `session_id`: from `feature_implement_started`
+- `completion_status`: `completed` if PR was created, otherwise `abandoned_at_planning`, `abandoned_at_implementation`, `abandoned_at_review`, or `error`
+- `plan_correction_count`, `plan_task_count`, `plan_phase_count`
+- `feature_flag_used`, `feature_flag_pattern` (`simple_conditional`, `di_switch`, `legacy`, or `none`)
+- `files_created`, `files_modified`, `tasks_completed`
+- `review_iterations`, `audit_result` (`all_pass`, `had_gaps`, or `skipped`), `audit_iterations`
+- `validation_result` (`pass`, `fail`, or `skipped`), `boundary_history_written`, `pr_created`
+- `boundary_history_value` (`none`, `irrelevant`, `low`, `medium`, or `high`)
+- `plan_deviation_notes`: brief note if plan changed (empty if no deviations)
+
+For fields not yet reached (early exit), use: 0 for counts, `skipped` for results, false for booleans.
+
+## Handoff principles
+
+- Each sub-agent starts with a clean context. Pass only what it needs for its stage.
+- Always include rationale and decisions context — not just file lists. This prevents the next agent from misunderstanding intentional choices.
+- Hold sub-agent summaries in your context, not their raw outputs.
+- When re-running a stage (audit loop, review loop), include what changed since the last run so the sub-agent can focus on the delta.
+- If a delegated stage is interrupted twice, continue inline instead of retrying the agent chain.

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -181,7 +181,7 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/kmp/bill-kmp-code-review/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review/SKILL.md
@@ -186,7 +186,7 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -180,7 +180,7 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/php/bill-php-code-review/SKILL.md
+++ b/skills/php/bill-php-code-review/SKILL.md
@@ -177,7 +177,7 @@ Call the `triage_findings` MCP tool:
 - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -299,7 +299,7 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
         self.assertIn("Call the `import_review` MCP tool:", skill_text)
         self.assertIn("## Auto-Triage", skill_text)
         self.assertIn("Call the `triage_findings` MCP tool:", skill_text)
-        self.assertIn("Skip auto-triage when the review produced no findings.", skill_text)
+        self.assertIn("When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.", skill_text)
         self.assertIn("Execution mode: inline | delegated", skill_text)
         self.assertIn("Use `inline` only", skill_text)
         self.assertIn("If execution mode is `delegated`", skill_text)

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -13,6 +13,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SCRIPT = ROOT / "install.sh"
 SKILLS_DIR = ROOT / "skills"
+COPILOT_AGENT_TEMPLATES_DIR = ROOT / ".github" / "agents"
 
 
 def skill_names(package_name: str) -> set[str]:
@@ -41,6 +42,62 @@ KMP_SKILLS = skill_names("kmp")
 PHP_SKILLS = skill_names("php")
 GO_SKILLS = skill_names("go")
 AGENT_CONFIG_SKILLS = skill_names("agent-config")
+COPILOT_AGENT_FILES = {path.name for path in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md")}
+
+READONLY_AGENTS = {"bill-plan"}
+READONLY_FORBIDDEN_TOOLS = {"edit", "execute"}
+
+
+def parse_agent_frontmatter(path: Path) -> dict[str, str]:
+  text = path.read_text(encoding="utf-8")
+  if not text.startswith("---\n"):
+    return {}
+  end = text.index("\n---\n", 4)
+  block = text[4:end]
+  values: dict[str, str] = {}
+  for line in block.splitlines():
+    if ":" not in line:
+      continue
+    key, value = line.split(":", 1)
+    values[key.strip()] = value.strip()
+  return values
+
+
+class CopilotAgentTemplateTest(unittest.TestCase):
+  maxDiff = None
+
+  def test_every_agent_template_has_required_frontmatter_fields(self) -> None:
+    for path in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
+      fm = parse_agent_frontmatter(path)
+      self.assertIn("name", fm, f"{path.name}: missing name")
+      self.assertIn("description", fm, f"{path.name}: missing description")
+      self.assertIn("tools", fm, f"{path.name}: missing tools")
+
+  def test_agent_cross_references_point_to_existing_templates(self) -> None:
+    known_names = set()
+    for path in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
+      fm = parse_agent_frontmatter(path)
+      known_names.add(fm.get("name", ""))
+
+    for path in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
+      fm = parse_agent_frontmatter(path)
+      agents_field = fm.get("agents", "")
+      if not agents_field:
+        continue
+      for ref in agents_field.strip("[]").replace('"', "").split(","):
+        ref = ref.strip()
+        if ref:
+          self.assertIn(ref, known_names, f"{path.name}: references unknown agent '{ref}'")
+
+  def test_readonly_agents_do_not_have_edit_or_execute_tools(self) -> None:
+    for path in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
+      fm = parse_agent_frontmatter(path)
+      name = fm.get("name", "")
+      if name not in READONLY_AGENTS:
+        continue
+      tools = fm.get("tools", "")
+      for forbidden in READONLY_FORBIDDEN_TOOLS:
+        self.assertNotIn(forbidden, tools, f"{path.name}: read-only agent has '{forbidden}' tool")
 
 
 class InstallScriptTest(unittest.TestCase):
@@ -101,6 +158,24 @@ class InstallScriptTest(unittest.TestCase):
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS | AGENT_CONFIG_SKILLS)
 
+  def test_installs_copilot_custom_agents_from_repo_templates(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nPHP\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+      self.assertIn("Installing Copilot custom agents:", result.stdout)
+
+      installed_agents = self.installed_custom_agents(temp_home)
+      self.assertEqual(installed_agents, COPILOT_AGENT_FILES)
+
+      for agent_file in COPILOT_AGENT_FILES:
+        installed_agent = Path(temp_home) / ".copilot" / "agents" / agent_file
+        self.assertTrue(installed_agent.is_file(), agent_file)
+        self.assertFalse(installed_agent.is_symlink(), agent_file)
+
+      agent_text = (Path(temp_home) / ".copilot" / "agents" / "bill-quality-check.agent.md").read_text(encoding="utf-8")
+      self.assertIn("name: bill-quality-check", agent_text)
+      self.assertIn("<!-- managed_by=skill-bill-agent -->", agent_text)
+
   def test_installs_custom_prefix_aliases_and_rewrites_skill_names(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       result = self.run_installer(temp_home, "copilot\nPHP\nacme\n")
@@ -119,6 +194,26 @@ class InstallScriptTest(unittest.TestCase):
       self.assertIn("name: acme-code-review", skill_text)
       self.assertIn("delegate to `acme-php-code-review`.", skill_text)
       self.assertNotIn("name: bill-code-review", skill_text)
+
+  def test_installs_custom_prefix_copilot_agents_as_generated_files(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "copilot\nPHP\nacme\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      expected_agents = {
+        f"acme-{name.removeprefix('bill-')}" if name.startswith("bill-") else name
+        for name in COPILOT_AGENT_FILES
+      }
+      installed_agents = self.installed_custom_agents(temp_home)
+      self.assertEqual(installed_agents, expected_agents)
+
+      installed_agent = Path(temp_home) / ".copilot" / "agents" / "acme-quality-check.agent.md"
+      self.assertTrue(installed_agent.is_file())
+      self.assertFalse(installed_agent.is_symlink())
+      agent_text = installed_agent.read_text(encoding="utf-8")
+      self.assertIn("name: acme-quality-check", agent_text)
+      self.assertNotIn("name: bill-quality-check", agent_text)
+      self.assertIn("<!-- managed_by=skill-bill-agent -->", agent_text)
 
   def test_accepts_numeric_multi_platform_selection(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
@@ -360,9 +455,16 @@ class InstallScriptTest(unittest.TestCase):
       return set()
     return {path.name for path in install_dir.iterdir() if not path.name.startswith(".")}
 
+  def installed_custom_agents(self, temp_home: str) -> set[str]:
+    install_dir = Path(temp_home) / ".copilot" / "agents"
+    if not install_dir.exists():
+      return set()
+    return {path.name for path in install_dir.iterdir() if path.name.endswith(".agent.md")}
+
   def prepare_agent_homes(self, temp_home: str) -> None:
     for relative_dir in (
       ".copilot",
+      ".copilot/agents",
       ".claude",
       ".glm",
       ".codex",

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -49,14 +49,17 @@ class UninstallScriptTest(unittest.TestCase):
       install = self.run_script(INSTALL_SCRIPT, temp_home, "copilot\nPHP\nacme\n")
       self.assertEqual(install.returncode, 0, install.stdout + install.stderr)
 
+      agents_dir = Path(temp_home) / ".copilot" / "agents"
       for agent_file in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
-        self.assertTrue((Path(temp_home) / ".copilot" / "agents" / agent_file.name).exists())
+        rewritten = agent_file.name.replace("bill-", "acme-", 1)
+        self.assertTrue((agents_dir / rewritten).exists(), rewritten)
 
       uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
       self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)
 
       for agent_file in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
-        self.assertFalse((Path(temp_home) / ".copilot" / "agents" / agent_file.name).exists())
+        rewritten = agent_file.name.replace("bill-", "acme-", 1)
+        self.assertFalse((agents_dir / rewritten).exists(), rewritten)
 
   def test_uninstall_removes_legacy_skill_symlinks_and_is_idempotent(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -10,6 +10,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SCRIPT = ROOT / "install.sh"
 UNINSTALL_SCRIPT = ROOT / "uninstall.sh"
+COPILOT_AGENT_TEMPLATES_DIR = ROOT / ".github" / "agents"
 
 
 class UninstallScriptTest(unittest.TestCase):
@@ -42,6 +43,21 @@ class UninstallScriptTest(unittest.TestCase):
       self.assertFalse((Path(temp_home) / ".copilot" / "skills" / "acme-code-review").exists())
       self.assertIn("Removed installs:", uninstall.stdout)
 
+  def test_uninstall_removes_copilot_custom_agents(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      install = self.run_script(INSTALL_SCRIPT, temp_home, "copilot\nPHP\nacme\n")
+      self.assertEqual(install.returncode, 0, install.stdout + install.stderr)
+
+      for agent_file in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
+        self.assertTrue((Path(temp_home) / ".copilot" / "agents" / agent_file.name).exists())
+
+      uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
+      self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)
+
+      for agent_file in COPILOT_AGENT_TEMPLATES_DIR.glob("*.agent.md"):
+        self.assertFalse((Path(temp_home) / ".copilot" / "agents" / agent_file.name).exists())
+
   def test_uninstall_removes_legacy_skill_symlinks_and_is_idempotent(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       self.prepare_agent_homes(temp_home)
@@ -61,6 +77,7 @@ class UninstallScriptTest(unittest.TestCase):
   def prepare_agent_homes(self, temp_home: str) -> None:
     for relative_dir in (
       ".copilot/skills",
+      ".copilot/agents",
       ".claude/commands",
       ".glm/commands",
       ".codex/skills",

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -485,7 +485,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       - `review_run_id`: the review run ID from the review output
       - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 
-      Skip auto-triage when the review produced no findings.
+      When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
       | Signal | Agent to spawn |
       | --- | --- |
       | fixture | `bill-php-code-review-security` |
@@ -543,7 +543,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       - `review_run_id`: the review run ID from the review output
       - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 
-      Skip auto-triage when the review produced no findings.
+      When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
       Specialist review fixture content.
       """
     )
@@ -599,7 +599,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       - `review_run_id`: the review run ID from the review output
       - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 
-      Skip auto-triage when the review produced no findings.
+      When the review produced no findings, call `triage_findings` with an empty decisions list to close the review lifecycle.
       Specialist review fixture content.
       """
     )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$PLUGIN_DIR/skills"
+CUSTOM_AGENT_SOURCE_DIR="$PLUGIN_DIR/.github/agents"
 MANAGED_INSTALL_MARKER=".skill-bill-install"
+MANAGED_AGENT_FILE_MARKER="<!-- managed_by=skill-bill-agent -->"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -40,6 +42,7 @@ declare -a RENAMED_SKILL_PAIRS=(
 )
 
 declare -a SKILL_NAMES=()
+declare -a CUSTOM_AGENT_FILE_NAMES=()
 declare -a LEGACY_SKILL_NAMES=()
 declare -a REMOVED_TARGETS=()
 declare -a SKIPPED_TARGETS=()
@@ -70,6 +73,20 @@ build_skill_names() {
       SKILL_NAMES+=("$skill_name")
     fi
   done < <(find "$SKILLS_DIR" -type f -name 'SKILL.md' | sort)
+}
+
+build_custom_agent_files() {
+  local agent_file
+
+  CUSTOM_AGENT_FILE_NAMES=()
+
+  if [[ ! -d "$CUSTOM_AGENT_SOURCE_DIR" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r agent_file; do
+    CUSTOM_AGENT_FILE_NAMES+=("$(basename "$agent_file")")
+  done < <(find "$CUSTOM_AGENT_SOURCE_DIR" -type f -name '*.agent.md' | sort)
 }
 
 add_legacy_name() {
@@ -123,6 +140,35 @@ remove_skill_target() {
   fi
 }
 
+custom_agent_file_is_managed() {
+  local target="$1"
+  [[ -f "$target" ]] || return 1
+  grep -Fqx "$MANAGED_AGENT_FILE_MARKER" "$target"
+}
+
+remove_custom_agent_target() {
+  local target="$1"
+
+  if [[ -L "$target" ]]; then
+    rm -f "$target"
+    REMOVED_TARGETS+=("$target")
+    ok "  removed $(basename "$target")"
+    return
+  fi
+
+  if custom_agent_file_is_managed "$target"; then
+    rm -f "$target"
+    REMOVED_TARGETS+=("$target")
+    ok "  removed $(basename "$target")"
+    return
+  fi
+
+  if [[ -e "$target" ]]; then
+    SKIPPED_TARGETS+=("$target")
+    warn "  skipped $(basename "$target") (not managed by Skill Bill)"
+  fi
+}
+
 remove_from_agent_dir() {
   local label="$1"
   local target_dir="$2"
@@ -153,6 +199,33 @@ remove_from_agent_dir() {
   done
 
   if [[ ${#REMOVED_TARGETS[@]} -eq "$before_removed" && ${#SKIPPED_TARGETS[@]} -eq "$before_skipped" ]]; then
+    info "  nothing to remove"
+  fi
+}
+
+remove_from_custom_agent_dir() {
+  local label="$1"
+  local target_dir="$2"
+  local before_removed
+  local agent_file
+
+  if [[ ! -d "$target_dir" ]]; then
+    return 0
+  fi
+
+  before_removed=${#REMOVED_TARGETS[@]}
+
+  info "Checking $label custom agents: $target_dir"
+  for agent_file in "$target_dir"/*.agent.md; do
+    [[ -e "$agent_file" ]] || continue
+    if custom_agent_file_is_managed "$agent_file"; then
+      rm -f "$agent_file"
+      REMOVED_TARGETS+=("$agent_file")
+      ok "  removed $(basename "$agent_file")"
+    fi
+  done
+
+  if [[ ${#REMOVED_TARGETS[@]} -eq "$before_removed" ]]; then
     info "  nothing to remove"
   fi
 }
@@ -222,6 +295,7 @@ open(path, 'w').write('\n'.join(filtered))
 }
 
 build_skill_names
+build_custom_agent_files
 build_legacy_skill_names
 
 echo ""
@@ -230,6 +304,7 @@ echo ""
 info "Removing Skill Bill installs from supported agent paths."
 
 remove_from_agent_dir "copilot" "$HOME/.copilot/skills"
+remove_from_custom_agent_dir "copilot" "$HOME/.copilot/agents"
 remove_from_agent_dir "claude" "$HOME/.claude/commands"
 remove_from_agent_dir "glm" "$HOME/.glm/commands"
 remove_from_agent_dir "codex" "$HOME/.codex/skills"


### PR DESCRIPTION
## Summary

- **Copilot custom agents**: Add 5 managed agent templates (`.github/agents/bill-{plan,implement,code-review-resolve,quality-check,finalize}.agent.md`) that Copilot can spawn as sub-agents with isolated context and dedicated tool permissions
- **Copilot feature-implement orchestrator**: Add `bill-feature-implement-copilot` skill that runs inline and delegates heavy stages (plan, implement, resolve, quality-check, finalize) to custom agents while running code review inline to avoid Copilot's nested-delegation runtime limits
- **Installer/uninstaller**: Extend `install.sh` to install managed custom agents into `~/.copilot/agents/` with prefix rewriting and a `<!-- managed_by=skill-bill-agent -->` marker; extend `uninstall.sh` to clean up managed agents; both refuse to touch non-managed files
- **Validator**: Extend `validate_agent_configs.py` to include Copilot agent names in cross-reference validation so SKILL.md files can reference agent names without false positives
- **Auto-triage contract update**: Change "Skip auto-triage when the review produced no findings" to "call `triage_findings` with an empty decisions list" across all 7 review SKILL.md files, the orchestrator playbook, validator, and tests — aligns the contract with actual telemetry lifecycle requirements
- **README**: Skill count 48 → 49, new catalog entry for `bill-feature-implement-copilot`, Copilot install path updated to include `~/.copilot/agents/`, uninstaller description updated

## Design decisions

- **Code review runs inline, not as a sub-agent**: The `bill-code-review` skill triggers deep nested delegation (stack routing → specialist subagents) that exceeds Copilot's runtime limits when spawned as a sub-agent. The orchestrator runs review directly in its thread instead.
- **No `bill-code-review.agent.md` or `bill-feature-implement.agent.md`**: Code review is handled by the portable skill (inline), and the feature-implement orchestration is the `bill-feature-implement-copilot` skill itself — neither needs a custom agent wrapper.
- **Agent filenames are prefix-rewritten**: Custom-prefix installs (e.g. `acme-`) rewrite both the agent filename and the internal `name:` field so cross-references from rewritten skills resolve correctly.
- **Managed-file marker for safe cleanup**: Installed agent files get a `<!-- managed_by=skill-bill-agent -->` marker appended so the uninstaller can distinguish Skill Bill agents from user-created agents.

## Test plan

- [x] `CopilotAgentTemplateTest`: validates frontmatter fields, cross-references between agents, and read-only tool restrictions
- [x] `test_installs_copilot_custom_agents_from_repo_templates`: default prefix installs agent files with correct names and managed marker
- [x] `test_installs_custom_prefix_copilot_agents_as_generated_files`: custom prefix rewrites agent filenames and internal names
- [x] `test_uninstall_removes_copilot_custom_agents`: uninstaller cleans up managed agents after install
- [x] Validator e2e fixtures updated for new auto-triage wording
- [ ] Manual: run `./install.sh` with Copilot selected, verify agents appear in `~/.copilot/agents/`
- [ ] Manual: run `./uninstall.sh`, verify agents are removed
- [ ] Manual: run `./install.sh` with custom prefix, verify agent filenames and internal names are rewritten