### PR TITLE
fix: pin test telemetry to loopback so test runs cannot pollute prod (#43)

### DIFF
--- a/tests/test_feature_implement_telemetry.py
+++ b/tests/test_feature_implement_telemetry.py
@@ -72,6 +72,10 @@ class FeatureImplementEnabledTest(unittest.TestCase):
       "SKILL_BILL_CONFIG_PATH": self.config_path,
       "SKILL_BILL_TELEMETRY_ENABLED": "true",
       "SKILL_BILL_INSTALL_ID": "test-install-id",
+      # Defensive: pin the relay URL to an unreachable loopback so any
+      # accidental telemetry sync during tests cannot ship events to the
+      # production PostHog project (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)
@@ -322,6 +326,9 @@ class FeatureImplementDisabledTest(unittest.TestCase):
       "SKILL_BILL_REVIEW_DB": os.path.join(self.temp_dir, "metrics.db"),
       "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
       "SKILL_BILL_TELEMETRY_ENABLED": "false",
+      # Belt-and-braces: even when telemetry is off in this fixture, pin the
+      # relay URL so an accidental enable can never ship to prod (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)

--- a/tests/test_feature_verify_telemetry.py
+++ b/tests/test_feature_verify_telemetry.py
@@ -52,6 +52,10 @@ class FeatureVerifyEnabledTest(unittest.TestCase):
       "SKILL_BILL_CONFIG_PATH": self.config_path,
       "SKILL_BILL_TELEMETRY_ENABLED": "true",
       "SKILL_BILL_INSTALL_ID": "test-install-id",
+      # Defensive: pin the relay URL to an unreachable loopback so any
+      # accidental telemetry sync during tests cannot ship events to the
+      # production PostHog project (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)
@@ -171,6 +175,9 @@ class FeatureVerifyDisabledTest(unittest.TestCase):
       "SKILL_BILL_REVIEW_DB": os.path.join(self.temp_dir, "metrics.db"),
       "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
       "SKILL_BILL_TELEMETRY_ENABLED": "false",
+      # Belt-and-braces: even when telemetry is off in this fixture, pin the
+      # relay URL so an accidental enable can never ship to prod (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -54,6 +54,10 @@ class McpServerEnabledTest(unittest.TestCase):
       "SKILL_BILL_CONFIG_PATH": self.config_path,
       "SKILL_BILL_TELEMETRY_ENABLED": "true",
       "SKILL_BILL_INSTALL_ID": "test-install-id",
+      # Defensive: pin the relay URL to an unreachable loopback so any
+      # accidental telemetry sync during tests cannot ship events to the
+      # production PostHog project (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)
@@ -166,6 +170,9 @@ class McpServerDisabledTest(unittest.TestCase):
       "SKILL_BILL_REVIEW_DB": os.path.join(self.temp_dir, "metrics.db"),
       "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
       "SKILL_BILL_TELEMETRY_ENABLED": "false",
+      # Belt-and-braces: even when telemetry is off in this fixture, pin the
+      # relay URL so an accidental enable can never ship to prod (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)

--- a/tests/test_mcp_stdio.py
+++ b/tests/test_mcp_stdio.py
@@ -58,6 +58,9 @@ class McpStdioTest(unittest.TestCase):
       "SKILL_BILL_REVIEW_DB": os.path.join(self.temp_dir, "metrics.db"),
       "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
       "SKILL_BILL_TELEMETRY_ENABLED": "false",
+      # Belt-and-braces: even when telemetry is off in this fixture, pin the
+      # relay URL so an accidental enable can never ship to prod (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     })
 
   def tearDown(self) -> None:

--- a/tests/test_pr_description_telemetry.py
+++ b/tests/test_pr_description_telemetry.py
@@ -43,6 +43,10 @@ class PrDescriptionEnabledTest(unittest.TestCase):
       "SKILL_BILL_CONFIG_PATH": self.config_path,
       "SKILL_BILL_TELEMETRY_ENABLED": "true",
       "SKILL_BILL_INSTALL_ID": "test-install-id",
+      # Defensive: pin the relay URL to an unreachable loopback so any
+      # accidental telemetry sync during tests cannot ship events to the
+      # production PostHog project (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)
@@ -139,6 +143,9 @@ class PrDescriptionDisabledTest(unittest.TestCase):
       "SKILL_BILL_REVIEW_DB": os.path.join(self.temp_dir, "metrics.db"),
       "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
       "SKILL_BILL_TELEMETRY_ENABLED": "false",
+      # Belt-and-braces: even when telemetry is off in this fixture, pin the
+      # relay URL so an accidental enable can never ship to prod (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)

--- a/tests/test_quality_check_telemetry.py
+++ b/tests/test_quality_check_telemetry.py
@@ -58,6 +58,10 @@ class QualityCheckEnabledTest(unittest.TestCase):
       "SKILL_BILL_CONFIG_PATH": self.config_path,
       "SKILL_BILL_TELEMETRY_ENABLED": "true",
       "SKILL_BILL_INSTALL_ID": "test-install-id",
+      # Defensive: pin the relay URL to an unreachable loopback so any
+      # accidental telemetry sync during tests cannot ship events to the
+      # production PostHog project (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)
@@ -214,6 +218,9 @@ class QualityCheckDisabledTest(unittest.TestCase):
       "SKILL_BILL_REVIEW_DB": os.path.join(self.temp_dir, "metrics.db"),
       "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
       "SKILL_BILL_TELEMETRY_ENABLED": "false",
+      # Belt-and-braces: even when telemetry is off in this fixture, pin the
+      # relay URL so an accidental enable can never ship to prod (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)

--- a/tests/test_review_metrics.py
+++ b/tests/test_review_metrics.py
@@ -2003,6 +2003,10 @@ class ReviewOrchestratedRetrofitTest(unittest.TestCase):
       "SKILL_BILL_CONFIG_PATH": self.config_path,
       "SKILL_BILL_TELEMETRY_ENABLED": "true",
       "SKILL_BILL_INSTALL_ID": "test-install-id",
+      # Defensive: pin the relay URL to an unreachable loopback so any
+      # accidental telemetry sync during tests cannot ship events to the
+      # production PostHog project (#43).
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
     }
     for key, value in env_overrides.items():
       self._original_env[key] = os.environ.get(key)

--- a/tests/test_telemetry_network_isolation.py
+++ b/tests/test_telemetry_network_isolation.py
@@ -1,0 +1,133 @@
+"""Regression coverage for #43: test runs must never reach the production relay.
+
+`auto_sync_telemetry` flushes pending outbox rows on every `open_db` close. If a
+telemetry-enabled test fixture leaves `SKILL_BILL_TELEMETRY_PROXY_URL` unset,
+the sync falls back to `DEFAULT_TELEMETRY_PROXY_URL` and ships synthetic test
+events into PostHog, polluting funnels under `distinct_id=test-install-id`.
+
+This test installs a network sentinel that records every `urlopen` attempt and
+asserts:
+  1. The configured proxy URL never resolves to the hosted relay host.
+  2. Any HTTP attempt that does fire targets the loopback address — never an
+     external host.
+
+It exercises the same code path the issue described: telemetry enabled, no
+custom proxy URL set in config, then `open_db` closes and triggers auto sync.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from skill_bill import sync as sync_module
+from skill_bill.constants import DEFAULT_TELEMETRY_PROXY_URL
+from skill_bill.mcp_server import feature_implement_started
+
+
+STARTED_PARAMS = {
+  "feature_size": "SMALL",
+  "acceptance_criteria_count": 2,
+  "open_questions_count": 0,
+  "spec_input_types": ["markdown_file"],
+  "spec_word_count": 200,
+  "rollout_needed": False,
+  "feature_name": "isolation-test",
+  "issue_key": "",
+  "issue_key_type": "none",
+  "spec_summary": "Network isolation regression",
+}
+
+
+class TelemetryNetworkIsolationTest(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir = tempfile.mkdtemp()
+    self.db_path = os.path.join(self.temp_dir, "metrics.db")
+    self.config_path = os.path.join(self.temp_dir, "config.json")
+    # Intentionally leave proxy_url empty in the config — we want to prove the
+    # env override is what keeps the sync off the production host even when the
+    # config itself does not steer us away from it.
+    Path(self.config_path).write_text(
+      json.dumps({
+        "install_id": "test-install-id",
+        "telemetry": {"level": "anonymous", "proxy_url": "", "batch_size": 50},
+      }),
+      encoding="utf-8",
+    )
+    self._original_env: dict[str, str | None] = {}
+    env_overrides = {
+      "SKILL_BILL_REVIEW_DB": self.db_path,
+      "SKILL_BILL_CONFIG_PATH": self.config_path,
+      "SKILL_BILL_TELEMETRY_ENABLED": "true",
+      "SKILL_BILL_INSTALL_ID": "test-install-id",
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
+    }
+    for key, value in env_overrides.items():
+      self._original_env[key] = os.environ.get(key)
+      os.environ[key] = value
+
+    self._urlopen_calls: list[str] = []
+    self._original_urlopen = urllib.request.urlopen
+    self._original_sync_urlopen = sync_module.urllib.request.urlopen
+
+    def sentinel_urlopen(request, *args, **kwargs):
+      url = request.full_url if hasattr(request, "full_url") else str(request)
+      self._urlopen_calls.append(url)
+      # Simulate connection refused so auto_sync_telemetry's exception handler
+      # marks the rows as failed instead of hanging on a real socket.
+      raise urllib.error.URLError("blocked by network isolation sentinel")
+
+    urllib.request.urlopen = sentinel_urlopen
+    sync_module.urllib.request.urlopen = sentinel_urlopen
+
+  def tearDown(self) -> None:
+    urllib.request.urlopen = self._original_urlopen
+    sync_module.urllib.request.urlopen = self._original_sync_urlopen
+    for key, value in self._original_env.items():
+      if value is None:
+        os.environ.pop(key, None)
+      else:
+        os.environ[key] = value
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def test_sync_target_is_loopback_not_hosted_relay(self) -> None:
+    # Trigger the same lifecycle production tools follow: emit an event, then
+    # let auto sync attempt to flush the outbox.
+    feature_implement_started(**STARTED_PARAMS)
+    sync_module.auto_sync_telemetry(Path(self.db_path))
+
+    self.assertGreater(
+      len(self._urlopen_calls),
+      0,
+      "Expected the auto-sync path to attempt at least one HTTP request so "
+      "the sentinel could observe it. If this fires, the sync codepath has "
+      "moved and this regression test needs to follow.",
+    )
+    hosted_host = urlsplit(DEFAULT_TELEMETRY_PROXY_URL).hostname
+    for url in self._urlopen_calls:
+      host = urlsplit(url).hostname
+      self.assertNotEqual(
+        host,
+        hosted_host,
+        f"Test telemetry attempted outbound HTTP to the production relay: {url}",
+      )
+      self.assertIn(
+        host,
+        ("127.0.0.1", "localhost", "::1"),
+        f"Test telemetry attempted outbound HTTP to a non-loopback host: {url}",
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary

Closes #43.

Telemetry-enabled test fixtures left `SKILL_BILL_TELEMETRY_PROXY_URL` unset, so `auto_sync_telemetry` fell back to the default hosted relay on every `open_db` close. Local `python -m unittest` runs were shipping ~2k synthetic events per week into the EU PostHog project under `distinct_id=test-install-id`, polluting funnels and collapsing every contributor's runs onto a single fake user.

This implements **Option 1 (network isolation)** from the issue — the cheapest, most defensive fix. Every telemetry test setUp now pins `SKILL_BILL_TELEMETRY_PROXY_URL` to `http://127.0.0.1:0`. The env override wins inside `load_telemetry_settings`, so even when `SKILL_BILL_TELEMETRY_ENABLED=true` and the config fixture's `proxy_url` is empty, sync targets a guaranteed-unreachable loopback URL and the events stay in the local outbox marked as failed.

A new regression test `tests/test_telemetry_network_isolation.py` sentinels `urllib.request.urlopen` in the sync codepath and asserts that auto-sync only ever attempts loopback hosts — never the production hosted relay. Sanity-checked: removing the env override reproduces the bug (sync hits `https://skill-bill-telemetry-proxy.skillbill.workers.dev`) and the regression test catches it.

The historical `test-install-id` pollution was bulk-deleted from the EU PostHog project as part of validating this fix.

## Files touched

- `tests/test_feature_implement_telemetry.py` (Enabled + Disabled fixtures)
- `tests/test_quality_check_telemetry.py` (Enabled + Disabled fixtures)
- `tests/test_pr_description_telemetry.py` (Enabled + Disabled fixtures)
- `tests/test_feature_verify_telemetry.py` (Enabled + Disabled fixtures)
- `tests/test_review_metrics.py` (`ReviewOrchestratedRetrofitTest`)
- `tests/test_mcp_server.py` (Enabled + Disabled fixtures)
- `tests/test_mcp_stdio.py` (belt-and-braces)
- `tests/test_telemetry_network_isolation.py` (new regression test)

## Test plan

- [x] `python3 -m unittest discover -s tests` — 159 tests pass
- [x] `npx --yes agnix --strict .` — 0 errors, 0 warnings
- [x] `python3 scripts/validate_agent_configs.py` — passed
- [x] Verified post-fix: ran the full suite, queried PostHog EU for `skillbill_*` events from `distinct_id=test-install-id` in the test window — **0 events**
- [x] Verified the regression test catches the original bug (without the env override, sync attempts `skill-bill-telemetry-proxy.skillbill.workers.dev`)