### PR TITLE
feat: [SKILL-18] anchor boundary_history_value rubric to fix central-tendency bias

### DIFF
--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-17] boundary-history-value-rubric
+Areas: skills/base/bill-feature-implement/, tests/
+- Anchored the `boundary_history_value` telemetry field with a five-value rubric (`none` | `irrelevant` | `low` | `medium` | `high`) nested under step 3 of the pre-planning briefing's Instructions list in `reference.md`. Added a citation guardrail: `medium`/`high` ratings MUST cite a specific past entry in `boundary_history_digest`, otherwise downgrade to `low`. Enum, DB schema, validation, MCP signature, and platform-pack manifests all unchanged — the field is pass-through so this is a prompt-level fix, not a contract change. reusable
+- Fixed `SKILL.md:171` `none` overload: clarified it means "no history existed at pre-read time" and documented that `boundary_history_written=true` paired with `value=none` is a legal combination (fresh boundary where `bill-boundary-history` creates the first entry post-completion). Full rubric stays in `reference.md`; SKILL.md keeps a one-line gloss per value.
+- Motivated by a 180-day PostHog distribution on `skillbill_feature_implement_finished` (553 runs: 89% `medium`, 1.1% `high`, 0.4% `none`, 0.2% `low`, 9.4% unreported) — classic central-tendency bias from an unanchored 5-point scale. Expect post-merge distribution to shift; split the time series at merge date when analyzing.
+- Added a round-trip test in `FeatureImplementEnabledTest` that loops every `BOUNDARY_HISTORY_VALUES` entry through `feature_implement_started` + `feature_implement_finished` and asserts persistence in both the `feature_implement_sessions` row and the emitted `skillbill_feature_implement_finished` outbox payload, pinning the enum tuple shape. reusable
+Feature flag: N/A
+Acceptance criteria: 10/10 implemented
+
 ## [2026-04-17] quality-check-shell-pilot
 Areas: orchestration/shell-content-contract/, skill_bill/, skills/base/bill-quality-check/, platform-packs/{agent-config,go,kotlin,php}/quality-check/, platform-packs/{agent-config,go,kotlin,php}/platform.yaml, scripts/, install.sh, uninstall.sh, tests/, README.md, docs/getting-started-for-teams.md, CLAUDE.md
 - Promoted `bill-quality-check` onto the shell+content contract via an additive extension: the shell contract version stays `1.0` and gains a new optional top-level manifest key, `declared_quality_check_file`, that points at a per-platform `platform-packs/<slug>/quality-check/<name>/SKILL.md`. Packs without the key remain contract-compliant. reusable

--- a/skills/base/bill-feature-implement/SKILL.md
+++ b/skills/base/bill-feature-implement/SKILL.md
@@ -168,7 +168,7 @@ After the PR is created (or when the workflow ends early due to error or user ab
 - `files_created`, `files_modified`, `tasks_completed`
 - `review_iterations`, `audit_result` (`all_pass`, `had_gaps`, or `skipped`), `audit_iterations`
 - `validation_result` (`pass`, `fail`, or `skipped`), `boundary_history_written`, `pr_created`
-- `boundary_history_value`: how useful the boundary history was during pre-planning (`none` if no history existed, `irrelevant`, `low`, `medium`, or `high`)
+- `boundary_history_value`: how useful the boundary history was during pre-planning — `none` means no history existed at pre-read time (so `boundary_history_written=true` paired with `value=none` is a legal combination, e.g. this run created the first entry); `irrelevant` means history was read but nothing applied; `low` means an adjacent entry was grazed but did not shape the plan; `medium` means an entry directly informed pre-planning; `high` means an entry was decisive in shaping the plan. Full anchored rubric lives in `reference.md`.
 - `plan_deviation_notes`: brief note if the plan changed during execution (empty if no deviations)
 - `child_steps`: list of `telemetry_payload` dicts collected from child tools invoked with `orchestrated=true` during the session
 

--- a/skills/base/bill-feature-implement/reference.md
+++ b/skills/base/bill-feature-implement/reference.md
@@ -39,7 +39,13 @@ Non-goals:
 Instructions:
 1. Read `CLAUDE.md`, `AGENTS.md`, and any `.agents/skill-overrides.md` section matching `bill-feature-implement`. Treat all standards as mandatory.
 2. For MEDIUM/LARGE, save the spec to `.feature-specs/{issue_key}-{feature_name}/spec.md` with status "In Progress", sources, acceptance criteria, and consolidated spec content. Preserve code blocks, schemas, and enums verbatim.
-3. Read `agent/history.md` in each boundary likely to be touched (newest first; stop when no longer relevant). Rate boundary-history value as: none | irrelevant | low | medium | high.
+3. Read `agent/history.md` in each boundary likely to be touched (newest first; stop when no longer relevant). Rate boundary-history value using one of the following anchored definitions:
+   - `none` — no `agent/history.md` file existed at pre-read time in any touched boundary (nothing was read because nothing was there).
+   - `irrelevant` — history existed and was read, but no entry concerned a boundary, pattern, or pitfall related to this feature.
+   - `low` — history existed and at least one entry grazed an adjacent area, but no entry materially shaped pre-planning or the plan.
+   - `medium` — history existed and at least one entry directly informed pre-planning: a reused pattern, a named pitfall avoided, or a concrete constraint carried into the plan.
+   - `high` — history existed and at least one entry was decisive: it changed the plan's shape, reused an established pattern verbatim, or prevented a known-bad approach that would otherwise have been taken.
+   If you report `medium` or `high`, `boundary_history_digest` MUST cite the specific past entry (issue key, date, or entry title) that drove the rating. Otherwise downgrade to `low`.
 4. Scan `agent/decisions.md` header lines in each likely boundary; open full entries only when titles look relevant.
 5. Discover codebase patterns: similar features referenced in the spec, build/runtime dependencies, reusable components.
    When `kmp` signals dominate, resolve governed add-ons only after stack routing settles on `kmp`. Start from `Selected add-ons: none`. Let the routed stack own add-on detection and selection, then scan the matching stack-owned add-on supporting files' `## Section index` headings first. If the add-on is split into topic files, open only the linked topic files whose cues match the work during pre-planning / pattern discovery.

--- a/tests/test_feature_implement_telemetry.py
+++ b/tests/test_feature_implement_telemetry.py
@@ -13,6 +13,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+from skill_bill.constants import BOUNDARY_HISTORY_VALUES
 from skill_bill.mcp_server import (
   feature_implement_finished,
   feature_implement_started,
@@ -290,6 +291,36 @@ class FeatureImplementEnabledTest(unittest.TestCase):
     self.assertEqual(payload["child_steps"][0]["total_findings"], 5)
     self.assertEqual(payload["child_steps"][1]["result"], "pass")
     self.assertTrue(payload["child_steps"][2]["pr_created"])
+
+  def test_boundary_history_value_round_trips_for_all_enum_values(self) -> None:
+    # Every value in BOUNDARY_HISTORY_VALUES must round-trip end-to-end:
+    # it lands in the feature_implement_sessions row AND in the emitted
+    # skillbill_feature_implement_finished outbox payload unchanged.
+    self.assertEqual(
+      BOUNDARY_HISTORY_VALUES,
+      ("none", "irrelevant", "low", "medium", "high"),
+    )
+    for value in BOUNDARY_HISTORY_VALUES:
+      with self.subTest(boundary_history_value=value):
+        started = feature_implement_started(**STARTED_PARAMS)
+        session_id = started["session_id"]
+        finished_params = dict(FINISHED_PARAMS)
+        finished_params["boundary_history_value"] = value
+        result = feature_implement_finished(session_id=session_id, **finished_params)
+        self.assertEqual(result["status"], "ok")
+
+        row = self._session_row(session_id)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["boundary_history_value"], value)
+
+        outbox_rows = self._outbox_rows("skillbill_feature_implement_finished")
+        matching = [
+          json.loads(r["payload_json"])
+          for r in outbox_rows
+          if json.loads(r["payload_json"]).get("session_id") == session_id
+        ]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0]["boundary_history_value"], value)
 
   def test_child_steps_respect_level_as_built_by_children(self) -> None:
     # The parent aggregates whatever the children returned. Anonymous-level


### PR DESCRIPTION
# Summary

Re-anchor the `boundary_history_value` telemetry rubric in `bill-feature-implement` to fix central-tendency bias. Prompt-only change: no enum, schema, contract, or installer churn.

**Motivation:** 180-day PostHog distribution on `skillbill_feature_implement_finished` shows 553 runs with 89% `medium`, 1.1% `high`, 0.4% `none`, 0.2% `low`, and 9.4% unreported — classic central-tendency collapse on an unanchored 5-point scale. Agents default to `medium` because no definition tells them what each value means.

**Key changes:**
- `skills/base/bill-feature-implement/reference.md`: step 3 rubric expanded into five anchored bullet definitions (`none` / `irrelevant` / `low` / `medium` / `high`). Step numbering and fenced block preserved.
- Citation requirement: `medium` / `high` MUST cite a specific past entry in `boundary_history_digest`, else downgrade to `low`.
- `skills/base/bill-feature-implement/SKILL.md`: bare enum replaced with one-line gloss per value; clarifies `none` = "no history existed at pre-read time" and that `boundary_history_written=true` with `value=none` is legal. Full rubric stays in reference.md.
- `tests/test_feature_implement_telemetry.py`: new round-trip test iterates all five `BOUNDARY_HISTORY_VALUES` through started + finished, asserting session row + outbox payload shape for each.
- `agent/history.md`: entry added.

Non-changes (deliberate): no enum / schema / validation / MCP-signature edits, no contract-version bump, no manifest changes, no PostHog rename, no README / CLAUDE.md / AGENTS.md edits.

## Feature Flags

N/A

# How Has This Been Tested?

- New round-trip test (`tests/test_feature_implement_telemetry.py`) pins the enum shape and asserts a full started + finished round-trip through all five values, verifying both the session row and the outbox payload.
- Canonical triad (unittest discover, agnix strict, validate_agent_configs.py) passes.

Reproduce locally:
1. `.venv/bin/python3 -m unittest discover -s tests`
2. `npx --yes agnix --strict .`
3. `.venv/bin/python3 scripts/validate_agent_configs.py`
4. Expected: all three green; the new test case iterates `none | irrelevant | low | medium | high` and asserts round-trip persistence.

**Post-merge success signal (behavioral, not in-repo):** re-run the PostHog distribution query on `skillbill_feature_implement_finished.boundary_history_value` over a 2-week window after rollout. Success = `medium` share drops below ~60% of reported values (down from 89%), with non-trivial mass on `low` / `high` / `irrelevant`.