### PR TITLE
chore: clarify orchestration role + smoke test + platform tiers + teams guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,10 @@
 # AGENTS.md
 
-This file is the project-wide guidance for AI agents working in this repository.
+## Project context
 
-## Purpose
-
-Treat this repo as governed skill infrastructure, not a loose prompt collection.
-
-The goal is to keep the skill suite:
-
-- focused
-- composable
-- portable across agents
-- safe to extend without naming drift or structural entropy
+skill-bill is a governed suite of AI-agent skills for code review, quality checking, feature implementation, feature verification, and PR description generation. It ships with a local-first SQLite telemetry CLI, an MCP server, and multi-agent installation (Claude Code, Copilot, Codex, OpenCode, GLM). Supported stacks: KMP, backend-Kotlin, Kotlin, PHP, Go, and agent-config.
 
 ## Core taxonomy
-
-The repository uses a strict governed model:
 
 - `skills/base/` — canonical, user-facing capabilities
 - `skills/<platform>/` — platform-specific overrides and approved platform-owned subskills
@@ -24,117 +13,41 @@ The repository uses a strict governed model:
 
 ## Naming rules
 
-### Base skills
-
-Base skills are flexible, but they must stay neutral:
-
-- allowed shape: `bill-<capability>`
-- examples: `bill-code-review`, `bill-quality-check`, `bill-feature-implement`
-
-### Platform skills
-
-Platform skills are strict:
-
-- override shape: `bill-<platform>-<base-capability>`
-- approved deeper specialization shape: `bill-<platform>-code-review-<area>`
-
-Use only these two platform naming patterns unless the taxonomy itself is intentionally expanded.
-
-### Approved `code-review` areas
-
-- `architecture`
-- `performance`
-- `platform-correctness`
-- `security`
-- `testing`
-- `api-contracts`
-- `persistence`
-- `reliability`
-- `ui`
-- `ux-accessibility`
+- Base skills: `bill-<capability>` (e.g. `bill-code-review`, `bill-feature-implement`)
+- Platform overrides: `bill-<platform>-<base-capability>`
+- Platform code-review specializations: `bill-<platform>-code-review-<area>`
+- Approved areas: `architecture`, `performance`, `platform-correctness`, `security`, `testing`, `api-contracts`, `persistence`, `reliability`, `ui`, `ux-accessibility`
 
 ## Governed add-ons
 
 - Add-ons are stack-owned supporting assets, not standalone skills.
-- Store add-ons only under `skills/<platform>/addons/`.
-- Keep add-on files flat inside `addons/`; do not create nested add-on directories.
-- Use lowercase kebab-case file names in one of these forms:
-  - `<addon-slug>.md`
-  - `<addon-slug>-<area>.md`
-- Conventional area names such as `implementation` and `review` are allowed when they are the governed add-on facets.
-- The shared `<addon-slug>` identifies one governed add-on. Area-scoped files refine that add-on only when materially needed.
-- Add-ons do not create new packages, slash commands, or install targets by default.
-- Resolve add-ons only after dominant-stack routing chooses the owning platform. Keep add-on detection owned by that platform and keep add-ons out of top-level stack classification.
-- Runtime-facing skills may consume governed add-ons only through sibling supporting files inside the consuming skill directory; do not rely on repo-relative runtime paths.
-- When an add-on is selected, report it explicitly in routing or review output using `Selected add-ons: ...`.
-- Every add-on change ships with validator coverage for accepted and rejected paths plus routing-contract coverage for detection/reporting behavior.
+- Store only under `skills/<platform>/addons/`, flat (no nested directories).
+- File names: `<addon-slug>.md` or `<addon-slug>-<area>.md` (lowercase kebab-case).
+- Resolve add-ons only after dominant-stack routing selects the owning platform.
+- Runtime skills consume add-ons only through sibling supporting files, not repo-relative paths.
+- Report selected add-ons explicitly using `Selected add-ons: ...`.
+- Every add-on change ships with validator and routing-contract test coverage.
 
 ## Non-negotiable rules
 
 - Add platform capabilities only as base-capability overrides or approved `code-review-<area>` specializations.
 - Add a new package only when behavior is materially different from existing packages.
-- Keep add-ons stack-owned under `skills/<platform>/addons/`; do not promote them to top-level packages.
-- Runtime-facing skills may reference sibling supporting files inside the same skill directory.
-- Use sibling supporting files for runtime-shared routing, review, delegation, and telemetry contracts instead of repo-relative or install-root-relative playbook paths.
-- Use sibling supporting-file links for governed add-on assets too; do not wire runtime add-on reads directly to repo-relative paths.
-- Keep `orchestration/` contracts aligned with the sibling supporting-file links when shared routing, review, delegation, or telemetry behavior changes.
-- Preserve stable base entry points even when a platform needs more depth behind the router.
-- Keep dominant-stack routing primary. Apply governed add-ons only after stack routing settles on the owning package.
-- Keep README.md (user-facing only, do not read for agent context) skill counts and catalog entries accurate whenever skills change.
+- Keep add-ons stack-owned under `skills/<platform>/addons/`; do not promote to top-level packages.
+- Use sibling supporting files for runtime-shared contracts instead of repo-relative paths.
+- Keep `orchestration/` contracts aligned with sibling supporting-file links.
+- Keep dominant-stack routing primary. Apply governed add-ons only after stack routing settles.
+- Keep README.md (user-facing only, do not read for agent context) skill counts and catalog entries accurate.
 - Update `install.sh` migration rules in the same change when renaming stack-bound skills.
 
-## Adding a new platform or language
+## Adding a new platform
 
-Only add a new platform package when there is real platform-specific behavior, heuristics, or tooling that cannot be expressed cleanly with existing packages.
+Only add a new platform package when there is real platform-specific behavior that cannot be expressed with existing packages. Before adding: confirm distinct review/validation behavior is needed, skills are true overrides of base capabilities, and the routing taxonomy recognizes the new platform.
 
-### Platform decision checklist
-
-Before adding a new package, confirm:
-
-1. the platform needs distinct review or validation behavior
-2. the new skills are true overrides of existing base capabilities, not random new commands
-3. the routing taxonomy recognizes the new platform as a first-class package
-
-### Platform implementation checklist
-
-When adding a new platform or language package:
-
-1. Add the package under `skills/<platform>/`.
-2. Keep names in one of the allowed platform forms:
-   - `bill-<platform>-<base-capability>`
-   - `bill-<platform>-code-review-<approved-area>`
-3. Update `scripts/validate_agent_configs.py`:
-   - `ALLOWED_PACKAGES`
-   - any package-specific validation logic
-   - any tests or assumptions tied to current package names
-4. Update shared contracts when routing, review, or telemetry behavior changes:
-   - `orchestration/stack-routing/PLAYBOOK.md`
-   - `orchestration/review-orchestrator/PLAYBOOK.md`
-   - `orchestration/review-delegation/PLAYBOOK.md`
-   - `orchestration/telemetry-contract/PLAYBOOK.md`
-5. Update base routers if needed:
-   - `skills/base/bill-code-review/SKILL.md`
-   - `skills/base/bill-quality-check/SKILL.md`
-6. Add or update platform overrides, not duplicate base workflows unnecessarily.
-7. If the platform needs governed add-ons, place them under `skills/<platform>/addons/`, keep names flat, and update validator/routing/reporting coverage in the same change.
-8. Update `README.md` (user-facing only, do not read for agent context):
-   - project description if platform support meaningfully changes the pitch
-   - current platform list
-   - skill catalog
-   - naming/enforcement explanation if the allowed shapes changed
-9. Update `install.sh` if a rename or migration path is involved.
-10. Add tests:
-   - validator e2e coverage for accepted and rejected names
-   - routing contract coverage when routing behavior changes
-11. Run validation before finishing.
+When adding: place under `skills/<platform>/`, use allowed naming forms, update `scripts/validate_agent_configs.py` (ALLOWED_PACKAGES + validation logic), update orchestration contracts (stack-routing, review-orchestrator, review-delegation, telemetry-contract), update base routers if needed, update README.md catalog, update `install.sh` if renaming, and add tests (validator e2e + routing contract coverage). Run validation before finishing.
 
 ## Quality-check guidance
 
-Prefer routing through `bill-quality-check` from shared workflows.
-
-If a new platform does not yet need a dedicated quality-check implementation, it may temporarily fall back to an existing implementation, but that fallback should be explicit in router docs and easy to remove later.
-
-If a platform-specific checker does not exist yet, document the fallback explicitly instead of implying dedicated coverage exists.
+Prefer routing through `bill-quality-check`. If a platform-specific checker does not exist yet, document the fallback explicitly instead of implying dedicated coverage exists.
 
 ## Preferred design bias
 
@@ -146,18 +59,8 @@ If a platform-specific checker does not exist yet, document the fallback explici
 
 ## Validation commands
 
-Run these after taxonomy, docs, routing, or skill changes:
-
 ```bash
-python3 -m unittest discover -s tests
+.venv/bin/python3 -m unittest discover -s tests
 npx --yes agnix --strict .
-python3 scripts/validate_agent_configs.py
+.venv/bin/python3 scripts/validate_agent_configs.py
 ```
-
-## Practical example
-
-The PHP package follows this shape:
-
-- base-facing override names such as `bill-php-code-review` or `bill-php-quality-check`
-- optional approved code-review subskills such as `bill-php-code-review-security`
-- no names like `bill-php-laravel-code-review` unless the naming rules themselves are intentionally changed and validated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ The repository uses a strict governed model:
 - `skills/base/` — canonical, user-facing capabilities
 - `skills/<platform>/` — platform-specific overrides and approved platform-owned subskills
 - `skills/<platform>/addons/` — governed stack-owned add-on assets that apply only after stack routing
-- `orchestration/` — maintainer-facing reference snapshots for shared routing, review, delegation, and telemetry contracts; not a runtime dependency for installed skills
+- `orchestration/` — single source of truth for shared routing, review, delegation, and telemetry contracts; skills consume these via sibling symlinks, so edits here change runtime behavior for every linked skill
 
 ## Naming rules
 
@@ -77,7 +77,7 @@ Use only these two platform naming patterns unless the taxonomy itself is intent
 - Runtime-facing skills may reference sibling supporting files inside the same skill directory.
 - Use sibling supporting files for runtime-shared routing, review, delegation, and telemetry contracts instead of repo-relative or install-root-relative playbook paths.
 - Use sibling supporting-file links for governed add-on assets too; do not wire runtime add-on reads directly to repo-relative paths.
-- Keep `orchestration/` snapshots aligned with the sibling supporting-file contracts when shared routing, review, delegation, or telemetry behavior changes.
+- Keep `orchestration/` contracts aligned with the sibling supporting-file links when shared routing, review, delegation, or telemetry behavior changes.
 - Preserve stable base entry points even when a platform needs more depth behind the router.
 - Keep dominant-stack routing primary. Apply governed add-ons only after stack routing settles on the owning package.
 - Keep README.md (user-facing only, do not read for agent context) skill counts and catalog entries accurate whenever skills change.
@@ -107,7 +107,7 @@ When adding a new platform or language package:
    - `ALLOWED_PACKAGES`
    - any package-specific validation logic
    - any tests or assumptions tied to current package names
-4. Update maintainer reference snapshots when shared routing, review, or telemetry behavior changes:
+4. Update shared contracts when routing, review, or telemetry behavior changes:
    - `orchestration/stack-routing/PLAYBOOK.md`
    - `orchestration/review-orchestrator/PLAYBOOK.md`
    - `orchestration/review-delegation/PLAYBOOK.md`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Treat your AI skills like software — with stable interfaces, platform override
 
 sKill Bill is a portable collection of 48 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Platform depth varies — see [platform coverage tiers](#platform-coverage-tiers) for what each stack gets today.
 
+Rolling out to a team? Start with [Getting Started for Teams](docs/getting-started-for-teams.md) — it covers customization, expectations, and when to trust vs verify review output.
+
 ## Why this exists
 
 Most prompt or skill repos degrade over time:

--- a/README.md
+++ b/README.md
@@ -300,13 +300,13 @@ The repo is organized around a strict three-layer model:
 
 - `skills/base/` — canonical, user-facing capabilities such as `bill-code-review`, `bill-quality-check`, and `bill-feature-implement`
 - `skills/<platform>/` — platform-specific overrides and approved subskills
-- `orchestration/` — maintainer-facing reference snapshots for shared routing, review, and delegation contracts
+- `orchestration/` — single source of truth for shared routing, review, delegation, and telemetry contracts
 
 Think of it as markdown with inheritance:
 
 - base skills define the stable contracts
 - platform skills specialize them
-- orchestration snapshots document the shared routing, review, delegation, and telemetry logic that runtime-facing skills can reference via sibling supporting files in the same skill directory
+- orchestration files are the canonical shared contracts for routing, review, delegation, and telemetry; skills link to them via sibling symlinks, so changes propagate to every linked skill immediately
 
 ### Fast mental model
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Treat your AI skills like software — with stable interfaces, platform overrides, and validation that prevents the repo from rotting.
 
-sKill Bill is a portable collection of 48 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Currently strongest for Kotlin, Android/KMP, Kotlin backend/server, PHP backends, Go backends/services, and governed skill/agent-config repositories.
+sKill Bill is a portable collection of 48 AI skills for code review, feature implementation, and developer tooling. One repo, synced to every supported agent. Platform depth varies — see [platform coverage tiers](#platform-coverage-tiers) for what each stack gets today.
 
 ## Why this exists
 
@@ -120,6 +120,24 @@ Base entry points stay stable for users:
 - `/bill-code-review` routes to `bill-agent-config-code-review` | `bill-kotlin-code-review` | `bill-backend-kotlin-code-review` | `bill-kmp-code-review` | `bill-php-code-review` | `bill-go-code-review`
 - `/bill-quality-check` routes to the matching stack-specific quality checker
 - `/bill-feature-implement` orchestrates the full workflow
+
+## Platform coverage tiers
+
+Not all platforms are at the same depth. The table below shows what each stack gets today so you know what to expect — and where to contribute.
+
+| Tier | Platforms | What you get | Skill count |
+|------|-----------|-------------|-------------|
+| **Deep** | Kotlin, KMP | Multi-layer specialist routing (KMP → Kotlin baseline), 12 governed Android add-ons (Compose, navigation, interop, design-system, R8), inline/delegated execution modes, quality-check | 10 skills + 12 add-ons |
+| **Deep** | Backend-Kotlin | Layers 3 backend-specific specialists (api-contracts, persistence, reliability) on the Kotlin baseline | 4 skills (+ Kotlin baseline) |
+| **Solid** | PHP, Go | Full code-review orchestrator with 8 specialist areas each, quality-check, no governed add-ons or framework-specific depth | 10 skills each |
+| **Meta** | Agent-config | Self-referential: reviews and validates this skill repo itself | 2 skills |
+
+**What "Deep" means vs "Solid":**
+
+- Deep platforms have multi-layer routing, governed add-ons for framework-specific guidance, and specialist areas that compose across packages.
+- Solid platforms have a full specialist roster but no governed add-ons or multi-layer routing. PHP and Go each cover 8 code-review areas — the gap is framework-specific depth (e.g., no Laravel add-ons for PHP, no Chi/Gin add-ons for Go).
+
+The PHP/Go gap is a visible backlog item, not a missing feature. Governed add-ons can be added under `skills/php/addons/` or `skills/go/addons/` when framework-specific guidance is needed.
 
 ## Review telemetry
 
@@ -326,12 +344,12 @@ That last file is the canonical map for:
 
 Current platform packages:
 
-- `agent-config`
-- `kotlin`
-- `backend-kotlin`
-- `kmp`
-- `php`
-- `go`
+- `kotlin` — Deep (7 skills, baseline for KMP and backend-kotlin)
+- `kmp` — Deep (3 skills + 12 governed add-ons, layers on kotlin)
+- `backend-kotlin` — Deep (4 skills, layers on kotlin)
+- `php` — Solid (10 skills, no add-ons)
+- `go` — Solid (10 skills, no add-ons)
+- `agent-config` — Meta (2 skills)
 
 ### Naming and enforcement
 
@@ -364,9 +382,9 @@ This repo validates both content quality and taxonomy rules.
 Local checks:
 
 ```bash
-python3 -m unittest discover -s tests
+.venv/bin/python3 -m unittest discover -s tests
 npx --yes agnix --strict .
-python3 scripts/validate_agent_configs.py
+.venv/bin/python3 scripts/validate_agent_configs.py
 ```
 
 CI runs the same checks.

--- a/docs/getting-started-for-teams.md
+++ b/docs/getting-started-for-teams.md
@@ -1,0 +1,157 @@
+# Getting Started for Teams
+
+A practical guide for teams evaluating or rolling out Skill Bill. For install mechanics and the full skill catalog, see the [README](../README.md).
+
+## Who this is for
+
+Engineers and tech leads deciding whether to adopt Skill Bill on a team. It focuses on **what to expect**, **how to customize**, and **when to trust the output** — the parts that matter once install is done.
+
+## Install in one minute
+
+Follow the [Installation section of README.md](../README.md#installation). The short version:
+
+1. Clone the repo somewhere stable (e.g. `~/Development/skill-bill`).
+2. Run `./install.sh`.
+3. Select your agents (Claude Code / Copilot / Codex / OpenCode / GLM).
+4. Select your platform packages — check the [platform coverage tiers](../README.md#platform-coverage-tiers) first so you know what each stack actually gets.
+
+Installed skills are symlinks back to the repo, so `git pull` updates everything without re-running install.
+
+## The three commands that matter
+
+99% of daily use comes down to three base commands. They auto-detect your stack and route to the specialist skills.
+
+| Command | Use it when | Expected output |
+|---------|-------------|-----------------|
+| `/bill-code-review` | Reviewing staged changes, a PR, or a commit range | Structured report: Summary, Risk Register, Action Items, Verdict |
+| `/bill-feature-implement` | Building a feature end-to-end from a design doc | Branch + atomic commits + review + quality-check + PR description |
+| `/bill-quality-check` | Verifying lint/tests/format before opening a PR | Pass/fail report per check, with fixes applied where possible |
+
+Everything else (`bill-feature-verify`, `bill-pr-description`, `bill-grill-plan`, etc.) is useful but sits on top of these three.
+
+## Customizing for your team
+
+Two customization files, applied in order of precedence:
+
+1. **`.agents/skill-overrides.md`** — per-skill rule overrides (project root)
+2. **`AGENTS.md`** — repo-wide guidance for all skills (project root)
+3. **built-in skill defaults** (lowest priority)
+
+### `.agents/skill-overrides.md` format
+
+Strict structure, enforced by the validator:
+
+- First line must be `# Skill Overrides`
+- Each section must be `## <existing-skill-name>`
+- Each section body must be a bullet list
+- Freeform text outside sections is invalid
+
+### Three realistic examples
+
+**Example 1 — Treat Kotlin warnings as blocking in your monorepo**
+
+```md
+# Skill Overrides
+
+## bill-kotlin-quality-check
+- Treat warnings as blocking work.
+- Skip formatting-only rewrites unless the user explicitly asks for them.
+```
+
+**Example 2 — Align PR descriptions with your team's template**
+
+```md
+# Skill Overrides
+
+## bill-pr-description
+- Always include the Jira ticket link when the branch name matches `SKILL-\d+`.
+- Include a "Rollout notes" section for changes behind feature flags.
+- Keep QA steps concise unless the user asks for a full matrix.
+```
+
+**Example 3 — Bias reviews toward your team's priorities**
+
+```md
+# Skill Overrides
+
+## bill-backend-kotlin-code-review
+- Prioritize persistence and reliability specialists over performance for this service.
+- Flag any new dependency additions as at minimum Minor severity.
+
+## bill-backend-kotlin-code-review-persistence
+- Require explicit migration rollback steps for any schema change.
+```
+
+`AGENTS.md` at the repo root applies to all skills. Use it for cross-cutting context like "this service writes to both Postgres and DynamoDB" — context every review skill benefits from knowing.
+
+## What to expect from review output
+
+A typical `/bill-code-review` run produces four sections:
+
+```text
+Routed to: bill-backend-kotlin-code-review
+Review session ID: rvs-...
+Review run ID: rvw-...
+Detected stack: backend-kotlin
+Execution mode: inline | delegated
+Applied learnings: none | L-001, L-002
+
+### 1. Summary
+<prose overview of the change>
+
+### 2. Risk Register
+- [F-001] Blocker | High | path/to/file.kt:42 | <description>
+- [F-002] Major | Medium | path/to/file.kt:88 | <description>
+
+### 3. Action Items
+<prioritized, max 10>
+
+### 4. Verdict
+Pass | Fail — <reason>
+```
+
+Severity is one of `Blocker | Major | Minor`. Confidence is `High | Medium | Low`. Every finding has a file:line reference.
+
+## When to trust it vs verify
+
+Treat every review as a **second opinion**, not a gate. It's calibrated for signal-to-noise, not for replacing human judgment.
+
+### Trust more
+
+- **Correctness findings with file:line references that you can open and verify in seconds.** The locations are accurate; the reasoning is usually worth reading.
+- **Specialist depth** on Deep-tier platforms (Kotlin family). Multi-layer routing means multiple specialist passes reinforce each other.
+- **Quality-check results.** These run real tools (Gradle, composer, go test) and report actual exit codes.
+- **Structural findings** — dependency direction, boundary violations, missing error paths. The model is good at spotting these.
+
+### Verify before acting
+
+- **Performance claims without benchmarks.** Review output will sometimes label a change "performance risk" based on pattern recognition alone. Confirm with a profile or benchmark before rewriting.
+- **Security findings on unfamiliar code paths.** High severity + confidence is a signal to look, not a signal to accept. Check the actual threat model.
+- **Findings on Solid-tier platforms (PHP, Go)** that reference framework-specific behavior. Without governed add-ons, framework-specific reasoning can be less reliable.
+- **Findings about library behavior.** The model may confidently describe an API that has changed between versions. Check your actual dependency version.
+- **Anything labeled "Confidence: Low."** This is the model flagging its own uncertainty — treat as a prompt to investigate, not a conclusion.
+
+### Expect these false positives
+
+- Wording nits on user-facing strings that your product team has already decided on.
+- Style suggestions that your linter/formatter already handles.
+- "Missing error handling" in paths where the error genuinely cannot occur.
+
+Use the triage workflow (`/bill-code-review` → respond to findings) or create a learning via `skill-bill learnings add` to stop flagging recurring false positives. Learnings apply automatically on future reviews in the same scope.
+
+## Rolling out to a team
+
+A suggested sequence:
+
+1. **Week 1 — one person.** Install on your own machine. Run `/bill-code-review` on 5-10 recent PRs and see what it catches and misses. Calibrate.
+2. **Week 2 — commit `.agents/skill-overrides.md`.** Encode the team's non-obvious preferences so new installs get the same behavior.
+3. **Week 3 — invite 2-3 engineers.** Have them install from the committed branch. Collect feedback on false positives; add learnings.
+4. **Week 4+ — open it up.** Once the override file is stable, the team can install independently.
+
+## Getting unstuck
+
+- The skill catalog drifted from README? Run `.venv/bin/python3 scripts/validate_agent_configs.py` — it fails loudly on catalog drift.
+- Review output won't parse into telemetry? See the exact required format in [review-telemetry.md](review-telemetry.md).
+- A skill routed to the wrong stack? Open an issue with the detected signals and scope; stack routing is the most commonly tuned part of the system.
+
+For the broader direction of the project, see [ROADMAP.md](ROADMAP.md).

--- a/orchestration/review-delegation/PLAYBOOK.md
+++ b/orchestration/review-delegation/PLAYBOOK.md
@@ -1,13 +1,13 @@
 ---
 name: review-delegation
-description: Maintainer-facing reference snapshot for agent-specific delegated code-review execution.
+description: Single source of truth for agent-specific delegated code-review execution. Skills link to this via sibling symlinks.
 ---
 
-# Shared Review Delegation Snapshot
+# Shared Review Delegation Contract
 
-This maintainer-facing reference snapshot documents the agent-specific delegation contract used when authoring or updating installable code-review skills.
+This is the canonical review-delegation contract. Skills consume it through sibling symlinks (e.g. `review-delegation.md` inside each skill directory), so changes here propagate to every linked skill immediately.
 
-Runtime-facing skills consume this contract through sibling supporting files such as `review-delegation.md` inside each skill directory. Do not reference this repo-relative path directly from installable skills.
+Do not reference this repo-relative path directly from installable skills — use the sibling symlink instead.
 
 ## Shared Delegation Rules
 

--- a/orchestration/review-orchestrator/PLAYBOOK.md
+++ b/orchestration/review-orchestrator/PLAYBOOK.md
@@ -1,13 +1,13 @@
 ---
 name: review-orchestrator
-description: Maintainer-facing reference snapshot for shared stack-specific code-review orchestration contracts, merge rules, and output structure.
+description: Single source of truth for shared stack-specific code-review orchestration contracts, merge rules, and output structure. Skills link to this via sibling symlinks.
 ---
 
-# Shared Code Review Orchestrator Snapshot
+# Shared Code Review Orchestrator Contract
 
-This maintainer-facing reference snapshot documents the shared review-orchestration contract used when authoring or updating installable skills.
+This is the canonical review-orchestration contract. Skills consume it through sibling symlinks (e.g. `review-orchestrator.md` inside each skill directory), so changes here propagate to every linked skill immediately.
 
-Runtime-facing skills consume this contract through sibling supporting files such as `review-orchestrator.md` inside each skill directory. Do not reference this repo-relative path directly from installable skills.
+Do not reference this repo-relative path directly from installable skills — use the sibling symlink instead.
 
 ## Shared Contract For Every Specialist
 

--- a/orchestration/stack-routing/PLAYBOOK.md
+++ b/orchestration/stack-routing/PLAYBOOK.md
@@ -1,13 +1,13 @@
 ---
 name: stack-routing
-description: Maintainer-facing reference snapshot for shared stack detection, dominant-signal tie-breakers, and router delegation decisions.
+description: Single source of truth for shared stack detection, dominant-signal tie-breakers, and router delegation decisions. Skills link to this via sibling symlinks.
 ---
 
-# Shared Stack Routing Snapshot
+# Shared Stack Routing Contract
 
-This maintainer-facing reference snapshot documents the shared stack-routing contract used when authoring or updating installable skills.
+This is the canonical stack-routing contract. Skills consume it through sibling symlinks (e.g. `stack-routing.md` inside each skill directory), so changes here propagate to every linked skill immediately.
 
-Runtime-facing skills consume this contract through sibling supporting files such as `stack-routing.md` inside each skill directory. Do not reference this repo-relative path directly from installable skills.
+Do not reference this repo-relative path directly from installable skills — use the sibling symlink instead.
 
 ## Signal Collection Order
 

--- a/orchestration/telemetry-contract/PLAYBOOK.md
+++ b/orchestration/telemetry-contract/PLAYBOOK.md
@@ -1,11 +1,13 @@
 ---
 name: telemetry-contract
-description: Canonical shared telemetry contract for skill-bill skills.
+description: Single source of truth for shared telemetry event semantics, orchestration flags, and learnings resolution. Skills link to this via sibling symlinks.
 ---
 
 # Shared Telemetry Contract
 
-This maintainer-facing reference snapshot documents the shared telemetry contract used across all telemeterable skills in the skill-bill suite. Runtime-facing skills consume this contract through a sibling `telemetry-contract.md` file inside each skill directory. Do not reference this repo-relative path directly from installable skills.
+This is the canonical telemetry contract for skill-bill skills. Skills consume it through a sibling `telemetry-contract.md` symlink inside each skill directory, so changes here propagate to every linked skill immediately.
+
+Do not reference this repo-relative path directly from installable skills — use the sibling symlink instead.
 
 ## Standalone-first contract
 

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -325,7 +325,7 @@ def validate_runtime_supporting_files(
     if not supporting_file.exists():
       issues.append(f"{skill_file}: supporting file '{file_name}' is missing")
     elif not supporting_file.is_symlink():
-      issues.append(f"{skill_file}: supporting file '{file_name}' must be a symlink to the shared snapshot")
+      issues.append(f"{skill_file}: supporting file '{file_name}' must be a symlink to the shared contract")
 
 
 def validate_portable_review_wording(

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -124,12 +124,12 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
         self.assertEqual(sidecar_path.resolve(), ROOT / "orchestration" / "stack-routing" / "PLAYBOOK.md")
 
   def test_reference_playbooks_remain_available_for_maintainers(self) -> None:
-    self.assertIn("maintainer-facing reference snapshot", STACK_ROUTING_PLAYBOOK)
-    self.assertIn("maintainer-facing reference snapshot", REVIEW_ORCHESTRATOR_PLAYBOOK)
-    self.assertIn("maintainer-facing reference snapshot", REVIEW_DELEGATION_PLAYBOOK)
-    self.assertIn("sibling supporting files", STACK_ROUTING_PLAYBOOK)
-    self.assertIn("sibling supporting files", REVIEW_ORCHESTRATOR_PLAYBOOK)
-    self.assertIn("sibling supporting files", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("canonical", STACK_ROUTING_PLAYBOOK)
+    self.assertIn("canonical", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("canonical", REVIEW_DELEGATION_PLAYBOOK)
+    self.assertIn("sibling symlinks", STACK_ROUTING_PLAYBOOK)
+    self.assertIn("sibling symlinks", REVIEW_ORCHESTRATOR_PLAYBOOK)
+    self.assertIn("sibling symlinks", REVIEW_DELEGATION_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", STACK_ROUTING_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", REVIEW_ORCHESTRATOR_PLAYBOOK)
     self.assertIn("Do not reference this repo-relative path directly", REVIEW_DELEGATION_PLAYBOOK)

--- a/tests/test_review_pipeline_smoke.py
+++ b/tests/test_review_pipeline_smoke.py
@@ -1,0 +1,343 @@
+"""Smoke test: end-to-end review pipeline against a toy codebase.
+
+Creates a small toy project with deliberate issues, constructs a review
+output as if bill-code-review was run against it, then verifies the full
+import → triage → stats pipeline round-trips correctly and findings
+reference actual files in the codebase.
+"""
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from skill_bill.cli import main  # noqa: E402
+from skill_bill.constants import CONFIG_ENVIRONMENT_KEY  # noqa: E402
+from skill_bill.review import parse_review  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Toy codebase: a small Kotlin backend project with 3 deliberate bugs
+# ---------------------------------------------------------------------------
+
+TOY_FILES: dict[str, str] = {
+    "build.gradle.kts": """\
+plugins {
+    kotlin("jvm") version "1.9.22"
+    kotlin("plugin.spring") version "1.9.22"
+    id("org.springframework.boot") version "3.2.2"
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.jetbrains.exposed:exposed-core:0.46.0")
+    implementation("org.jetbrains.exposed:exposed-jdbc:0.46.0")
+    runtimeOnly("org.postgresql:postgresql:42.7.1")
+}
+""",
+    "src/main/kotlin/com/example/UserController.kt": """\
+package com.example
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/users")
+class UserController(private val userService: UserService) {
+
+    @GetMapping("/{id}")
+    fun getUser(@PathVariable id: String): User {
+        // BUG: no input validation on id — SQL injection vector
+        return userService.findById(id)
+    }
+
+    @PostMapping
+    fun createUser(@RequestBody body: Map<String, Any>): User {
+        val name = body["name"] as String
+        val email = body["email"] as String
+        // BUG: unchecked cast — ClassCastException if fields are missing
+        return userService.create(name, email)
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteUser(@PathVariable id: String) {
+        userService.delete(id)
+        // BUG: no authorization check — any caller can delete any user
+    }
+}
+""",
+    "src/main/kotlin/com/example/UserService.kt": """\
+package com.example
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class UserService {
+
+    fun findById(id: String): User = transaction {
+        val row = Users.select { Users.id eq id }.single()
+        User(row[Users.id], row[Users.name], row[Users.email])
+    }
+
+    fun create(name: String, email: String): User = transaction {
+        val id = Users.insert {
+            it[Users.name] = name
+            it[Users.email] = email
+        } get Users.id
+        User(id, name, email)
+    }
+
+    fun delete(id: String): Unit = transaction {
+        Users.deleteWhere { Users.id eq id }
+    }
+}
+""",
+    "src/main/kotlin/com/example/User.kt": """\
+package com.example
+
+data class User(
+    val id: String,
+    val name: String,
+    val email: String,
+)
+""",
+    "src/main/kotlin/com/example/Users.kt": """\
+package com.example
+
+import org.jetbrains.exposed.sql.Table
+
+object Users : Table("users") {
+    val id = varchar("id", 36)
+    val name = varchar("name", 255)
+    val email = varchar("email", 255)
+    override val primaryKey = PrimaryKey(id)
+}
+""",
+}
+
+
+# ---------------------------------------------------------------------------
+# Simulated review output — what bill-backend-kotlin-code-review would
+# produce when reviewing the toy codebase. Findings reference real files.
+# ---------------------------------------------------------------------------
+
+TOY_REVIEW_OUTPUT = """\
+Routed to: bill-backend-kotlin-code-review
+Review session ID: rvs-smoke-001
+Review run ID: rvw-smoke-001
+Detected review scope: files
+Detected stack: backend-kotlin
+Signals: build.gradle.kts (spring-boot, exposed), src/main/kotlin
+Execution mode: inline
+Applied learnings: none
+Reason: backend-kotlin signals dominate — Spring Boot + Exposed with Kotlin source layout
+
+### 1. Summary
+
+Small CRUD API with a `UserController` and `UserService` backed by Exposed ORM.
+Three findings: one SQL injection vector (Blocker), one missing authorization check (Major),
+and one unsafe cast that can throw at runtime (Major).
+
+### 2. Risk Register
+- [F-001] Blocker | High | src/main/kotlin/com/example/UserController.kt:12 | No input validation on `id` path variable — string is passed directly to a SQL query, creating a potential injection vector.
+- [F-002] Major | High | src/main/kotlin/com/example/UserController.kt:24 | `deleteUser` performs no authorization check — any authenticated caller can delete any user.
+- [F-003] Major | Medium | src/main/kotlin/com/example/UserController.kt:19 | Unchecked `as String` cast on request body fields will throw `ClassCastException` if `name` or `email` is missing or non-string.
+
+### 3. Action Items
+
+1. **[F-001]** Add input validation for path variable `id` (e.g., UUID format check) before it reaches the service layer.
+2. **[F-002]** Add an authorization guard to `deleteUser` — verify the caller has permission to delete the target user.
+3. **[F-003]** Replace unsafe casts with null-safe extraction and return 400 on missing/invalid fields.
+
+### 4. Verdict
+
+**Fail** — one Blocker finding (potential SQL injection) must be addressed before merge.
+"""
+
+
+class ReviewPipelineSmokeTest(unittest.TestCase):
+    """End-to-end smoke test: toy codebase → review → import → triage → stats."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.mkdtemp()
+        self.project_dir = os.path.join(self.temp_dir, "toy-project")
+        os.makedirs(self.project_dir)
+        for relative_path, content in TOY_FILES.items():
+            full_path = os.path.join(self.project_dir, relative_path)
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            Path(full_path).write_text(content, encoding="utf-8")
+        self.db_path = os.path.join(self.temp_dir, "metrics.db")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # --- Parse contract ---
+
+    def test_review_output_parses_with_expected_metadata(self) -> None:
+        review = parse_review(TOY_REVIEW_OUTPUT)
+
+        self.assertEqual(review.review_run_id, "rvw-smoke-001")
+        self.assertEqual(review.review_session_id, "rvs-smoke-001")
+        self.assertEqual(review.routed_skill, "bill-backend-kotlin-code-review")
+        self.assertEqual(review.detected_scope, "files")
+        self.assertEqual(review.detected_stack, "backend-kotlin")
+        self.assertEqual(review.execution_mode, "inline")
+
+    def test_review_output_contains_all_four_sections(self) -> None:
+        self.assertIn("### 1. Summary", TOY_REVIEW_OUTPUT)
+        self.assertIn("### 2. Risk Register", TOY_REVIEW_OUTPUT)
+        self.assertIn("### 3. Action Items", TOY_REVIEW_OUTPUT)
+        self.assertIn("### 4. Verdict", TOY_REVIEW_OUTPUT)
+
+    def test_findings_reference_files_that_exist_in_toy_codebase(self) -> None:
+        review = parse_review(TOY_REVIEW_OUTPUT)
+
+        self.assertEqual(len(review.findings), 3)
+        for finding in review.findings:
+            file_path = finding.location.split(":")[0]
+            full_path = os.path.join(self.project_dir, file_path)
+            self.assertTrue(
+                os.path.isfile(full_path),
+                f"Finding {finding.finding_id} references non-existent file: {file_path}",
+            )
+
+    def test_findings_cover_known_deliberate_bugs(self) -> None:
+        review = parse_review(TOY_REVIEW_OUTPUT)
+        descriptions = " ".join(f.description.lower() for f in review.findings)
+
+        self.assertIn("injection", descriptions, "Expected a finding about SQL injection")
+        self.assertIn("authorization", descriptions, "Expected a finding about missing auth")
+        self.assertIn("cast", descriptions, "Expected a finding about unsafe cast")
+
+    def test_finding_severities_and_confidences_are_valid(self) -> None:
+        review = parse_review(TOY_REVIEW_OUTPUT)
+        allowed_severities = {"Blocker", "Major", "Minor"}
+        allowed_confidences = {"High", "Medium", "Low"}
+        for finding in review.findings:
+            self.assertIn(finding.severity, allowed_severities)
+            self.assertIn(finding.confidence, allowed_confidences)
+
+    # --- Full pipeline round-trip ---
+
+    def test_import_triage_stats_round_trip(self) -> None:
+        """Import → triage → stats produces consistent results."""
+        # Import
+        import_result = self._run_cli([
+            "--db", self.db_path,
+            "import-review", "-",
+            "--format", "json",
+        ], stdin=TOY_REVIEW_OUTPUT)
+        self.assertEqual(import_result["exit_code"], 0, import_result["stderr"])
+        imported = json.loads(import_result["stdout"])
+        self.assertEqual(imported["review_run_id"], "rvw-smoke-001")
+        self.assertEqual(imported["finding_count"], 3)
+
+        # Triage: fix the blocker + auth, reject the cast finding
+        triage_result = self._run_cli([
+            "--db", self.db_path,
+            "triage", "--run-id", "rvw-smoke-001",
+            "--decision", "1 fix - added UUID validation",
+            "--decision", "2 fix - added auth guard",
+            "--decision", "3 reject - cast is safe in our controlled API",
+            "--format", "json",
+        ])
+        self.assertEqual(triage_result["exit_code"], 0, triage_result["stderr"])
+        triaged = json.loads(triage_result["stdout"])
+        self.assertEqual(len(triaged["recorded"]), 3)
+        self.assertEqual(triaged["recorded"][0]["outcome_type"], "fix_applied")
+        self.assertEqual(triaged["recorded"][1]["outcome_type"], "fix_applied")
+        self.assertEqual(triaged["recorded"][2]["outcome_type"], "fix_rejected")
+
+        # Stats
+        stats_result = self._run_cli([
+            "--db", self.db_path,
+            "stats", "--run-id", "rvw-smoke-001",
+            "--format", "json",
+        ])
+        self.assertEqual(stats_result["exit_code"], 0, stats_result["stderr"])
+        stats = json.loads(stats_result["stdout"])
+        self.assertEqual(stats["total_findings"], 3)
+        self.assertEqual(stats["accepted_findings"], 2)
+        self.assertEqual(stats["rejected_findings"], 1)
+        self.assertEqual(stats["unresolved_findings"], 0)
+        self.assertEqual(stats["accepted_severity_counts"]["Blocker"], 1)
+        self.assertEqual(stats["accepted_severity_counts"]["Major"], 1)
+
+    def test_reimport_same_review_is_idempotent(self) -> None:
+        for _ in range(2):
+            result = self._run_cli([
+                "--db", self.db_path,
+                "import-review", "-",
+                "--format", "json",
+            ], stdin=TOY_REVIEW_OUTPUT)
+            self.assertEqual(result["exit_code"], 0, result["stderr"])
+
+        stats = self._run_cli([
+            "--db", self.db_path,
+            "stats", "--run-id", "rvw-smoke-001",
+            "--format", "json",
+        ])
+        payload = json.loads(stats["stdout"])
+        self.assertEqual(payload["total_findings"], 3)
+
+    def test_structured_triage_selection_works(self) -> None:
+        self._run_cli([
+            "--db", self.db_path,
+            "import-review", "-",
+            "--format", "json",
+        ], stdin=TOY_REVIEW_OUTPUT)
+
+        triage_result = self._run_cli([
+            "--db", self.db_path,
+            "triage", "--run-id", "rvw-smoke-001",
+            "--decision", "fix=[1,2] reject=[3]",
+            "--format", "json",
+        ])
+        self.assertEqual(triage_result["exit_code"], 0, triage_result["stderr"])
+        triaged = json.loads(triage_result["stdout"])
+        self.assertEqual(len(triaged["recorded"]), 3)
+
+    # --- Helpers ---
+
+    def _run_cli(
+        self,
+        argv: list[str],
+        *,
+        stdin: str | None = None,
+    ) -> dict[str, str | int]:
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+        patched_env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("SKILL_BILL_")
+        }
+        patched_env[CONFIG_ENVIRONMENT_KEY] = os.path.join(
+            self.temp_dir, "config.json"
+        )
+        with patch.dict(os.environ, patched_env, clear=True):
+            if stdin is not None:
+                with patch("sys.stdin", io.StringIO(stdin)):
+                    with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+                        exit_code = main(argv)
+            else:
+                with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+                    exit_code = main(argv)
+        return {
+            "exit_code": exit_code,
+            "stdout": stdout_buf.getvalue(),
+            "stderr": stderr_buf.getvalue(),
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -446,13 +446,13 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
         """\
         ---
         name: stack-routing
-        description: Maintainer-facing reference snapshot for shared stack routing behavior.
+        description: Single source of truth for shared stack routing behavior.
         ---
 
-        # Shared Stack Routing Snapshot
+        # Shared Stack Routing Contract
 
-        This maintainer-facing reference snapshot exists to document the shared routing contract.
-        It is not a runtime dependency for installed skills.
+        This is the canonical stack-routing contract. Skills consume it through sibling symlinks,
+        so changes here propagate to every linked skill immediately.
         """
       ),
       encoding="utf-8",
@@ -472,13 +472,13 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       """\
       ---
       name: review-orchestrator
-      description: Maintainer-facing reference snapshot for shared review orchestration behavior.
+      description: Single source of truth for shared review orchestration contracts.
       ---
 
-      # Shared Review Orchestrator Snapshot
+      # Shared Code Review Orchestrator Contract
 
-      This maintainer-facing reference snapshot exists to document the shared review contract.
-      It is not a runtime dependency for installed skills.
+      This is the canonical review-orchestration contract. Skills consume it through sibling symlinks,
+      so changes here propagate to every linked skill immediately.
       """
     )
     if include_telemetry:
@@ -516,13 +516,13 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
         """\
         ---
         name: review-delegation
-        description: Maintainer-facing reference snapshot for agent-specific delegated review execution.
+        description: Single source of truth for agent-specific delegated review execution.
         ---
 
-        # Shared Review Delegation Snapshot
+        # Shared Review Delegation Contract
 
-        This maintainer-facing reference snapshot exists to document the shared delegation contract.
-        Runtime-facing skills consume it through sibling supporting files.
+        This is the canonical review-delegation contract. Skills consume it through sibling symlinks,
+        so changes here propagate to every linked skill immediately.
 
         ## GitHub Copilot CLI
         ## Claude Code
@@ -543,12 +543,13 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
         f"""\
         ---
         name: telemetry-contract
-        description: Canonical shared telemetry contract for skill-bill skills.
+        description: Single source of truth for shared telemetry event semantics, orchestration flags, and learnings resolution.
         ---
 
         # Shared Telemetry Contract
 
-        This maintainer-facing reference snapshot documents the shared telemetry contract.
+        This is the canonical telemetry contract for skill-bill skills. Skills consume it through sibling symlinks,
+        so changes here propagate to every linked skill immediately.
 
         ## Telemetry Ownership
 


### PR DESCRIPTION
## Summary

Batch of roadmap follow-ups — five commits across four themes. Each commit is self-contained and independently revertable.

- **`orchestration/` is a source of truth, not snapshots** (77a895a) — the directory was described as "maintainer-facing reference snapshots, not a runtime dependency" in 8 locations, but 52 symlinks from skill directories make it a true runtime dependency. Reframed consistently across AGENTS.md, README.md, all 4 orchestration PLAYBOOK.md files, the validator, and two test files.
- **End-to-end smoke test for review pipeline** (cec8b7c) — creates a 5-file Kotlin toy project with 3 deliberate bugs (SQL injection, missing auth, unsafe cast) and exercises the full parse → import → triage → stats pipeline. Asserts findings reference real files, all 4 output sections are present, and the round-trip is consistent. Moves test coverage from pure contract validation toward "does the pipeline actually work" confidence.
- **Trim AGENTS.md, fix validation commands** (050f39a) — adds a Project context section (satisfies agnix), compresses the platform checklist to stay under the 1500-token limit, and switches validation commands from `python3` to `.venv/bin/python3`. The system `python3` is 3.9 and can't install `mcp`, causing 3 pre-existing MCP test failures. The venv has Python 3.12 with `mcp`. All 180 tests pass with the venv.
- **Honest platform coverage tiering in README** (5b1807d) — replaces the flat "Currently strongest for Kotlin, KMP, PHP, Go..." pitch with a Deep/Solid/Meta tier table. Makes the PHP/Go add-on gap a visible backlog item rather than a hidden disappointment.
- **Getting Started for Teams guide** (9508ed3) — new ~130-line doc at `docs/getting-started-for-teams.md` covering `.agents/skill-overrides.md` customization with 3 realistic examples, review output format reference, and explicit "when to trust vs verify" guidance. Links to README for install rather than duplicating.

## Test plan

- [x] `.venv/bin/python3 -m unittest discover -s tests` — 180 tests, 0 failures (including 8 new smoke tests and the 3 previously-broken MCP tests now passing)
- [x] `npx --yes agnix --strict .` — 0 errors, 0 warnings
- [x] `.venv/bin/python3 scripts/validate_agent_configs.py` — 48 skills + 12 governed add-ons validated
- [ ] Reviewer: confirm the "trust vs verify" calibration in the teams guide matches your mental model of the tool's current reliability
- [ ] Reviewer: confirm the platform tier labels (Deep/Solid/Meta) match your intent before this framing ships publicly