### PR TITLE
feat: [SKILL-8] add opencode support

### DIFF
--- a/.feature-specs/SKILL-8-opencode-agent-support/spec.md
+++ b/.feature-specs/SKILL-8-opencode-agent-support/spec.md
@@ -1,0 +1,36 @@
+# Opencode agent support
+
+- Issue key: SKILL-8
+- Status: In Progress
+- Date: 2026-04-11
+- Sources:
+  - User request: "i want to add support for opencode"
+  - User detail: opencode uses its global skills directory for skill installation
+  - User decision: include MCP registration in the opencode global config file
+
+## Acceptance criteria
+
+1. `install.sh` can target opencode and install selected skills into the opencode global skills directory.
+2. `uninstall.sh` removes Skill Bill-managed installs from the opencode skills directory.
+3. The installer also registers the Skill Bill MCP server in the opencode global config file, and the uninstaller removes that registration.
+4. User-facing docs list opencode as a supported agent with the correct install path.
+5. `bill-new-skill-all-agents` includes opencode in its known agent targets and paths.
+6. Automated coverage is updated for the new agent path and MCP registration behavior.
+
+## Non-goals
+
+- Adding opencode-specific platform packages.
+- Changing skill taxonomy or routing behavior.
+- Refactoring unrelated installer or uninstaller logic.
+
+## Consolidated spec
+
+Add opencode as a first-class supported agent alongside Copilot, Claude, GLM, and Codex.
+
+The installer must allow selecting opencode, install skills into the opencode global skills directory, and register the local Skill Bill MCP server in the opencode global config file.
+
+The uninstaller must remove Skill Bill-managed skill installs from the opencode skills directory and remove the Skill Bill MCP entry from the opencode config file.
+
+User-facing documentation and the `bill-new-skill-all-agents` skill must also recognize opencode as a supported target.
+
+Tests must cover the new install path and MCP registration/removal behavior.

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ Skill Bill records review acceptance metrics locally in SQLite and can optionall
 | Claude Code | `~/.claude/commands/` |
 | GLM | `~/.glm/commands/` |
 | OpenAI Codex | `~/.codex/skills/` or `~/.agents/skills/` |
+| OpenCode | `~/.config/opencode/skills/` |
 
-The installer links all selected agents to the same repo so updates stay in sync.
+The installer links all selected agents to the same repo so updates stay in sync, and registers the local Skill Bill MCP server for agents with config-based MCP support.
 
 ## Installation
 

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-11] opencode-agent-support
+Areas: install.sh, uninstall.sh, README, skills/base/bill-new-skill-all-agents, tests
+- Added OpenCode as a first-class installer target with skills installed into its global skills directory and included in supported-agent docs and skill-sync guidance.
+- Registered Skill Bill in the OpenCode global config using the `mcp.skill-bill` local-command shape instead of the existing `mcpServers`/TOML patterns used by other agents.
+- Added JSONC-aware OpenCode config handling (comments and trailing commas) so MCP registration/removal stays compatible with real user configs. reusable
+- Extended installer and uninstaller regression coverage to lock the OpenCode path and MCP contract in place.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-04-05] mcp-server
 Areas: skill_bill/, skills/base/bill-code-review, install.sh, pyproject.toml, tests/
 - Added MCP server (FastMCP/stdio) exposing 5 tools: import_review, triage_findings, resolve_learnings, review_stats, doctor

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ get_agent_path() {
     copilot) echo "$HOME/.copilot/skills" ;;
     claude)  echo "$HOME/.claude/commands" ;;
     glm)     echo "$HOME/.glm/commands" ;;
+    opencode) echo "$HOME/.config/opencode/skills" ;;
     codex)
       if [[ -d "$HOME/.codex" || -d "$HOME/.codex/skills" ]]; then
         echo "$HOME/.codex/skills"
@@ -77,7 +78,7 @@ declare -a RENAMED_SKILL_PAIRS=(
   'bill-gcheck:bill-quality-check'
 )
 
-declare -a SUPPORTED_AGENTS=(copilot claude glm codex)
+declare -a SUPPORTED_AGENTS=(copilot claude glm codex opencode)
 declare -a SKILL_NAMES=()
 declare -a SKILL_PATHS=()
 declare -a INSTALL_SKILL_NAMES=()
@@ -813,7 +814,7 @@ build_platform_packages
 echo ""
 printf "${CYAN}━━━ Skill Bill Installer ━━━${NC}\n"
 echo ""
-info "Supported agents: copilot, claude, glm, codex"
+info "Supported agents: copilot, claude, glm, codex, opencode"
 info "Install behavior: replace existing Skill Bill installs and reinstall the selected platforms."
 prompt_for_agent_selection
 prompt_for_platform_selection
@@ -922,12 +923,134 @@ open(path, 'w').write('\n'.join(filtered))
         warn "  Could not register MCP server ($label)."
       fi
     }
+    register_mcp_jsonc_opencode() {
+      local config_path="$1"
+      local label="$2"
+      if python3 -c "
+import json, sys, os
+
+path = sys.argv[1]
+
+def strip_jsonc(text):
+    result = []
+    in_string = False
+    escape = False
+    in_line_comment = False
+    in_block_comment = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ''
+        if in_line_comment:
+            if ch in '\r\n':
+                in_line_comment = False
+                result.append(ch)
+            i += 1
+            continue
+        if in_block_comment:
+            if ch == '*' and nxt == '/':
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+        if in_string:
+            result.append(ch)
+            if escape:
+                escape = False
+            elif ch == '\\\\':
+                escape = True
+            elif ch == '\"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '\"':
+            in_string = True
+            result.append(ch)
+            i += 1
+            continue
+        if ch == '/' and nxt == '/':
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == '/' and nxt == '*':
+            in_block_comment = True
+            i += 2
+            continue
+        result.append(ch)
+        i += 1
+    return ''.join(result)
+
+def strip_trailing_commas(text):
+    result = []
+    in_string = False
+    escape = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            result.append(ch)
+            if escape:
+                escape = False
+            elif ch == '\\\\':
+                escape = True
+            elif ch == '\"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '\"':
+            in_string = True
+            result.append(ch)
+            i += 1
+            continue
+        if ch == ',':
+            j = i + 1
+            while j < len(text) and text[j] in ' \t\r\n':
+                j += 1
+            if j < len(text) and text[j] in '}]':
+                i += 1
+                continue
+        result.append(ch)
+        i += 1
+    return ''.join(result)
+
+try:
+    raw = open(path).read()
+except FileNotFoundError:
+    settings = {}
+else:
+    if raw.strip():
+        settings = json.loads(strip_trailing_commas(strip_jsonc(raw)))
+    else:
+        settings = {}
+
+if not isinstance(settings, dict):
+    sys.exit(1)
+
+mcp = settings.get('mcp', {})
+if not isinstance(mcp, dict):
+    mcp = {}
+mcp['skill-bill'] = {
+    'type': 'local',
+    'command': [sys.executable, '-m', 'skill_bill.mcp_server'],
+    'enabled': True,
+}
+settings['mcp'] = mcp
+os.makedirs(os.path.dirname(path), exist_ok=True)
+open(path, 'w').write(json.dumps(settings, indent=2, sort_keys=True) + '\n')
+" "$config_path" 2>/dev/null; then
+        ok "  skill-bill MCP server registered ($label)"
+      else
+        warn "  Could not register MCP server ($label)."
+      fi
+    }
     for i in "${!AGENT_NAMES[@]}"; do
       case "${AGENT_NAMES[$i]}" in
         claude)  register_mcp_json "$HOME/.claude.json" "claude" ;;
         copilot) register_mcp_json "$HOME/.copilot/mcp-config.json" "copilot" ;;
         codex)   register_mcp_toml "$HOME/.codex/config.toml" "codex" ;;
         glm)     register_mcp_json "$HOME/.glm/mcp-config.json" "glm" ;;
+        opencode) register_mcp_jsonc_opencode "$HOME/.config/opencode/opencode.json" "opencode" ;;
       esac
     done
   else

--- a/skills/base/bill-new-skill-all-agents/SKILL.md
+++ b/skills/base/bill-new-skill-all-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-new-skill-all-agents
-description: Use when creating a new skill and syncing it to all detected local AI agents (Claude, Copilot, GLM, Codex). Use when user mentions create skill, new skill, add skill, or sync skill to agents.
+description: Use when creating a new skill and syncing it to all detected local AI agents (Claude, Copilot, GLM, Codex, Opencode). Use when user mentions create skill, new skill, add skill, or sync skill to agents.
 ---
 
 ## Project Overrides
@@ -38,10 +38,11 @@ When asked to create a new skill, follow this workflow:
    - If the package is unclear, ask once before creating files
 
 2. Known agents and their paths:
-   - copilot: `$HOME/.copilot/skills`
-   - claude: `$HOME/.claude/commands`
-   - glm: `$HOME/.glm/commands`
-   - codex: prefer `$HOME/.codex/skills`, fallback to `$HOME/.agents/skills`
+    - copilot: `$HOME/.copilot/skills`
+    - claude: `$HOME/.claude/commands`
+    - glm: `$HOME/.glm/commands`
+    - codex: prefer `$HOME/.codex/skills`, fallback to `$HOME/.agents/skills`
+    - opencode: `$HOME/.config/opencode/skills`
 
 3. Normalize the skill name to a slug:
    - lowercase

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -62,6 +62,7 @@ class InstallScriptTest(unittest.TestCase):
         ".claude/commands/bill-code-review",
         ".glm/commands/bill-code-review",
         ".codex/skills/bill-code-review",
+        ".config/opencode/skills/bill-code-review",
       ):
         path = Path(temp_home) / relative_path
         self.assertTrue(path.is_symlink(), relative_path)
@@ -100,6 +101,33 @@ class InstallScriptTest(unittest.TestCase):
 
       installed = self.installed_skills(temp_home)
       self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS | AGENT_CONFIG_SKILLS)
+
+  def test_installs_opencode_skills_and_registers_mcp(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      result = self.run_installer(temp_home, "opencode\nPHP\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      installed = self.installed_skills(temp_home, relative_dir=".config/opencode/skills")
+      self.assertEqual(installed, BASE_SKILLS | PHP_SKILLS | AGENT_CONFIG_SKILLS)
+      self.assertIn("Installed agent: opencode", result.stdout)
+
+      config = json.loads((Path(temp_home) / ".config" / "opencode" / "opencode.json").read_text(encoding="utf-8"))
+      self.assertEqual(config["mcp"]["skill-bill"]["type"], "local")
+      self.assertEqual(config["mcp"]["skill-bill"]["command"][1:], ["-m", "skill_bill.mcp_server"])
+      self.assertTrue(config["mcp"]["skill-bill"]["enabled"])
+
+  def test_installer_merges_opencode_jsonc_config_when_registering_mcp(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      config_path = Path(temp_home) / ".config" / "opencode" / "opencode.json"
+      config_path.parent.mkdir(parents=True, exist_ok=True)
+      config_path.write_text('{\n  // keep this user setting\n  "theme": "opencode",\n}\n', encoding="utf-8")
+
+      result = self.run_installer(temp_home, "opencode\nPHP\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      config = json.loads(config_path.read_text(encoding="utf-8"))
+      self.assertEqual(config["theme"], "opencode")
+      self.assertIn("skill-bill", config["mcp"])
 
   def test_installs_custom_prefix_aliases_and_rewrites_skill_names(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
@@ -354,8 +382,8 @@ class InstallScriptTest(unittest.TestCase):
       env=env,
     )
 
-  def installed_skills(self, temp_home: str) -> set[str]:
-    install_dir = Path(temp_home) / ".copilot" / "skills"
+  def installed_skills(self, temp_home: str, *, relative_dir: str = ".copilot/skills") -> set[str]:
+    install_dir = Path(temp_home) / relative_dir
     if not install_dir.exists():
       return set()
     return {path.name for path in install_dir.iterdir() if not path.name.startswith(".")}
@@ -366,6 +394,7 @@ class InstallScriptTest(unittest.TestCase):
       ".claude",
       ".glm",
       ".codex",
+      ".config/opencode",
     ):
       (Path(temp_home) / relative_dir).mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import os
 import subprocess
@@ -42,6 +43,24 @@ class UninstallScriptTest(unittest.TestCase):
       self.assertFalse((Path(temp_home) / ".copilot" / "skills" / "acme-code-review").exists())
       self.assertIn("Removed installs:", uninstall.stdout)
 
+  def test_uninstall_removes_opencode_skill_and_mcp_registration(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      install = self.run_script(INSTALL_SCRIPT, temp_home, "opencode\nPHP\n")
+      self.assertEqual(install.returncode, 0, install.stdout + install.stderr)
+      self.assertTrue((Path(temp_home) / ".config" / "opencode" / "skills" / "bill-code-review").is_symlink())
+
+      config_path = Path(temp_home) / ".config" / "opencode" / "opencode.json"
+      config = json.loads(config_path.read_text(encoding="utf-8"))
+      self.assertIn("skill-bill", config["mcp"])
+
+      uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
+      self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)
+      self.assertFalse((Path(temp_home) / ".config" / "opencode" / "skills" / "bill-code-review").exists())
+
+      config = json.loads(config_path.read_text(encoding="utf-8"))
+      self.assertNotIn("mcp", config)
+
   def test_uninstall_removes_legacy_skill_symlinks_and_is_idempotent(self) -> None:
     with tempfile.TemporaryDirectory() as temp_home:
       self.prepare_agent_homes(temp_home)
@@ -65,6 +84,7 @@ class UninstallScriptTest(unittest.TestCase):
       ".glm/commands",
       ".codex/skills",
       ".agents/skills",
+      ".config/opencode/skills",
     ):
       (Path(temp_home) / relative_dir).mkdir(parents=True, exist_ok=True)
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -234,12 +234,139 @@ remove_from_agent_dir "claude" "$HOME/.claude/commands"
 remove_from_agent_dir "glm" "$HOME/.glm/commands"
 remove_from_agent_dir "codex" "$HOME/.codex/skills"
 remove_from_agent_dir "codex" "$HOME/.agents/skills"
+remove_from_agent_dir "opencode" "$HOME/.config/opencode/skills"
 
 info "Removing MCP server registrations."
 unregister_mcp_json "$HOME/.claude.json" "claude"
 unregister_mcp_json "$HOME/.copilot/mcp-config.json" "copilot"
 unregister_mcp_toml "$HOME/.codex/config.toml" "codex"
 unregister_mcp_json "$HOME/.glm/mcp-config.json" "glm"
+unregister_mcp_jsonc_opencode() {
+  local config_path="$1"
+  local label="$2"
+  if [[ ! -f "$config_path" ]]; then
+    return 0
+  fi
+  if python3 -c "
+import json, sys, os
+
+path = sys.argv[1]
+
+def strip_jsonc(text):
+    result = []
+    in_string = False
+    escape = False
+    in_line_comment = False
+    in_block_comment = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ''
+        if in_line_comment:
+            if ch in '\r\n':
+                in_line_comment = False
+                result.append(ch)
+            i += 1
+            continue
+        if in_block_comment:
+            if ch == '*' and nxt == '/':
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+        if in_string:
+            result.append(ch)
+            if escape:
+                escape = False
+            elif ch == '\\\\':
+                escape = True
+            elif ch == '\"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '\"':
+            in_string = True
+            result.append(ch)
+            i += 1
+            continue
+        if ch == '/' and nxt == '/':
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == '/' and nxt == '*':
+            in_block_comment = True
+            i += 2
+            continue
+        result.append(ch)
+        i += 1
+    return ''.join(result)
+
+def strip_trailing_commas(text):
+    result = []
+    in_string = False
+    escape = False
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            result.append(ch)
+            if escape:
+                escape = False
+            elif ch == '\\\\':
+                escape = True
+            elif ch == '\"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '\"':
+            in_string = True
+            result.append(ch)
+            i += 1
+            continue
+        if ch == ',':
+            j = i + 1
+            while j < len(text) and text[j] in ' \t\r\n':
+                j += 1
+            if j < len(text) and text[j] in '}]':
+                i += 1
+                continue
+        result.append(ch)
+        i += 1
+    return ''.join(result)
+
+try:
+    raw = open(path).read()
+except FileNotFoundError:
+    sys.exit(0)
+
+if raw.strip():
+    try:
+        settings = json.loads(strip_trailing_commas(strip_jsonc(raw)))
+    except json.JSONDecodeError:
+        sys.exit(0)
+else:
+    settings = {}
+
+if not isinstance(settings, dict):
+    sys.exit(0)
+
+servers = settings.get('mcp', {})
+if not isinstance(servers, dict) or 'skill-bill' not in servers:
+    sys.exit(0)
+
+del servers['skill-bill']
+if servers:
+    settings['mcp'] = servers
+elif 'mcp' in settings:
+    del settings['mcp']
+
+open(path, 'w').write(json.dumps(settings, indent=2, sort_keys=True) + '\n')
+" "$config_path" 2>/dev/null; then
+    ok "  removed skill-bill MCP server ($label)"
+  fi
+}
+unregister_mcp_jsonc_opencode "$HOME/.config/opencode/opencode.json" "opencode"
 
 SKILL_BILL_STATE_DIR="${HOME}/.skill-bill"
 if [[ -d "$SKILL_BILL_STATE_DIR" ]]; then


### PR DESCRIPTION
# Summary

Add OpenCode as a supported Skill Bill agent target so installs, uninstalls, docs, and the all-agents skill stay aligned. This also registers the Skill Bill MCP server using OpenCodes mcp local-command config shape and preserves existing user config by handling JSONC comments and trailing commas.

- extend installer and uninstaller support for OpenCode
- update README and bill-new-skill-all-agents
- add regression coverage for OpenCode skill installation and MCP registration/removal

## Feature Flags

N/A

# How Has This Been Tested?

Ran the governed repo validation flow covering unit tests, repo lint/contract checks, and agent-config validation.

1. Run python3 -m unittest discover -s tests
2. Run npx --yes agnix --strict .
3. Run python3 scripts/validate_agent_configs.py
4. Verify OpenCode installs skills and writes/removes the Skill Bill MCP entry in the global config file.