### PR TITLE
feat: replace auto-import/triage with parent-owned telemetry ownership contract

### DIFF
--- a/docs/review-telemetry.md
+++ b/docs/review-telemetry.md
@@ -56,6 +56,8 @@ The `triage` command maps the visible numbers back to the stable `F-001` ids int
 - `skip`, `dismiss`, or `reject` -> records `fix_rejected`
 - `false positive` -> records `false_positive`
 
+In agent-driven review flows, only the parent review that owns the final merged review output for the current review lifecycle should call `import_review` and `triage_findings`. Delegated child reviews stay telemetry-free and return their review data and metadata to that parent.
+
 You can still use the low-level command when you want direct control:
 
 ```bash

--- a/orchestration/review-delegation/PLAYBOOK.md
+++ b/orchestration/review-delegation/PLAYBOOK.md
@@ -15,8 +15,9 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Delegated review layers and specialist review passes must run as separate subagents on supported runtimes; do not collapse a delegated-required scope into a single inline review.
 - Launch one delegated worker per routed stack-specific review skill or selected specialist review pass unless the current agent-specific section explicitly says otherwise.
 - The parent review owns only the delegated workers it launched itself. If a delegated child review launches more workers internally, treat those nested workers as opaque implementation detail and consume only the child review's final merged result.
+- The parent review that owns the final merged review output also owns `import_review` and `triage_findings`. Delegated workers must not call those telemetry tools themselves.
 - When the runtime supports delegated-worker model inheritance, delegated workers should use the same model as the parent thread by default. Do not override the delegated-worker model unless the current runtime-specific section explicitly requires it.
-- Every delegated worker must receive the exact review scope, changed files or diff source, relevant project guidance, the delegated skill file path, the current `review_session_id` and `review_run_id` when they already exist, any applicable active learnings when they are available, and the shared specialist contract from `specialist-contract.md`.
+- Every delegated worker must receive the exact review scope, changed files or diff source, relevant project guidance, the delegated skill file path, the current `review_session_id` and `review_run_id` when they already exist, any applicable active learnings when they are available, the shared specialist contract from `specialist-contract.md`, and the rule that delegated workers must return telemetry-relevant metadata to the parent instead of calling telemetry tools directly.
 - Wait for all delegated workers to finish, then merge and deduplicate findings by root cause, severity, and confidence.
 - Track delegated workers by the ids returned when they are launched. Do not discover or poll delegated workers through broad global listing in the normal review path.
 - If delegated review is required for the current scope and a supported runtime refuses or cannot start delegated workers, stop and report that delegated review is required for this scope but unavailable on the current runtime.
@@ -27,6 +28,7 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Use the `task` tool.
 - Launch one `code-review` agent per delegated review skill or specialist review pass.
 - Use prompts that tell each subagent to read the delegated skill's `SKILL.md` as the primary rubric and apply `review-orchestrator.md` for shared output structure.
+- Tell each delegated worker to return structured review output plus telemetry-relevant metadata to the parent and not to call `import_review` or `triage_findings`.
 - Use background mode for parallel delegated passes, capture every returned `agent_id`, then wait on and read only those tracked ids before merging results in the parent review.
 - Do not use `list_agents` to discover delegated workers during normal review execution. Reserve it for explicit recovery/debugging only.
 - Do not call `read_agent` on nested workers launched by a delegated child review. Read only the child review agent you launched and let that child return its own merged result.
@@ -37,6 +39,7 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Use the `Task` tool / subagent mechanism.
 - Launch one subagent per delegated review skill or specialist review pass.
 - Tell each subagent to read the delegated skill file as the primary rubric and return only meaningful findings.
+- Tell each delegated worker to return structured review output plus telemetry-relevant metadata to the parent and not to call `import_review` or `triage_findings`.
 - Run eligible delegated passes in parallel and merge the results in the parent review.
 - Do not inline delegated review logic on Claude when Task/subagents are available.
 
@@ -46,6 +49,7 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Spawn one subagent per delegated review skill or specialist review pass.
 - Use the same model as the parent thread by default.
 - Tell each subagent to read the delegated skill file and return structured review findings only.
+- Tell each delegated worker to return structured review output plus telemetry-relevant metadata to the parent and not to call `import_review` or `triage_findings`.
 - Wait for all subagents and merge their results in the parent review.
 - Do not run delegated review passes inline.
 
@@ -54,5 +58,6 @@ Runtime-facing skills consume this contract through sibling supporting files suc
 - Use the Task/subagent mechanism.
 - Spawn one subagent per delegated review skill or specialist review pass.
 - Provide the delegated skill file and `review-orchestrator.md` contract to each subagent.
+- Tell each delegated worker to return structured review output plus telemetry-relevant metadata to the parent and not to call `import_review` or `triage_findings`.
 - Run delegated passes in parallel when possible and merge the results in the parent review.
 - Do not inline delegated review passes.

--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -69,9 +69,9 @@ Section 1 summary must include `Detected review scope: <staged changes / unstage
 Section 1 summary must include `Execution mode: inline | delegated`.
 Section 1 summary must include `Applied learnings: none | <learning references>`.
 
-Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, follow-up telemetry, and any learnings-resolution workflow for the current review lifecycle.
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
 
-Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any follow-up feedback workflow for the current review output.
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
 
 After Section 1 in a stack-specific review skill, use:
 
@@ -92,16 +92,19 @@ Do NOT use markdown tables, numbered lists, or any other format for findings. Th
 - Finding ids must be unique within the current review run and stable enough for follow-up feedback or fix requests in the same workflow
 - Assign finding ids sequentially in risk-register order using `F-001`, `F-002`, `F-003`, and so on
 
-## Auto-Import
+## Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-## Auto-Triage
+## Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the review lifecycle can complete and the finished telemetry event can fire.
+The same parent review owns triage recording after the user responds to findings so the review lifecycle can complete and the finished telemetry event can fire.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -109,12 +112,12 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.
 
 ## Specialist Contract Subset
 

--- a/scripts/skill_repo_contracts.py
+++ b/scripts/skill_repo_contracts.py
@@ -48,6 +48,27 @@ REVIEW_SESSION_ID_PLACEHOLDER = "Review session ID: <review-session-id>"
 REVIEW_SESSION_ID_FORMAT = "rvs-<uuid4>"
 APPLIED_LEARNINGS_PLACEHOLDER = "Applied learnings: none | <learning references>"
 RISK_REGISTER_FINDING_FORMAT = "- [F-001] <Severity> | <Confidence> | <file:line> | <description>"
+TELEMETRY_OWNERSHIP_HEADING = "Telemetry Ownership"
+TRIAGE_OWNERSHIP_HEADING = "Triage Ownership"
+PARENT_IMPORT_RULE = (
+  "If this review owns the final merged review output for the current review lifecycle, call the "
+  "`import_review` MCP tool:"
+)
+CHILD_NO_IMPORT_RULE = (
+  "If this review is delegated or layered under another review, do not call `import_review`."
+)
+CHILD_METADATA_HANDOFF_RULE = (
+  "Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, "
+  "detected scope/stack, execution mode, specialist reviews) to the parent review instead."
+)
+PARENT_TRIAGE_RULE = (
+  "If this review owns the final merged review output for the current review lifecycle and the user "
+  "responds to findings, call the `triage_findings` MCP tool:"
+)
+CHILD_NO_TRIAGE_RULE = (
+  "If this review is delegated or layered under another review, do not call `triage_findings`;"
+)
+NO_FINDINGS_TRIAGE_RULE = "Skip triage recording when the final parent-owned review produced no findings."
 
 
 def skills_requiring_supporting_file(file_name: str) -> tuple[str, ...]:

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -9,7 +9,13 @@ import sys
 
 from skill_repo_contracts import (
   APPLIED_LEARNINGS_PLACEHOLDER,
+  CHILD_METADATA_HANDOFF_RULE,
+  CHILD_NO_IMPORT_RULE,
+  CHILD_NO_TRIAGE_RULE,
   ORCHESTRATION_PLAYBOOKS,
+  NO_FINDINGS_TRIAGE_RULE,
+  PARENT_IMPORT_RULE,
+  PARENT_TRIAGE_RULE,
   PORTABLE_REVIEW_SKILLS,
   REVIEW_DELEGATION_REQUIRED_SECTIONS,
   REVIEW_RUN_ID_FORMAT,
@@ -18,6 +24,8 @@ from skill_repo_contracts import (
   REVIEW_SESSION_ID_PLACEHOLDER,
   RISK_REGISTER_FINDING_FORMAT,
   RUNTIME_SUPPORTING_FILES,
+  TELEMETRY_OWNERSHIP_HEADING,
+  TRIAGE_OWNERSHIP_HEADING,
 )
 
 
@@ -77,12 +85,21 @@ NON_PORTABLE_REVIEW_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     "must use portable summary wording such as 'Specialist reviews'",
   ),
 )
-PORTABLE_REVIEW_LIFECYCLE_REQUIREMENTS: tuple[tuple[str, str], ...] = (
-  ("## Auto-Import", "portable review skills must define the inline auto-import section"),
-  ("Call the `import_review` MCP tool:", "portable review skills must describe the import_review lifecycle handoff"),
-  ("## Auto-Triage", "portable review skills must define the inline auto-triage section"),
-  ("Call the `triage_findings` MCP tool:", "portable review skills must describe the triage_findings lifecycle handoff"),
-  ("Skip auto-triage when the review produced no findings.", "portable review skills must define the no-findings auto-triage rule"),
+PORTABLE_REVIEW_TELEMETRY_REQUIREMENTS: tuple[tuple[str, str], ...] = (
+  (PARENT_IMPORT_RULE, "portable review skills must describe the parent-owned import_review handoff"),
+  (CHILD_NO_IMPORT_RULE, "portable review skills must forbid delegated child reviews from calling import_review"),
+  (CHILD_METADATA_HANDOFF_RULE, "portable review skills must describe the delegated child metadata handoff"),
+  (PARENT_TRIAGE_RULE, "portable review skills must describe the parent-owned triage_findings handoff"),
+  (CHILD_NO_TRIAGE_RULE, "portable review skills must forbid delegated child reviews from calling triage_findings"),
+  (NO_FINDINGS_TRIAGE_RULE, "portable review skills must define the final parent-owned no-findings triage rule"),
+)
+REVIEW_ORCHESTRATOR_TELEMETRY_REQUIREMENTS: tuple[tuple[str, str], ...] = (
+  (PARENT_IMPORT_RULE, "review orchestration contract must describe the parent-owned import_review handoff"),
+  (CHILD_NO_IMPORT_RULE, "review orchestration contract must forbid delegated child reviews from calling import_review"),
+  (CHILD_METADATA_HANDOFF_RULE, "review orchestration contract must describe the delegated child metadata handoff"),
+  (PARENT_TRIAGE_RULE, "review orchestration contract must describe the parent-owned triage_findings handoff"),
+  (CHILD_NO_TRIAGE_RULE, "review orchestration contract must forbid delegated child reviews from calling triage_findings"),
+  (NO_FINDINGS_TRIAGE_RULE, "review orchestration contract must define the final parent-owned no-findings triage rule"),
 )
 
 
@@ -241,7 +258,19 @@ def validate_portable_review_wording(
     issues.append(f"{skill_file}: portable review skills must expose '{REVIEW_RUN_ID_PLACEHOLDER}'")
   if APPLIED_LEARNINGS_PLACEHOLDER not in text:
     issues.append(f"{skill_file}: portable review skills must expose '{APPLIED_LEARNINGS_PLACEHOLDER}'")
-  for required_text, message in PORTABLE_REVIEW_LIFECYCLE_REQUIREMENTS:
+  require_markdown_heading(
+    text,
+    TELEMETRY_OWNERSHIP_HEADING,
+    f"{skill_file}: portable review skills must define the telemetry ownership section as a markdown heading",
+    issues,
+  )
+  require_markdown_heading(
+    text,
+    TRIAGE_OWNERSHIP_HEADING,
+    f"{skill_file}: portable review skills must define the triage ownership section as a markdown heading",
+    issues,
+  )
+  for required_text, message in PORTABLE_REVIEW_TELEMETRY_REQUIREMENTS:
     if required_text not in text:
       issues.append(f"{skill_file}: {message}; missing '{required_text}'")
 
@@ -292,6 +321,26 @@ def validate_orchestration_playbooks(root: Path, issues: list[str]) -> None:
         issues.append(
           f"{relative_path}: review orchestration contract must define machine-readable findings as '{RISK_REGISTER_FINDING_FORMAT}'"
         )
+      require_markdown_heading(
+        text,
+        TELEMETRY_OWNERSHIP_HEADING,
+        f"{relative_path}: review orchestration contract must define the telemetry ownership section as a markdown heading",
+        issues,
+      )
+      require_markdown_heading(
+        text,
+        TRIAGE_OWNERSHIP_HEADING,
+        f"{relative_path}: review orchestration contract must define the triage ownership section as a markdown heading",
+        issues,
+      )
+      for required_text, message in REVIEW_ORCHESTRATOR_TELEMETRY_REQUIREMENTS:
+        if required_text not in text:
+          issues.append(f"{relative_path}: {message}; missing '{required_text}'")
+
+
+def require_markdown_heading(text: str, heading: str, message: str, issues: list[str]) -> None:
+  if not re.search(rf"(?m)^#{{2,6}} {re.escape(heading)}$", text):
+    issues.append(message)
 
 
 def validate_skill_location(skill_name: str, skill_file: Path, issues: list[str]) -> None:

--- a/skills/agent-config/bill-agent-config-code-review/SKILL.md
+++ b/skills/agent-config/bill-agent-config-code-review/SKILL.md
@@ -91,16 +91,19 @@ Every finding in `### 2. Risk Register` must use this exact bullet format (do NO
 
 Severity: `Blocker | Major | Minor`. Confidence: `High | Medium | Low`.
 
-### Auto-Import
+### Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-### Auto-Triage
+### Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the telemetry event fires.
+The same parent review owns triage recording after the user responds to findings.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -108,12 +111,12 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/agent-config/bill-agent-config-code-review/specialist-contract.md
+++ b/skills/agent-config/bill-agent-config-code-review/specialist-contract.md
@@ -27,9 +27,9 @@ Section 1 summary must include `Detected review scope: <staged changes / unstage
 Section 1 summary must include `Execution mode: inline | delegated`.
 Section 1 summary must include `Applied learnings: none | <learning references>`.
 
-Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, follow-up telemetry, and any learnings-resolution workflow for the current review lifecycle.
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
 
-Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any follow-up feedback workflow for the current review output.
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
 
 After Section 1 in a stack-specific review skill, use:
 

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/SKILL.md
@@ -153,16 +153,19 @@ Every finding in `### 2. Risk Register` must use this exact bullet format (do NO
 
 Severity: `Blocker | Major | Minor`. Confidence: `High | Medium | Low`.
 
-### Auto-Import
+### Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-### Auto-Triage
+### Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the telemetry event fires.
+The same parent review owns triage recording after the user responds to findings.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -170,12 +173,12 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/backend-kotlin/bill-backend-kotlin-code-review/specialist-contract.md
+++ b/skills/backend-kotlin/bill-backend-kotlin-code-review/specialist-contract.md
@@ -27,9 +27,9 @@ Section 1 summary must include `Detected review scope: <staged changes / unstage
 Section 1 summary must include `Execution mode: inline | delegated`.
 Section 1 summary must include `Applied learnings: none | <learning references>`.
 
-Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, follow-up telemetry, and any learnings-resolution workflow for the current review lifecycle.
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
 
-Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any follow-up feedback workflow for the current review output.
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
 
 After Section 1 in a stack-specific review skill, use:
 

--- a/skills/base/bill-code-review/SKILL.md
+++ b/skills/base/bill-code-review/SKILL.md
@@ -154,16 +154,19 @@ Signals: <markers>
 Result: No matching stack-specific code-review skill is available yet.
 ```
 
-## Auto-Import
+## Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-## Auto-Triage
+## Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the telemetry event fires.
+The same parent review owns triage recording after the user responds to findings.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -171,9 +174,9 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.

--- a/skills/go/bill-go-code-review/SKILL.md
+++ b/skills/go/bill-go-code-review/SKILL.md
@@ -159,16 +159,19 @@ Every finding in `### 2. Risk Register` must use this exact bullet format (do NO
 
 Severity: `Blocker | Major | Minor`. Confidence: `High | Medium | Low`.
 
-### Auto-Import
+### Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-### Auto-Triage
+### Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the telemetry event fires.
+The same parent review owns triage recording after the user responds to findings.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -176,12 +179,12 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/go/bill-go-code-review/specialist-contract.md
+++ b/skills/go/bill-go-code-review/specialist-contract.md
@@ -27,9 +27,9 @@ Section 1 summary must include `Detected review scope: <staged changes / unstage
 Section 1 summary must include `Execution mode: inline | delegated`.
 Section 1 summary must include `Applied learnings: none | <learning references>`.
 
-Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, follow-up telemetry, and any learnings-resolution workflow for the current review lifecycle.
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
 
-Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any follow-up feedback workflow for the current review output.
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
 
 After Section 1 in a stack-specific review skill, use:
 

--- a/skills/kmp/bill-kmp-code-review/SKILL.md
+++ b/skills/kmp/bill-kmp-code-review/SKILL.md
@@ -164,16 +164,19 @@ Every finding in `### 2. Risk Register` must use this exact bullet format (do NO
 
 Severity: `Blocker | Major | Minor`. Confidence: `High | Medium | Low`.
 
-### Auto-Import
+### Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-### Auto-Triage
+### Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the telemetry event fires.
+The same parent review owns triage recording after the user responds to findings.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -181,12 +184,12 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/kmp/bill-kmp-code-review/specialist-contract.md
+++ b/skills/kmp/bill-kmp-code-review/specialist-contract.md
@@ -27,9 +27,9 @@ Section 1 summary must include `Detected review scope: <staged changes / unstage
 Section 1 summary must include `Execution mode: inline | delegated`.
 Section 1 summary must include `Applied learnings: none | <learning references>`.
 
-Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, follow-up telemetry, and any learnings-resolution workflow for the current review lifecycle.
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
 
-Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any follow-up feedback workflow for the current review output.
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
 
 After Section 1 in a stack-specific review skill, use:
 

--- a/skills/kotlin/bill-kotlin-code-review/SKILL.md
+++ b/skills/kotlin/bill-kotlin-code-review/SKILL.md
@@ -158,16 +158,19 @@ Every finding in `### 2. Risk Register` must use this exact bullet format (do NO
 
 Severity: `Blocker | Major | Minor`. Confidence: `High | Medium | Low`.
 
-### Auto-Import
+### Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-### Auto-Triage
+### Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the telemetry event fires.
+The same parent review owns triage recording after the user responds to findings.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -175,12 +178,12 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/kotlin/bill-kotlin-code-review/specialist-contract.md
+++ b/skills/kotlin/bill-kotlin-code-review/specialist-contract.md
@@ -27,9 +27,9 @@ Section 1 summary must include `Detected review scope: <staged changes / unstage
 Section 1 summary must include `Execution mode: inline | delegated`.
 Section 1 summary must include `Applied learnings: none | <learning references>`.
 
-Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, follow-up telemetry, and any learnings-resolution workflow for the current review lifecycle.
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
 
-Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any follow-up feedback workflow for the current review output.
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
 
 After Section 1 in a stack-specific review skill, use:
 

--- a/skills/php/bill-php-code-review/SKILL.md
+++ b/skills/php/bill-php-code-review/SKILL.md
@@ -155,16 +155,19 @@ Every finding in `### 2. Risk Register` must use this exact bullet format (do NO
 
 Severity: `Blocker | Major | Minor`. Confidence: `High | Medium | Low`.
 
-### Auto-Import
+### Telemetry Ownership
 
-After producing the final review output, automatically import it into the local telemetry store so the review run and findings are recorded without manual intervention.
+The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.
 
-Call the `import_review` MCP tool:
-- `review_text`: the complete review output (Section 1 through Section 4)
+- If this review is delegated or layered under another review, do not call `import_review`. Return the complete review output plus summary metadata (`review_session_id`, `review_run_id`, detected scope/stack, execution mode, specialist reviews) to the parent review instead.
+- If this review owns the final merged review output for the current review lifecycle, call the `import_review` MCP tool:
+  - `review_text`: the complete review output (Section 1 through Section 4)
 
-### Auto-Triage
+### Triage Ownership
 
-After the user responds to the review findings and the agent has acted on each decision (applied fixes, skipped findings, etc.), record the triage decisions so the telemetry event fires.
+The same parent review owns triage recording after the user responds to findings.
+
+- If this review is delegated or layered under another review, do not call `triage_findings`; the parent review owns triage handoff and telemetry completion.
 
 Each finding gets one decision using its position number from the risk register:
 - `fix` — the finding was accepted and the fix was applied
@@ -172,12 +175,12 @@ Each finding gets one decision using its position number from the risk register:
 - `skip` — the finding was intentionally skipped (append a reason after ` - `)
 - `false_positive` — the finding was incorrect
 
-Call the `triage_findings` MCP tool:
-- `review_run_id`: the review run ID from the review output
-- `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
-- fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
+- If this review owns the final merged review output for the current review lifecycle and the user responds to findings, call the `triage_findings` MCP tool:
+  - `review_run_id`: the review run ID from the review output
+  - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+  - fallback: explicit numbered decisions still work, e.g. `["1 fix", "2 skip - intentional", "3 accept"]`
 
-Skip auto-triage when the review produced no findings.
+Skip triage recording when the final parent-owned review produced no findings.
 
 For action items, verdict format, merge rules, and review principles, follow [review-orchestrator.md](review-orchestrator.md).
 

--- a/skills/php/bill-php-code-review/specialist-contract.md
+++ b/skills/php/bill-php-code-review/specialist-contract.md
@@ -27,9 +27,9 @@ Section 1 summary must include `Detected review scope: <staged changes / unstage
 Section 1 summary must include `Execution mode: inline | delegated`.
 Section 1 summary must include `Applied learnings: none | <learning references>`.
 
-Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, follow-up telemetry, and any learnings-resolution workflow for the current review lifecycle.
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
 
-Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any follow-up feedback workflow for the current review output.
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
 
 After Section 1 in a stack-specific review skill, use:
 

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import sys
 import unittest
 
@@ -10,6 +11,12 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from skill_repo_contracts import (  # noqa: E402
   APPLIED_LEARNINGS_PLACEHOLDER,
+  CHILD_METADATA_HANDOFF_RULE,
+  CHILD_NO_IMPORT_RULE,
+  CHILD_NO_TRIAGE_RULE,
+  NO_FINDINGS_TRIAGE_RULE,
+  PARENT_IMPORT_RULE,
+  PARENT_TRIAGE_RULE,
   PORTABLE_REVIEW_SKILLS,
   REVIEW_DELEGATION_REQUIRED_SECTIONS,
   REVIEW_RUN_ID_FORMAT,
@@ -18,6 +25,8 @@ from skill_repo_contracts import (  # noqa: E402
   REVIEW_SESSION_ID_PLACEHOLDER,
   RISK_REGISTER_FINDING_FORMAT,
   RUNTIME_SUPPORTING_FILES,
+  TELEMETRY_OWNERSHIP_HEADING,
+  TRIAGE_OWNERSHIP_HEADING,
   supporting_file_targets,
   skills_requiring_supporting_file,
 )
@@ -65,6 +74,24 @@ def sidecar_paths(file_name: str) -> dict[str, Path]:
   }
 
 
+def markdown_heading_pattern(heading: str) -> re.Pattern[str]:
+  return re.compile(rf"^#{{2,6}} {re.escape(heading)}$", re.MULTILINE)
+
+
+def extract_level_two_section(text: str, heading: str) -> str:
+  match = re.search(
+    rf"(?ms)^## {re.escape(heading)}\n.*?(?=^## |\Z)",
+    text,
+  )
+  if not match:
+    raise AssertionError(f"Missing level-two section '{heading}'")
+  return match.group(0).strip()
+
+
+def read_specialist_contract(skill_name: str) -> str:
+  return (find_skill_dir(skill_name) / "specialist-contract.md").read_text(encoding="utf-8")
+
+
 class FeatureImplementRoutingContractTest(unittest.TestCase):
   def test_shared_router_skills_reference_local_stack_routing_sidecars(self) -> None:
     self.assertIn("[stack-routing.md](stack-routing.md)", CODE_REVIEW)
@@ -101,11 +128,22 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("Prefer more specific scopes in this order: `skill`, `repo`, `global`", REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn("reuse it instead of generating a new one", REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn(RISK_REGISTER_FINDING_FORMAT, REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertRegex(REVIEW_ORCHESTRATOR_PLAYBOOK, markdown_heading_pattern(TELEMETRY_OWNERSHIP_HEADING))
+    self.assertIn("The review layer that owns the final merged review output for the current review lifecycle owns review telemetry.", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn(CHILD_NO_IMPORT_RULE, REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn(CHILD_METADATA_HANDOFF_RULE, REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn(PARENT_IMPORT_RULE, REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertRegex(REVIEW_ORCHESTRATOR_PLAYBOOK, markdown_heading_pattern(TRIAGE_OWNERSHIP_HEADING))
+    self.assertIn(CHILD_NO_TRIAGE_RULE, REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn(PARENT_TRIAGE_RULE, REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn(NO_FINDINGS_TRIAGE_RULE, REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn("The parent review owns only the delegated workers it launched itself.", REVIEW_DELEGATION_PLAYBOOK)
     self.assertIn("Track delegated workers by the ids returned when they are launched.", REVIEW_DELEGATION_PLAYBOOK)
     self.assertIn("the current `review_session_id` and `review_run_id` when they already exist", REVIEW_DELEGATION_PLAYBOOK)
     self.assertIn("any applicable active learnings when they are available", REVIEW_DELEGATION_PLAYBOOK)
     self.assertIn("Do not use `list_agents` to discover delegated workers during normal review execution.", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("Delegated workers must not call those telemetry tools themselves.", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("return structured review output plus telemetry-relevant metadata to the parent", REVIEW_DELEGATION_PLAYBOOK)
     for section in REVIEW_DELEGATION_REQUIRED_SECTIONS:
       self.assertIn(section, REVIEW_DELEGATION_PLAYBOOK)
 
@@ -265,6 +303,14 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       "If delegated review is required for the current scope and the runtime lacks a documented delegation path or cannot start the required worker(s), stop and report that delegated review is required for this scope but unavailable on the current runtime",
       CODE_REVIEW,
     )
+    self.assertRegex(CODE_REVIEW, markdown_heading_pattern(TELEMETRY_OWNERSHIP_HEADING))
+    self.assertIn(PARENT_IMPORT_RULE, CODE_REVIEW)
+    self.assertIn(CHILD_NO_IMPORT_RULE, CODE_REVIEW)
+    self.assertIn(CHILD_METADATA_HANDOFF_RULE, CODE_REVIEW)
+    self.assertRegex(CODE_REVIEW, markdown_heading_pattern(TRIAGE_OWNERSHIP_HEADING))
+    self.assertIn(PARENT_TRIAGE_RULE, CODE_REVIEW)
+    self.assertIn(CHILD_NO_TRIAGE_RULE, CODE_REVIEW)
+    self.assertIn(NO_FINDINGS_TRIAGE_RULE, CODE_REVIEW)
 
   def test_stack_review_skills_define_adaptive_execution_modes(self) -> None:
     forbidden_phrases = (
@@ -295,11 +341,14 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
         )
         self.assertIn(REVIEW_RUN_ID_PLACEHOLDER, skill_text)
         self.assertIn(APPLIED_LEARNINGS_PLACEHOLDER, skill_text)
-        self.assertIn("## Auto-Import", skill_text)
-        self.assertIn("Call the `import_review` MCP tool:", skill_text)
-        self.assertIn("## Auto-Triage", skill_text)
-        self.assertIn("Call the `triage_findings` MCP tool:", skill_text)
-        self.assertIn("Skip auto-triage when the review produced no findings.", skill_text)
+        self.assertRegex(skill_text, markdown_heading_pattern(TELEMETRY_OWNERSHIP_HEADING))
+        self.assertIn(PARENT_IMPORT_RULE, skill_text)
+        self.assertIn(CHILD_NO_IMPORT_RULE, skill_text)
+        self.assertIn(CHILD_METADATA_HANDOFF_RULE, skill_text)
+        self.assertRegex(skill_text, markdown_heading_pattern(TRIAGE_OWNERSHIP_HEADING))
+        self.assertIn(PARENT_TRIAGE_RULE, skill_text)
+        self.assertIn(CHILD_NO_TRIAGE_RULE, skill_text)
+        self.assertIn(NO_FINDINGS_TRIAGE_RULE, skill_text)
         self.assertIn("Execution mode: inline | delegated", skill_text)
         self.assertIn("Use `inline` only", skill_text)
         self.assertIn("If execution mode is `delegated`", skill_text)
@@ -323,6 +372,29 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
       with self.subTest(skill=skill_name):
         self.assertTrue(sidecar_path.is_symlink())
         self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "review-delegation" / "PLAYBOOK.md")
+
+  def test_specialist_contracts_match_orchestrator_subset(self) -> None:
+    expected = "\n\n".join(
+      (
+        extract_level_two_section(REVIEW_ORCHESTRATOR_PLAYBOOK, "Shared Contract For Every Specialist"),
+        extract_level_two_section(REVIEW_ORCHESTRATOR_PLAYBOOK, "Shared Report Structure"),
+      )
+    )
+
+    for skill_name in PORTABLE_REVIEW_SKILL_TEXTS:
+      with self.subTest(skill=skill_name):
+        specialist_text = read_specialist_contract(skill_name)
+        actual = "\n\n".join(
+          (
+            extract_level_two_section(specialist_text, "Shared Contract For Every Specialist"),
+            extract_level_two_section(specialist_text, "Shared Report Structure"),
+          )
+        )
+        self.assertEqual(expected, actual)
+        self.assertNotIn("## Shared Scope Contract", specialist_text)
+        self.assertNotIn("## Shared Execution Mode Contract", specialist_text)
+        self.assertNotIn("## Shared Learnings Context", specialist_text)
+        self.assertNotIn("## Shared Delegation Contract", specialist_text)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -15,12 +15,20 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from skill_repo_contracts import (  # noqa: E402
   APPLIED_LEARNINGS_PLACEHOLDER,
+  CHILD_METADATA_HANDOFF_RULE,
+  CHILD_NO_IMPORT_RULE,
+  CHILD_NO_TRIAGE_RULE,
+  NO_FINDINGS_TRIAGE_RULE,
+  PARENT_IMPORT_RULE,
+  PARENT_TRIAGE_RULE,
   REVIEW_RUN_ID_FORMAT,
   REVIEW_RUN_ID_PLACEHOLDER,
   REVIEW_SESSION_ID_FORMAT,
   REVIEW_SESSION_ID_PLACEHOLDER,
   RISK_REGISTER_FINDING_FORMAT,
   RUNTIME_SUPPORTING_FILES,
+  TELEMETRY_OWNERSHIP_HEADING,
+  TRIAGE_OWNERSHIP_HEADING,
   supporting_file_targets,
 )
 
@@ -194,7 +202,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       self.assertIn("portable review skills must expose", result.stdout)
       self.assertIn("review orchestration contract must expose", result.stdout)
 
-  def test_rejects_portable_review_skill_without_inline_lifecycle_handoff(self) -> None:
+  def test_rejects_portable_review_skill_without_parent_owned_telemetry_handoff(self) -> None:
     with self.fixture_repo(
       [
         ("base", "bill-code-review"),
@@ -208,8 +216,25 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
     ) as repo_root:
       result = self.run_validator(repo_root)
       self.assertEqual(result.returncode, 1, result.stdout)
-      self.assertIn("portable review skills must define the inline auto-import section", result.stdout)
-      self.assertIn("portable review skills must describe the triage_findings lifecycle handoff", result.stdout)
+      self.assertIn("portable review skills must define the telemetry ownership section", result.stdout)
+      self.assertIn("portable review skills must describe the parent-owned triage_findings handoff", result.stdout)
+
+  def test_rejects_portable_review_skill_without_heading_based_telemetry_sections(self) -> None:
+    with self.fixture_repo(
+      [
+        ("base", "bill-code-review"),
+        ("php", "bill-php-code-review"),
+      ],
+      skill_contents={
+        "bill-php-code-review": self.portable_review_fixture_with_plaintext_telemetry_sections(
+          "bill-php-code-review"
+        ),
+      },
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn("portable review skills must define the telemetry ownership section as a markdown heading", result.stdout)
+      self.assertIn("portable review skills must define the triage ownership section as a markdown heading", result.stdout)
 
   def test_rejects_review_orchestrator_without_machine_readable_finding_contract(self) -> None:
     with self.fixture_repo(
@@ -221,6 +246,16 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       self.assertIn("review orchestration contract must expose", result.stdout)
       self.assertIn(REVIEW_SESSION_ID_PLACEHOLDER, result.stdout)
       self.assertIn("review orchestration contract must define machine-readable findings", result.stdout)
+
+  def test_rejects_review_orchestrator_without_heading_based_telemetry_sections(self) -> None:
+    with self.fixture_repo(
+      [("base", "bill-code-review")],
+      review_orchestrator_uses_heading_sections=False,
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn("review orchestration contract must define the telemetry ownership section as a markdown heading", result.stdout)
+      self.assertIn("review orchestration contract must define the triage ownership section as a markdown heading", result.stdout)
 
   def run_validator(self, repo_root: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -238,6 +273,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
     skill_contents: dict[str, str] | None = None,
     review_orchestrator_has_telemetry: bool = True,
     review_orchestrator_has_applied_learnings: bool = True,
+    review_orchestrator_uses_heading_sections: bool = True,
   ):
     with tempfile.TemporaryDirectory() as temp_dir:
       repo_root = Path(temp_dir)
@@ -249,6 +285,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
         repo_root,
         include_telemetry=review_orchestrator_has_telemetry,
         include_applied_learnings=review_orchestrator_has_applied_learnings,
+        use_heading_sections=review_orchestrator_uses_heading_sections,
       )
       self.write_review_delegation_playbook(repo_root)
 
@@ -335,6 +372,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
     *,
     include_telemetry: bool = True,
     include_applied_learnings: bool = True,
+    use_heading_sections: bool = True,
   ) -> None:
     path = repo_root / "orchestration" / "review-orchestrator" / "PLAYBOOK.md"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -358,11 +396,24 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
         + f"Use the review session id format {REVIEW_SESSION_ID_FORMAT}.\n"
         + f"\n{REVIEW_RUN_ID_PLACEHOLDER}\n"
         + f"Use the review run id format {REVIEW_RUN_ID_FORMAT}.\n"
-      )
+    )
     if include_applied_learnings:
       playbook = playbook + f"{APPLIED_LEARNINGS_PLACEHOLDER}\n"
     if include_telemetry:
-      playbook = playbook + f"{RISK_REGISTER_FINDING_FORMAT}\n"
+      telemetry_heading = f"## {TELEMETRY_OWNERSHIP_HEADING}" if use_heading_sections else TELEMETRY_OWNERSHIP_HEADING
+      triage_heading = f"## {TRIAGE_OWNERSHIP_HEADING}" if use_heading_sections else TRIAGE_OWNERSHIP_HEADING
+      playbook = (
+        playbook
+        + f"{RISK_REGISTER_FINDING_FORMAT}\n"
+        + f"{telemetry_heading}\n"
+        + f"{PARENT_IMPORT_RULE}\n"
+        + f"{CHILD_NO_IMPORT_RULE}\n"
+        + f"{CHILD_METADATA_HANDOFF_RULE}\n"
+        + f"{triage_heading}\n"
+        + f"{PARENT_TRIAGE_RULE}\n"
+        + f"{CHILD_NO_TRIAGE_RULE}\n"
+        + f"{NO_FINDINGS_TRIAGE_RULE}\n"
+      )
     path.write_text(playbook, encoding="utf-8")
 
   def write_review_delegation_playbook(self, repo_root: Path) -> None:
@@ -474,18 +525,21 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       {REVIEW_SESSION_ID_PLACEHOLDER}
       {REVIEW_RUN_ID_PLACEHOLDER}
       {APPLIED_LEARNINGS_PLACEHOLDER}
-      ## Auto-Import
+      ## Telemetry Ownership
 
-      Call the `import_review` MCP tool:
+      {CHILD_NO_IMPORT_RULE}
+      {CHILD_METADATA_HANDOFF_RULE}
+      {PARENT_IMPORT_RULE}
       - `review_text`: the complete review output (Section 1 through Section 4)
 
-      ## Auto-Triage
+      ## Triage Ownership
 
-      Call the `triage_findings` MCP tool:
+      {CHILD_NO_TRIAGE_RULE} the parent review owns triage handoff and telemetry completion.
+      {PARENT_TRIAGE_RULE}
       - `review_run_id`: the review run ID from the review output
       - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 
-      Skip auto-triage when the review produced no findings.
+      {NO_FINDINGS_TRIAGE_RULE}
       | Signal | Agent to spawn |
       | --- | --- |
       | fixture | `bill-php-code-review-security` |
@@ -532,18 +586,21 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       {APPLIED_LEARNINGS_PLACEHOLDER}
       [review-orchestrator.md](review-orchestrator.md)
       [review-delegation.md](review-delegation.md)
-      ## Auto-Import
+      ## Telemetry Ownership
 
-      Call the `import_review` MCP tool:
+      {CHILD_NO_IMPORT_RULE}
+      {CHILD_METADATA_HANDOFF_RULE}
+      {PARENT_IMPORT_RULE}
       - `review_text`: the complete review output (Section 1 through Section 4)
 
-      ## Auto-Triage
+      ## Triage Ownership
 
-      Call the `triage_findings` MCP tool:
+      {CHILD_NO_TRIAGE_RULE} the parent review owns triage handoff and telemetry completion.
+      {PARENT_TRIAGE_RULE}
       - `review_run_id`: the review run ID from the review output
       - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 
-      Skip auto-triage when the review produced no findings.
+      {NO_FINDINGS_TRIAGE_RULE}
       Specialist review fixture content.
       """
     )
@@ -588,18 +645,21 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       {REVIEW_RUN_ID_PLACEHOLDER}
       [review-orchestrator.md](review-orchestrator.md)
       [review-delegation.md](review-delegation.md)
-      ## Auto-Import
+      ## Telemetry Ownership
 
-      Call the `import_review` MCP tool:
+      {CHILD_NO_IMPORT_RULE}
+      {CHILD_METADATA_HANDOFF_RULE}
+      {PARENT_IMPORT_RULE}
       - `review_text`: the complete review output (Section 1 through Section 4)
 
-      ## Auto-Triage
+      ## Triage Ownership
 
-      Call the `triage_findings` MCP tool:
+      {CHILD_NO_TRIAGE_RULE} the parent review owns triage handoff and telemetry completion.
+      {PARENT_TRIAGE_RULE}
       - `review_run_id`: the review run ID from the review output
       - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
 
-      Skip auto-triage when the review produced no findings.
+      {NO_FINDINGS_TRIAGE_RULE}
       Specialist review fixture content.
       """
     )
@@ -609,7 +669,7 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       f"""\
       ---
       name: {skill_name}
-      description: Fixture review skill missing inline lifecycle handoff.
+      description: Fixture review skill missing parent-owned telemetry handoff.
       ---
 
       # {skill_name}
@@ -623,6 +683,44 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       {APPLIED_LEARNINGS_PLACEHOLDER}
       [review-orchestrator.md](review-orchestrator.md)
       [review-delegation.md](review-delegation.md)
+      Specialist review fixture content.
+      """
+    )
+
+  def portable_review_fixture_with_plaintext_telemetry_sections(self, skill_name: str) -> str:
+    return textwrap.dedent(
+      f"""\
+      ---
+      name: {skill_name}
+      description: Fixture review skill with plain-text telemetry labels instead of markdown headings.
+      ---
+
+      # {skill_name}
+
+      ## Project Overrides
+
+      If `.agents/skill-overrides.md` exists in the project root and contains a `## {skill_name}` section, read that section and apply it as the highest-priority instruction for this skill.
+
+      {REVIEW_SESSION_ID_PLACEHOLDER}
+      {REVIEW_RUN_ID_PLACEHOLDER}
+      {APPLIED_LEARNINGS_PLACEHOLDER}
+      [review-orchestrator.md](review-orchestrator.md)
+      [review-delegation.md](review-delegation.md)
+      {TELEMETRY_OWNERSHIP_HEADING}
+
+      {CHILD_NO_IMPORT_RULE}
+      {CHILD_METADATA_HANDOFF_RULE}
+      {PARENT_IMPORT_RULE}
+      - `review_text`: the complete review output (Section 1 through Section 4)
+
+      {TRIAGE_OWNERSHIP_HEADING}
+
+      {CHILD_NO_TRIAGE_RULE} the parent review owns triage handoff and telemetry completion.
+      {PARENT_TRIAGE_RULE}
+      - `review_run_id`: the review run ID from the review output
+      - `decisions`: prefer a single structured selection string that fully resolves the review, e.g. `["fix=[1,3] reject=[2]"]`
+
+      {NO_FINDINGS_TRIAGE_RULE}
       Specialist review fixture content.
       """
     )


### PR DESCRIPTION
## Summary

- Replaces the unconditional "Auto-Import" / "Auto-Triage" telemetry pattern with a parent/child ownership model — only the parent review layer that owns the final merged output calls `import_review` and `triage_findings`; delegated children return metadata to the parent instead
- Renames sections to "Telemetry Ownership" / "Triage Ownership" across all 7 review SKILL.md files, both orchestration PLAYBOOKs, specialist contracts, docs, validator, and tests
- Adds 6 validated contract constants and extends test coverage to the base router (`bill-code-review`)

## Test plan

- [x] All 127 tests pass (`python3 -m unittest discover -s tests`)
- [x] Agent-config validator passes
- [x] All specialist-contract.md files are byte-identical across packages
- [x] No stale "Auto-Import" / "Auto-Triage" references remain