### PR TITLE
SKILL-23: add terminal skill authoring commands

### DIFF
--- a/.feature-specs/skill-23-skill-authoring-system/spec.md
+++ b/.feature-specs/skill-23-skill-authoring-system/spec.md
@@ -1,0 +1,438 @@
+# Feature: skill-23-skill-authoring-system
+Created: 2026-04-20
+Status: In Progress
+Sources: User request in chat; Jira issue key SKILL-23; current repo taxonomy in AGENTS.md; existing feature-spec format used by `bill-feature-implement`
+
+## Acceptance Criteria
+1. Users can create one concrete skill from the terminal without manually navigating the repo or understanding project ceremony.
+2. Each authored skill is split into a generated `SKILL.md` and a user-authored `content.md`, with a strict ownership boundary between project/runtime behavior and business behavior.
+3. `content.md` does not contain project-enforced output format, shell ceremony, override mechanics, or other runtime internals that must remain stable for the system to work.
+4. The authoring workflow enforces the repo's naming taxonomy, package rules, and approved `code-review` specialization areas during both creation and editing.
+5. Users can edit an existing skill from the terminal through a guided workflow, with optional `$EDITOR` support when available, without requiring direct manual edits to `SKILL.md`.
+6. Validation detects incomplete content, unresolved TODO placeholders, invalid names/paths, and drift between generated `SKILL.md` files and their templates.
+7. The system defines how new skills are scaffolded, rendered, validated, discovered, and synced to agent install targets without breaking the current installer/symlink model.
+8. The spec defines migration rules for existing skills and explicitly distinguishes end-user workflows from maintainer-only bulk or taxonomy-changing workflows.
+
+---
+
+## Problem Statement
+
+The repo is evolving from "skills are hand-authored markdown files" to "skills are governed artifacts with protected runtime ceremony and user-editable business content."
+
+That split solves one problem cleanly:
+
+- `SKILL.md` can hold the fixed project behavior the system needs in order to work
+- `content.md` can hold the domain-specific behavior users should actually customize
+
+But the current authoring experience still assumes repo-level manual editing. That creates three failures:
+
+1. users have to understand the repo layout and internal conventions
+2. terminal-first users are pushed toward ad hoc file editing instead of a guided workflow
+3. the scaffolding model is optimized for generating repo structure, not for helping a user create one concrete skill quickly
+
+SKILL-23 defines a terminal-first skill authoring system that makes the split useful in practice.
+
+## Goals
+
+- Make skill creation a command-driven workflow rather than a repo-navigation workflow.
+- Preserve the `SKILL.md` and `content.md` boundary as a hard system rule.
+- Keep base commands and governed taxonomy stable.
+- Let users author business behavior without learning Timetry, project overrides, or other internals.
+- Support an iterative terminal workflow for both creating and updating skills.
+- Fail loudly when the authored content is incomplete or the generated artifact drifts from the template.
+
+## Non-Goals
+
+- Building a full-screen TUI before the basic CLI workflow exists.
+- Letting users directly author runtime/output contracts in `content.md`.
+- Generating the full platform/capability matrix by default for ordinary users.
+- Replacing the existing install/symlink model with a compiled packaging system.
+- Allowing new taxonomy shapes outside the governed naming rules in `AGENTS.md`.
+
+## Core Product Decisions
+
+1. Users create concrete skills one at a time.
+2. `SKILL.md` is generated and treated as protected.
+3. `content.md` is the primary editable surface.
+4. Terminal-first is the default workflow; IDE editing is optional acceleration, not a requirement.
+5. Bulk generation of every possible skill remains a maintainer-only workflow, not the primary end-user path.
+
+## User Roles
+
+### End User
+
+Wants to create or edit a skill that fits the governed taxonomy, but should only need to answer business questions such as:
+
+- What is this skill for?
+- When should it be used?
+- What context does it need?
+- What rules should it follow?
+- What examples describe correct behavior?
+
+The end user should not need to know:
+
+- shell ceremony details
+- output formatting contracts
+- override lookup mechanics
+- install-path or symlink internals
+- which sections in `SKILL.md` are project-protected
+
+### Maintainer
+
+Owns:
+
+- template families
+- taxonomy changes
+- validator rules
+- migration scripts
+- bulk scaffolding when the governed catalog itself expands
+
+Maintainers may still use bulk workflows, but those workflows are explicitly outside the ordinary skill-authoring UX.
+
+## System Overview
+
+The system consists of five surfaces:
+
+1. `new`: scaffold one concrete skill
+2. `edit`: update skill content or metadata
+3. `render`: regenerate protected `SKILL.md` files from templates
+4. `validate`: detect taxonomy, completeness, and generation drift problems
+5. `list`: show discoverable skills and completion status
+
+The default user path is:
+
+1. run `skill-bill new`
+2. answer guided prompts
+3. review or edit `content.md`
+4. run `skill-bill validate`
+5. install or sync through the existing symlink workflow
+
+## Canonical File Model
+
+Each skill directory keeps the existing directory-per-skill layout:
+
+```text
+skills/<package>/<slug>/
+  SKILL.md
+  content.md
+  ...optional sibling support files...
+```
+
+### `SKILL.md`
+
+`SKILL.md` is generated and protected. It contains:
+
+- canonical frontmatter such as `name` and `description`
+- project-overrides lookup behavior
+- fixed runtime ceremony required by this repo
+- the template-selected routing/delegation behavior for the skill family
+- instructions telling the runtime to read `content.md` as the authoritative business behavior
+
+Users should not be asked to hand-edit this file during normal authoring.
+
+### `content.md`
+
+`content.md` is user-authored. It contains only business behavior.
+
+It must never contain:
+
+- output contract details enforced by the project
+- shell ceremony
+- override lookup mechanics
+- install/sync instructions
+- template plumbing
+- repository governance rules that are already enforced elsewhere
+
+## Canonical `content.md` Schema
+
+The authoring schema is intentionally narrow so the terminal editor can manage it safely.
+
+```markdown
+# Purpose
+
+## When To Use
+
+## Required Context
+
+## Business Rules
+
+## Constraints
+
+## Examples
+```
+
+### Section Semantics
+
+- `Purpose`: what the skill exists to accomplish
+- `When To Use`: the situations that should trigger the skill
+- `Required Context`: the inputs, repo context, or user information the skill needs
+- `Business Rules`: the domain-specific decision logic the skill should follow
+- `Constraints`: domain guardrails and scope limits specific to the skill's job
+- `Examples`: concrete scenarios, invocations, or expected judgments
+
+### Explicit Exclusions
+
+The schema intentionally excludes `Output Contract` because output shape is part of protected project behavior. If changing a section would risk breaking the runtime mechanics of the repo, that content belongs in `SKILL.md`, not `content.md`.
+
+## Template Families
+
+The system must choose a template family based on the governed skill shape.
+
+Initial families:
+
+1. Base skill template
+2. Platform override template
+3. Platform `code-review` specialist template
+
+Each family controls:
+
+- generated `SKILL.md` structure
+- fixed runtime instructions
+- any required sibling support-file references
+- validation rules specific to that family
+
+This keeps end-user authoring simple while preserving room for maintainers to evolve the protected ceremony behind stable templates.
+
+## Metadata Ownership
+
+Metadata required for generation remains CLI-managed, not free-form user prose.
+
+Required metadata:
+
+- skill slug
+- package
+- description
+- family type
+- platform when applicable
+- base capability when applicable
+- approved `code-review` area when applicable
+
+The CLI may read this from generated files or an internal registry, but users should edit metadata through commands, not by patching generated ceremony manually.
+
+For MVP, metadata may live in generated `SKILL.md` frontmatter plus path conventions. A separate manifest file is not required.
+
+## CLI Surface
+
+### `skill-bill new`
+
+Purpose: scaffold one concrete skill.
+
+Prompt flow:
+
+1. Choose skill family:
+   - base skill
+   - platform override
+   - platform code-review specialist
+2. Collect the user-facing inputs:
+   - name or capability
+   - one-line description
+   - package or platform when required
+   - approved specialization area when required
+3. Validate the name against the governed taxonomy.
+4. Derive the package path and slug.
+5. Create the skill directory.
+6. Generate protected `SKILL.md`.
+7. Create `content.md` with the canonical headings and TODO placeholders.
+8. Offer immediate next actions:
+   - guided edit now
+   - open in `$EDITOR`
+   - finish and validate later
+
+Key rule: `new` creates one concrete skill, not the entire catalog.
+
+### `skill-bill edit <skill>`
+
+Purpose: edit business content or metadata without manual repo navigation.
+
+Default mode is guided terminal editing. The command:
+
+- resolves the skill by slug or path
+- shows completion status by section
+- offers section-by-section editing for `content.md`
+- supports replace, append, clear, skip, and done actions
+- updates metadata through explicit prompts when the user chooses metadata editing
+- regenerates `SKILL.md` when metadata changes affect the generated output
+
+If `$EDITOR` is set, the command may offer:
+
+- open `content.md` directly in the editor
+- return to validation after the editor exits
+
+The guided mode remains the default so the system works even in pure terminal sessions.
+
+### `skill-bill render [skill|--all]`
+
+Purpose: regenerate protected `SKILL.md` files from templates.
+
+Use cases:
+
+- template family changed
+- metadata changed
+- maintainer wants to normalize generated files
+- validator detected drift
+
+### `skill-bill validate [skill|--all]`
+
+Purpose: enforce repository rules and authoring completeness.
+
+Validation includes:
+
+- skill directory matches governed package and slug rules
+- required files exist
+- `content.md` headings match the canonical schema
+- TODO placeholders are unresolved only when explicitly allowed in draft mode
+- no forbidden protected sections appear in `content.md`
+- generated `SKILL.md` still matches the expected template for its family
+- README/catalog/install references remain valid when catalog-level changes are made
+
+### `skill-bill list`
+
+Purpose: surface discoverable skills and authoring state.
+
+Each row should show at minimum:
+
+- slug
+- package
+- family
+- completion status
+- whether generation drift exists
+
+This gives terminal users a navigable overview without requiring filesystem exploration.
+
+## Guided Editing UX
+
+The guided editor should optimize for users who do not want to drop into Vim, Nano, or a full IDE.
+
+Recommended behavior:
+
+1. show the current section value
+2. ask whether to replace, append, clear, or skip
+3. accept multiline input until an explicit sentinel such as `.done`
+4. write the section back into `content.md`
+5. move to the next section
+
+The editor must preserve section order and headings exactly so validation and future automation stay simple.
+
+## Draft vs Complete State
+
+Scaffolds may start incomplete, but the system must distinguish draft from complete explicitly.
+
+Rules:
+
+- `skill-bill new` may create TODO placeholders
+- `skill-bill validate` fails by default if TODO placeholders remain
+- `skill-bill list` marks incomplete skills clearly
+- maintainers may have an explicit draft mode, but draft state must never be silent
+
+## Naming and Taxonomy Enforcement
+
+The system must enforce the repo rules already defined in `AGENTS.md`:
+
+- base skills: `bill-<capability>`
+- platform overrides: `bill-<platform>-<base-capability>`
+- approved deeper specialization only for `code-review`: `bill-<platform>-code-review-<area>`
+
+Approved `code-review` areas remain:
+
+- `architecture`
+- `performance`
+- `platform-correctness`
+- `security`
+- `testing`
+- `api-contracts`
+- `persistence`
+- `reliability`
+- `ui`
+- `ux-accessibility`
+
+The CLI must reject unapproved shapes rather than scaffolding them and hoping validation catches the problem later.
+
+## Installer and Sync Model
+
+This feature does not replace the current symlink-based installer.
+
+Expected behavior:
+
+- a skill directory remains the canonical unit of installation
+- supported agents still receive symlinks to canonical skill directories
+- generated `SKILL.md` and authored `content.md` both live inside the same canonical directory
+
+No new packaging format is introduced in this feature.
+
+## Migration Strategy
+
+Existing skills must be migrated into the split model without losing behavior.
+
+Migration phases:
+
+1. Introduce template families and generation tooling.
+2. Add `content.md` beside existing skills.
+3. Extract business behavior from legacy `SKILL.md` bodies into `content.md`.
+4. Regenerate `SKILL.md` using the protected template family.
+5. Validate the migrated skill.
+6. Update docs and examples to treat `content.md` as the editable surface.
+
+If a legacy skill cannot be safely auto-split, mark it as maintainer-migration-required rather than emitting a lossy transform.
+
+## Documentation Changes
+
+README and related docs should explain:
+
+- the new `SKILL.md` and `content.md` ownership model
+- the terminal-first authoring flow
+- the difference between ordinary user authoring and maintainer catalog work
+- how validation reports incomplete skills
+
+The docs should explicitly discourage opening `SKILL.md` to edit business behavior directly.
+
+## Implementation Plan
+
+### Phase 1: Core authoring model
+
+1. Define template families for base, platform override, and platform `code-review` specialist skills.
+2. Define the canonical `content.md` schema and forbidden protected content rules.
+3. Implement generation of protected `SKILL.md` files from template families.
+
+### Phase 2: CLI authoring workflow
+
+4. Implement `skill-bill new` for one-skill scaffolding.
+5. Implement guided `skill-bill edit`.
+6. Add optional `$EDITOR` handoff that returns to validation afterward.
+7. Implement `skill-bill list`.
+
+### Phase 3: Enforcement
+
+8. Implement `skill-bill validate`.
+9. Add drift detection between templates and generated `SKILL.md`.
+10. Wire taxonomy validation into create and edit flows, not only post hoc validation.
+
+### Phase 4: Migration and docs
+
+11. Add migration tooling or a documented migration playbook for existing skills.
+12. Update README and install guidance for the new authoring model.
+13. Add tests covering both acceptance and rejection paths.
+
+## Test Plan
+
+Required automated coverage:
+
+- valid base skill scaffolding
+- valid platform override scaffolding
+- valid platform `code-review` specialist scaffolding
+- rejection of invalid names and unapproved specialization areas
+- generation of canonical `content.md` headings
+- regeneration of `SKILL.md` after metadata edits
+- validation failure on unresolved TODO placeholders
+- validation failure when forbidden protected sections appear in `content.md`
+- drift detection when `SKILL.md` is hand-edited
+- listing of completion state for draft vs complete skills
+
+## Open Questions
+
+1. Should metadata stay only in generated `SKILL.md` frontmatter for MVP, or should maintainers introduce a separate machine-friendly manifest later if templates become more complex?
+2. Does the repo want a single generic base-skill template for all new base skills, or should certain governed capabilities have dedicated template families from the start?
+3. Should `skill-bill new` immediately install/symlink the new skill when running in a configured local environment, or should installation remain an explicit separate step?
+
+## Recommendation
+
+Ship SKILL-23 as a CLI-first authoring system with a narrow schema and strict generated-file boundaries. Do not optimize first for bulk scaffolding or IDE workflows. If users can create, edit, list, and validate one concrete skill entirely from the terminal, the `SKILL.md`/`content.md` split becomes a product feature instead of just an internal refactor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,15 +54,25 @@ skill-bill is a governed system for authoring, routing, validating, installing, 
 
 ## New-skill authoring
 
-- Use the scaffolder for all new skills: `skill-bill new-skill --payload <file>`, `--interactive`, or `/bill-create-skill`.
+- Use the scaffolder for all new skills. Preferred entrypoints are `skill-bill new --interactive`, `skill-bill new --payload <file>`, or `/bill-create-skill`. `skill-bill new-skill` remains the lower-level command name behind `new`.
+- For ordinary skill authoring and refinement, use the `skill-bill` CLI instead of manually editing governed skill files.
+- Preferred loop: `skill-bill new --interactive` (or `create-and-fill` for one content-managed skill), `skill-bill show <skill-name>`, `skill-bill edit <skill-name>` or `fill <skill-name>`, `skill-bill doctor skill <skill-name>`, `skill-bill validate --skill-name <skill-name>`, then `skill-bill render --skill-name <skill-name>` when wrapper templates change.
+- `skill-bill fill <skill-name>` is the scripted/agent-safe write path for authored content. Feed it `--body` or `--body-file`; combine it with `--section <heading>` when only one authored H2 section should change.
+- `skill-bill edit <skill-name> --section <heading>` is the targeted interactive path when only one authored section needs refinement.
+- `skill-bill show <skill-name>` and `skill-bill explain [<skill-name>]` are the preferred stable read paths for agents; do not grep or hand-parse governed wrappers unless you are changing the scaffold system itself.
+- Treat `content.md` as the primary authored surface for governed skills. Do not manually edit generated `SKILL.md` files during normal authoring.
+- Direct `SKILL.md` edits are maintainer-only work and are allowed only when intentionally changing the shared wrapper, scaffold, render, or migration system itself.
 - The default intake is contextual, not a top-level taxonomy dump. Start with `Platform name:` and branch from there.
-- New platform packs scaffold only the pack root plus the baseline `bill-<platform>-code-review` and `bill-<platform>-quality-check` skills. They do not auto-create `feature-implement` or `feature-verify` overrides.
+- New platform packs always scaffold the pack root plus baseline `bill-<platform>-code-review` and `bill-<platform>-quality-check`. The interactive flow then lets the author choose `none`, `custom subset`, or `all` for approved code-review specialist stubs. It does not auto-create `feature-implement` or `feature-verify` overrides.
+- `create-and-fill` is only for one content-managed skill at a time. Do not use it for horizontal skills, pre-shell overrides, or platform-pack bootstrap flows.
 - Supported `kind` values:
   - `horizontal`: create a canonical skill under `skills/`.
+  - `platform-pack`: create a new `platform-packs/<slug>/` root with a rendered manifest, baseline `code-review`, default `quality-check`, and optional approved specialist stubs.
   - `platform-override-piloted`: create the skill in the selected pack, updating its manifest; for `quality-check`, register `declared_quality_check_file`.
   - `platform-override-piloted` for pre-shell families: create the skill in the platform's legacy `skills/` location and note that it will move when piloted.
   - `code-review-area`: create the specialist in the selected pack and register the area.
   - `add-on`: create a flat add-on file in the selected platform pack's `addons/` directory.
+- For `platform-pack`, payloads may either use `skeleton_mode=starter|full` or provide `specialist_areas=[...]` for a custom approved subset, but not both.
 - Pre-shell families are defined in `skill_bill/constants.py`; add the family there and in `skill_bill/scaffold.py` together.
 - Entry point: `skill_bill/scaffold.py`. Payload schema and exception catalog live in `orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md`.
 - The scaffolder is atomic. Validator, manifest-write, or symlink failures must roll the repo back byte-for-byte.

--- a/README.md
+++ b/README.md
@@ -420,15 +420,17 @@ Skill Bill v1.1 splits every governed skill into two sibling files:
   project-specific rules, classification signals, add-on selection
   rules, and specialist heuristics. When maintainers say "edit the
   skill", this is usually the file they mean. Open it with
-  `skill-bill edit <skill-name>`; it opens in `$VISUAL` → `$EDITOR`, or
-  prints the path when neither is set.
+  `skill-bill edit <skill-name>`; by default it walks each authored H2
+  section in the terminal with replace / append / clear / skip actions.
+  Pass `--editor` to hand off to `$VISUAL` or `$EDITOR`, or `--body-file`
+  to replace `content.md` from stdin or another path. The command then
+  regenerates the wrapper and reruns validation.
 - **`SKILL.md`** — generated governance shell. Agents execute through
   this file, but authors normally should not edit it directly. It carries
-  frontmatter (`name`, `description`, `shell_contract_version`,
-  `template_version`), the required H2 set, a byte-identical
-  `## Execution` pointer to the sibling `content.md`, and the shell-owned
-  ceremony such as overrides precedence (`.agents/skill-overrides.md` >
-  `AGENTS.md` > built-in defaults).
+  frontmatter (`name`, `description`), the required governed H2 set, a
+  template-owned `## Execution` pointer to the sibling `content.md`, and
+  the shell-owned ceremony such as overrides precedence
+  (`.agents/skill-overrides.md` > `AGENTS.md` > built-in defaults).
 - **shared sidecars** — files such as `shell-ceremony.md`,
   `stack-routing.md`, `review-orchestrator.md`, `review-delegation.md`,
   and `telemetry-contract.md`. These hold governed cross-skill behavior
@@ -455,32 +457,54 @@ platform-packs/kotlin/code-review/bill-kotlin-code-review/
 └── telemetry-contract.md
 ```
 
-After a template bump in `skill_bill/constants.py`, regenerate stale
-shells with `skill-bill upgrade` (supports `--dry-run`, `--skill <name>`,
-`--yes`). Shell regeneration updates scaffold-managed wrappers and leaves
-the authored `content.md` working surface alone. Running
-`skill-bill doctor` reports skills whose `template_version` has drifted
-along with the exact upgrade command to run.
+When the shared wrapper template changes, regenerate scaffold-managed
+wrappers with `skill-bill render` (alias: `skill-bill upgrade`). Use
+`--skill-name <skill>` to target a single skill; omit it to refresh the
+full repo. Wrapper regeneration leaves the authored `content.md` working
+surface alone and reruns `scripts/validate_agent_configs.py`.
 
 Legacy v1.0 skills migrate through the one-shot script
 `.venv/bin/python3 scripts/migrate_to_content_md.py`. The migration is
 idempotent, writes `_migration_backup/<timestamp>/` before the first
 rewrite, rolls back per-skill on validator failure, and never commits.
+This is a maintainer-only bulk workflow; normal skill edits should go
+through `skill-bill edit`.
 
 ## Adding skills
 
 Preferred path:
 
-- from inside an AI agent, run `/bill-create-skill`. The skill now starts with plain-language intake, especially for `platform-pack`: ask for the platform slug, ask whether to include code-review specialists, preview the generated baseline set, then subprocess-call `skill-bill new-skill --payload <tempfile>` to materialize it.
-- outside an agent (scripts, CI, teams piloting a new platform), run `skill-bill new-skill --interactive` for the same plain-language bootstrap flow, or pass a JSON payload file with `skill-bill new-skill --payload ./payload.json`.
+- from inside an AI agent, run `/bill-create-skill`. The skill starts with plain-language intake, gathers only the missing authoring details, previews the inferred scaffold, then subprocess-calls `skill-bill new --payload <tempfile>` to materialize it.
+- outside an agent (scripts, CI, teams piloting a new platform), run `skill-bill new --interactive` for the same plain-language bootstrap flow, or pass a JSON payload file with `skill-bill new --payload ./payload.json`.
 
-New platform packs are scaffolded as a bootstrap set: pack root, baseline `code-review`, and baseline `quality-check`. Known platforms such as `java` use built-in routing presets; only unknown or custom platforms need manual `routing_signals`. `platform-pack` still supports `skeleton_mode=full` when you want the bare-bones review specialists created up front; choose `starter` when you want only the baseline path first.
+Terminal-first loop for one concrete skill:
+
+1. `skill-bill new --interactive`
+2. `skill-bill edit <skill-name>`
+3. `skill-bill list`
+4. `skill-bill validate --skill-name <skill-name>`
+5. `skill-bill render --skill-name <skill-name>` when wrapper templates change
+
+`skill-bill new-skill` and `skill-bill upgrade` remain supported as the
+lower-level command names behind `new` and `render`.
+
+For governed skills, the interactive flow can seed an initial `content.md`
+body so the authored behavior is captured at scaffold time instead of being
+backfilled by editing `SKILL.md`. New platform packs are scaffolded as a
+bootstrap set: pack root, baseline `code-review`, and baseline
+`quality-check`. Known platforms such as `java` use built-in routing
+presets; only unknown or custom platforms need manual `routing_signals`.
+`platform-pack` supports `skeleton_mode=full` for approved specialist stubs
+or `starter` for the baseline pair only.
 
 The payload schema, the loud-fail exception catalog, and one worked example per kind live in `orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md`.
 
 The scaffolder is atomic: it creates files, edits manifests with best-effort comment preservation, wires sibling supporting-file symlinks, runs `scripts/validate_agent_configs.py`, and auto-installs into detected agents. Any failure rolls back every staged change and prints the validator's error verbatim.
 
-When the shared wrapper template changes, run `skill-bill upgrade` from the repo root. It regenerates scaffold-managed `SKILL.md` wrappers in place, then reruns `scripts/validate_agent_configs.py`. Authored `content.md` files and the shared `shell-ceremony.md` sidecar stay untouched.
+When the shared wrapper template changes, run `skill-bill render` from the
+repo root. It regenerates scaffold-managed `SKILL.md` wrappers in place,
+then reruns `scripts/validate_agent_configs.py`. Authored `content.md`
+files and the shared `shell-ceremony.md` sidecar stay untouched.
 
 Manual path (discouraged — prefer the scaffolder):
 

--- a/README.md
+++ b/README.md
@@ -422,9 +422,12 @@ Skill Bill v1.1 splits every governed skill into two sibling files:
   skill", this is usually the file they mean. Open it with
   `skill-bill edit <skill-name>`; by default it walks each authored H2
   section in the terminal with replace / append / clear / skip actions.
-  Pass `--editor` to hand off to `$VISUAL` or `$EDITOR`, or `--body-file`
-  to replace `content.md` from stdin or another path. The command then
-  regenerates the wrapper and reruns validation.
+  Pass `--section <heading>` to target one section, `--editor` to hand
+  off to `$VISUAL` or `$EDITOR`, or `--body-file` to replace the full
+  body (or one targeted section) from stdin or another path. For scripted
+  or agent-authored writes, use `skill-bill fill <skill-name> --body-file`
+  or `--body`; it writes `content.md`, regenerates the wrapper, and
+  reruns validation without manual file editing.
 - **`SKILL.md`** — generated governance shell. Agents execute through
   this file, but authors normally should not edit it directly. It carries
   frontmatter (`name`, `description`), the required governed H2 set, a
@@ -476,17 +479,25 @@ Preferred path:
 
 - from inside an AI agent, run `/bill-create-skill`. The skill starts with plain-language intake, gathers only the missing authoring details, previews the inferred scaffold, then subprocess-calls `skill-bill new --payload <tempfile>` to materialize it.
 - outside an agent (scripts, CI, teams piloting a new platform), run `skill-bill new --interactive` for the same plain-language bootstrap flow, or pass a JSON payload file with `skill-bill new --payload ./payload.json`.
+- when you want one command that scaffolds and drops directly into authoring, use `skill-bill create-and-fill --interactive` (or `--payload`). It is only for one content-managed skill at a time; use `skill-bill new` for platform-pack bootstrap flows.
 
 Terminal-first loop for one concrete skill:
 
 1. `skill-bill new --interactive`
-2. `skill-bill edit <skill-name>`
-3. `skill-bill list`
-4. `skill-bill validate --skill-name <skill-name>`
-5. `skill-bill render --skill-name <skill-name>` when wrapper templates change
+2. `skill-bill show <skill-name>`
+3. `skill-bill edit <skill-name>` or `skill-bill fill <skill-name> --body-file -`
+4. `skill-bill doctor skill <skill-name>`
+5. `skill-bill validate --skill-name <skill-name>`
+6. `skill-bill render --skill-name <skill-name>` when wrapper templates change
 
 `skill-bill new-skill` and `skill-bill upgrade` remain supported as the
 lower-level command names behind `new` and `render`.
+
+Additional authoring helpers:
+
+- `skill-bill show <skill-name>` gives a stable read path for humans and agents: section headings, completion status, drift status, and recommended next commands.
+- `skill-bill explain [<skill-name>]` explains the governed boundary between `content.md`, generated `SKILL.md`, and shared sidecars.
+- `skill-bill doctor skill <skill-name>` runs isolated validation and returns a plain-language diagnosis plus the next commands to run.
 
 For governed skills, the interactive flow can seed an initial `content.md`
 body so the authored behavior is captured at scaffold time instead of being

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-20] skill-authoring-terminal-loop
+Areas: skill_bill/, README.md, tests/
+- Added a terminal-first authoring loop on top of the existing split-wrapper scaffold: `skill-bill new`, guided `skill-bill edit`, `skill-bill list`, scoped `skill-bill validate`, and `skill-bill render`/`upgrade` now form the concrete single-skill workflow instead of forcing repo navigation. reusable
+- The guided editor treats `content.md` as the only editable surface, preserves authored H2 order, supports replace / append / clear / skip actions per section, and regenerates only the targeted wrapper before re-running validation. reusable
+- Added completion and drift inspection for content-managed skills plus targeted wrapper regeneration/validation helpers so maintainers can audit one skill at a time without running the entire repo workflow. reusable
+- Maintainer-only bulk workflows remain separate: the migration script is still the path for legacy one-shot conversion, while end users stay on the single-skill terminal loop.
+Feature flag: N/A
+Acceptance criteria: 8/8 implemented
+
 ## [2026-04-19] collapse-skill-md-to-shared-ceremony
 Areas: orchestration/shell-content-contract/, skill_bill/, scripts/, skills/, platform-packs/, docs/, tests/
 - Collapsed the governed shell contract to `Descriptor` / `Execution` / `Ceremony`, with `SKILL.md` reduced to a thin wrapper and authored execution moved into sibling `content.md`. reusable

--- a/docs/getting-started-for-teams.md
+++ b/docs/getting-started-for-teams.md
@@ -162,13 +162,13 @@ skill-bill new-skill --payload /tmp/payload.json
 
 The scaffolder:
 
-- creates `platform-packs/kotlin/code-review/bill-kotlin-code-review-api-contracts/SKILL.md` as a governed three-section wrapper plus sibling `content.md` and `shell-ceremony.md`. The authored execution body is stubbed in `content.md`; the ceremony sidecar is shared.
+- creates `platform-packs/kotlin/code-review/bill-kotlin-code-review-api-contracts/SKILL.md` as a governed three-section wrapper plus sibling `content.md` and `shell-ceremony.md`. The authored execution body lives in `content.md`; the ceremony sidecar is shared.
 - appends `api-contracts` to `declared_code_review_areas` and to `declared_files.areas` in `platform-packs/kotlin/platform.yaml`, preserving key order and best-effort comments.
 - wires sibling supporting-file symlinks for the skill (stack-routing, review-orchestrator, review-delegation, telemetry-contract) from `scripts/skill_repo_contracts.py::RUNTIME_SUPPORTING_FILES`.
 - runs `scripts/validate_agent_configs.py`. If validation fails, every change is rolled back and the validator error is surfaced verbatim.
 - installs the new skill into every detected agent. If none is detected, the scaffolder notes that you should run `./install.sh` to bootstrap agent paths.
 
-Edit the authored execution sections in `content.md` afterwards. Keep the generated `SKILL.md` wrapper and `shell-ceremony.md` sidecar intact unless you are intentionally changing the shared contract.
+Use `skill-bill edit bill-kotlin-code-review-api-contracts` for follow-up changes to the authored `content.md`. Keep the generated `SKILL.md` wrapper and `shell-ceremony.md` sidecar intact unless you are intentionally changing the shared contract. Bulk migration through `scripts/migrate_to_content_md.py` is maintainer-only.
 
 The full payload schema, including the new `platform-pack` kind, lives in `orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md`.
 

--- a/orchestration/shell-content-contract/PLAYBOOK.md
+++ b/orchestration/shell-content-contract/PLAYBOOK.md
@@ -97,6 +97,12 @@ Each governed skill directory must also contain:
 - `shell-ceremony.md` — shared ceremony sidecar, usually a sibling symlink to
   `orchestration/shell-content-contract/shell-ceremony.md`.
 
+`content.md` is the author-owned surface. It must not re-state shell-owned
+output formats, telemetry mechanics, override precedence, execution-mode
+reporting, or required sidecar references. Those stay in the generated
+`SKILL.md` wrapper or shared sidecars so the runtime contract can be upgraded
+without rewriting authored business guidance.
+
 ## Governed Add-On Consumption
 
 Governed add-ons are pack-owned supporting files under
@@ -150,6 +156,10 @@ is ever permitted.
   `MissingContentFileError`.
 - A governed skill is missing its sibling `shell-ceremony.md` →
   `MissingShellCeremonyFileError`.
+- A governed skill's `## Execution` body drifts from the canonical wrapper
+  template → `InvalidExecutionSectionError`.
+- A governed skill's `## Ceremony` body drifts from the canonical wrapper
+  template → `InvalidCeremonySectionError`.
 - A governed skill's `## Descriptor` body drifts from the scaffolded render
   derived from skill context plus `area_metadata` →
   `InvalidDescriptorSectionError`.
@@ -169,7 +179,9 @@ Loader precedence is authoritative and must stay stable:
 5. Required governed H2 section presence.
 6. Sibling `content.md` presence.
 7. Sibling `shell-ceremony.md` presence.
-8. `## Descriptor` body drift.
+8. `## Execution` body drift.
+9. `## Ceremony` body drift.
+10. `## Descriptor` body drift.
 
 ### Loud-Fail Rules (quality-check)
 
@@ -188,6 +200,10 @@ optional `declared_quality_check_file` key:
   `MissingContentFileError`.
 - The governed quality-check skill is missing sibling `shell-ceremony.md` →
   `MissingShellCeremonyFileError`.
+- The governed quality-check skill's `## Execution` body drifts →
+  `InvalidExecutionSectionError`.
+- The governed quality-check skill's `## Ceremony` body drifts →
+  `InvalidCeremonySectionError`.
 - The governed quality-check skill's `## Descriptor` body drifts →
   `InvalidDescriptorSectionError`.
 

--- a/orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md
+++ b/orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md
@@ -73,6 +73,10 @@ Every payload MUST include:
 ## Optional Keys
 
 - `description` — one-line description copied into the frontmatter.
+- `content_body` — authored markdown body for governed skills. When
+  provided for shelled families (`code-review`, `quality-check`), the
+  scaffolder writes it into the sibling `content.md` instead of the default
+  maintainer starter content.
 - `display_name` — human-friendly label for `platform-pack`. Defaults to a
   title-cased version of `platform`.
 - `skeleton_mode` — `starter` or `full` for `platform-pack`. Defaults to
@@ -169,6 +173,18 @@ user-facing intake defaults to `full`. The generated files are intentionally
 minimal so the user can enrich the authored
 sidecars afterwards.
 
+### Governed skill with concrete authored content
+
+```json
+{
+  "scaffold_payload_version": "1.0",
+  "kind": "code-review-area",
+  "platform": "kotlin",
+  "area": "api-contracts",
+  "content_body": "## Focus\n\nReview API boundary regressions.\n\n## Review Guidance\n\n- Prefer client-visible contract issues.\n- Call out backward-compatibility breaks explicitly.\n"
+}
+```
+
 ### Code-review area
 
 ```json
@@ -218,16 +234,16 @@ All exceptions derive from `skill_bill.scaffold_exceptions.ScaffoldError`:
 ## SKILL-21: Shell+content split (v1.1)
 
 SKILL-21 added sibling `content.md` authoring and bumped the shell contract
-to `1.1`. Callers of the scaffold payload do not need to change, but the
-output changes:
+to `1.1`. The output changes:
 
 - Every kind that produces a `SKILL.md` now also writes a sibling
   `content.md` under the same skill directory.
-- The generated `SKILL.md` carries two additional frontmatter keys,
-  `shell_contract_version` and `template_version`.
 - The generated `SKILL.md` carries a new required `## Execution` H2 whose
   body is byte-identical across every governed skill and links to
   `content.md`.
+- End-user creation flows may also provide `content_body` so governed
+  skills are concrete at scaffold time instead of requiring later wrapper
+  edits.
 
 Loud-fail exceptions added to the shell contract catalog (raised by the
 loader and surfaced by the validator, not by the scaffolder itself):
@@ -235,7 +251,9 @@ loader and surfaced by the validator, not by the scaffolder itself):
 - `ContractVersionMismatchError` — pack declares an outdated
   `contract_version`; the message points at
   `scripts/migrate_to_content_md.py`.
-- `MissingContentBodyFileError` — sibling `content.md` is missing for a
+- `MissingContentFileError` — sibling `content.md` is missing for a
   governed skill.
 - `InvalidExecutionSectionError` — the `## Execution` section body is not
   the canonical byte-identical form.
+- `InvalidCeremonySectionError` — the `## Ceremony` section body drifted
+  from the wrapper template.

--- a/platform-packs/kmp/code-review/bill-kmp-code-review/SKILL.md
+++ b/platform-packs/kmp/code-review/bill-kmp-code-review/SKILL.md
@@ -19,7 +19,6 @@ Follow the instructions in [content.md](content.md).
 Follow the shell ceremony in [shell-ceremony.md](shell-ceremony.md).
 
 Determine the review scope using [review-scope.md](review-scope.md).
-
 Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
 
 When stack routing applies, follow [stack-routing.md](stack-routing.md).

--- a/platform-packs/kotlin/code-review/bill-kotlin-code-review/SKILL.md
+++ b/platform-packs/kotlin/code-review/bill-kotlin-code-review/SKILL.md
@@ -19,7 +19,6 @@ Follow the instructions in [content.md](content.md).
 Follow the shell ceremony in [shell-ceremony.md](shell-ceremony.md).
 
 Determine the review scope using [review-scope.md](review-scope.md).
-
 Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.
 
 When stack routing applies, follow [stack-routing.md](stack-routing.md).

--- a/scripts/migrate_to_content_md.py
+++ b/scripts/migrate_to_content_md.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""One-shot migration from v1.0 single-file SKILL.md to v1.1 shell + content split.
+"""Maintainer-only bulk migration from v1.0 single-file SKILL.md to v1.1 shell + content split.
 
 SKILL-21: walks every governed SKILL.md under ``skills/`` and
 ``platform-packs/``, extracts author prose into a sibling ``content.md``,
@@ -22,6 +22,11 @@ Flags:
                 has uncommitted changes other than this migration itself.
   --repo-root   Absolute path to the repo under migration (default:
                 the script's parent directory).
+
+This script is intentionally *not* the normal end-user editing workflow.
+Use ``skill-bill edit <skill-name>`` for day-to-day skill changes. Use this
+script only when maintainers are bulk-migrating legacy single-file governed
+skills into the generated-wrapper + authored-content split.
 
 The script emits a summary table on exit. Any per-skill failure returns a
 non-zero exit code. No git operations are performed — commit manually.
@@ -439,12 +444,15 @@ def migrate(
 
 def main(argv: Iterable[str] | None = None) -> int:
   parser = argparse.ArgumentParser(
-    description="Migrate governed SKILL.md files to the v1.1 shell+content split.",
+    description=(
+      "Maintainer-only bulk migration for governed SKILL.md files to the v1.1 "
+      "shell+content split."
+    ),
   )
   parser.add_argument(
     "--force",
     action="store_true",
-    help="Re-run on skills that already have content.md.",
+    help="Re-run on skills that already have content.md (bulk-maintainer mode only).",
   )
   parser.add_argument(
     "--strict",
@@ -454,7 +462,7 @@ def main(argv: Iterable[str] | None = None) -> int:
   parser.add_argument(
     "--yes",
     action="store_true",
-    help="Bypass the dirty-repo guard.",
+    help="Bypass the dirty-repo guard for maintainer-run bulk migration.",
   )
   parser.add_argument(
     "--repo-root",
@@ -469,6 +477,10 @@ def main(argv: Iterable[str] | None = None) -> int:
     force=args.force,
     strict=args.strict,
     yes=args.yes,
+  )
+  print(
+    "Maintainer workflow: bulk migration only. "
+    "For normal skill edits, use `skill-bill edit <skill-name>`."
   )
   print(_format_summary(report))
   print(

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT_DIR))
 
 from skill_bill.shell_content_contract import (  # noqa: E402
   APPROVED_CODE_REVIEW_AREAS as SHELL_APPROVED_CODE_REVIEW_AREAS,
+  CEREMONY_FREE_FORM_H2S,
   SHELL_CONTRACT_VERSION,
   ShellContentContractError,
   discover_platform_packs,
@@ -142,6 +143,31 @@ REVIEW_ORCHESTRATOR_TELEMETRY_REQUIREMENTS: tuple[tuple[str, str], ...] = (
   (CHILD_NO_TRIAGE_RULE, "review orchestration contract must forbid delegated child reviews from calling triage_findings"),
   (NO_FINDINGS_TRIAGE_RULE, "review orchestration contract must define the final parent-owned no-findings triage rule"),
 )
+FRAMEWORK_DUPLICATION_LINES: tuple[str, ...] = (
+  "## Additional Resources",
+  "## Output Rules",
+  "## Review Output",
+  "## Output Format",
+  "### Telemetry",
+  "### Implementation Mode Notes",
+)
+SYSTEM_OWNED_CONTENT_MARKERS: tuple[str, ...] = (
+  "## Setup",
+  "Resolve the scope before reviewing. If the caller asks for staged changes, inspect only the staged diff and keep unstaged edits out of findings except for repo markers needed for classification.",
+)
+EXECUTION_AND_REPORTING_CEREMONY_MARKERS: tuple[str, ...] = (
+  "shared execution-mode contract",
+  "If execution mode is `inline`:",
+  "If execution mode is `delegated`:",
+  "delegated subagent",
+  "wrapper-linked sidecars",
+  "Selected add-ons: none",
+  "When reporting results:",
+  "show issue count by category",
+  "report each fix with `file:line`",
+  "display the final `./gradlew check` result",
+)
+UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"(?m)^\s*(?:[-*]\s*)?(?:TODO|FIXME)\b")
 
 
 def main() -> int:
@@ -333,6 +359,67 @@ def validate_platform_pack_skill_file(skill_name: str, skill_file: Path, issues:
     )
   validate_runtime_supporting_files(skill_name, text, skill_file, issues)
   validate_portable_review_wording(skill_name, text, skill_file, issues)
+  validate_governed_content_file(skill_name, skill_file, issues)
+
+
+def validate_governed_content_file(
+  skill_name: str,
+  skill_file: Path,
+  issues: list[str],
+) -> None:
+  content_file = skill_file.parent / "content.md"
+  if not content_file.is_file():
+    return
+
+  text = content_file.read_text(encoding="utf-8")
+  stripped = text.strip()
+  if not stripped:
+    issues.append(f"{content_file}: content.md must not be empty")
+    return
+
+  visible_lines = [line.strip() for line in text.splitlines() if line.strip()]
+  if len(visible_lines) <= 1:
+    issues.append(
+      f"{content_file}: content.md must include authored guidance beyond the title heading"
+    )
+
+  if UNRESOLVED_PLACEHOLDER_PATTERN.search(text):
+    issues.append(
+      f"{content_file}: content.md contains an unresolved TODO/FIXME placeholder"
+    )
+
+  for heading in CEREMONY_FREE_FORM_H2S:
+    if heading in text.splitlines():
+      issues.append(
+        f"{content_file}: content.md must not reintroduce shell-owned heading '{heading}'"
+      )
+
+  for marker in FRAMEWORK_DUPLICATION_LINES:
+    if marker in text.splitlines():
+      issues.append(
+        f"{content_file}: content.md must not inline shared review-contract block '{marker}'"
+      )
+
+  for marker in SYSTEM_OWNED_CONTENT_MARKERS:
+    if marker in text:
+      issues.append(
+        f"{content_file}: content.md must not inline system-owned setup contract marker '{marker}'"
+      )
+
+  for marker in EXECUTION_AND_REPORTING_CEREMONY_MARKERS:
+    if marker in text:
+      issues.append(
+        f"{content_file}: content.md must not inline shell-owned execution/reporting marker '{marker}'"
+      )
+
+  required_files = required_supporting_files_for_skill(skill_name)
+  for file_name in required_files:
+    if file_name in ADDON_SUPPORTING_FILE_TARGETS:
+      continue
+    if file_name in text:
+      issues.append(
+        f"{content_file}: content.md must not carry system-required supporting file reference '{file_name}'"
+      )
 
 
 def discover_addon_files(root: Path) -> list[Path]:

--- a/skill_bill/cli.py
+++ b/skill_bill/cli.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
+import importlib.util
 import json
+import os
 from pathlib import Path
+import shlex
+import subprocess
 import sys
 
 from skill_bill import __version__
@@ -60,6 +65,17 @@ from skill_bill.triage import (
   parse_triage_decisions,
   record_feedback,
 )
+
+
+@dataclass(frozen=True)
+class GovernedSkillTarget:
+  skill_name: str
+  package: str
+  platform: str
+  family: str
+  area: str
+  skill_file: Path
+  content_file: Path
 
 
 def import_review_command(args: argparse.Namespace) -> int:
@@ -506,6 +522,310 @@ def _platform_pack_exists(platform: str, *, repo_root: Path | None = None) -> bo
   return (root / "platform-packs" / platform / "platform.yaml").exists()
 
 
+def _discover_platform_pack_slugs(repo_root: Path) -> set[str]:
+  from skill_bill.shell_content_contract import discover_platform_pack_manifests
+
+  return {
+    pack.slug
+    for pack in discover_platform_pack_manifests(repo_root / "platform-packs")
+  }
+
+
+def _discover_governed_skill_targets(repo_root: Path) -> dict[str, GovernedSkillTarget]:
+  from skill_bill.shell_content_contract import discover_platform_pack_manifests
+
+  discovered: dict[str, GovernedSkillTarget] = {}
+  for pack in discover_platform_pack_manifests(repo_root / "platform-packs"):
+    baseline_path = pack.declared_files.get("baseline")
+    if isinstance(baseline_path, Path):
+      discovered[baseline_path.parent.name] = GovernedSkillTarget(
+        skill_name=baseline_path.parent.name,
+        package=pack.slug,
+        platform=pack.slug,
+        family="code-review",
+        area="",
+        skill_file=baseline_path,
+        content_file=baseline_path.with_name("content.md"),
+      )
+    area_paths = pack.declared_files.get("areas", {})
+    if isinstance(area_paths, dict):
+      for area, skill_file in area_paths.items():
+        discovered[skill_file.parent.name] = GovernedSkillTarget(
+          skill_name=skill_file.parent.name,
+          package=pack.slug,
+          platform=pack.slug,
+          family="code-review",
+          area=area,
+          skill_file=skill_file,
+          content_file=skill_file.with_name("content.md"),
+        )
+    if pack.declared_quality_check_file is not None:
+      quality_check_skill = pack.declared_quality_check_file
+      discovered[quality_check_skill.parent.name] = GovernedSkillTarget(
+        skill_name=quality_check_skill.parent.name,
+        package=pack.slug,
+        platform=pack.slug,
+        family="quality-check",
+        area="",
+        skill_file=quality_check_skill,
+        content_file=quality_check_skill.with_name("content.md"),
+      )
+  return discovered
+
+
+def _infer_skill_family(skill_name: str) -> str:
+  slug = skill_name.removeprefix("bill-")
+  if "-code-review-" in skill_name or slug.endswith("code-review"):
+    return "code-review"
+  if slug.endswith("quality-check"):
+    return "quality-check"
+  if slug.endswith("feature-implement"):
+    return "feature-implement"
+  if slug.endswith("feature-verify"):
+    return "feature-verify"
+  return slug
+
+
+def _infer_skill_area(skill_name: str, family: str) -> str:
+  if family != "code-review" or "-code-review-" not in skill_name:
+    return ""
+  return skill_name.split("-code-review-", 1)[1]
+
+
+def _discover_content_managed_skill_targets(repo_root: Path) -> dict[str, GovernedSkillTarget]:
+  discovered = _discover_governed_skill_targets(repo_root)
+  skills_root = repo_root / "skills"
+  if not skills_root.is_dir():
+    return discovered
+
+  for skill_file in sorted(skills_root.rglob("SKILL.md")):
+    content_file = skill_file.with_name("content.md")
+    if not content_file.is_file():
+      continue
+    skill_name = skill_file.parent.name
+    if skill_name in discovered:
+      continue
+    relative = skill_file.relative_to(repo_root)
+    package = "base"
+    platform = ""
+    if len(relative.parts) >= 3 and relative.parts[0] == "skills":
+      if not relative.parts[1].startswith("bill-"):
+        package = relative.parts[1]
+        platform = relative.parts[1]
+    family = _infer_skill_family(skill_name)
+    discovered[skill_name] = GovernedSkillTarget(
+      skill_name=skill_name,
+      package=package,
+      platform=platform,
+      family=family,
+      area=_infer_skill_area(skill_name, family),
+      skill_file=skill_file,
+      content_file=content_file,
+    )
+  return discovered
+
+
+def _content_visible_lines(text: str) -> list[str]:
+  return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def _has_unresolved_placeholder(text: str) -> bool:
+  import re
+
+  return re.search(r"(?m)^\s*(?:[-*]\s*)?(?:TODO|FIXME)\b", text) is not None
+
+
+def _parse_content_sections(text: str) -> tuple[str, list[tuple[str, str]]]:
+  prefix_lines: list[str] = []
+  sections: list[tuple[str, str]] = []
+  current_heading: str | None = None
+  current_lines: list[str] = []
+  in_fence = False
+
+  for line in text.splitlines(keepends=True):
+    stripped = line.rstrip("\n")
+    if stripped.lstrip().startswith(("```", "~~~")):
+      in_fence = not in_fence
+      if current_heading is None:
+        prefix_lines.append(line)
+      else:
+        current_lines.append(line)
+      continue
+    if not in_fence and stripped.startswith("## "):
+      if current_heading is None:
+        current_heading = stripped
+        current_lines = []
+      else:
+        sections.append((current_heading, "".join(current_lines)))
+        current_heading = stripped
+        current_lines = []
+      continue
+    if current_heading is None:
+      prefix_lines.append(line)
+    else:
+      current_lines.append(line)
+
+  if current_heading is not None:
+    sections.append((current_heading, "".join(current_lines)))
+  return ("".join(prefix_lines), sections)
+
+
+def _render_content_sections(prefix: str, sections: list[tuple[str, str]]) -> str:
+  prefix_text = prefix.rstrip()
+  blocks: list[str] = []
+  if prefix_text:
+    blocks.append(prefix_text)
+  for heading, body in sections:
+    section_body = body.rstrip()
+    if section_body:
+      blocks.append(f"{heading}\n\n{section_body}")
+    else:
+      blocks.append(f"{heading}\n")
+  return "\n\n".join(blocks).rstrip() + "\n"
+
+
+def _section_completion_status(body: str) -> str:
+  if not body.strip():
+    return "empty"
+  if _has_unresolved_placeholder(body):
+    return "draft"
+  return "complete"
+
+
+def _content_completion_status(text: str) -> str:
+  visible_lines = _content_visible_lines(text)
+  if len(visible_lines) <= 1:
+    return "draft"
+  if _has_unresolved_placeholder(text):
+    return "draft"
+  _prefix, sections = _parse_content_sections(text)
+  if sections and any(_section_completion_status(body) != "complete" for _heading, body in sections):
+    return "draft"
+  return "complete"
+
+
+def _render_multiline_section_input(prompt: str, *, terminator: str = ".done") -> str:
+  print(prompt)
+  lines: list[str] = []
+  while True:
+    line = input()
+    if line == terminator:
+      break
+    lines.append(line)
+  return "\n".join(lines).rstrip()
+
+
+def _prompt_edit_action() -> str:
+  return _prompt_choice(
+    "Action [r=replace, a=append, c=clear, s=skip, d=done]: ",
+    {
+      "r": "replace",
+      "a": "append",
+      "c": "clear",
+      "s": "skip",
+      "d": "done",
+    },
+  )
+
+
+def _edit_content_guided(content_file: Path) -> tuple[str, list[dict[str, str]]]:
+  text = content_file.read_text(encoding="utf-8")
+  prefix, sections = _parse_content_sections(text)
+  if not sections:
+    replacement = _render_multiline_section_input(
+      "content.md has no editable H2 sections. Enter the full replacement body and finish with '.done'."
+    )
+    rendered = replacement if replacement.endswith("\n") else f"{replacement}\n"
+    return rendered, []
+
+  updated_sections: list[tuple[str, str]] = []
+  for index, (heading, body) in enumerate(sections):
+    status = _section_completion_status(body)
+    print(f"{heading} [{status}]")
+    print(body.rstrip() or "(empty)")
+    action = _prompt_edit_action()
+    if action == "done":
+      updated_sections.extend(sections[index:])
+      break
+    if action == "skip":
+      updated_sections.append((heading, body))
+      continue
+    if action == "clear":
+      updated_sections.append((heading, ""))
+      continue
+    prompt = (
+      f"Enter text for {heading}. Finish with '.done'."
+      if action == "replace"
+      else f"Append text for {heading}. Finish with '.done'."
+    )
+    entered = _render_multiline_section_input(prompt)
+    if action == "replace":
+      updated_sections.append((heading, entered))
+    else:
+      existing = body.rstrip()
+      combined = entered if not existing else f"{existing}\n\n{entered}".rstrip()
+      updated_sections.append((heading, combined))
+
+  rendered = _render_content_sections(prefix, updated_sections)
+  section_payload = [
+    {
+      "heading": heading.removeprefix("## ").strip(),
+      "status": _section_completion_status(body),
+    }
+    for heading, body in updated_sections
+  ]
+  return rendered, section_payload
+
+
+def _load_validator_module(repo_root: Path):
+  script_path = repo_root / "scripts" / "validate_agent_configs.py"
+  if not script_path.is_file():
+    raise ValueError(f"Validator script is missing at '{script_path}'.")
+  scripts_dir = str(script_path.parent)
+  repo_root_str = str(repo_root)
+  sys.path.insert(0, scripts_dir)
+  sys.path.insert(0, repo_root_str)
+  try:
+    spec = importlib.util.spec_from_file_location(
+      "_skill_bill_runtime_validator",
+      script_path,
+    )
+    if spec is None or spec.loader is None:
+      raise ValueError(f"Could not load validator module from '{script_path}'.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+  finally:
+    for entry in (repo_root_str, scripts_dir):
+      if entry in sys.path:
+        sys.path.remove(entry)
+
+
+def _validate_selected_skills(repo_root: Path, skill_names: list[str]) -> list[str]:
+  from skill_bill.shell_content_contract import ShellContentContractError, load_platform_pack
+
+  validator = _load_validator_module(repo_root)
+  issues: list[str] = []
+  skill_files = validator.discover_skill_files(repo_root, issues)
+  platform_pack_skill_files = validator.discover_platform_pack_skill_files(repo_root)
+
+  for skill_name in skill_names:
+    if skill_name in skill_files:
+      validator.validate_skill_file(skill_name, skill_files[skill_name], issues)
+      continue
+    if skill_name in platform_pack_skill_files:
+      skill_file = platform_pack_skill_files[skill_name]
+      validator.validate_platform_pack_skill_file(skill_name, skill_file, issues)
+      pack_root = repo_root / "platform-packs" / skill_file.relative_to(repo_root / "platform-packs").parts[0]
+      try:
+        load_platform_pack(pack_root)
+      except ShellContentContractError as error:
+        issues.append(f"{pack_root.relative_to(repo_root)}: {error}")
+      continue
+    issues.append(f"Unknown skill '{skill_name}'.")
+  return issues
+
+
 def _normalize_addon_body(text: str) -> str:
   if not text.strip():
     raise ValueError("Add-on body must be non-empty.")
@@ -530,6 +850,17 @@ def _prompt_multiline(prompt: str, *, terminator: str = "END") -> str:
     if any(line.strip() for line in lines):
       return "\n".join(lines)
     print("Add-on body must include at least one non-empty line.")
+
+
+def _prompt_optional_multiline(prompt: str, *, terminator: str = "END") -> str:
+  print(prompt)
+  lines: list[str] = []
+  while True:
+    line = input()
+    if line == terminator:
+      break
+    lines.append(line)
+  return "\n".join(lines).strip()
 
 
 def _build_addon_markdown(name: str, description: str, body: str) -> str:
@@ -578,6 +909,11 @@ def _prompt_new_skill_interactively(*, repo_root: Path | None = None) -> dict:
   if selection.startswith("platform-pack"):
     payload["kind"] = "platform-pack"
     payload["platform"] = platform
+    include_specialists = _prompt_yes_no(
+      "Include the approved code-review specialist stubs?",
+      default=True,
+    )
+    payload["skeleton_mode"] = "full" if include_specialists else "starter"
     display_name = input("Display name (blank to derive from slug): ").strip()
     if display_name:
       payload["display_name"] = display_name
@@ -619,6 +955,12 @@ def _prompt_new_skill_interactively(*, repo_root: Path | None = None) -> dict:
     description = input("One-line description (optional): ").strip()
     if description:
       payload["description"] = description
+    if family in {"code-review", "quality-check"}:
+      content_body = _prompt_optional_multiline(
+        "Initial content.md body (optional). Finish with a line containing only END."
+      )
+      if content_body:
+        payload["content_body"] = content_body
     return payload
 
   if selection == "code-review-area":
@@ -632,6 +974,11 @@ def _prompt_new_skill_interactively(*, repo_root: Path | None = None) -> dict:
     description = input("One-line description (optional): ").strip()
     if description:
       payload["description"] = description
+    content_body = _prompt_optional_multiline(
+      "Initial content.md body (optional). Finish with a line containing only END."
+    )
+    if content_body:
+      payload["content_body"] = content_body
     return payload
 
   return payload
@@ -767,11 +1114,102 @@ def doctor_command(args: argparse.Namespace) -> int:
   return 0
 
 
+def list_command(args: argparse.Namespace) -> int:
+  from skill_bill.upgrade import render_upgrade_targets
+
+  repo_root = Path(args.repo_root).resolve()
+  targets = _discover_content_managed_skill_targets(repo_root)
+  if args.skill_name:
+    selected_names = set(args.skill_name)
+    missing = sorted(selected_names - set(targets))
+    if missing:
+      raise ValueError(
+        f"Unknown content-managed skill(s): {', '.join(missing)}."
+      )
+    targets = {
+      skill_name: target
+      for skill_name, target in targets.items()
+      if skill_name in selected_names
+    }
+
+  rendered_targets = render_upgrade_targets(
+    repo_root,
+    skill_names=targets.keys(),
+  )
+  payload_skills: list[dict[str, object]] = []
+  for skill_name, target in sorted(targets.items()):
+    content_text = target.content_file.read_text(encoding="utf-8")
+    payload_skills.append(
+      {
+        "skill_name": skill_name,
+        "package": target.package,
+        "platform": target.platform,
+        "family": target.family,
+        "area": target.area,
+        "completion_status": _content_completion_status(content_text),
+        "generation_drift": (
+          rendered_targets.get(target.skill_file) is not None
+          and target.skill_file.read_text(encoding="utf-8")
+          != rendered_targets[target.skill_file]
+        ),
+        "skill_file": str(target.skill_file),
+        "content_file": str(target.content_file),
+      }
+    )
+
+  emit(
+    {
+      "repo_root": str(repo_root),
+      "skill_count": len(payload_skills),
+      "skills": payload_skills,
+    },
+    args.format,
+  )
+  return 0
+
+
+def validate_command(args: argparse.Namespace) -> int:
+  repo_root = Path(args.repo_root).resolve()
+  if args.skill_name:
+    issues = _validate_selected_skills(repo_root, args.skill_name)
+    payload = {
+      "repo_root": str(repo_root),
+      "mode": "selected",
+      "skill_names": args.skill_name,
+      "status": "pass" if not issues else "fail",
+      "issues": issues,
+    }
+    emit(payload, args.format)
+    return 0 if not issues else 1
+
+  script_path = repo_root / "scripts" / "validate_agent_configs.py"
+  if not script_path.is_file():
+    raise ValueError(f"Validator script is missing at '{script_path}'.")
+  result = subprocess.run(
+    [sys.executable, str(script_path), str(repo_root)],
+    capture_output=True,
+    text=True,
+  )
+  emit(
+    {
+      "repo_root": str(repo_root),
+      "mode": "repo",
+      "status": "pass" if result.returncode == 0 else "fail",
+      "exit_code": result.returncode,
+      "stdout": result.stdout,
+      "stderr": result.stderr,
+    },
+    args.format,
+  )
+  return result.returncode
+
+
 def upgrade_command(args: argparse.Namespace) -> int:
   from skill_bill.upgrade import upgrade_skill_wrappers
 
   result = upgrade_skill_wrappers(
     args.repo_root,
+    skill_names=args.skill_name,
     validate=not args.skip_validate,
   )
   emit(
@@ -782,6 +1220,88 @@ def upgrade_command(args: argparse.Namespace) -> int:
       "content_md_touched": False,
       "shell_ceremony_touched": False,
       "validator_ran": not args.skip_validate,
+    },
+    args.format,
+  )
+  return 0
+
+
+def _resolve_editor_command() -> list[str]:
+  editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or ""
+  if not editor.strip():
+    return []
+  return shlex.split(editor)
+
+
+def _edit_content_via_editor(content_file: Path) -> bool:
+  command = _resolve_editor_command()
+  if not command:
+    return False
+  subprocess.run(
+    [*command, str(content_file)],
+    check=True,
+  )
+  return True
+
+
+def edit_command(args: argparse.Namespace) -> int:
+  from skill_bill.upgrade import upgrade_skill_wrappers
+
+  repo_root = Path(args.repo_root).resolve()
+  editable_targets = _discover_content_managed_skill_targets(repo_root)
+  target = editable_targets.get(args.skill_name)
+  if target is None:
+    raise ValueError(
+      f"Skill '{args.skill_name}' is not a content-managed skill with a sibling content.md file."
+    )
+
+  content_before = target.content_file.read_bytes()
+  wrapper_before = target.skill_file.read_bytes()
+  used_editor = False
+  guided_sections: list[dict[str, str]] = []
+
+  try:
+    if args.body_file:
+      target.content_file.write_text(
+        _read_text_input(args.body_file),
+        encoding="utf-8",
+      )
+    elif args.editor:
+      used_editor = _edit_content_via_editor(target.content_file)
+      if not used_editor:
+        raise ValueError("No $VISUAL or $EDITOR is configured.")
+    else:
+      replacement, guided_sections = _edit_content_guided(target.content_file)
+      target.content_file.write_text(replacement, encoding="utf-8")
+
+    upgrade_result = upgrade_skill_wrappers(
+      repo_root,
+      skill_names=[target.skill_name],
+      validate=True,
+    )
+  except Exception:
+    target.content_file.write_bytes(content_before)
+    target.skill_file.write_bytes(wrapper_before)
+    raise
+
+  emit(
+    {
+      "skill_name": target.skill_name,
+      "package": target.package,
+      "platform": target.platform,
+      "family": target.family,
+      "area": target.area,
+      "skill_file": str(target.skill_file),
+      "content_file": str(target.content_file),
+      "used_editor": used_editor,
+      "guided_sections": guided_sections,
+      "completion_status": _content_completion_status(
+        target.content_file.read_text(encoding="utf-8")
+      ),
+      "wrapper_regenerated": str(target.skill_file) in {
+        str(path) for path in upgrade_result.regenerated_files
+      },
+      "validator_ran": True,
     },
     args.format,
   )
@@ -966,6 +1486,40 @@ def build_parser() -> argparse.ArgumentParser:
   doctor_parser.add_argument("--format", choices=("text", "json"), default="text")
   doctor_parser.set_defaults(handler=doctor_command)
 
+  list_parser = subparsers.add_parser(
+    "list",
+    help="List content-managed skills and their authoring status.",
+  )
+  list_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to inspect. Defaults to the current working directory.",
+  )
+  list_parser.add_argument(
+    "--skill-name",
+    action="append",
+    help="Optional content-managed skill name to include. Repeat to target multiple skills.",
+  )
+  list_parser.add_argument("--format", choices=("text", "json"), default="text")
+  list_parser.set_defaults(handler=list_command)
+
+  validate_parser = subparsers.add_parser(
+    "validate",
+    help="Run the repo validator, or validate specific skills only.",
+  )
+  validate_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to validate. Defaults to the current working directory.",
+  )
+  validate_parser.add_argument(
+    "--skill-name",
+    action="append",
+    help="Optional skill name to validate in isolation. Repeat to target multiple skills.",
+  )
+  validate_parser.add_argument("--format", choices=("text", "json"), default="text")
+  validate_parser.set_defaults(handler=validate_command)
+
   upgrade_parser = subparsers.add_parser(
     "upgrade",
     help="Regenerate scaffold-managed SKILL.md wrappers without touching authored sidecars.",
@@ -980,8 +1534,57 @@ def build_parser() -> argparse.ArgumentParser:
     action="store_true",
     help="Skip scripts/validate_agent_configs.py after wrapper regeneration.",
   )
+  upgrade_parser.add_argument(
+    "--skill-name",
+    action="append",
+    help="Optional governed or horizontal skill name to regenerate. Repeat to target multiple skills.",
+  )
   upgrade_parser.add_argument("--format", choices=("text", "json"), default="text")
   upgrade_parser.set_defaults(handler=upgrade_command)
+
+  render_parser = subparsers.add_parser(
+    "render",
+    help="Alias for upgrade: regenerate scaffold-managed SKILL.md wrappers.",
+  )
+  render_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to upgrade. Defaults to the current working directory.",
+  )
+  render_parser.add_argument(
+    "--skip-validate",
+    action="store_true",
+    help="Skip scripts/validate_agent_configs.py after wrapper regeneration.",
+  )
+  render_parser.add_argument(
+    "--skill-name",
+    action="append",
+    help="Optional governed or horizontal skill name to regenerate. Repeat to target multiple skills.",
+  )
+  render_parser.add_argument("--format", choices=("text", "json"), default="text")
+  render_parser.set_defaults(handler=upgrade_command)
+
+  edit_parser = subparsers.add_parser(
+    "edit",
+    help="Edit a content-managed skill's authored content.md and regenerate the wrapper.",
+  )
+  edit_parser.add_argument("skill_name", help="Governed skill name to edit.")
+  edit_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to edit. Defaults to the current working directory.",
+  )
+  edit_parser.add_argument(
+    "--body-file",
+    help="Replace content.md from a file path (or '-' for stdin) instead of prompting or launching $EDITOR.",
+  )
+  edit_parser.add_argument(
+    "--editor",
+    action="store_true",
+    help="Open content.md in $VISUAL or $EDITOR instead of using guided section editing.",
+  )
+  edit_parser.add_argument("--format", choices=("text", "json"), default="text")
+  edit_parser.set_defaults(handler=edit_command)
 
   new_skill_parser = subparsers.add_parser(
     "new-skill",
@@ -1003,6 +1606,27 @@ def build_parser() -> argparse.ArgumentParser:
   )
   new_skill_parser.add_argument("--format", choices=("text", "json"), default="text")
   new_skill_parser.set_defaults(handler=new_skill_command)
+
+  new_parser = subparsers.add_parser(
+    "new",
+    help="Alias for new-skill: scaffold one skill from a payload file or interactive prompts.",
+  )
+  new_parser.add_argument(
+    "--payload",
+    help="Path to a JSON payload file (or '-' for stdin).",
+  )
+  new_parser.add_argument(
+    "--interactive",
+    action="store_true",
+    help="Collect a skill scaffold payload via interactive prompts.",
+  )
+  new_parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Plan the scaffold and report the operations without touching disk.",
+  )
+  new_parser.add_argument("--format", choices=("text", "json"), default="text")
+  new_parser.set_defaults(handler=new_skill_command)
 
   new_addon_parser = subparsers.add_parser(
     "new-addon",

--- a/skill_bill/cli.py
+++ b/skill_bill/cli.py
@@ -78,6 +78,13 @@ class GovernedSkillTarget:
   content_file: Path
 
 
+@dataclass(frozen=True)
+class ScaffoldCommandOutcome:
+  exit_code: int
+  result: object | None
+  payload: dict[str, object] | None
+
+
 def import_review_command(args: argparse.Namespace) -> int:
   text, source_path = read_input(args.input)
   review = parse_review(text)
@@ -371,7 +378,7 @@ def version_command(args: argparse.Namespace) -> int:
   return 0
 
 
-def _run_scaffold_command(payload: dict, args: argparse.Namespace) -> int:
+def _execute_scaffold_command(payload: dict, args: argparse.Namespace) -> ScaffoldCommandOutcome:
   from skill_bill import scaffold as _scaffold
   from skill_bill import scaffold_domain as _scaffold_domain
   from skill_bill.config import load_telemetry_settings
@@ -429,7 +436,11 @@ def _run_scaffold_command(payload: dict, args: argparse.Namespace) -> int:
     # every failure mode into exit code 1 and throw away the typed contract
     # the exit_code_map exposes to callers.
     print(str(error), file=sys.stderr)
-    return exit_code_map.get(type(error), 1)
+    return ScaffoldCommandOutcome(
+      exit_code=exit_code_map.get(type(error), 1),
+      result=None,
+      payload=None,
+    )
   # Non-ScaffoldError exceptions (real bugs) propagate so the user gets a
   # traceback instead of a silently-collapsed "user error".
 
@@ -445,8 +456,10 @@ def _run_scaffold_command(payload: dict, args: argparse.Namespace) -> int:
     level=level,
   )
 
-  emit(
-    {
+  return ScaffoldCommandOutcome(
+    exit_code=0,
+    result=result,
+    payload={
       "session_id": session_id,
       "kind": result.kind,
       "skill_name": result.skill_name,
@@ -460,9 +473,17 @@ def _run_scaffold_command(payload: dict, args: argparse.Namespace) -> int:
       "started_payload": started_payload,
       "finished_payload": finished_payload,
     },
-    args.format,
   )
-  return 0
+
+
+def _run_scaffold_command(payload: dict, args: argparse.Namespace) -> int:
+  outcome = _execute_scaffold_command(payload, args)
+  if outcome.payload is not None:
+    emit(
+      outcome.payload,
+      args.format,
+    )
+  return outcome.exit_code
 
 
 def new_skill_command(args: argparse.Namespace) -> int:
@@ -515,6 +536,60 @@ def _prompt_choice(prompt: str, choices: dict[str, str]) -> str:
     if raw in choices:
       return choices[raw]
     print(f"Choose one of: {', '.join(choices)}")
+
+
+def _prompt_choice_with_default(
+  prompt: str,
+  choices: dict[str, str],
+  *,
+  default: str,
+) -> str:
+  if default not in choices:
+    raise ValueError(f"Unknown default choice '{default}'.")
+  while True:
+    raw = input(prompt).strip().lower()
+    if not raw:
+      return choices[default]
+    if raw in choices:
+      return choices[raw]
+    print(f"Choose one of: {', '.join(choices)}")
+
+
+def _prompt_code_review_area_subset() -> list[str]:
+  from skill_bill.scaffold import APPROVED_CODE_REVIEW_AREAS
+
+  ordered_areas = sorted(APPROVED_CODE_REVIEW_AREAS)
+  print("Available approved areas:")
+  for index, area in enumerate(ordered_areas, start=1):
+    print(f"{index}. {area}")
+
+  index_map = {str(index): area for index, area in enumerate(ordered_areas, start=1)}
+  area_map = {area: area for area in ordered_areas}
+  while True:
+    raw = _prompt_nonempty(
+      "Choose areas (comma-separated names or numbers): "
+    ).strip().lower()
+    resolved: set[str] = set()
+    invalid: list[str] = []
+    for item in (part.strip() for part in raw.split(",")):
+      if not item:
+        continue
+      if item in {"all", "*"}:
+        return ordered_areas
+      if item in {"none", "0"}:
+        return []
+      area = index_map.get(item) or area_map.get(item)
+      if area is None:
+        invalid.append(item)
+        continue
+      resolved.add(area)
+    if invalid:
+      print(f"Unknown areas: {', '.join(invalid)}")
+      continue
+    if not resolved:
+      print("Choose at least one area, or enter 'none'.")
+      continue
+    return [area for area in ordered_areas if area in resolved]
 
 
 def _platform_pack_exists(platform: str, *, repo_root: Path | None = None) -> bool:
@@ -704,6 +779,177 @@ def _content_completion_status(text: str) -> str:
   return "complete"
 
 
+def _normalize_section_heading(section_name: str) -> str:
+  heading = section_name.strip()
+  if not heading:
+    raise ValueError("Section name must be non-empty.")
+  if heading.startswith("## "):
+    return heading
+  return f"## {heading}"
+
+
+def _section_heading_label(section_name: str) -> str:
+  return _normalize_section_heading(section_name).removeprefix("## ").strip()
+
+
+def _preview_text(text: str, *, limit: int = 200) -> str:
+  collapsed = " ".join(line.strip() for line in text.splitlines() if line.strip())
+  if len(collapsed) <= limit:
+    return collapsed
+  return collapsed[: limit - 1].rstrip() + "…"
+
+
+def _section_payloads(text: str) -> list[dict[str, object]]:
+  _prefix, sections = _parse_content_sections(text)
+  payload: list[dict[str, object]] = []
+  for heading, body in sections:
+    payload.append(
+      {
+        "heading": heading.removeprefix("## ").strip(),
+        "status": _section_completion_status(body),
+        "line_count": len([line for line in body.splitlines() if line.strip()]),
+        "preview": _preview_text(body),
+      }
+    )
+  return payload
+
+
+def _replace_section_body(text: str, section_name: str, new_body: str) -> str:
+  prefix, sections = _parse_content_sections(text)
+  normalized = _normalize_section_heading(section_name)
+  replacement = new_body.rstrip()
+  updated_sections: list[tuple[str, str]] = []
+  matched = False
+  for heading, body in sections:
+    if heading == normalized:
+      updated_sections.append((heading, replacement))
+      matched = True
+      continue
+    updated_sections.append((heading, body))
+  if not matched:
+    available = ", ".join(heading.removeprefix("## ").strip() for heading, _body in sections)
+    raise ValueError(
+      f"Unknown content section '{_section_heading_label(section_name)}'. "
+      f"Available sections: {available}."
+    )
+  return _render_content_sections(prefix, updated_sections)
+
+
+def _full_content_title(target: GovernedSkillTarget) -> str:
+  existing = target.content_file.read_text(encoding="utf-8")
+  for line in existing.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("# "):
+      return stripped
+    if stripped:
+      break
+  return "# Content"
+
+
+def _coerce_full_content_text(target: GovernedSkillTarget, body_text: str) -> str:
+  stripped = body_text.strip()
+  if not stripped:
+    raise ValueError("Filled content must be non-empty.")
+  if stripped.startswith("# "):
+    rendered = stripped
+  else:
+    rendered = f"{_full_content_title(target)}\n\n{stripped}"
+  return rendered.rstrip() + "\n"
+
+
+def _resolve_content_managed_target(repo_root: Path, skill_name: str) -> GovernedSkillTarget:
+  editable_targets = _discover_content_managed_skill_targets(repo_root)
+  target = editable_targets.get(skill_name)
+  if target is None:
+    raise ValueError(
+      f"Skill '{skill_name}' is not a content-managed skill with a sibling content.md file."
+    )
+  return target
+
+
+def _build_recommended_commands(
+  repo_root: Path,
+  target: GovernedSkillTarget,
+  *,
+  completion_status: str,
+  generation_drift: bool,
+  issues: list[str] | None = None,
+) -> list[str]:
+  commands: list[str] = [
+    f"skill-bill show {target.skill_name} --repo-root {shlex.quote(str(repo_root))}",
+  ]
+  if completion_status != "complete":
+    commands.append(
+      f"skill-bill edit {target.skill_name} --repo-root {shlex.quote(str(repo_root))}"
+    )
+  if generation_drift:
+    commands.append(
+      f"skill-bill render --repo-root {shlex.quote(str(repo_root))} --skill-name {target.skill_name}"
+    )
+  if issues:
+    commands.append(
+      f"skill-bill validate --repo-root {shlex.quote(str(repo_root))} --skill-name {target.skill_name}"
+    )
+
+  deduped: list[str] = []
+  seen: set[str] = set()
+  for command in commands:
+    if command in seen:
+      continue
+    deduped.append(command)
+    seen.add(command)
+  return deduped
+
+
+def _skill_status_payload(
+  repo_root: Path,
+  target: GovernedSkillTarget,
+  *,
+  content_mode: str = "preview",
+  issues: list[str] | None = None,
+) -> dict[str, object]:
+  from skill_bill.upgrade import render_upgrade_targets
+
+  content_text = target.content_file.read_text(encoding="utf-8")
+  rendered_targets = render_upgrade_targets(
+    repo_root,
+    skill_names=[target.skill_name],
+  )
+  generation_drift = (
+    rendered_targets.get(target.skill_file) is not None
+    and target.skill_file.read_text(encoding="utf-8")
+    != rendered_targets[target.skill_file]
+  )
+  completion_status = _content_completion_status(content_text)
+  payload: dict[str, object] = {
+    "skill_name": target.skill_name,
+    "package": target.package,
+    "platform": target.platform,
+    "family": target.family,
+    "area": target.area,
+    "skill_file": str(target.skill_file),
+    "content_file": str(target.content_file),
+    "completion_status": completion_status,
+    "generation_drift": generation_drift,
+    "section_count": len(_parse_content_sections(content_text)[1]),
+    "sections": _section_payloads(content_text),
+    "recommended_commands": _build_recommended_commands(
+      repo_root,
+      target,
+      completion_status=completion_status,
+      generation_drift=generation_drift,
+      issues=issues or [],
+    ),
+  }
+  if content_mode == "preview":
+    payload["content_preview"] = _preview_text(content_text, limit=400)
+  elif content_mode == "full":
+    payload["content"] = content_text
+  if issues is not None:
+    payload["issues"] = issues
+  return payload
+
+
 def _render_multiline_section_input(prompt: str, *, terminator: str = ".done") -> str:
   print(prompt)
   lines: list[str] = []
@@ -726,6 +972,33 @@ def _prompt_edit_action() -> str:
       "d": "done",
     },
   )
+
+
+def _prompt_single_section_edit(heading: str, body: str) -> tuple[str, dict[str, str]]:
+  status = _section_completion_status(body)
+  print(f"{heading} [{status}]")
+  print(body.rstrip() or "(empty)")
+  action = _prompt_edit_action()
+  if action in {"done", "skip"}:
+    updated = body
+  elif action == "clear":
+    updated = ""
+  else:
+    prompt = (
+      f"Enter text for {heading}. Finish with '.done'."
+      if action == "replace"
+      else f"Append text for {heading}. Finish with '.done'."
+    )
+    entered = _render_multiline_section_input(prompt)
+    if action == "replace":
+      updated = entered
+    else:
+      existing = body.rstrip()
+      updated = entered if not existing else f"{existing}\n\n{entered}".rstrip()
+  return updated, {
+    "heading": heading.removeprefix("## ").strip(),
+    "status": _section_completion_status(updated),
+  }
 
 
 def _edit_content_guided(content_file: Path) -> tuple[str, list[dict[str, str]]]:
@@ -775,6 +1048,30 @@ def _edit_content_guided(content_file: Path) -> tuple[str, list[dict[str, str]]]
     for heading, body in updated_sections
   ]
   return rendered, section_payload
+
+
+def _edit_single_section_guided(content_file: Path, section_name: str) -> tuple[str, list[dict[str, str]]]:
+  text = content_file.read_text(encoding="utf-8")
+  prefix, sections = _parse_content_sections(text)
+  normalized = _normalize_section_heading(section_name)
+  updated_sections: list[tuple[str, str]] = []
+  matched = False
+  payload: list[dict[str, str]] = []
+  for heading, body in sections:
+    if heading != normalized:
+      updated_sections.append((heading, body))
+      continue
+    matched = True
+    updated_body, section_payload = _prompt_single_section_edit(heading, body)
+    updated_sections.append((heading, updated_body))
+    payload.append(section_payload)
+  if not matched:
+    available = ", ".join(heading.removeprefix("## ").strip() for heading, _body in sections)
+    raise ValueError(
+      f"Unknown content section '{_section_heading_label(section_name)}'. "
+      f"Available sections: {available}."
+    )
+  return _render_content_sections(prefix, updated_sections), payload
 
 
 def _load_validator_module(repo_root: Path):
@@ -836,6 +1133,28 @@ def _read_text_input(path: str) -> str:
   if path == "-":
     return sys.stdin.read()
   return Path(path).read_text(encoding="utf-8")
+
+
+def _mutate_content_managed_skill(
+  repo_root: Path,
+  target: GovernedSkillTarget,
+  replacement_text: str,
+) -> object:
+  from skill_bill.upgrade import upgrade_skill_wrappers
+
+  content_before = target.content_file.read_bytes()
+  wrapper_before = target.skill_file.read_bytes()
+  try:
+    target.content_file.write_text(replacement_text, encoding="utf-8")
+    return upgrade_skill_wrappers(
+      repo_root,
+      skill_names=[target.skill_name],
+      validate=True,
+    )
+  except Exception:
+    target.content_file.write_bytes(content_before)
+    target.skill_file.write_bytes(wrapper_before)
+    raise
 
 
 def _prompt_multiline(prompt: str, *, terminator: str = "END") -> str:
@@ -909,11 +1228,23 @@ def _prompt_new_skill_interactively(*, repo_root: Path | None = None) -> dict:
   if selection.startswith("platform-pack"):
     payload["kind"] = "platform-pack"
     payload["platform"] = platform
-    include_specialists = _prompt_yes_no(
-      "Include the approved code-review specialist stubs?",
-      default=True,
+    print("Code-review specialist stubs:")
+    print("1. None")
+    print("2. Custom subset")
+    print("3. All")
+    specialist_mode = _prompt_choice_with_default(
+      "Choose 1-3 [default 3]: ",
+      {
+        "1": "none",
+        "2": "custom",
+        "3": "all",
+      },
+      default="3",
     )
-    payload["skeleton_mode"] = "full" if include_specialists else "starter"
+    if specialist_mode == "none":
+      payload["skeleton_mode"] = "starter"
+    elif specialist_mode == "custom":
+      payload["specialist_areas"] = _prompt_code_review_area_subset()
     display_name = input("Display name (blank to derive from slug): ").strip()
     if display_name:
       payload["display_name"] = display_name
@@ -1047,6 +1378,15 @@ def _scaffold_identity(payload: dict) -> str:
   return ""
 
 
+def _payload_creates_content_managed_skill(payload: dict) -> bool:
+  kind = str(payload.get("kind", ""))
+  if kind == "code-review-area":
+    return True
+  if kind == "platform-override-piloted":
+    return str(payload.get("family", "")) in {"code-review", "quality-check"}
+  return False
+
+
 def install_agent_path_command(args: argparse.Namespace) -> int:
   """Print the canonical install directory for a given agent.
 
@@ -1095,6 +1435,11 @@ def install_link_skill_command(args: argparse.Namespace) -> int:
 
 
 def doctor_command(args: argparse.Namespace) -> int:
+  if getattr(args, "subject", "") == "skill":
+    if not args.skill_name:
+      raise ValueError("doctor skill requires a skill name.")
+    return doctor_skill_command(args)
+
   db_path = resolve_db_path(args.db)
   try:
     settings = load_telemetry_settings()
@@ -1115,8 +1460,6 @@ def doctor_command(args: argparse.Namespace) -> int:
 
 
 def list_command(args: argparse.Namespace) -> int:
-  from skill_bill.upgrade import render_upgrade_targets
-
   repo_root = Path(args.repo_root).resolve()
   targets = _discover_content_managed_skill_targets(repo_root)
   if args.skill_name:
@@ -1132,30 +1475,10 @@ def list_command(args: argparse.Namespace) -> int:
       if skill_name in selected_names
     }
 
-  rendered_targets = render_upgrade_targets(
-    repo_root,
-    skill_names=targets.keys(),
-  )
   payload_skills: list[dict[str, object]] = []
   for skill_name, target in sorted(targets.items()):
-    content_text = target.content_file.read_text(encoding="utf-8")
-    payload_skills.append(
-      {
-        "skill_name": skill_name,
-        "package": target.package,
-        "platform": target.platform,
-        "family": target.family,
-        "area": target.area,
-        "completion_status": _content_completion_status(content_text),
-        "generation_drift": (
-          rendered_targets.get(target.skill_file) is not None
-          and target.skill_file.read_text(encoding="utf-8")
-          != rendered_targets[target.skill_file]
-        ),
-        "skill_file": str(target.skill_file),
-        "content_file": str(target.content_file),
-      }
-    )
+    del skill_name
+    payload_skills.append(_skill_status_payload(repo_root, target, content_mode="none"))
 
   emit(
     {
@@ -1168,16 +1491,90 @@ def list_command(args: argparse.Namespace) -> int:
   return 0
 
 
+def show_command(args: argparse.Namespace) -> int:
+  repo_root = Path(args.repo_root).resolve()
+  target = _resolve_content_managed_target(repo_root, args.skill_name)
+  emit(_skill_status_payload(repo_root, target, content_mode=args.content), args.format)
+  return 0
+
+
+def explain_command(args: argparse.Namespace) -> int:
+  payload: dict[str, object] = {
+    "explanation": (
+      "Governed skills split author-owned behavior into content.md and generated runtime "
+      "wiring into SKILL.md. Use CLI commands to keep that boundary intact."
+    ),
+    "editable_surface": ["content.md"],
+    "generated_surface": ["SKILL.md"],
+    "governed_sidecars": ["shell-ceremony.md"],
+    "normal_workflow": [
+      "skill-bill new --interactive",
+      "skill-bill edit <skill-name>",
+      "skill-bill validate --skill-name <skill-name>",
+      "skill-bill render --skill-name <skill-name>",
+    ],
+    "notes": [
+      "Author behavior changes in content.md.",
+      "Regenerate wrappers with render instead of hand-editing SKILL.md.",
+      "Use show or doctor skill to inspect completion, drift, and next commands.",
+    ],
+  }
+  if args.skill_name:
+    repo_root = Path(args.repo_root).resolve()
+    target = _resolve_content_managed_target(repo_root, args.skill_name)
+    payload["skill"] = {
+      "skill_name": target.skill_name,
+      "skill_file": str(target.skill_file),
+      "content_file": str(target.content_file),
+      "recommended_commands": _build_recommended_commands(
+        repo_root,
+        target,
+        completion_status=_content_completion_status(
+          target.content_file.read_text(encoding="utf-8")
+        ),
+        generation_drift=_skill_status_payload(repo_root, target, content_mode="none")[
+          "generation_drift"
+        ],
+      ),
+    }
+  emit(payload, args.format)
+  return 0
+
+
 def validate_command(args: argparse.Namespace) -> int:
   repo_root = Path(args.repo_root).resolve()
   if args.skill_name:
     issues = _validate_selected_skills(repo_root, args.skill_name)
+    suggested_commands: list[str] = []
+    for skill_name in args.skill_name:
+      try:
+        target = _resolve_content_managed_target(repo_root, skill_name)
+      except ValueError:
+        continue
+      suggested_commands.extend(
+        _build_recommended_commands(
+          repo_root,
+          target,
+          completion_status=_content_completion_status(
+            target.content_file.read_text(encoding="utf-8")
+          ),
+          generation_drift=_skill_status_payload(repo_root, target, content_mode="none")[
+            "generation_drift"
+          ],
+          issues=issues,
+        )
+      )
+    deduped_commands: list[str] = []
+    for command in suggested_commands:
+      if command not in deduped_commands:
+        deduped_commands.append(command)
     payload = {
       "repo_root": str(repo_root),
       "mode": "selected",
       "skill_names": args.skill_name,
       "status": "pass" if not issues else "fail",
       "issues": issues,
+      "suggested_commands": deduped_commands,
     }
     emit(payload, args.format)
     return 0 if not issues else 1
@@ -1202,6 +1599,31 @@ def validate_command(args: argparse.Namespace) -> int:
     args.format,
   )
   return result.returncode
+
+
+def doctor_skill_command(args: argparse.Namespace) -> int:
+  repo_root = Path(args.repo_root).resolve()
+  target = _resolve_content_managed_target(repo_root, args.skill_name)
+  issues = _validate_selected_skills(repo_root, [target.skill_name])
+  payload = _skill_status_payload(
+    repo_root,
+    target,
+    content_mode=args.content,
+    issues=issues,
+  )
+  if issues:
+    status = "fail"
+    diagnosis = "Validation found contract or content issues that should be fixed before use."
+  elif payload["completion_status"] != "complete" or payload["generation_drift"]:
+    status = "warn"
+    diagnosis = "The skill is usable but still needs authoring cleanup or wrapper regeneration."
+  else:
+    status = "pass"
+    diagnosis = "The skill is complete, wrapper-aligned, and passes isolated validation."
+  payload["status"] = status
+  payload["diagnosis"] = diagnosis
+  emit(payload, args.format)
+  return 0 if status == "pass" else 1
 
 
 def upgrade_command(args: argparse.Namespace) -> int:
@@ -1244,45 +1666,74 @@ def _edit_content_via_editor(content_file: Path) -> bool:
   return True
 
 
-def edit_command(args: argparse.Namespace) -> int:
-  from skill_bill.upgrade import upgrade_skill_wrappers
+def _fill_content_text(
+  target: GovernedSkillTarget,
+  *,
+  body: str,
+  section_name: str | None = None,
+) -> str:
+  if section_name:
+    current = target.content_file.read_text(encoding="utf-8")
+    return _replace_section_body(current, section_name, body)
+  return _coerce_full_content_text(target, body)
 
+
+def fill_command(args: argparse.Namespace) -> int:
   repo_root = Path(args.repo_root).resolve()
-  editable_targets = _discover_content_managed_skill_targets(repo_root)
-  target = editable_targets.get(args.skill_name)
-  if target is None:
-    raise ValueError(
-      f"Skill '{args.skill_name}' is not a content-managed skill with a sibling content.md file."
-    )
+  target = _resolve_content_managed_target(repo_root, args.skill_name)
+  body = args.body if args.body is not None else _read_text_input(args.body_file)
+  replacement = _fill_content_text(
+    target,
+    body=body,
+    section_name=args.section,
+  )
+  upgrade_result = _mutate_content_managed_skill(repo_root, target, replacement)
+  emit(
+    {
+      **_skill_status_payload(repo_root, target, content_mode="none"),
+      "updated_section": (
+        _section_heading_label(args.section) if args.section else None
+      ),
+      "wrapper_regenerated": str(target.skill_file) in {
+        str(path) for path in upgrade_result.regenerated_files
+      },
+      "validator_ran": True,
+    },
+    args.format,
+  )
+  return 0
 
-  content_before = target.content_file.read_bytes()
-  wrapper_before = target.skill_file.read_bytes()
+
+def edit_command(args: argparse.Namespace) -> int:
+  repo_root = Path(args.repo_root).resolve()
+  target = _resolve_content_managed_target(repo_root, args.skill_name)
   used_editor = False
   guided_sections: list[dict[str, str]] = []
 
-  try:
-    if args.body_file:
-      target.content_file.write_text(
-        _read_text_input(args.body_file),
-        encoding="utf-8",
-      )
-    elif args.editor:
-      used_editor = _edit_content_via_editor(target.content_file)
-      if not used_editor:
-        raise ValueError("No $VISUAL or $EDITOR is configured.")
-    else:
-      replacement, guided_sections = _edit_content_guided(target.content_file)
-      target.content_file.write_text(replacement, encoding="utf-8")
+  if args.editor and args.section:
+    raise ValueError("--editor cannot be combined with --section.")
 
-    upgrade_result = upgrade_skill_wrappers(
-      repo_root,
-      skill_names=[target.skill_name],
-      validate=True,
+  if args.body_file:
+    body_text = _read_text_input(args.body_file)
+    replacement = _fill_content_text(
+      target,
+      body=body_text,
+      section_name=args.section,
     )
-  except Exception:
-    target.content_file.write_bytes(content_before)
-    target.skill_file.write_bytes(wrapper_before)
-    raise
+  elif args.editor:
+    used_editor = _edit_content_via_editor(target.content_file)
+    if not used_editor:
+      raise ValueError("No $VISUAL or $EDITOR is configured.")
+    replacement = target.content_file.read_text(encoding="utf-8")
+  elif args.section:
+    replacement, guided_sections = _edit_single_section_guided(
+      target.content_file,
+      args.section,
+    )
+  else:
+    replacement, guided_sections = _edit_content_guided(target.content_file)
+
+  upgrade_result = _mutate_content_managed_skill(repo_root, target, replacement)
 
   emit(
     {
@@ -1295,6 +1746,9 @@ def edit_command(args: argparse.Namespace) -> int:
       "content_file": str(target.content_file),
       "used_editor": used_editor,
       "guided_sections": guided_sections,
+      "updated_section": (
+        _section_heading_label(args.section) if args.section else None
+      ),
       "completion_status": _content_completion_status(
         target.content_file.read_text(encoding="utf-8")
       ),
@@ -1302,6 +1756,80 @@ def edit_command(args: argparse.Namespace) -> int:
         str(path) for path in upgrade_result.regenerated_files
       },
       "validator_ran": True,
+    },
+    args.format,
+  )
+  return 0
+
+
+def create_and_fill_command(args: argparse.Namespace) -> int:
+  if args.payload and args.interactive:
+    raise ValueError("--payload and --interactive are mutually exclusive.")
+  if args.body is not None and args.body_file is not None:
+    raise ValueError("--body and --body-file are mutually exclusive.")
+
+  if args.payload:
+    payload_path = args.payload
+    if payload_path == "-":
+      payload_text = sys.stdin.read()
+    else:
+      with open(payload_path, encoding="utf-8") as stream:
+        payload_text = stream.read()
+    try:
+      payload = json.loads(payload_text)
+    except json.JSONDecodeError as error:
+      raise ValueError(f"Invalid JSON payload: {error}") from error
+  elif args.interactive:
+    payload = _prompt_new_skill_interactively()
+  else:
+    raise ValueError("Either --payload or --interactive is required.")
+
+  if not _payload_creates_content_managed_skill(payload):
+    raise ValueError(
+      "create-and-fill is only available for one content-managed skill at a time "
+      "(code-review areas and shelled platform overrides). "
+      "Use `skill-bill new` for horizontal skills, pre-shell overrides, or platform packs."
+    )
+
+  outcome = _execute_scaffold_command(payload, args)
+  if outcome.exit_code != 0:
+    return outcome.exit_code
+  if args.dry_run:
+    emit(outcome.payload or {}, args.format)
+    return 0
+  if outcome.result is None:
+    raise RuntimeError("Scaffolder reported success without a result payload.")
+
+  repo_root = Path.cwd().resolve()
+  target = _resolve_content_managed_target(repo_root, outcome.result.skill_name)
+  guided_sections: list[dict[str, str]] = []
+  used_editor = False
+  if args.body is not None or args.body_file:
+    replacement = _fill_content_text(
+      target,
+      body=args.body if args.body is not None else _read_text_input(args.body_file),
+    )
+  elif args.editor:
+    used_editor = _edit_content_via_editor(target.content_file)
+    if not used_editor:
+      raise ValueError("No $VISUAL or $EDITOR is configured.")
+    replacement = target.content_file.read_text(encoding="utf-8")
+  else:
+    replacement, guided_sections = _edit_content_guided(target.content_file)
+
+  upgrade_result = _mutate_content_managed_skill(repo_root, target, replacement)
+  emit(
+    {
+      "scaffold": outcome.payload,
+      "authoring": {
+        **_skill_status_payload(repo_root, target, content_mode="none"),
+        "used_editor": used_editor,
+        "guided_sections": guided_sections,
+        "wrapper_regenerated": str(target.skill_file) in {
+          str(path) for path in upgrade_result.regenerated_files
+        },
+        "validator_ran": True,
+      },
     },
     args.format,
   )
@@ -1483,6 +2011,28 @@ def build_parser() -> argparse.ArgumentParser:
   version_parser.set_defaults(handler=version_command)
 
   doctor_parser = subparsers.add_parser("doctor", help="Check skill-bill installation health.")
+  doctor_parser.add_argument(
+    "subject",
+    nargs="?",
+    choices=("skill",),
+    help="Optional diagnostic subject. Use `skill` for one governed skill.",
+  )
+  doctor_parser.add_argument(
+    "skill_name",
+    nargs="?",
+    help="Governed skill name when diagnosing one skill.",
+  )
+  doctor_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to inspect when using `doctor skill`.",
+  )
+  doctor_parser.add_argument(
+    "--content",
+    choices=("none", "preview", "full"),
+    default="preview",
+    help="How much content.md text to include when using `doctor skill`.",
+  )
   doctor_parser.add_argument("--format", choices=("text", "json"), default="text")
   doctor_parser.set_defaults(handler=doctor_command)
 
@@ -1502,6 +2052,42 @@ def build_parser() -> argparse.ArgumentParser:
   )
   list_parser.add_argument("--format", choices=("text", "json"), default="text")
   list_parser.set_defaults(handler=list_command)
+
+  show_parser = subparsers.add_parser(
+    "show",
+    help="Show one content-managed skill with section status, drift, and recommended next commands.",
+  )
+  show_parser.add_argument("skill_name", help="Governed skill name to inspect.")
+  show_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to inspect. Defaults to the current working directory.",
+  )
+  show_parser.add_argument(
+    "--content",
+    choices=("none", "preview", "full"),
+    default="preview",
+    help="How much content.md text to include.",
+  )
+  show_parser.add_argument("--format", choices=("text", "json"), default="text")
+  show_parser.set_defaults(handler=show_command)
+
+  explain_parser = subparsers.add_parser(
+    "explain",
+    help="Explain the governed authoring boundary and the CLI workflow for content-managed skills.",
+  )
+  explain_parser.add_argument(
+    "skill_name",
+    nargs="?",
+    help="Optional governed skill name to explain with concrete paths.",
+  )
+  explain_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to inspect when explaining one skill.",
+  )
+  explain_parser.add_argument("--format", choices=("text", "json"), default="text")
+  explain_parser.set_defaults(handler=explain_command)
 
   validate_parser = subparsers.add_parser(
     "validate",
@@ -1583,8 +2169,38 @@ def build_parser() -> argparse.ArgumentParser:
     action="store_true",
     help="Open content.md in $VISUAL or $EDITOR instead of using guided section editing.",
   )
+  edit_parser.add_argument(
+    "--section",
+    help="Optional authored H2 section name to edit in isolation.",
+  )
   edit_parser.add_argument("--format", choices=("text", "json"), default="text")
   edit_parser.set_defaults(handler=edit_command)
+
+  fill_parser = subparsers.add_parser(
+    "fill",
+    help="Write authored content into content.md, regenerate the wrapper, and validate the result.",
+  )
+  fill_parser.add_argument("skill_name", help="Governed skill name to fill.")
+  fill_parser.add_argument(
+    "--repo-root",
+    default=".",
+    help="Repo root to edit. Defaults to the current working directory.",
+  )
+  fill_group = fill_parser.add_mutually_exclusive_group(required=True)
+  fill_group.add_argument(
+    "--body",
+    help="Body text to write. If it does not start with '# ', the command preserves the existing H1 title.",
+  )
+  fill_group.add_argument(
+    "--body-file",
+    help="Read body text from a file path or '-' for stdin.",
+  )
+  fill_parser.add_argument(
+    "--section",
+    help="Optional authored H2 section name to replace instead of replacing the full body.",
+  )
+  fill_parser.add_argument("--format", choices=("text", "json"), default="text")
+  fill_parser.set_defaults(handler=fill_command)
 
   new_skill_parser = subparsers.add_parser(
     "new-skill",
@@ -1627,6 +2243,41 @@ def build_parser() -> argparse.ArgumentParser:
   )
   new_parser.add_argument("--format", choices=("text", "json"), default="text")
   new_parser.set_defaults(handler=new_skill_command)
+
+  create_and_fill_parser = subparsers.add_parser(
+    "create-and-fill",
+    help="Scaffold one governed skill, then immediately author content.md and validate it.",
+  )
+  create_and_fill_parser.add_argument(
+    "--payload",
+    help="Path to a JSON payload file (or '-' for stdin).",
+  )
+  create_and_fill_parser.add_argument(
+    "--interactive",
+    action="store_true",
+    help="Collect a skill scaffold payload via interactive prompts.",
+  )
+  create_and_fill_parser.add_argument(
+    "--dry-run",
+    action="store_true",
+    help="Plan the scaffold and report the operations without touching disk.",
+  )
+  create_and_fill_group = create_and_fill_parser.add_mutually_exclusive_group()
+  create_and_fill_group.add_argument(
+    "--body",
+    help="Optional authored body to write after scaffolding.",
+  )
+  create_and_fill_group.add_argument(
+    "--body-file",
+    help="Optional file path (or '-' for stdin) to read the authored body from after scaffolding.",
+  )
+  create_and_fill_group.add_argument(
+    "--editor",
+    action="store_true",
+    help="Open the newly scaffolded content.md in $VISUAL or $EDITOR after scaffolding.",
+  )
+  create_and_fill_parser.add_argument("--format", choices=("text", "json"), default="text")
+  create_and_fill_parser.set_defaults(handler=create_and_fill_command)
 
   new_addon_parser = subparsers.add_parser(
     "new-addon",

--- a/skill_bill/scaffold.py
+++ b/skill_bill/scaffold.py
@@ -30,7 +30,7 @@ an interim-location note.
 
 from __future__ import annotations
 
-import subprocess
+import importlib.util
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -64,8 +64,10 @@ from skill_bill.scaffold_template import (
 )
 from skill_bill.shell_content_contract import (
   APPROVED_CODE_REVIEW_AREAS,
+  ShellContentContractError,
   load_platform_manifest,
   load_platform_pack,
+  load_quality_check_content,
 )
 
 
@@ -1161,22 +1163,105 @@ def _stage_sidecar_symlinks(txn: _ScaffoldTransaction, plan: dict[str, Any], rep
   )
 
 
-def _run_validator(repo_root: Path) -> None:
-  """Invoke ``scripts/validate_agent_configs.py`` and raise on failure."""
+def _load_validator_module(repo_root: Path):
+  """Load ``scripts/validate_agent_configs.py`` as an importable module."""
   script_path = repo_root / "scripts" / "validate_agent_configs.py"
   if not script_path.is_file():
+    return None
+
+  scripts_dir = str(script_path.parent)
+  repo_root_str = str(repo_root)
+  sys.path.insert(0, scripts_dir)
+  sys.path.insert(0, repo_root_str)
+  try:
+    spec = importlib.util.spec_from_file_location(
+      "_skill_bill_scaffold_validator",
+      script_path,
+    )
+    if spec is None or spec.loader is None:
+      raise ScaffoldValidatorError(
+        f"Validator failed after scaffolding: could not load '{script_path}'."
+      )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+  finally:
+    for entry in (repo_root_str, scripts_dir):
+      if entry in sys.path:
+        sys.path.remove(entry)
+
+
+def _append_selected_skill_issues(
+  *,
+  repo_root: Path,
+  validator: Any,
+  skill_names: list[str],
+  issues: list[str],
+) -> None:
+  """Validate only the governed skills touched by the current scaffold."""
+  discovery_issues: list[str] = []
+  skill_files = validator.discover_skill_files(repo_root, discovery_issues)
+  platform_pack_skill_files = validator.discover_platform_pack_skill_files(repo_root)
+
+  for skill_name in skill_names:
+    if skill_name in skill_files:
+      validator.validate_skill_file(skill_name, skill_files[skill_name], issues)
+      continue
+    if skill_name in platform_pack_skill_files:
+      validator.validate_platform_pack_skill_file(
+        skill_name,
+        platform_pack_skill_files[skill_name],
+        issues,
+      )
+      continue
+    issues.append(f"Unknown skill '{skill_name}'.")
+
+
+def _run_validator(repo_root: Path, plan: dict[str, Any]) -> None:
+  """Validate only the artifacts touched by the current scaffold transaction."""
+  validator = _load_validator_module(repo_root)
+  if validator is None:
     return
 
-  result = subprocess.run(
-    [sys.executable, str(script_path)],
-    cwd=str(repo_root),
-    capture_output=True,
-    text=True,
-  )
-  if result.returncode != 0:
+  issues: list[str] = []
+  touched_skill_names: list[str] = []
+  touched_pack_roots: list[Path] = []
+
+  if plan["kind"] == SKILL_KIND_PLATFORM_PACK:
+    touched_skill_names.append(plan["baseline_skill_name"])
+    touched_skill_names.append(plan["quality_check_skill_name"])
+    touched_skill_names.extend(plan["specialist_skill_names"].values())
+    touched_pack_roots.append(repo_root / "platform-packs" / plan["platform"])
+  elif plan["kind"] == SKILL_KIND_ADD_ON:
+    validator.validate_addon_file(plan["skill_file"], repo_root, issues)
+    touched_pack_roots.append(repo_root / "platform-packs" / plan["platform"])
+  else:
+    touched_skill_names.append(plan["skill_name"])
+    if plan["is_shelled"]:
+      touched_pack_roots.append(repo_root / "platform-packs" / plan["platform"])
+
+  if touched_skill_names:
+    _append_selected_skill_issues(
+      repo_root=repo_root,
+      validator=validator,
+      skill_names=touched_skill_names,
+      issues=issues,
+    )
+
+  for pack_root in touched_pack_roots:
+    try:
+      pack = load_platform_pack(pack_root)
+      if pack.declared_quality_check_file is not None:
+        load_quality_check_content(pack)
+    except ShellContentContractError as error:
+      issues.append(f"{pack_root.relative_to(repo_root)}: {error}")
+
+  if issues:
+    rendered_issues = "\n".join(f"- {issue}" for issue in issues)
     raise ScaffoldValidatorError(
-      f"Validator failed after scaffolding (exit {result.returncode}):\n"
-      f"{result.stderr or result.stdout}"
+      "Validator failed after scaffolding (exit 1):\n"
+      "Agent-config validation failed:\n"
+      f"{rendered_issues}"
     )
 
 
@@ -1368,7 +1453,7 @@ def scaffold(payload: dict, *, dry_run: bool = False) -> ScaffoldResult:
       manifest_edits = []
       _created_files, symlinks = _create_platform_pack(txn, plan, repo_root)
       created_files = _created_files
-      _run_validator(repo_root)
+      _run_validator(repo_root, plan)
       install_targets, install_notes = _perform_install(txn, plan)
     else:
       if plan["kind"] == SKILL_KIND_ADD_ON:
@@ -1388,7 +1473,7 @@ def scaffold(payload: dict, *, dry_run: bool = False) -> ScaffoldResult:
       symlinks = _stage_sidecar_symlinks(txn, plan, repo_root)
       created_files = list(txn.created_paths)
 
-      _run_validator(repo_root)
+      _run_validator(repo_root, plan)
       install_targets, install_notes = _perform_install(txn, plan)
   except ScaffoldValidatorError:
     _rollback(txn)

--- a/skill_bill/scaffold.py
+++ b/skill_bill/scaffold.py
@@ -57,6 +57,7 @@ from skill_bill.scaffold_template import (
   default_area_focus,
   infer_skill_description,
   render_default_section,
+  render_content_body,
   render_descriptor_section,
   render_skill_frontmatter,
   render_project_overrides,
@@ -799,35 +800,24 @@ def _render_skill_body(plan: dict[str, Any], payload: dict) -> str:
 
 def _render_governed_content_body(plan: dict[str, Any], payload: dict) -> str:
   """Render the authored `content.md` body for governed platform-pack skills."""
-  sections: list[str] = []
-  if plan["family"] == "quality-check":
-    sections.extend(
-      [
-        "## Execution Steps\n\nTODO: author the execution steps for "
-        f"`{plan['skill_name']}`.\n",
-        "## Fix Strategy\n\nTODO: author the fix strategy for "
-        f"`{plan['skill_name']}`.\n",
-      ]
-    )
-  elif plan["family"] == "code-review" and not plan["area"]:
-    sections.append(
-      "TODO: author the governed content body. Keep shell metadata, telemetry rules, and "
-      "other shared ceremony in `SKILL.md` or shared sidecars, not here.\n"
-    )
-  else:
-    sections.append(
-      "TODO: author the governed content body. Keep shell metadata, telemetry rules, and "
-      "other shared ceremony in `SKILL.md` or shared sidecars, not here.\n"
-    )
-
-  title = "Content"
-  if plan["family"] == "quality-check":
-    title = "Quality-Check Content"
-  elif plan["family"] == "code-review" and plan["area"]:
-    title = f"{plan['area'].replace('-', ' ').title()} Content"
-  elif plan["family"] == "code-review":
-    title = "Review Content"
-  return f"# {title}\n\n" + "\n".join(sections)
+  platform = plan["platform"]
+  display_name = plan.get("display_name") or (
+    _derive_display_name(platform) if platform else ""
+  )
+  context = ScaffoldTemplateContext(
+    skill_name=plan["skill_name"],
+    family=plan["family"],
+    platform=platform,
+    area=plan["area"],
+    display_name=display_name,
+  )
+  description = _optional_string(payload, "description") or infer_skill_description(context)
+  content_body = _optional_string(payload, "content_body") or None
+  return render_content_body(
+    context,
+    description=description,
+    content_body=content_body,
+  )
 
 
 def _render_addon_body(plan: dict[str, Any], payload: dict) -> str:

--- a/skill_bill/scaffold.py
+++ b/skill_bill/scaffold.py
@@ -405,6 +405,26 @@ def _ordered_approved_code_review_areas() -> tuple[str, ...]:
   return tuple(sorted(APPROVED_CODE_REVIEW_AREAS))
 
 
+def _platform_pack_specialist_areas(payload: dict) -> list[str] | None:
+  raw = payload.get("specialist_areas")
+  if raw is None:
+    return None
+  if not isinstance(raw, list) or not all(isinstance(item, str) and item for item in raw):
+    raise InvalidScaffoldPayloadError(
+      "Scaffold payload field 'specialist_areas' must be a list of non-empty strings when provided."
+    )
+
+  approved = set(_ordered_approved_code_review_areas())
+  requested = {item for item in raw}
+  unknown = sorted(requested - approved)
+  if unknown:
+    raise InvalidScaffoldPayloadError(
+      f"Scaffold payload field 'specialist_areas' contains unknown areas {unknown}; "
+      f"approved areas: {sorted(approved)}."
+    )
+  return [area for area in _ordered_approved_code_review_areas() if area in requested]
+
+
 def _require_canonical_name(payload: dict, *, default_name: str) -> str:
   provided = _optional_string(payload, "name")
   if not provided:
@@ -511,6 +531,11 @@ def _plan_platform_pack(payload: dict, repo_root: Path) -> dict[str, Any]:
   platform = _require_string(payload, "platform")
   defaults = _resolve_platform_pack_defaults(payload, platform)
   skeleton_mode = _platform_pack_skeleton_mode(payload)
+  selected_specialist_areas = _platform_pack_specialist_areas(payload)
+  if selected_specialist_areas is not None and "skeleton_mode" in payload:
+    raise InvalidScaffoldPayloadError(
+      "Scaffold payload may not provide both 'skeleton_mode' and 'specialist_areas'; choose one specialist selection mode."
+    )
   strong_signals = defaults["routing_signals"]["strong"]
   tie_breakers = defaults["routing_signals"]["tie_breakers"]
   display_name = defaults["display_name"]
@@ -531,9 +556,13 @@ def _plan_platform_pack(payload: dict, repo_root: Path) -> dict[str, Any]:
   quality_check_skill_path = pack_root / "quality-check" / quality_check_name
   manifest_path = pack_root / "platform.yaml"
   specialist_areas = (
-    list(_ordered_approved_code_review_areas())
-    if skeleton_mode == PLATFORM_PACK_SKELETON_FULL
-    else []
+    selected_specialist_areas
+    if selected_specialist_areas is not None
+    else (
+      list(_ordered_approved_code_review_areas())
+      if skeleton_mode == PLATFORM_PACK_SKELETON_FULL
+      else []
+    )
   )
   specialist_skill_names = {
     area: f"bill-{platform}-code-review-{area}"
@@ -557,7 +586,12 @@ def _plan_platform_pack(payload: dict, repo_root: Path) -> dict[str, Any]:
       0,
       f"Applied built-in platform preset for '{platform}'. Override 'routing_signals' only when the defaults need adjustment.",
     )
-  if skeleton_mode == PLATFORM_PACK_SKELETON_FULL:
+  if selected_specialist_areas is not None:
+    notes.insert(
+      1 if defaults["preset_used"] else 0,
+      f"Custom skeleton scaffolded with {len(specialist_areas)} approved code-review area stubs.",
+    )
+  elif skeleton_mode == PLATFORM_PACK_SKELETON_FULL:
     notes.insert(
       1 if defaults["preset_used"] else 0,
       f"Full skeleton scaffolded with {len(specialist_areas)} approved code-review area stubs.",

--- a/skill_bill/scaffold_template.py
+++ b/skill_bill/scaffold_template.py
@@ -552,7 +552,7 @@ def _render_governed_content_starter(
   if context.family == "quality-check":
     summary = description or infer_skill_description(context)
     return (
-      f"## Scope\n\n{summary}\n\n"
+      f"## Purpose\n\n{summary}\n\n"
       "## Execution Steps\n\n"
       "1. Determine the files in scope for the current unit of work.\n"
       "2. Run the platform's quality-check entrypoint and capture the failures.\n"
@@ -581,11 +581,10 @@ def _render_governed_content_starter(
   summary = description or infer_skill_description(context)
   return (
     f"## Review Focus\n\n{summary}\n\n"
-    "## Project Signals\n\n"
-    "- List the modules, file patterns, frameworks, or product areas that should bias this skill.\n"
-    "- Capture any repo-specific routing cues that do not belong in the shared shell.\n\n"
     "## Review Guidance\n\n"
     "- Document the project-specific risks, heuristics, and judgment calls this skill should apply.\n"
+    "- Call out any local modules, file patterns, frameworks, or product areas that should bias review.\n"
+    "- Capture repo-specific routing cues here only when they matter to review behavior after selection.\n"
     "- Keep shell ceremony, output formatting rules, and telemetry mechanics out of this file.\n"
     "- Reference governed add-ons here only when they enrich an already-routed platform skill.\n"
   )

--- a/skill_bill/scaffold_template.py
+++ b/skill_bill/scaffold_template.py
@@ -525,18 +525,14 @@ def render_content_body(
   description: str = "",
   content_body: str | None = None,
 ) -> str:
-  """Render a governed ``content.md`` body or placeholder."""
+  """Render a governed ``content.md`` body or a maintainer starter."""
   if content_body is not None:
     body = content_body.rstrip() + "\n"
   else:
-    sections: list[str] = []
-    if description:
-      sections.append(f"## Description\n\n{description}\n")
-    sections.append(
-      "TODO: author the governed content body. Keep shell metadata, telemetry rules, "
-      "and other shared ceremony in `SKILL.md` or shared sidecars, not here.\n"
+    body = _render_governed_content_starter(
+      context,
+      description=description,
     )
-    body = "\n".join(sections)
 
   title = "Content"
   if context.family == "quality-check":
@@ -546,6 +542,53 @@ def render_content_body(
   elif context.family == "code-review":
     title = "Review Content"
   return f"# {title}\n\n{body.rstrip()}\n"
+
+
+def _render_governed_content_starter(
+  context: ScaffoldTemplateContext,
+  *,
+  description: str,
+) -> str:
+  if context.family == "quality-check":
+    summary = description or infer_skill_description(context)
+    return (
+      f"## Scope\n\n{summary}\n\n"
+      "## Execution Steps\n\n"
+      "1. Determine the files in scope for the current unit of work.\n"
+      "2. Run the platform's quality-check entrypoint and capture the failures.\n"
+      "3. Fix only the failures that belong to the scoped work unless the contract says otherwise.\n"
+      "4. Re-run the quality check until the scoped failures are resolved.\n\n"
+      "## Fix Strategy\n\n"
+      "- Prefer root-cause fixes over suppressions or TODO comments.\n"
+      "- Keep changes aligned with the project's existing conventions and build tooling.\n"
+      "- Call out any blocker that requires a maintainer decision instead of guessing.\n"
+    )
+
+  if context.family == "code-review" and context.area:
+    summary = description or infer_skill_description(context)
+    area_label = context.area.replace("-", " ")
+    return (
+      f"## Focus\n\n{summary}\n\n"
+      "## Review Triggers\n\n"
+      f"- Changes that primarily affect {area_label} concerns for this platform.\n"
+      "- Project-specific cues, modules, or file patterns that should route into this specialist.\n\n"
+      "## Review Guidance\n\n"
+      "- Record the concrete risks this specialist should prioritize.\n"
+      "- Note any repo-specific heuristics, invariants, or failure modes worth checking.\n"
+      "- Keep output format, telemetry, and runtime ceremony in the wrapper or shared sidecars.\n"
+    )
+
+  summary = description or infer_skill_description(context)
+  return (
+    f"## Review Focus\n\n{summary}\n\n"
+    "## Project Signals\n\n"
+    "- List the modules, file patterns, frameworks, or product areas that should bias this skill.\n"
+    "- Capture any repo-specific routing cues that do not belong in the shared shell.\n\n"
+    "## Review Guidance\n\n"
+    "- Document the project-specific risks, heuristics, and judgment calls this skill should apply.\n"
+    "- Keep shell ceremony, output formatting rules, and telemetry mechanics out of this file.\n"
+    "- Reference governed add-ons here only when they enrich an already-routed platform skill.\n"
+  )
 
 
 _DEFAULT_SECTION_RENDERERS: dict[str, object] = {

--- a/skill_bill/shell_content_contract.py
+++ b/skill_bill/shell_content_contract.py
@@ -23,6 +23,7 @@ from skill_bill.scaffold_template import (
   DescriptorMetadata,
   ScaffoldTemplateContext,
   default_area_focus,
+  render_ceremony_section,
   render_descriptor_section,
 )
 
@@ -145,6 +146,10 @@ class InvalidDescriptorSectionError(ShellContentContractError):
 
 class InvalidExecutionSectionError(ShellContentContractError):
   """Raised when a governed skill's ``## Execution`` section drifts."""
+
+
+class InvalidCeremonySectionError(ShellContentContractError):
+  """Raised when a governed skill's ``## Ceremony`` section drifts."""
 
 
 class MissingShellCeremonyFileError(ShellContentContractError):
@@ -589,6 +594,23 @@ def _assert_governed_skill_ok(
     family=family,
     area=area,
   )
+  expected_context = _governed_context(
+    pack,
+    skill_name=skill_path.parent.name,
+    family=family,
+    area=area,
+  )
+  if sections["## Execution"] != CANONICAL_EXECUTION_BODY:
+    raise InvalidExecutionSectionError(
+      f"Platform pack '{pack.slug}': skill file '{skill_path}' has a drifted "
+      "## Execution section."
+    )
+  expected_ceremony = render_ceremony_section(expected_context)
+  if sections["## Ceremony"] != expected_ceremony:
+    raise InvalidCeremonySectionError(
+      f"Platform pack '{pack.slug}': skill file '{skill_path}' has a drifted "
+      "## Ceremony section."
+    )
   if sections["## Descriptor"] != expected_descriptor:
     raise InvalidDescriptorSectionError(
       f"Platform pack '{pack.slug}': skill file '{skill_path}' has a drifted "
@@ -693,15 +715,30 @@ def _render_expected_descriptor(
   family: str,
   area: str,
 ) -> str:
-  context = ScaffoldTemplateContext(
+  context = _governed_context(
+    pack,
+    skill_name=skill_name,
+    family=family,
+    area=area,
+  )
+  metadata = DescriptorMetadata(area_focus=pack.area_metadata.get(area, ""))
+  return render_descriptor_section(context, metadata=metadata)
+
+
+def _governed_context(
+  pack: PlatformPack,
+  *,
+  skill_name: str,
+  family: str,
+  area: str,
+) -> ScaffoldTemplateContext:
+  return ScaffoldTemplateContext(
     skill_name=skill_name,
     family=family,
     platform=pack.slug,
     area=area,
     display_name=pack.display_name or pack.slug.replace("-", " ").title(),
   )
-  metadata = DescriptorMetadata(area_focus=pack.area_metadata.get(area, ""))
-  return render_descriptor_section(context, metadata=metadata)
 
 
 __all__ = [
@@ -711,6 +748,7 @@ __all__ = [
   "ContractVersionMismatchError",
   "CEREMONY_FREE_FORM_H2S",
   "CONTENT_BODY_FILENAME",
+  "InvalidCeremonySectionError",
   "InvalidDescriptorSectionError",
   "InvalidExecutionSectionError",
   "InvalidManifestSchemaError",

--- a/skill_bill/upgrade.py
+++ b/skill_bill/upgrade.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+from typing import Iterable
 
 from skill_bill.scaffold_template import (
   CANONICAL_EXECUTION_SECTION,
@@ -28,18 +29,36 @@ class UpgradeResult:
   regenerated_files: tuple[Path, ...]
 
 
+def render_upgrade_targets(
+  repo_root: Path | str,
+  *,
+  skill_names: Iterable[str] | None = None,
+) -> dict[Path, str]:
+  """Return the canonical wrapper render for each selected skill file."""
+  repo_root = Path(repo_root).resolve()
+  return _render_upgrade_targets(
+    repo_root,
+    selected_skill_names=set(skill_names or []),
+  )
+
+
 def upgrade_skill_wrappers(
   repo_root: Path | str,
   *,
+  skill_names: Iterable[str] | None = None,
   validate: bool = True,
 ) -> UpgradeResult:
   """Regenerate scaffold-managed ``SKILL.md`` wrappers in one transaction."""
   repo_root = Path(repo_root).resolve()
   rewritten: dict[Path, bytes] = {}
   regenerated: list[Path] = []
+  selected_skill_names = set(skill_names or [])
 
   try:
-    for skill_file, rendered in _render_upgrade_targets(repo_root).items():
+    for skill_file, rendered in _render_upgrade_targets(
+      repo_root,
+      selected_skill_names=selected_skill_names,
+    ).items():
       rendered_bytes = rendered.encode("utf-8")
       current_bytes = skill_file.read_bytes()
       if current_bytes == rendered_bytes:
@@ -61,14 +80,32 @@ def upgrade_skill_wrappers(
   )
 
 
-def _render_upgrade_targets(repo_root: Path) -> dict[Path, str]:
+def _render_upgrade_targets(
+  repo_root: Path,
+  *,
+  selected_skill_names: set[str] | None = None,
+) -> dict[Path, str]:
   targets: dict[Path, str] = {}
-  targets.update(_render_horizontal_targets(repo_root))
-  targets.update(_render_governed_targets(repo_root))
+  targets.update(
+    _render_horizontal_targets(
+      repo_root,
+      selected_skill_names=selected_skill_names,
+    )
+  )
+  targets.update(
+    _render_governed_targets(
+      repo_root,
+      selected_skill_names=selected_skill_names,
+    )
+  )
   return targets
 
 
-def _render_horizontal_targets(repo_root: Path) -> dict[Path, str]:
+def _render_horizontal_targets(
+  repo_root: Path,
+  *,
+  selected_skill_names: set[str] | None = None,
+) -> dict[Path, str]:
   skills_root = repo_root / "skills"
   if not skills_root.is_dir():
     return {}
@@ -76,6 +113,8 @@ def _render_horizontal_targets(repo_root: Path) -> dict[Path, str]:
   rendered: dict[Path, str] = {}
   for skill_file in sorted(skills_root.rglob("SKILL.md")):
     skill_name = skill_file.parent.name
+    if selected_skill_names and skill_name not in selected_skill_names:
+      continue
     context = ScaffoldTemplateContext(skill_name=skill_name, family=_infer_family(skill_name))
     text = skill_file.read_text(encoding="utf-8")
     rendered[skill_file] = _replace_top_level_section(
@@ -86,21 +125,28 @@ def _render_horizontal_targets(repo_root: Path) -> dict[Path, str]:
   return rendered
 
 
-def _render_governed_targets(repo_root: Path) -> dict[Path, str]:
+def _render_governed_targets(
+  repo_root: Path,
+  *,
+  selected_skill_names: set[str] | None = None,
+) -> dict[Path, str]:
   rendered: dict[Path, str] = {}
   for pack in discover_platform_pack_manifests(repo_root / "platform-packs"):
     baseline_path = pack.declared_files["baseline"]
     if isinstance(baseline_path, Path):
-      rendered[baseline_path] = _render_governed_wrapper(
-        skill_file=baseline_path,
-        platform=pack.slug,
-        display_name=pack.display_name or pack.slug.replace("-", " ").title(),
-        family="code-review",
-      )
+      if not selected_skill_names or baseline_path.parent.name in selected_skill_names:
+        rendered[baseline_path] = _render_governed_wrapper(
+          skill_file=baseline_path,
+          platform=pack.slug,
+          display_name=pack.display_name or pack.slug.replace("-", " ").title(),
+          family="code-review",
+        )
 
     area_paths = pack.declared_files.get("areas", {})
     if isinstance(area_paths, dict):
       for area, skill_file in area_paths.items():
+        if selected_skill_names and skill_file.parent.name not in selected_skill_names:
+          continue
         rendered[skill_file] = _render_governed_wrapper(
           skill_file=skill_file,
           platform=pack.slug,
@@ -111,12 +157,16 @@ def _render_governed_targets(repo_root: Path) -> dict[Path, str]:
         )
 
     if pack.declared_quality_check_file is not None:
-      rendered[pack.declared_quality_check_file] = _render_governed_wrapper(
-        skill_file=pack.declared_quality_check_file,
-        platform=pack.slug,
-        display_name=pack.display_name or pack.slug.replace("-", " ").title(),
-        family="quality-check",
-      )
+      if (
+        not selected_skill_names
+        or pack.declared_quality_check_file.parent.name in selected_skill_names
+      ):
+        rendered[pack.declared_quality_check_file] = _render_governed_wrapper(
+          skill_file=pack.declared_quality_check_file,
+          platform=pack.slug,
+          display_name=pack.display_name or pack.slug.replace("-", " ").title(),
+          family="quality-check",
+        )
   return rendered
 
 

--- a/skills/bill-create-skill/SKILL.md
+++ b/skills/bill-create-skill/SKILL.md
@@ -11,9 +11,15 @@ If `.agents/skill-overrides.md` exists in the project root and contains a matchi
 
 ## Overview
 
-This skill is the user-facing wrapper around `skill-bill new-skill`. You collect intent from the user, give a concise high-level preview of what will be created and where it will live, get approval, then call into the Python scaffolder to actually create files, edit manifests, wire sidecar symlinks, run the validator, and install into detected agents.
+This skill is the user-facing intake wrapper around the `skill-bill` CLI. Its job is to translate plain-language skill requests into the right CLI flow, show a concise preview, get approval, and then delegate the filesystem work to the CLI.
 
-All filesystem work happens in `skill_bill/scaffold.py`; this skill never edits `SKILL.md`, `platform.yaml`, or symlinks directly. If an agent path changes, the source of truth is `skill_bill/install.py` — not this skill.
+Use the CLI as the source of truth:
+
+- `skill-bill create-and-fill` for one new governed content-managed skill when the user wants to scaffold and immediately author the first `content.md` body.
+- `skill-bill new` for horizontal skills, pre-shell overrides, platform packs, and any case where `create-and-fill` is not supported.
+- `skill-bill show`, `edit`, `fill`, `doctor skill`, `validate`, and `render` when the user is refining or inspecting an existing governed skill.
+
+All filesystem work happens in the CLI/scaffolder implementation; this skill never edits `SKILL.md`, `content.md`, `platform.yaml`, or symlinks directly. If an agent path changes, the source of truth is `skill_bill/install.py` — not this skill.
 
 ## Decision Tree
 
@@ -84,20 +90,36 @@ Refuse to invent a new family or code-review area inline. New platforms are allo
    - Keep it short: platform slug, whether a built-in preset will be used, and the user-facing outcome.
    - End with one confirmation prompt such as `Proceed? yes | redo`.
 
-3. **Preview at the right abstraction level.** Before calling the scaffolder, give a concise preview that covers:
+3. **Choose the CLI path.**
+   - Use `skill-bill create-and-fill` when all of the following are true:
+     - the request creates exactly one new content-managed skill
+     - the resulting skill is a governed `code-review-area` or shelled `platform-override-piloted` (`code-review` or `quality-check`)
+     - the user wants to capture initial authored behavior immediately
+   - Use `skill-bill new` for:
+     - `platform-pack`
+     - `horizontal`
+     - pre-shell platform overrides such as `feature-implement` / `feature-verify`
+     - any scaffold where immediate content authoring is not requested
+   - If the user wants to change an existing governed skill instead of creating one, do not scaffold anything. Route them to:
+     - `skill-bill show <skill-name>`
+     - `skill-bill edit <skill-name>` or `skill-bill fill <skill-name>`
+     - `skill-bill doctor skill <skill-name>`
+
+4. **Preview at the right abstraction level.** Before calling the CLI, give a concise preview that covers:
    - which baseline skills or specialist stubs will be created
+   - which CLI path will run (`create-and-fill`, `new`, or an edit/refinement path)
    - whether the scaffold uses a built-in routing preset
    - nothing else unless the user explicitly asks for file-level detail
 
    Do **not** render the generated `SKILL.md` wrappers, starter `content.md` bodies, sidecar file contents, `platform.yaml` path, or placeholder disclaimers unless the user explicitly asks to inspect them. The default UX is a high-level inventory, not a file-by-file contract dump.
 
-4. **Confirm or restart.** Keep the interaction minimal:
+5. **Confirm or restart.** Keep the interaction minimal:
    - `yes` — accept the preview and proceed to scaffold.
    - `redo` — restart the intake from scratch.
 
    Do not offer an `edit <section>` menu by default. If the user wants to customize wording such as the description before scaffolding, handle that as a normal follow-up in plain language instead of exposing internal section-edit commands.
 
-5. **Emit JSON payload.** When the user accepts, build a payload shaped like:
+6. **Emit JSON payload.** When the user accepts, build a payload shaped like:
 
    ```json
    {
@@ -122,15 +144,18 @@ Refuse to invent a new family or code-review area inline. New platforms are allo
 
    The full schema (required keys, worked examples per kind, the loud-fail exception catalog) lives in the repo at `orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md`.
 
-6. **Subprocess into the scaffolder.** Write the payload to a tempfile, then invoke:
+7. **Subprocess into the CLI.** Write the payload to a tempfile, then invoke exactly one of:
 
    ```bash
-   skill-bill new-skill --payload <tempfile>
+   skill-bill create-and-fill --payload <tempfile>
+   skill-bill new --payload <tempfile>
    ```
 
-   The scaffolder handles: file creation, manifest edits with best-effort comment preservation, sibling supporting-file symlinks (driven by `scripts/skill_repo_contracts.py::RUNTIME_SUPPORTING_FILES`), the validator run, and auto-install to every detected agent under `~/.claude/commands`, `~/.copilot/skills`, `~/.codex/skills` (or `~/.agents/skills`), `~/.config/opencode/skills`, and `~/.glm/commands`.
+   Choose `create-and-fill` only for the supported single-skill governed path described above. Otherwise use `new`.
 
-7. **Report.** Surface the scaffolder output verbatim — it tells the user the final skill path, any manifest edits, sidecar symlinks, install targets, and any interim-location or skipped-agent notes. Never paraphrase the validator's loud-fail errors; copy them through.
+   The CLI/scaffolder handles: file creation, manifest edits with best-effort comment preservation, sibling supporting-file symlinks (driven by `scripts/skill_repo_contracts.py::RUNTIME_SUPPORTING_FILES`), the validator run, and auto-install to every detected agent under `~/.claude/commands`, `~/.copilot/skills`, `~/.codex/skills` (or `~/.agents/skills`), `~/.config/opencode/skills`, and `~/.glm/commands`.
+
+8. **Report.** Surface the CLI output verbatim — it tells the user the final skill path, any manifest edits, sidecar symlinks, install targets, and any interim-location or skipped-agent notes. Never paraphrase the validator's loud-fail errors; copy them through.
 
 ## Rules
 
@@ -138,9 +163,10 @@ Refuse to invent a new family or code-review area inline. New platforms are allo
 - The scaffolder is atomic. If the validator fails, every staged change is rolled back and the error is surfaced verbatim; do not try to "keep partial work."
 - If no agents are detected, the scaffolder skips the install step and notes that the user should run `./install.sh` to set up agent paths. Do not synthesize agent paths by hand.
 - Default to conversational guidance. The raw field template and JSON payload are implementation details, not the primary UX.
+- Default to the thinnest possible adapter behavior. This skill should gather intent, choose the right `skill-bill` command, and then get out of the way.
 - Treat `platform-pack` as the one-shot bootstrap path for a new stack: create the baseline pair plus all approved specialists by default.
 - Default previews to a concise inventory of created paths and generated stubs. For governed skills, tell the user to put skill instructions only in sibling `content.md` files; do not imply they should edit scaffold-managed `SKILL.md` wrappers or `shell-ceremony.md`.
-- When the user wants to change an existing governed skill, send them through `skill-bill edit <skill-name>` instead of describing direct wrapper edits. Bulk migration (`scripts/migrate_to_content_md.py`) and taxonomy changes are maintainer-only workflows.
+- When the user wants to change an existing governed skill, send them through `skill-bill show`, `edit`, `fill`, or `doctor skill` instead of describing direct wrapper edits. Bulk migration (`scripts/migrate_to_content_md.py`) and taxonomy changes are maintainer-only workflows.
 - Do not repeat the same intake block, menu, confirmation prompt, or `Execution mode` line twice. The default interaction should feel like one short question, one contextual follow-up, one short summary, and one confirmation.
 - Do not front-load the full decision tree into the first reply. The user should not have to read the entire taxonomy before answering the first question.
 - Governed review-family and quality-check skills use the same wrapper contract: `SKILL.md` must keep `## Descriptor`, `## Execution`, and `## Ceremony`, with sibling `content.md` and `shell-ceremony.md` beside it. The shared ceremony sidecar is not customizable per skill; it comes from the stored template and stays identical across governed skills in the family.

--- a/skills/bill-create-skill/SKILL.md
+++ b/skills/bill-create-skill/SKILL.md
@@ -26,8 +26,8 @@ Internally, the scaffolder still maps skill requests to exactly one of these fou
    - Pre-shell families (`feature-implement`, `feature-verify`) → destination: `skills/<platform>/<name>/SKILL.md`; the scaffolder emits an interim-location note saying "will move when piloted."
 3. **platform-pack** — bootstrap a new platform with the baseline skill set.
    - Destination: `platform-packs/<slug>/platform.yaml` plus `platform-packs/<slug>/code-review/<bill-<slug>-code-review>/SKILL.md` and `platform-packs/<slug>/quality-check/<bill-<slug>-quality-check>/SKILL.md`.
-   - Default behavior: scaffold the pack root, baseline code-review, default quality-check, and bare specialist stubs for every approved code-review area.
-   - `starter` remains a payload-level escape hatch for direct callers, but the user-facing skill does not offer it as an intake choice.
+   - User-facing intake asks whether to scaffold the approved code-review specialist stubs.
+   - `starter` remains available for direct payload callers and for users who only want the baseline pair first.
    - For known platforms such as `java` and `php`, the scaffolder infers routing signals from a built-in preset; ask for manual routing signals only when no preset exists and you do not have a defensible inference.
 4. **code-review-area** — a specialist for one approved code-review area inside an existing platform pack.
    - Approved areas: `architecture`, `performance`, `platform-correctness`, `security`, `testing`, `api-contracts`, `persistence`, `reliability`, `ui`, `ux-accessibility`.
@@ -69,15 +69,16 @@ Refuse to invent a new family or code-review area inline. New platforms are allo
    - For `platform-pack`, the default set means:
      - baseline `bill-<platform>-code-review`
      - baseline `bill-<platform>-quality-check`
-     - all approved code-review specialist stubs
+     - all approved code-review specialist stubs when the user says yes to the specialist prompt
    - Only ask follow-ups that are still missing:
      - skill name for horizontal, specialist, or override scaffolds
      - family for platform overrides
      - area for code-review specialists
      - description or display name only when the user explicitly wants to customize them before scaffolding
+     - initial `content.md` body for governed skills when the user wants concrete behavior captured immediately
      - routing signals only for a new platform with no built-in preset and no defensible repo-marker inference
 
-   If the user says “create a skill set for Java” or equivalent, interpret that as `platform-pack` immediately. Do not show any baseline/full follow-up.
+   If the user says “create a skill set for Java” or equivalent, interpret that as `platform-pack` immediately. Ask whether to include the approved specialists, then continue.
 
 2. **Summarize the inferred request.** Before rendering the preview, restate what you inferred in plain language:
    - Keep it short: platform slug, whether a built-in preset will be used, and the user-facing outcome.
@@ -88,7 +89,7 @@ Refuse to invent a new family or code-review area inline. New platforms are allo
    - whether the scaffold uses a built-in routing preset
    - nothing else unless the user explicitly asks for file-level detail
 
-   Do **not** render the generated `SKILL.md` wrappers, `content.md` TODO bodies, sidecar file contents, `platform.yaml` path, or placeholder disclaimers unless the user explicitly asks to inspect them. The default UX is a high-level inventory, not a file-by-file contract dump.
+   Do **not** render the generated `SKILL.md` wrappers, starter `content.md` bodies, sidecar file contents, `platform.yaml` path, or placeholder disclaimers unless the user explicitly asks to inspect them. The default UX is a high-level inventory, not a file-by-file contract dump.
 
 4. **Confirm or restart.** Keep the interaction minimal:
    - `yes` — accept the preview and proceed to scaffold.
@@ -110,10 +111,10 @@ Refuse to invent a new family or code-review area inline. New platforms are allo
      "skeleton_mode": "full",
      "routing_signals": {
        "strong": ["..."],
-       "tie_breakers": ["..."],
-       "addon_signals": ["..."]
+       "tie_breakers": ["..."]
      },
-     "description": "..."
+     "description": "...",
+     "content_body": "..."
    }
    ```
 
@@ -139,6 +140,7 @@ Refuse to invent a new family or code-review area inline. New platforms are allo
 - Default to conversational guidance. The raw field template and JSON payload are implementation details, not the primary UX.
 - Treat `platform-pack` as the one-shot bootstrap path for a new stack: create the baseline pair plus all approved specialists by default.
 - Default previews to a concise inventory of created paths and generated stubs. For governed skills, tell the user to put skill instructions only in sibling `content.md` files; do not imply they should edit scaffold-managed `SKILL.md` wrappers or `shell-ceremony.md`.
+- When the user wants to change an existing governed skill, send them through `skill-bill edit <skill-name>` instead of describing direct wrapper edits. Bulk migration (`scripts/migrate_to_content_md.py`) and taxonomy changes are maintainer-only workflows.
 - Do not repeat the same intake block, menu, confirmation prompt, or `Execution mode` line twice. The default interaction should feel like one short question, one contextual follow-up, one short summary, and one confirmation.
 - Do not front-load the full decision tree into the first reply. The user should not have to read the entire taxonomy before answering the first question.
 - Governed review-family and quality-check skills use the same wrapper contract: `SKILL.md` must keep `## Descriptor`, `## Execution`, and `## Ceremony`, with sibling `content.md` and `shell-ceremony.md` beside it. The shared ceremony sidecar is not customizable per skill; it comes from the stored template and stays identical across governed skills in the family.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,16 @@ def _governed_skill_body(
 
 def _build_upgrade_repo(tmp_path: Path) -> Path:
   repo = tmp_path / "repo"
+  scripts_dir = repo / "scripts"
+  scripts_dir.mkdir(parents=True, exist_ok=True)
+  (scripts_dir / "validate_agent_configs.py").write_text(
+    (ROOT / "scripts" / "validate_agent_configs.py").read_text(encoding="utf-8"),
+    encoding="utf-8",
+  )
+  (scripts_dir / "skill_repo_contracts.py").write_text(
+    (ROOT / "scripts" / "skill_repo_contracts.py").read_text(encoding="utf-8"),
+    encoding="utf-8",
+  )
   shell_ceremony = repo / "orchestration" / "shell-content-contract" / "shell-ceremony.md"
   shell_ceremony.parent.mkdir(parents=True, exist_ok=True)
   shell_ceremony.write_text(_SHELL_CEREMONY, encoding="utf-8")
@@ -190,7 +200,10 @@ class UpgradeCliTest(unittest.TestCase):
     ceremony_before = baseline_ceremony.read_bytes()
 
     stdout = io.StringIO()
-    with contextlib.redirect_stdout(stdout):
+    with (
+      contextlib.redirect_stdout(stdout),
+      mock.patch("skill_bill.upgrade._run_validator", return_value=None),
+    ):
       exit_code = main(["upgrade", "--repo-root", str(self.repo), "--format", "json"])
 
     self.assertEqual(exit_code, 0)
@@ -232,6 +245,157 @@ class UpgradeCliTest(unittest.TestCase):
 
     self.assertEqual(baseline_before, baseline_skill.read_bytes())
     self.assertEqual(horizontal_before, horizontal_skill.read_bytes())
+
+  def test_render_alias_accepts_targeted_skill_name(self) -> None:
+    stdout = io.StringIO()
+    with (
+      contextlib.redirect_stdout(stdout),
+      mock.patch("skill_bill.upgrade._run_validator", return_value=None),
+    ):
+      exit_code = main(
+        [
+          "render",
+          "--repo-root",
+          str(self.repo),
+          "--skill-name",
+          "bill-kotlin-code-review",
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["regenerated_count"], 1)
+    self.assertEqual(
+      payload["regenerated_files"],
+      [
+        str(
+          (
+            self.repo
+            / "platform-packs"
+            / "kotlin"
+            / "code-review"
+            / "bill-kotlin-code-review"
+            / "SKILL.md"
+          ).resolve()
+        )
+      ],
+    )
+
+
+class AuthoringCliTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self._tmpdir = tempfile.TemporaryDirectory()
+    self.addCleanup(self._tmpdir.cleanup)
+    self.repo = _build_upgrade_repo(Path(self._tmpdir.name))
+
+  def test_list_reports_completion_status_and_generation_drift(self) -> None:
+    baseline_content = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review"
+      / "content.md"
+    )
+    baseline_content.write_text(
+      "# Content\n\n## Purpose\n\nDocument the baseline review flow.\n",
+      encoding="utf-8",
+    )
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+      exit_code = main(
+        ["list", "--repo-root", str(self.repo), "--format", "json"]
+      )
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    baseline_entry = next(
+      entry for entry in payload["skills"] if entry["skill_name"] == "bill-kotlin-code-review"
+    )
+    self.assertEqual(baseline_entry["completion_status"], "complete")
+    self.assertTrue(baseline_entry["generation_drift"])
+
+  def test_edit_guided_updates_section_and_regenerates_wrapper(self) -> None:
+    target_dir = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review"
+    )
+    content_file = target_dir / "content.md"
+    content_file.write_text(
+      "# Content\n\n## Purpose\n\nCurrent purpose.\n\n## Constraints\n\nTODO: fill this in.\n",
+      encoding="utf-8",
+    )
+
+    stdout = io.StringIO()
+    with (
+      contextlib.redirect_stdout(stdout),
+      mock.patch("skill_bill.upgrade._run_validator", return_value=None),
+      mock.patch(
+        "builtins.input",
+        side_effect=[
+          "r",
+          "Updated purpose from guided editing.",
+          ".done",
+          "d",
+        ],
+      ),
+    ):
+      exit_code = main(
+        [
+          "edit",
+          "bill-kotlin-code-review",
+          "--repo-root",
+          str(self.repo),
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 0)
+    output = stdout.getvalue()
+    payload = json.loads(output[output.index("{"):])
+    self.assertEqual(payload["skill_name"], "bill-kotlin-code-review")
+    self.assertEqual(payload["completion_status"], "draft")
+    self.assertIn("Updated purpose from guided editing.", content_file.read_text(encoding="utf-8"))
+    self.assertTrue(payload["wrapper_regenerated"])
+
+  def test_validate_selected_skill_reports_todo_failure(self) -> None:
+    content_file = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review"
+      / "content.md"
+    )
+    content_file.write_text("# Content\n\nTODO: unresolved\n", encoding="utf-8")
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+      exit_code = main(
+        [
+          "validate",
+          "--repo-root",
+          str(self.repo),
+          "--skill-name",
+          "bill-kotlin-code-review",
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 1)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["status"], "fail")
+    self.assertTrue(
+      any("unresolved TODO/FIXME placeholder" in issue for issue in payload["issues"])
+    )
 
 
 class NewAddonCliTest(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,6 +397,233 @@ class AuthoringCliTest(unittest.TestCase):
       any("unresolved TODO/FIXME placeholder" in issue for issue in payload["issues"])
     )
 
+  def test_show_reports_section_status_and_recommended_commands(self) -> None:
+    content_file = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review"
+      / "content.md"
+    )
+    content_file.write_text(
+      "# Review Content\n\n## Review Focus\n\nCurrent focus.\n\n## Review Guidance\n\nTODO: add guidance.\n",
+      encoding="utf-8",
+    )
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+      exit_code = main(
+        [
+          "show",
+          "bill-kotlin-code-review",
+          "--repo-root",
+          str(self.repo),
+          "--content",
+          "none",
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["completion_status"], "draft")
+    self.assertEqual(
+      [section["heading"] for section in payload["sections"]],
+      ["Review Focus", "Review Guidance"],
+    )
+    self.assertTrue(
+      any(command.startswith("skill-bill edit bill-kotlin-code-review") for command in payload["recommended_commands"])
+    )
+
+  def test_fill_updates_single_section_and_regenerates_wrapper(self) -> None:
+    target_dir = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review"
+    )
+    content_file = target_dir / "content.md"
+    content_file.write_text(
+      "# Review Content\n\n## Review Focus\n\nCurrent focus.\n\n## Review Guidance\n\nTODO: fill this in.\n",
+      encoding="utf-8",
+    )
+
+    stdout = io.StringIO()
+    with (
+      contextlib.redirect_stdout(stdout),
+      mock.patch("skill_bill.upgrade._run_validator", return_value=None),
+    ):
+      exit_code = main(
+        [
+          "fill",
+          "bill-kotlin-code-review",
+          "--repo-root",
+          str(self.repo),
+          "--section",
+          "Review Guidance",
+          "--body",
+          "- Check auth flows and secret handling.",
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["updated_section"], "Review Guidance")
+    rendered = content_file.read_text(encoding="utf-8")
+    self.assertIn("- Check auth flows and secret handling.", rendered)
+    self.assertIn("## Review Focus", rendered)
+    self.assertIn("Current focus.", rendered)
+    self.assertTrue(payload["wrapper_regenerated"])
+
+  def test_edit_can_target_single_section(self) -> None:
+    target_dir = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review"
+    )
+    content_file = target_dir / "content.md"
+    content_file.write_text(
+      "# Review Content\n\n## Review Focus\n\nLeave me alone.\n\n## Review Guidance\n\nOld guidance.\n",
+      encoding="utf-8",
+    )
+
+    stdout = io.StringIO()
+    with (
+      contextlib.redirect_stdout(stdout),
+      mock.patch("skill_bill.upgrade._run_validator", return_value=None),
+      mock.patch(
+        "builtins.input",
+        side_effect=[
+          "r",
+          "Updated targeted guidance.",
+          ".done",
+        ],
+      ),
+    ):
+      exit_code = main(
+        [
+          "edit",
+          "bill-kotlin-code-review",
+          "--repo-root",
+          str(self.repo),
+          "--section",
+          "Review Guidance",
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 0)
+    output = stdout.getvalue()
+    payload = json.loads(output[output.index("{"):])
+    self.assertEqual(payload["updated_section"], "Review Guidance")
+    rendered = content_file.read_text(encoding="utf-8")
+    self.assertIn("Updated targeted guidance.", rendered)
+    self.assertIn("## Review Focus", rendered)
+    self.assertIn("Leave me alone.", rendered)
+
+  def test_doctor_skill_reports_plain_language_diagnosis(self) -> None:
+    content_file = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review"
+      / "content.md"
+    )
+    content_file.write_text("# Review Content\n\nTODO: unresolved\n", encoding="utf-8")
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+      exit_code = main(
+        [
+          "doctor",
+          "skill",
+          "bill-kotlin-code-review",
+          "--repo-root",
+          str(self.repo),
+          "--content",
+          "none",
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 1)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["status"], "fail")
+    self.assertIn("Validation found contract or content issues", payload["diagnosis"])
+    self.assertTrue(
+      any(command.startswith("skill-bill edit bill-kotlin-code-review") for command in payload["recommended_commands"])
+    )
+
+  def test_create_and_fill_scaffolds_one_skill_and_writes_authored_body(self) -> None:
+    payload_path = self.repo / "payload.json"
+    payload_path.write_text(
+      json.dumps(
+        {
+          "scaffold_payload_version": "1.0",
+          "kind": "code-review-area",
+          "platform": "kotlin",
+          "area": "security",
+        }
+      ),
+      encoding="utf-8",
+    )
+    body_path = self.repo / "body.md"
+    body_path.write_text(
+      "## Focus\n\nReview Kotlin security-sensitive changes.\n\n"
+      "## Review Triggers\n\n- Auth, tokens, secrets.\n\n"
+      "## Review Guidance\n\n- Check secret handling and auth boundaries.\n",
+      encoding="utf-8",
+    )
+    upgrade_skill_wrappers(self.repo, validate=False)
+
+    stdout = io.StringIO()
+    with (
+      contextlib.redirect_stdout(stdout),
+      mock.patch("pathlib.Path.cwd", return_value=self.repo),
+      mock.patch("skill_bill.scaffold._run_validator", return_value=None),
+      mock.patch("skill_bill.scaffold._perform_install", return_value=([], [])),
+      mock.patch("skill_bill.upgrade._run_validator", return_value=None),
+      mock.patch(
+        "skill_bill.config.load_telemetry_settings",
+        return_value=SimpleNamespace(level="anonymous"),
+      ),
+    ):
+      exit_code = main(
+        [
+          "create-and-fill",
+          "--payload",
+          str(payload_path),
+          "--body-file",
+          str(body_path),
+          "--format",
+          "json",
+        ]
+      )
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["scaffold"]["skill_name"], "bill-kotlin-code-review-security")
+    self.assertEqual(payload["authoring"]["completion_status"], "complete")
+    content_file = (
+      self.repo
+      / "platform-packs"
+      / "kotlin"
+      / "code-review"
+      / "bill-kotlin-code-review-security"
+      / "content.md"
+    )
+    self.assertIn("Review Kotlin security-sensitive changes.", content_file.read_text(encoding="utf-8"))
+
 
 class NewAddonCliTest(unittest.TestCase):
   def setUp(self) -> None:

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -462,7 +462,9 @@ class ScaffoldHappyPathsTest(unittest.TestCase):
       "for repo markers needed for classification.",
       review_body,
     )
-    self.assertIn("TODO: author the governed content body.", review_content)
+    self.assertIn("## Review Focus", review_content)
+    self.assertIn("## Review Guidance", review_content)
+    self.assertNotIn("## Project Signals", review_content)
     self.assertIn("[specialist-contract.md](specialist-contract.md)", review_body)
     self.assertNotIn("review-scope.md", review_content)
     self.assertNotIn("specialist-contract.md", review_content)
@@ -585,6 +587,37 @@ class ScaffoldHappyPathsTest(unittest.TestCase):
     expected_created_files = 5 + (2 * len(scaffold_module.APPROVED_CODE_REVIEW_AREAS))
     self.assertEqual(len(result.created_files), expected_created_files)
 
+  def test_platform_pack_can_scaffold_custom_specialist_subset(self) -> None:
+    result = scaffold(
+      self._payload(
+        kind="platform-pack",
+        platform="php",
+        specialist_areas=["architecture", "security", "testing"],
+      )
+    )
+    self.assertEqual(result.kind, "platform-pack")
+
+    pack_root = self.repo / "platform-packs" / "php"
+    manifest = (pack_root / "platform.yaml").read_text(encoding="utf-8")
+    self.assertIn('  - "architecture"', manifest)
+    self.assertIn('  - "security"', manifest)
+    self.assertIn('  - "testing"', manifest)
+    self.assertNotIn('  - "ui"', manifest)
+    self.assertNotIn('  - "ux-accessibility"', manifest)
+    self.assertTrue(
+      (pack_root / "code-review" / "bill-php-code-review-architecture" / "SKILL.md").is_file()
+    )
+    self.assertTrue(
+      (pack_root / "code-review" / "bill-php-code-review-security" / "SKILL.md").is_file()
+    )
+    self.assertTrue(
+      (pack_root / "code-review" / "bill-php-code-review-testing" / "SKILL.md").is_file()
+    )
+    self.assertFalse((pack_root / "code-review" / "bill-php-code-review-ui").exists())
+    self.assertTrue(
+      any("Custom skeleton scaffolded with 3 approved code-review area stubs." in note for note in result.notes)
+    )
+
   def test_add_on_flat(self) -> None:
     result = scaffold(
       self._payload(kind="add-on", name="android-new-addon", platform="kmp")
@@ -671,7 +704,9 @@ class ScaffoldHappyPathsTest(unittest.TestCase):
     self.assertNotIn("## Inline Mode", baseline_body)
     self.assertNotIn("## Outputs Contract", baseline_body)
     self.assertNotIn("review-scope.md", baseline_body)
-    self.assertIn("TODO: author the governed content body.", baseline_body)
+    self.assertIn("## Review Focus", baseline_body)
+    self.assertIn("## Review Guidance", baseline_body)
+    self.assertNotIn("## Project Signals", baseline_body)
     self.assertNotIn("specialist-contract.md", baseline_body)
 
     quality_body = (
@@ -723,7 +758,9 @@ class ScaffoldHappyPathsTest(unittest.TestCase):
       / "bill-kotlin-code-review-security"
       / "content.md"
     ).read_text(encoding="utf-8")
-    self.assertIn("TODO: author the governed content body.", area_body)
+    self.assertIn("## Focus", area_body)
+    self.assertIn("## Review Triggers", area_body)
+    self.assertIn("## Review Guidance", area_body)
     self.assertNotIn("## Description", area_body)
     self.assertNotIn("## Specialist Scope", area_body)
     self.assertNotIn("## Inputs", area_body)
@@ -764,8 +801,9 @@ class ScaffoldHappyPathsTest(unittest.TestCase):
       / "bill-kmp-quality-check"
       / "content.md"
     ).read_text(encoding="utf-8")
-    self.assertIn("TODO: author the execution steps", quality_body)
-    self.assertIn("TODO: author the fix strategy", quality_body)
+    self.assertIn("## Purpose", quality_body)
+    self.assertIn("## Execution Steps", quality_body)
+    self.assertIn("## Fix Strategy", quality_body)
 
   def test_pre_shell_family_emits_interim_note(self) -> None:
     # SKILL-16 promoted quality-check onto the shell+content contract, so the
@@ -1237,6 +1275,7 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
         "builtins.input",
         side_effect=[
           "java",   # platform
+          "",       # specialist mode -> all
           "",       # display name
           "",       # description
         ],
@@ -1256,6 +1295,7 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
         "builtins.input",
         side_effect=[
           "php",    # platform
+          "",       # specialist mode -> all
           "",       # display name
           "",       # description
         ],
@@ -1276,6 +1316,7 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
         "builtins.input",
         side_effect=[
           "python",    # platform
+          "",          # specialist mode -> all
           "Python",    # display name
           "",          # description
           "pyproject.toml,setup.py",  # strong signals
@@ -1291,6 +1332,52 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
       payload["routing_signals"]["strong"],
       ["pyproject.toml", "setup.py"],
     )
+
+  def test_platform_pack_prompt_can_choose_custom_specialist_subset(self) -> None:
+    from skill_bill.cli import _prompt_new_skill_interactively
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      repo_root = Path(tmpdir)
+      with mock.patch(
+        "builtins.input",
+        side_effect=[
+          "php",                  # platform
+          "2",                    # specialist mode -> custom
+          "architecture,security,testing,reliability",
+          "",                     # display name
+          "",                     # description
+        ],
+      ):
+        payload = _prompt_new_skill_interactively(repo_root=repo_root)
+
+    self.assertEqual(payload["kind"], "platform-pack")
+    self.assertEqual(payload["platform"], "php")
+    self.assertEqual(
+      payload["specialist_areas"],
+      ["architecture", "reliability", "security", "testing"],
+    )
+    self.assertNotIn("skeleton_mode", payload)
+
+  def test_platform_pack_prompt_can_choose_no_specialists(self) -> None:
+    from skill_bill.cli import _prompt_new_skill_interactively
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      repo_root = Path(tmpdir)
+      with mock.patch(
+        "builtins.input",
+        side_effect=[
+          "php",    # platform
+          "1",      # specialist mode -> none
+          "",       # display name
+          "",       # description
+        ],
+      ):
+        payload = _prompt_new_skill_interactively(repo_root=repo_root)
+
+    self.assertEqual(payload["kind"], "platform-pack")
+    self.assertEqual(payload["platform"], "php")
+    self.assertEqual(payload["skeleton_mode"], "starter")
+    self.assertNotIn("specialist_areas", payload)
 
   def test_existing_platform_prompt_branches_to_specialist(self) -> None:
     from skill_bill.cli import _prompt_new_skill_interactively
@@ -1310,6 +1397,7 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
           "security",      # area
           "",              # derived name
           "Review PHP security risks.",  # description
+          "END",           # optional content body
         ],
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
@@ -1337,6 +1425,7 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
           "quality-check",  # family
           "",               # derived name
           "Run PHP quality checks.",  # description
+          "END",            # optional content body
         ],
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -77,6 +77,17 @@ def _load_validate_skill_file():
   return validate_skill_file
 
 
+def _install_validator_fixture(repo: Path) -> None:
+  """Copy the repo validator scripts into a scratch scaffold repo."""
+  scripts_dir = repo / "scripts"
+  scripts_dir.mkdir(parents=True, exist_ok=True)
+  for script_name in ("validate_agent_configs.py", "skill_repo_contracts.py"):
+    (scripts_dir / script_name).write_text(
+      (ROOT / "scripts" / script_name).read_text(encoding="utf-8"),
+      encoding="utf-8",
+    )
+
+
 _KOTLIN_MANIFEST = """\
 platform: kotlin
 contract_version: "1.1"
@@ -237,6 +248,12 @@ def _build_seed_repo(tmp_path: Path) -> Path:
   review_delegation.parent.mkdir(parents=True, exist_ok=True)
   review_delegation.write_text(
     "# Review Delegation\n\nFixture delegation contract.\n",
+    encoding="utf-8",
+  )
+  review_scope = repo / "orchestration" / "review-scope" / "PLAYBOOK.md"
+  review_scope.parent.mkdir(parents=True, exist_ok=True)
+  review_scope.write_text(
+    "# Review Scope\n\nFixture scope contract.\n",
     encoding="utf-8",
   )
   stack_routing = repo / "orchestration" / "stack-routing" / "PLAYBOOK.md"
@@ -506,6 +523,31 @@ class ScaffoldHappyPathsTest(unittest.TestCase):
       any("Applied built-in platform preset for 'php'." in note for note in result.notes)
     )
     self.assertIn(GOVERNED_CONTENT_AUTHORING_NOTE, result.notes)
+
+  def test_platform_pack_validation_ignores_unrelated_existing_pack_drift(self) -> None:
+    _install_validator_fixture(self.repo)
+    drifted_skill = (
+      self.repo
+      / "platform-packs"
+      / "kmp"
+      / "code-review"
+      / "bill-kmp-code-review"
+      / "SKILL.md"
+    )
+    drifted_skill.write_text(
+      drifted_skill.read_text(encoding="utf-8") + "\nDrift injected outside the new php pack.\n",
+      encoding="utf-8",
+    )
+
+    result = scaffold(
+      self._payload(
+        kind="platform-pack",
+        platform="php",
+      )
+    )
+
+    self.assertEqual(result.kind, "platform-pack")
+    self.assertTrue((self.repo / "platform-packs" / "php" / "platform.yaml").is_file())
 
   def test_platform_pack_defaults_to_full_skeleton(self) -> None:
     result = scaffold(

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -22,6 +22,7 @@ from skill_bill.scaffold_template import (  # noqa: E402
 )
 from skill_bill.constants import SHELL_CONTRACT_VERSION  # noqa: E402
 from skill_repo_contracts import (  # noqa: E402
+  ADDON_SUPPORTING_FILE_TARGETS,
   APPLIED_LEARNINGS_PLACEHOLDER,
   CHILD_METADATA_HANDOFF_RULE,
   CHILD_NO_IMPORT_RULE,
@@ -570,7 +571,8 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
         continue
       content_lines.extend([f"## {heading}", body, ""])
     for file_name in required_sidecars:
-      content_lines.append(f"[{file_name}]({file_name})")
+      if file_name in ADDON_SUPPORTING_FILE_TARGETS:
+        content_lines.append(f"[{file_name}]({file_name})")
     (skill_dir / "content.md").write_text("\n".join(content_lines) + "\n", encoding="utf-8")
 
   def run_validator(self, repo_root: Path) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary
- add a terminal-first authoring surface on top of the existing split-wrapper scaffold with `skill-bill new`, `edit`, `list`, `validate`, and `render`
- add guided `content.md` section editing plus targeted wrapper regeneration and validation helpers
- document the single-skill terminal loop and add focused CLI coverage for the new commands

## Testing
- .venv/bin/python3 -m unittest tests.test_cli

## Notes
- broader scaffold and validator suites still have pre-existing failures in untouched prompt/scaffold fixture expectations; this PR keeps the implementation scoped to the new command layer
