### PR TITLE
feat: [SKILL-25] Split bill-feature-implement into shell and content

### DIFF
--- a/.feature-specs/SKILL-25-feature-implement-shell-pilot/spec.md
+++ b/.feature-specs/SKILL-25-feature-implement-shell-pilot/spec.md
@@ -1,0 +1,241 @@
+---
+issue_key: SKILL-25
+feature_name: feature-implement-shell-pilot
+feature_size: MEDIUM
+status: Complete
+created: 2026-04-21
+depends_on: SKILL-21 (shell+content split — shipped), workflow contract pilot for bill-feature-implement (shipped)
+---
+
+# SKILL-25 — Pilot `bill-feature-implement` onto a shell + content split
+
+## Problem
+
+`bill-feature-implement` is now a real top-level workflow with durable state,
+stable step ids, named artifacts, and CLI/MCP resume surfaces. But its skill
+file still mixes two different concerns:
+
+1. **Shell-owned workflow contract** — project overrides, workflow-state tools,
+   continuation rules, telemetry ownership, artifact names, and the stable
+   step graph.
+2. **Author-owned execution body** — the procedural prompt that explains how
+   to assess the spec, brief subagents, loop through review/audit, apply
+   add-ons, and finish the PR flow.
+
+That makes `skills/bill-feature-implement/SKILL.md` harder to maintain than
+the other stable commands that already separate shell concerns from authored
+content. It also leaves the workflow contract partially buried in a long skill
+body instead of standing on its own as the authoritative orchestration layer.
+
+## Why now
+
+- The workflow runtime is now explicit and tested, so there is finally a
+  stable shell-owned contract worth separating from the execution prose.
+- The roadmap calls out reliability first and strengthening the existing
+  stable commands before adding new surfaces.
+- `bill-feature-implement` is the highest-leverage next candidate because it
+  is already the first workflow pilot and carries the most orchestration
+  detail.
+- Keeping this step narrow avoids the bigger mistake: turning feature-workflow
+  migration into another large framework project before the value is proven.
+
+## Scope of this pilot
+
+This pilot is intentionally narrow.
+
+It applies only to the canonical top-level skill at:
+
+- `skills/bill-feature-implement/`
+
+It does **not** yet:
+
+- flip `feature-implement` out of `PRE_SHELL_FAMILIES`
+- change scaffolder output for downstream `bill-<platform>-feature-implement`
+  overrides
+- introduce pack-manifest declarations for feature-implement content
+- migrate `bill-feature-verify`
+
+The goal is to prove that separating shell from content makes the workflow
+clearer and easier to validate without widening the contract surface again.
+
+## Target shape
+
+After SKILL-25, `skills/bill-feature-implement/` should look like:
+
+```text
+skills/bill-feature-implement/
+  SKILL.md
+  content.md
+  reference.md
+  shell-ceremony.md
+  telemetry-contract.md
+  <existing add-on supporting files / symlinks>
+```
+
+Ownership split:
+
+- `SKILL.md` owns:
+  - frontmatter
+  - project overrides
+  - workflow-state contract
+  - continuation-mode contract
+  - stable step ids
+  - stable artifact names
+  - telemetry lifecycle ownership
+  - explicit pointer to `content.md`
+- `content.md` owns:
+  - phase-by-phase execution instructions
+  - subagent briefing expectations
+  - review/audit loop procedure
+  - quality-check / PR-description handoff procedure
+  - add-on discovery and add-on reading guidance
+  - any human-authored prompt detail that is not part of the stable shell
+
+## Acceptance criteria
+
+1. `skills/bill-feature-implement/content.md` exists and contains the
+   author-owned execution body that currently lives in `SKILL.md`.
+
+2. `skills/bill-feature-implement/SKILL.md` becomes a shell-oriented file that
+   keeps the workflow contract explicit and readable. It must retain:
+   - frontmatter
+   - project overrides
+   - workflow-state section
+   - continuation-mode section
+   - stable step ids
+   - stable workflow artifact names
+   - telemetry ownership rules
+   - a required execution pointer to `content.md`
+
+3. The split preserves runtime behavior. This is a documentation/contract
+   refactor, not a workflow-runtime rewrite. The existing
+   `feature_implement_workflow_*` CLI, MCP, and persistence behavior stay
+   unchanged.
+
+4. The workflow shell remains the source of truth for the durable artifact
+   contract. At minimum the shell must continue to name and describe:
+   - `assessment`
+   - `branch`
+   - `preplan_digest`
+   - `plan`
+   - `implementation_summary`
+   - `review_result`
+   - `audit_report`
+   - `validation_result`
+   - `history_result`
+   - `commit_push_result`
+   - `pr_result`
+
+5. The workflow shell remains the source of truth for continuation behavior.
+   Resume semantics must stay documented in `SKILL.md`, not drift into
+   `content.md` prose.
+
+6. Existing supporting-file references remain valid:
+   - `reference.md`
+   - `shell-ceremony.md`
+   - `telemetry-contract.md`
+   - existing add-on supporting files or symlinks
+
+7. Validator coverage is extended so `bill-feature-implement` loud-fails when
+   the shell loses any of its required workflow markers or the new
+   `content.md` sibling is missing.
+
+8. Tests cover both acceptance and rejection paths for the new split:
+   - valid `bill-feature-implement` shell with `content.md`
+   - missing `content.md`
+   - shell missing workflow-state section
+   - shell missing continuation-mode section
+   - shell missing the execution pointer to `content.md`
+
+9. README and authoring docs are updated anywhere they currently imply that
+   `bill-feature-implement` is still a single-file authored skill.
+
+10. Validation still passes:
+    - `.venv/bin/python3 -m unittest discover -s tests`
+    - `npx --yes agnix --strict .`
+    - `.venv/bin/python3 scripts/validate_agent_configs.py`
+
+## Shell/content split rules
+
+### What stays in `SKILL.md`
+
+- Anything the runtime or validator should treat as contract.
+- Anything a future resume/continue implementation depends on being stable.
+- Anything that defines ownership boundaries between parent workflow and child
+  skills.
+- Anything that should remain short, inspectable, and durable across prompt
+  edits.
+
+### What moves to `content.md`
+
+- Procedural instructions for how to perform each phase.
+- Human-authored explanation of what to read and when.
+- Subagent briefing detail.
+- Review and audit loop detail.
+- Add-on scanning and usage guidance.
+- Any prompt copy that can evolve without changing the workflow contract.
+
+### What should not happen
+
+- Do not create a second shell contract for feature workflows.
+- Do not move workflow artifact names into `content.md`.
+- Do not move continuation semantics into `reference.md` only.
+- Do not let `SKILL.md` become a full prompt again after the split.
+
+## Non-goals
+
+- Migrating `bill-feature-verify` in the same change.
+- Flipping `feature-implement` out of `PRE_SHELL_FAMILIES`.
+- Adding manifest-driven routing or pack-owned `feature-implement` content.
+- Changing the workflow runtime schema, DB tables, CLI commands, or MCP tools.
+- Rewriting the implementation methodology, subagent strategy, or audit logic.
+- Introducing a generic workflow-shell abstraction shared by feature skills.
+
+## Open questions to resolve in planning
+
+1. Should `reference.md` stay as the detailed subagent contract source, with
+   `content.md` linking to it, or should some of that material move into
+   `content.md` directly? Recommendation: keep `reference.md` and let
+   `content.md` reference it.
+
+2. Should the validator treat the `content.md` pointer as a generic governed
+   rule for workflow skills, or as a special-case rule for
+   `bill-feature-implement` only? Recommendation: special-case it for
+   `bill-feature-implement` in this pilot and generalize only after
+   `bill-feature-verify` follows the same pattern.
+
+3. Should `skill-bill show bill-feature-implement` prefer rendering
+   `content.md`, `SKILL.md`, or both? Recommendation: keep the read path
+   unchanged unless current tooling makes the split confusing in practice.
+
+## Files expected to change
+
+Created:
+
+- `skills/bill-feature-implement/content.md`
+
+Modified:
+
+- `skills/bill-feature-implement/SKILL.md`
+- `README.md`
+- `scripts/validate_agent_configs.py`
+- `tests/test_validate_agent_configs_e2e.py`
+- any docs that describe the authored surface for `bill-feature-implement`
+
+Possibly modified:
+
+- `AGENTS.md`
+- `docs/getting-started-for-teams.md`
+- `skill_bill/show.py` or related read-surface helpers if the split exposes a
+  bad authoring UX
+
+Not modified:
+
+- workflow DB schema
+- workflow CLI/MCP transport surfaces
+- `skills/bill-feature-verify/`
+- `skill_bill/scaffold.py` family placement for `feature-implement`
+
+## Feature flag
+
+N/A. Contract and authoring-surface cleanup only.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A governed system for portable AI-agent behavior: stable base commands, shared orchestration, validator-backed contracts, cross-agent installers, scaffolding, and local-first telemetry that keep one source of truth from drifting as the repo grows.
 
-Skill Bill is a governance product, not a prompt dump. This repo ships the shared orchestration playbooks under `orchestration/`, validators and CLI/MCP runtime under `skill_bill/` and `scripts/`, cross-agent installers, the `bill-create-skill` authoring path, SQLite-backed telemetry, and stable base shells such as `bill-code-review` and `bill-quality-check`. Governed pack skills now use a thin `SKILL.md` wrapper plus sibling `content.md` and `shell-ceremony.md` sidecars. For humans, `content.md` is the real working surface where authored skill behavior lives; `SKILL.md` is scaffold-managed wiring that points the runtime at the right authored content and shared ceremony. The shell+content contract is versioned at `orchestration/shell-content-contract/PLAYBOOK.md`, and top-level orchestrators can additionally adopt the workflow contract at `orchestration/workflow-contract/PLAYBOOK.md`.
+Skill Bill is a governance product, not a prompt dump. This repo ships the shared orchestration playbooks under `orchestration/`, validators and CLI/MCP runtime under `skill_bill/` and `scripts/`, cross-agent installers, the `bill-create-skill` authoring path, SQLite-backed telemetry, and stable base shells such as `bill-code-review` and `bill-quality-check`. Governed pack skills now use a thin `SKILL.md` wrapper plus sibling `content.md` and `shell-ceremony.md` sidecars. `bill-feature-implement` now follows the same split as a top-level workflow shell: the workflow contract and telemetry ownership stay in `skills/bill-feature-implement/SKILL.md`, while the detailed execution body lives in `skills/bill-feature-implement/content.md`. For humans, `content.md` is the real working surface where authored skill behavior lives; `SKILL.md` is scaffold-managed wiring that points the runtime at the right authored content and shared ceremony. The shell+content contract is versioned at `orchestration/shell-content-contract/PLAYBOOK.md`, and top-level orchestrators can additionally adopt the workflow contract at `orchestration/workflow-contract/PLAYBOOK.md`.
 
 Shipped platform packs live under `platform-packs/`. Routing, validation, and installation are manifest-driven, so any conforming platform pack can live here without changing the shell.
 
@@ -278,7 +278,7 @@ Reference pack at `platform-packs/kmp/`. Layers Android/KMP-specific reviewers o
 
 | Skill | Purpose |
 |-------|---------|
-| `/bill-feature-implement` | Spec-to-verified implementation workflow — heavy phases run in subagents to keep the orchestrator context small |
+| `/bill-feature-implement` | Spec-to-verified implementation workflow shell - heavy phases run in subagents, with authored execution guidance in sibling `content.md` |
 | `/bill-feature-verify` | Spec-to-PR verification workflow with durable workflow-state support |
 | `/bill-feature-guard` | Add feature-flag rollout safety |
 | `/bill-feature-guard-cleanup` | Remove feature flags after rollout |
@@ -332,7 +332,7 @@ Example:
 
 The repo is organized around a strict four-layer model:
 
-- `skills/` — canonical, user-facing capabilities such as `bill-code-review` (a governed shell), `bill-quality-check` (also a governed shell), and `bill-feature-implement`
+- `skills/` — canonical, user-facing capabilities such as `bill-code-review` (a governed shell), `bill-quality-check` (also a governed shell), and `bill-feature-implement` (a top-level workflow shell with sibling `content.md`)
 - `skills/<platform>/` — platform-specific overrides for skills that have not been piloted onto the shell+content contract yet (today: `bill-feature-implement` and `bill-feature-verify` only; code-review and quality-check are shelled)
 - `platform-packs/<platform>/` — user-owned platform packs consumed by the `bill-code-review` shell via the shell+content contract. Each pack ships a `platform.yaml` manifest plus per-area reviewer content
 - `orchestration/` — single source of truth for shared routing, review, delegation, telemetry, and shell+content contracts
@@ -458,6 +458,8 @@ The repo now has three distinct layers, and it helps to read them in that order:
 - sibling supporting files such as `shell-ceremony.md`, `stack-routing.md`, `review-orchestrator.md`, and `telemetry-contract.md` provide shared behavior when that family needs it. These are contract surfaces, not the place for day-to-day authored skill logic.
 
 In practice: if you are changing what a skill tells an agent to do, you almost always want `content.md`. If you are changing shared runtime ceremony, reporting, routing, or telemetry behavior, you are usually in a governed sidecar or orchestration playbook instead.
+
+That now includes `skills/bill-feature-implement/`: keep workflow-state markers, continuation behavior, stable artifact names, and telemetry ownership in `SKILL.md`, but edit the detailed execution flow in sibling `content.md`.
 
 ## Authoring a skill
 

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-21] feature-implement-shell-pilot
+Areas: skills/bill-feature-implement/, scripts/, tests/, README.md, orchestration/workflow-contract/
+- Split `bill-feature-implement` into a workflow shell in `SKILL.md` and an author-owned `content.md`, keeping workflow-state, continuation, stable artifact names, and telemetry ownership in the shell while moving phase-by-phase execution guidance into the sibling content file. reusable
+- Keep `commit_push_result` as a reserved shell-owned artifact name until runtime persistence actually exists; document the name in the shell/reference contract but do not widen workflow storage just to satisfy the docs split. reusable
+- Add a dedicated validator hook for `bill-feature-implement` so missing `content.md`, missing shell workflow markers, or a missing execution pointer fail loudly even though this workflow pilot does not use the generic governed wrapper contract. reusable
+- Cover the split with both routing-contract assertions and validator fixture failures so future prompt edits cannot quietly collapse the shell back into a single authored file. reusable
+Feature flag: N/A
+Acceptance criteria: 10/10 implemented
+
 ## [2026-04-21] feature-implement-workflow-runtime
 Areas: skill_bill/, skills/bill-feature-implement/, orchestration/workflow-contract/, tests/
 - Added a durable `bill-feature-implement` workflow runtime with persisted workflow ids, step state, attempt counts, named artifacts, and a dedicated `feature_implement_workflows` store behind CLI and MCP surfaces for open/get/update/list/latest/resume/continue. reusable

--- a/orchestration/workflow-contract/PLAYBOOK.md
+++ b/orchestration/workflow-contract/PLAYBOOK.md
@@ -215,6 +215,15 @@ ids are:
 11. `pr_description`
 12. `finish`
 
+For this pilot, the workflow shell stays in `skills/bill-feature-implement/SKILL.md`
+and the authored execution body lives in sibling `content.md`.
+`SKILL.md` remains the source of truth for:
+
+- workflow-state and continuation sections
+- stable step headings used by continuation payloads
+- stable artifact names
+- telemetry ownership and final lifecycle fields
+
 Required workflow artifacts for the pilot:
 
 - `assessment` — accepted criteria, non-goals, open questions, feature size,
@@ -228,6 +237,8 @@ Required workflow artifacts for the pilot:
 - `audit_report` — per-criterion pass/fail evidence
 - `validation_result` — routed skill or repo-native validator result
 - `history_result` — written/skipped outcome for boundary history
+- `commit_push_result` — reserved shell-owned artifact name for Step 8; the
+  current pilot documents it but does not require runtime persistence yet
 - `pr_result` — PR url/title or terminal failure note
 
 Pilot-specific retry rules:

--- a/scripts/validate_agent_configs.py
+++ b/scripts/validate_agent_configs.py
@@ -196,6 +196,7 @@ def main() -> int:
   validate_skill_references(root, skill_names, issues)
   validate_orchestrator_passthrough(root, issues)
   validate_workflow_driven_skills(root, issues)
+  validate_feature_implement_shell_contract(root, issues)
   validate_skill_override_markdown(
     root / SKILL_OVERRIDE_EXAMPLE_FILE,
     skill_names,
@@ -477,6 +478,37 @@ WORKFLOW_DRIVEN_SKILLS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...]
     ),
   ),
 )
+FEATURE_IMPLEMENT_SHELL_REQUIRED_MARKERS: tuple[str, ...] = (
+  "## Execution",
+  "[content.md](content.md)",
+  "## Workflow State",
+  "### Stable Step Ids",
+  "### Stable Artifact Names",
+  "## Continuation Mode",
+  "## Step 1: Collect Design Doc + Assess Size (orchestrator)",
+  "## Step 1b: Create Feature Branch (orchestrator)",
+  "## Step 2: Pre-Planning (subagent)",
+  "## Step 3: Create Implementation Plan (subagent)",
+  "## Step 4: Execute Plan (subagent)",
+  "## Step 5: Code Review (orchestrator)",
+  "## Step 6: Completeness Audit (subagent)",
+  "## Finalization sequence (Steps 6b -> 9)",
+  "## Telemetry: Record Finished",
+  "feature_implement_workflow_open",
+  "feature_implement_workflow_update",
+  "feature_implement_workflow_continue",
+  "`assessment`",
+  "`branch`",
+  "`preplan_digest`",
+  "`plan`",
+  "`implementation_summary`",
+  "`review_result`",
+  "`audit_report`",
+  "`validation_result`",
+  "`history_result`",
+  "`commit_push_result`",
+  "`pr_result`",
+)
 
 
 def validate_orchestrator_passthrough(root: Path, issues: list[str]) -> None:
@@ -522,6 +554,31 @@ def validate_workflow_driven_skills(root: Path, issues: list[str]) -> None:
         issues.append(
           f"{skill_dir}: workflow-driven skill must include '{marker}'"
         )
+
+
+def validate_feature_implement_shell_contract(root: Path, issues: list[str]) -> None:
+  """`bill-feature-implement` is a shell/content split pilot with shell-owned
+  workflow markers that must remain in `SKILL.md`.
+  """
+  skill_dir = root / "skills" / "bill-feature-implement"
+  if not skill_dir.exists():
+    return
+
+  skill_file = skill_dir / "SKILL.md"
+  content_file = skill_dir / "content.md"
+  if not skill_file.is_file():
+    return
+
+  if not content_file.is_file():
+    issues.append(f"{skill_dir}: bill-feature-implement must include sibling content.md")
+    return
+
+  text = skill_file.read_text(encoding="utf-8")
+  for marker in FEATURE_IMPLEMENT_SHELL_REQUIRED_MARKERS:
+    if marker not in text:
+      issues.append(
+        f"{skill_file}: bill-feature-implement shell must include '{marker}'"
+      )
 
 
 def validate_no_inline_telemetry_contract_drift(root: Path, issues: list[str]) -> None:

--- a/skills/bill-feature-implement/SKILL.md
+++ b/skills/bill-feature-implement/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: bill-feature-implement
-description: Use when doing end-to-end feature implementation from design doc to verified code. Automatically scales ceremony based on feature size — lightweight for small changes, full orchestration for large features. Runs each heavy phase (pre-planning, planning, implementation, completeness audit, quality check, PR description) inside its own subagent with a rich self-contained briefing, to keep the orchestrator context small. Code review stays in the orchestrator because it already spawns specialist subagents internally. Use when user mentions implement feature, build feature, implement spec, or feature from design doc.
+description: Use when doing end-to-end feature implementation from design doc to verified code. Automatically scales ceremony based on feature size - lightweight for small changes, full orchestration for large features. Runs each heavy phase (pre-planning, planning, implementation, completeness audit, quality check, PR description) inside its own subagent with a rich self-contained briefing, to keep the orchestrator context small. Code review stays in the orchestrator because it already spawns specialist subagents internally. Use when user mentions implement feature, build feature, implement spec, or feature from design doc.
 ---
 
 # Feature Implement
-
-End-to-end feature implementation from design doc to verified code (spec → plan → implement → review → audit → validate → history → commit → PR). Heavy phases run inside dedicated subagents to keep the orchestrator context small.
 
 ## Project Overrides
 
@@ -13,31 +11,17 @@ Follow the shell ceremony in [shell-ceremony.md](shell-ceremony.md).
 
 If `.agents/skill-overrides.md` exists in the project root and contains a matching section, read that section and apply it as the highest-priority instruction for this skill.
 
-## Orchestrator vs subagent split
+## Execution
 
-| Step                                            | Where it runs    | Why                                                                  |
-|-------------------------------------------------|------------------|----------------------------------------------------------------------|
-| 1 — Collect design doc + assess                 | **Orchestrator** | Requires user interaction                                            |
-| 1b — Create feature branch                      | **Orchestrator** | Trivial git op; keeps branch state visible                           |
-| 2 — Pre-planning (history, spec save, patterns) | **Subagent**     | Heavy reading; digest is small                                       |
-| 3 — Create implementation plan                  | **Subagent**     | Heavy reading; returns structured plan                               |
-| 4 — Execute plan                                | **Subagent**     | Biggest context win; many file edits                                 |
-| 5 — Code review (`bill-code-review`)            | **Orchestrator** | Already spawns specialist subagents internally — do not nest further |
-| 6 — Completeness audit                          | **Subagent**     | Re-reads code + criteria; returns pass/fail digest                   |
-| 6b — Quality check (`bill-quality-check`)       | **Subagent**     | Shell-heavy; returns structured result + telemetry payload           |
-| 7 — Boundary history (`bill-boundary-history`)  | **Orchestrator** | Small write, git-auditable                                           |
-| 8 — Commit and push                             | **Orchestrator** | Git ops must stay visible                                            |
-| 9 — PR description (`bill-pr-description`)      | **Subagent**     | Reads branch diff; returns PR URL + telemetry payload                |
+Follow the detailed step instructions in [content.md](content.md).
 
-Subagents run **sequentially**, in the **same worktree** (no `isolation: "worktree"`). Do not launch any of these subagents in parallel.
+This shell remains the source of truth for the workflow-state contract, continuation contract, stable step ids, stable artifact names, and telemetry ownership. `content.md` is the author-owned execution body.
 
-Each subagent receives a **self-contained briefing** (see [reference.md](reference.md) for the per-phase briefing templates and structured return contracts). A subagent must not re-read the raw spec — it operates on what the orchestrator hands it. Its return value is a structured object the orchestrator can consume without re-parsing prose.
+For KMP implementation work, resolve governed add-ons only after stack routing settles on `kmp`, then scan the matching pack-owned add-on supporting files whose cues match the work.
 
 ## Workflow State
 
-This skill is the first runtime workflow-state pilot. In addition to the
-top-level telemetry tools, the orchestrator must persist durable workflow
-state with these MCP tools:
+This skill is the first runtime workflow-state pilot. In addition to the top-level telemetry tools, the orchestrator must persist durable workflow state with these MCP tools:
 
 - `feature_implement_workflow_open`
 - `feature_implement_workflow_update`
@@ -49,254 +33,205 @@ Workflow-state rules:
 - Save both ids:
   - `session_id` from `feature_implement_started` for telemetry
   - `workflow_id` from `feature_implement_workflow_open` for durable state
-- Maintain a local `child_steps` list for orchestrated child telemetry exactly
-  as before.
-- After every major phase boundary, call `feature_implement_workflow_update`
-  with:
+- Maintain a local `child_steps` list for orchestrated child telemetry exactly as before.
+- After every major phase boundary, call `feature_implement_workflow_update` with:
   - the new `workflow_status`
   - the new `current_step_id`
   - `step_updates` for the steps whose status changed
   - `artifacts_patch` for the structured artifact produced by that phase
-- Workflow state is independent of telemetry settings. Persist it even when
-  `feature_implement_started` or `feature_implement_finished` returns
-  `status: skipped`.
-- Follow the artifact names and phase-to-artifact mapping in
-  [reference.md](reference.md). Do not invent prose-only handoffs when a
-  structured artifact exists.
+- Workflow state is independent of telemetry settings. Persist it even when `feature_implement_started` or `feature_implement_finished` returns `status: skipped`.
+- Follow the detailed per-phase briefing contracts in [reference.md](reference.md). Do not invent prose-only handoffs when a structured artifact exists.
+
+### Stable Step Ids
+
+1. `assess`
+2. `create_branch`
+3. `preplan`
+4. `plan`
+5. `implement`
+6. `review`
+7. `audit`
+8. `validate`
+9. `write_history`
+10. `commit_push`
+11. `pr_description`
+12. `finish`
+
+### Stable Artifact Names
+
+- `assessment`
+- `branch`
+- `preplan_digest`
+- `plan`
+- `implementation_summary`
+- `review_result`
+- `audit_report`
+- `validation_result`
+- `history_result`
+- `commit_push_result`
+- `pr_result`
+
+### Phase-to-Artifact Mapping
+
+- Step 1 -> `assessment`
+- Step 1b -> `branch`
+- Step 2 -> `preplan_digest`
+- Step 3 -> `plan`
+- Step 4 -> `implementation_summary`
+- Step 5 -> `review_result`
+- Step 6 -> `audit_report`
+- Step 6b -> `validation_result`
+- Step 7 -> `history_result`
+- Step 8 -> `commit_push_result` is a reserved shell-owned artifact name for this pilot; keep runtime behavior unchanged unless the workflow runtime already persists it.
+- Step 9 -> `pr_result`
 
 ## Continuation Mode
 
-When an external caller re-enters this skill using the payload returned by
-`feature_implement_workflow_continue`, treat that payload as the authoritative
-continuation contract for the resumed run.
+When an external caller re-enters this skill using the payload returned by `feature_implement_workflow_continue`, treat that payload as the authoritative continuation contract for the resumed run.
 
 Continuation-mode rules:
 
 - Keep the same `workflow_id` and `session_id`; do not open a new workflow.
 - Use `continue_step_id` as the starting point.
-- Use `step_artifacts` and `session_summary` as authoritative recovered
-  context; do not reconstruct earlier phases from chat history unless the step
-  explicitly requires user confirmation.
-- Read the `reference_sections` listed in the continuation payload before
-  resuming work.
-- Skip already-completed earlier steps unless the normal workflow loop sends
-  work backwards (for example review back to implement, or audit back to plan).
+- Use `step_artifacts` and `session_summary` as authoritative recovered context; do not reconstruct earlier phases from chat history unless the step explicitly requires user confirmation.
+- Read the `reference_sections` listed in the continuation payload before resuming work.
+- Skip already-completed earlier steps unless the normal workflow loop sends work backwards (for example review back to implement, or audit back to plan).
 - After the resumed step completes, continue the normal sequence defined below.
-- If `continue_status` is `done`, do not rerun the workflow; summarize the
-  terminal state instead.
-- If `continue_status` is `blocked`, stop and restore the missing artifacts
-  named by the workflow payload before continuing.
+- If `continue_status` is `done`, do not rerun the workflow; summarize the terminal state instead.
+- If `continue_status` is `blocked`, stop and restore the missing artifacts named by the workflow payload before continuing.
+
+## Orchestrator vs subagent split
+
+| Step | Where it runs | Why |
+| --- | --- | --- |
+| 1 - Collect design doc + assess | **Orchestrator** | Requires user interaction |
+| 1b - Create feature branch | **Orchestrator** | Trivial git op; keeps branch state visible |
+| 2 - Pre-planning (history, spec save, patterns) | **Subagent** | Heavy reading; digest is small |
+| 3 - Create implementation plan | **Subagent** | Heavy reading; returns structured plan |
+| 4 - Execute plan | **Subagent** | Biggest context win; many file edits |
+| 5 - Code review (`bill-code-review`) | **Orchestrator** | Already spawns specialist subagents internally - do not nest further |
+| 6 - Completeness audit | **Subagent** | Re-reads code + criteria; returns pass/fail digest |
+| 6b - Quality check (`bill-quality-check`) | **Subagent** | Shell-heavy; returns structured result + telemetry payload |
+| 7 - Boundary history (`bill-boundary-history`) | **Orchestrator** | Small write, git-auditable |
+| 8 - Commit and push | **Orchestrator** | Git ops must stay visible |
+| 9 - PR description (`bill-pr-description`) | **Subagent** | Reads branch diff; returns PR URL + telemetry payload |
+
+Subagents run sequentially, in the same worktree (no `isolation: "worktree"`). Do not launch any of these subagents in parallel.
+
+Each subagent receives a self-contained briefing. See [reference.md](reference.md) for the per-phase briefing templates and structured return contracts.
 
 ## Step 1: Collect Design Doc + Assess Size (orchestrator)
 
-Ask the user for:
-1. **Feature design doc** — inline text, file path, or directory of spec files
-2. **Issue key** (e.g., `ME-5066`, `SKILL-10`) — **required**. The issue key prefixes the branch name, spec directory, and commit message. If the user has no issue yet, stop and ask them to create one before continuing; do not invent a placeholder.
+Step id: `assess`
 
-Accept PDFs (read in page ranges if >10 pages), markdown, images. If a directory, read all files and synthesize. If spec exceeds ~8,000 words, ask which sections matter most.
+Primary artifact: `assessment`
 
-### Single-Pass Assessment
+Follow the detailed assessment flow in [content.md](content.md#step-1-collect-design-doc--assess-size-orchestrator).
 
-Present everything together in one pass:
-1. **Acceptance criteria** — numbered list
-2. **Non-goals** — things explicitly out of scope
-3. **Open questions** — unresolved decisions (if any)
-4. **Feature size** — SMALL / MEDIUM / LARGE
-5. **Feature name** inferred from spec
-6. **Rollout need** — N/A unless spec/user/repo requires guarded rollout
-
-Then ask: **Confirm or adjust the above before I plan.** Open questions must be resolved before proceeding. The confirmed criteria are the **contract** for the completeness audit and for every subagent briefing from Step 2 onward.
-
-### Telemetry: Record Started
-
-After the user confirms the assessment, call the `feature_implement_started` MCP tool with:
-- `feature_size`, `acceptance_criteria_count`, `open_questions_count`
-- `spec_input_types`: list of input types the user provided (`raw_text`, `pdf`, `markdown_file`, `image`, `directory`)
-- `spec_word_count`: approximate word count of the design spec
-- `rollout_needed`: whether a feature flag / guarded rollout is needed
-- `feature_name`: the inferred feature name
-- `issue_key`: the issue key the user provided (required — Step 1 does not proceed without it)
-- `issue_key_type`: `jira`, `linear`, `github`, or `other`
-- `spec_summary`: one sentence summarizing what the feature does
-
-Save the returned `session_id` for `feature_implement_finished`. If the tool returns `status: skipped`, continue normally.
-
-### Workflow State: Open
-
-After Step 1 is confirmed:
-
-1. Call `feature_implement_workflow_open` with:
-   - `session_id`: the `session_id` from `feature_implement_started`
-   - `current_step_id`: `assess`
-2. Save the returned `workflow_id`.
-3. Immediately call `feature_implement_workflow_update` to:
-   - mark `assess` as completed
-   - set `create_branch` to running
-   - persist the `assessment` artifact
-
-The `assessment` artifact must include:
-- acceptance criteria
-- non-goals
-- open questions
-- feature size
-- feature name
-- rollout need
+After the assessment is confirmed, record the Step 1 telemetry fields, open workflow state, save both ids, and persist the `assessment` artifact before advancing to `create_branch`.
 
 ## Step 1b: Create Feature Branch (orchestrator)
 
-`git checkout -b feat/{ISSUE_KEY}-{feature-name}`
+Step id: `create_branch`
 
-After the branch is created, call `feature_implement_workflow_update` to:
-- mark `create_branch` as completed
-- set `preplan` to running
-- persist a `branch` artifact with the branch name
+Primary artifact: `branch`
+
+Follow the detailed branch-creation instructions in [content.md](content.md#step-1b-create-feature-branch-orchestrator).
+
+After the branch is created, update workflow state to persist `branch`, mark `create_branch` completed, and advance to `preplan`.
 
 ## Step 2: Pre-Planning (subagent)
 
-Spawn a subagent with the pre-planning briefing defined in [reference.md](reference.md) under "Pre-planning subagent briefing". The briefing includes: acceptance criteria, non-goals, issue key, feature name, spec content (or saved spec path for MEDIUM/LARGE), feature size, expected affected boundaries (if known), rollout need, and explicit instructions to:
+Step id: `preplan`
 
-- Read `agent/history.md` in each boundary the feature is likely to touch (newest first; stop when no longer relevant).
-- Read `agent/decisions.md` header lines in each boundary and only open full entries when titles look relevant.
-- For MEDIUM/LARGE, save the spec to `.feature-specs/{ISSUE_KEY}-{feature-name}/spec.md` with status `In Progress`.
-- Read `CLAUDE.md`, `AGENTS.md`, and the matching `bill-feature-implement` section in `.agents/skill-overrides.md` when present.
-- Discover codebase patterns: similar features referenced in the spec, build/runtime dependencies for affected boundaries, reusable components.
-- When `kmp` signals dominate, resolve governed add-ons only after stack routing. Start from `Selected add-ons: none`. Let the routed pack own add-on detection and selection, then scan the matching pack-owned add-on supporting files' `## Section index` headings first. If the add-on is split into topic files, open only the linked topic files whose cues match the work during pre-planning / pattern discovery.
-- Confirm `bill-quality-check` can route this repo; if not, pick a repo-native validation command.
-- If the rollout uses a feature flag, read `bill-feature-guard` inline and choose a pattern (Legacy / DI Switch / Simple Conditional).
+Primary artifact: `preplan_digest`
 
-The subagent returns the **pre-planning return contract** (see reference.md), including any selected governed add-ons as metadata. The orchestrator keeps this digest in context and passes it to later subagents — the raw findings stay in the subagent.
+Follow the detailed pre-planning instructions in [content.md](content.md#step-2-pre-planning-subagent).
 
-After the subagent returns, call `feature_implement_workflow_update` to:
-- mark `preplan` as completed
-- set `plan` to running
-- persist the `preplan_digest` artifact
+Spawn the pre-planning subagent with the briefing defined in [reference.md](reference.md) under `Pre-planning subagent briefing`, then persist `preplan_digest` before advancing to `plan`.
 
 ## Step 3: Create Implementation Plan (subagent)
 
-Spawn a subagent with the planning briefing defined in [reference.md](reference.md) under "Planning subagent briefing". The briefing includes: acceptance criteria, non-goals, feature size, pre-planning digest (from Step 2), rollout info, feature-flag pattern (if any), and validation strategy.
+Step id: `plan`
 
-The subagent returns the **planning return contract**: an ordered task list, each task with description, files to create/modify, which acceptance criteria it satisfies, and test coverage (or `None` when deferred to the final test task). For MEDIUM/LARGE with >15 tasks, the plan must be split into phases with checkpoints.
+Primary artifact: `plan`
 
-If the plan includes testable logic, the **final task must be a dedicated test task**. The subagent is responsible for enforcing this rule in the plan it returns.
+Follow the detailed planning instructions in [content.md](content.md#step-3-create-implementation-plan-subagent).
 
-The orchestrator presents the plan, then proceeds to implementation — the plan is not a second approval gate.
-
-After the plan is accepted for execution, call `feature_implement_workflow_update` to:
-- mark `plan` as completed
-- set `implement` to running
-- persist the `plan` artifact
+Spawn the planning subagent with the briefing defined in [reference.md](reference.md) under `Planning subagent briefing`, then persist `plan` before advancing to `implement`.
 
 ## Step 4: Execute Plan (subagent)
 
-Spawn a subagent with the implementation briefing defined in [reference.md](reference.md) under "Implementation subagent briefing". The briefing includes: acceptance criteria, plan (from Step 3), pre-planning digest (from Step 2), rollout info, feature-flag pattern (if any), spec path (for MEDIUM/LARGE), and execution rules (project standards, test gate, orphan cleanup, catalog updates for agent-config changes).
+Step id: `implement`
 
-The subagent executes the plan atomically (one task per turn), prints per-task progress, writes tests as specified, and stops to re-plan if a task reveals the plan is wrong. On stop-and-re-plan, the subagent returns with `plan_deviation_notes` populated so the orchestrator can decide whether to re-spawn the planning subagent.
+Primary artifact: `implementation_summary`
 
-The subagent returns the **implementation return contract**: `files_created`, `files_modified`, `tasks_completed`, `plan_deviation_notes`, `tests_written`, `notes_for_review`.
+Follow the detailed implementation instructions in [content.md](content.md#step-4-execute-plan-subagent).
 
-For MEDIUM/LARGE, the subagent performs the **post-implementation compact** internally before returning: summarize files, feature flag info, criteria-to-file mapping, deviations; then re-read the saved spec to verify every criterion is mapped.
-
-After the subagent returns, call `feature_implement_workflow_update` to:
-- mark `implement` as completed
-- set `review` to running
-- persist the `implementation_summary` artifact
+Spawn the implementation subagent with the briefing defined in [reference.md](reference.md) under `Implementation subagent briefing`, then persist `implementation_summary` before advancing to `review`.
 
 ## Step 5: Code Review (orchestrator)
 
-Run `bill-code-review` **inline in the orchestrator** (read its skill file and apply inline). Scope: current unit of work for SMALL, branch diff for MEDIUM/LARGE. Do not wrap `bill-code-review` in an additional subagent — it already spawns specialist subagents internally.
+Step id: `review`
 
-**Review loop:** Auto-fix Blocker and Major findings by spawning the implementation subagent again with a fix briefing (acceptance criteria + list of findings + pointer to the current diff + instruction to fix only those findings). Before respawning, capture the exact diff pointer the review was run against — the branch name, commit range (e.g. `main..HEAD`), or explicit file list — and pass it as `{branch_or_commit_range}` in the fix briefing so the subagent knows which diff "the findings" refer to. Re-run review. Continue past Minor-only findings. Max **3 iterations**. Do not pause to ask the user which finding to fix.
+Primary artifact: `review_result`
 
-**Orchestrated child telemetry:** when this workflow invokes `import_review` and `triage_findings` for the review it owns, pass `orchestrated=true` to both tools. Collect the `telemetry_payload` returned by `triage_findings` (or by `import_review` when the review has no findings) and append it to the local `child_steps` list. The review will not emit `skillbill_review_finished` on its own — its payload will be embedded in the `skillbill_feature_implement_finished` event instead.
+Follow the detailed review-loop instructions in [content.md](content.md#step-5-code-review-orchestrator).
 
-Workflow-state rules for review:
-
-- After each review pass, persist a `review_result` artifact containing:
-  - the diff pointer reviewed
-  - prioritized findings summary
-  - current review iteration count
-- If the review loop sends work back to implementation:
-  - update workflow state so `review` is no longer running
-  - set `implement` back to running
-  - increment the `implement` step's `attempt_count`
-- Once review is complete, call `feature_implement_workflow_update` to:
-  - mark `review` as completed
-  - set `audit` to running
+Run `bill-code-review` inline in the orchestrator, pass `orchestrated=true` to the review MCP tools it owns, append returned child telemetry payloads to `child_steps`, persist `review_result`, and loop back to `implement` when the review contract requires fixes.
 
 ## Step 6: Completeness Audit (subagent)
 
-Spawn a subagent with the audit briefing defined in [reference.md](reference.md) under "Completeness audit subagent briefing". The briefing includes: acceptance criteria, implementation return contract (from Step 4), and — for MEDIUM/LARGE — a pointer to the branch diff.
+Step id: `audit`
 
-**SMALL:** the subagent returns a quick confirmation for each criterion.
-**MEDIUM/LARGE:** the subagent returns a full per-criterion report with evidence paths.
+Primary artifact: `audit_report`
 
-The subagent returns the **audit return contract**: `pass: bool`, `per_criterion: [...]`, `gaps: [...]`.
+Follow the detailed audit instructions in [content.md](content.md#step-6-completeness-audit-subagent).
 
-If gaps found: the orchestrator respawns the planning subagent with the gaps, then the implementation subagent, then re-runs code review, then re-spawns the audit subagent. Max **2 audit iterations**. When complete, the orchestrator updates the saved spec status to **Complete** (MEDIUM/LARGE only).
+Spawn the audit subagent with the briefing defined in [reference.md](reference.md) under `Completeness audit subagent briefing`, persist `audit_report`, and loop back to `plan` only when the audit contract requires it.
 
-Workflow-state rules for audit:
+## Finalization sequence (Steps 6b -> 9)
 
-- After each audit pass, persist the `audit_report` artifact.
-- If the audit finds gaps and loops back:
-  - mark `audit` as no longer running
-  - set `plan` back to running
-  - increment the `plan` step's `attempt_count`
-- Once the audit passes, call `feature_implement_workflow_update` to:
-  - mark `audit` as completed
-  - set `validate` to running
-
-## Finalization sequence (Steps 6b → 9)
-
-Once the audit passes, run Steps 6b through 9 as a **continuous sequence without pausing**. The only reason to stop is if a step fails.
+Once the audit passes, run the finalization sequence as a continuous flow without pausing. Follow the detailed finalization instructions in [content.md](content.md#finalization-sequence-steps-6b---9).
 
 ### Step 6b: Final Validation Gate (subagent)
 
-Spawn a subagent with the quality-check briefing defined in [reference.md](reference.md) under "Quality-check subagent briefing". The subagent runs `bill-quality-check` (which auto-routes to the matching stack quality-check skill), fixes any issues at their root without using suppressions, and **must call `quality_check_finished` with `orchestrated=true`** itself. The subagent returns: `validation_result`, `routed_skill`, `detected_stack`, `initial_failure_count`, `final_failure_count`, and the `telemetry_payload` returned by `quality_check_finished`.
+Step id: `validate`
 
-If `bill-quality-check` reports no supported stack for the affected repo, the subagent falls back to the closest existing repo-native validation command.
+Primary artifact: `validation_result`
 
-The orchestrator appends the returned `telemetry_payload` to the `child_steps` list.
-
-After validation finishes, call `feature_implement_workflow_update` to:
-- mark `validate` as completed
-- set `write_history` to running
-- persist the `validation_result` artifact
+Spawn the quality-check subagent with the briefing defined in [reference.md](reference.md) under `Quality-check subagent briefing`, require it to call `quality_check_finished` with `orchestrated=true`, append the returned child telemetry payload to `child_steps`, persist `validation_result`, and advance to `write_history`.
 
 ### Step 7: Write Boundary History (orchestrator)
 
-Run `bill-boundary-history` inline in the orchestrator (read its skill file and apply inline). The skill owns write/skip rules and entry format.
+Step id: `write_history`
 
-After Step 7, call `feature_implement_workflow_update` to:
-- mark `write_history` as completed
-- set `commit_push` to running
-- persist the `history_result` artifact
+Primary artifact: `history_result`
+
+Run `bill-boundary-history` inline in the orchestrator, persist `history_result`, and advance to `commit_push`.
 
 ### Step 8: Commit and Push (orchestrator)
 
-1. Stage all new and modified files from this feature (do not use `git add -A`)
-2. Commit with message format: `feat: <concise description>` (omit the issue key — the branch name already carries it)
-3. Push the branch to the remote with `-u` to set upstream tracking
+Step id: `commit_push`
 
-After push succeeds, call `feature_implement_workflow_update` to:
-- mark `commit_push` as completed
-- set `pr_description` to running
+Reserved artifact name: `commit_push_result`
+
+Stage only this feature's files, commit with `feat: <concise description>`, and push with upstream tracking. Keep workflow runtime behavior unchanged unless Step 8 already persists a structured artifact.
 
 ### Step 9: Generate PR Description (subagent)
 
-Spawn a subagent with the PR-description briefing defined in [reference.md](reference.md) under "PR-description subagent briefing". The subagent runs `bill-pr-description` (read its skill file and apply inline), creates the PR, and **must call `pr_description_generated` with `orchestrated=true`** itself. The subagent returns: PR URL, PR title, and the `telemetry_payload` returned by `pr_description_generated`.
+Step id: `pr_description`
 
-The orchestrator appends the returned `telemetry_payload` to the `child_steps` list.
+Primary artifact: `pr_result`
 
-After the PR step finishes, call `feature_implement_workflow_update` to:
-- mark `pr_description` as completed
-- set `finish` to running
-- persist the `pr_result` artifact
+Spawn the PR-description subagent with the briefing defined in [reference.md](reference.md) under `PR-description subagent briefing`, require it to call `pr_description_generated` with `orchestrated=true`, append the returned child telemetry payload to `child_steps`, persist `pr_result`, and advance to `finish`.
 
-### Telemetry: Record Finished
+## Telemetry: Record Finished
 
 For the shared telemetry contract including orchestrated flag semantics, child step collection, and graceful-degradation rules, follow [telemetry-contract.md](telemetry-contract.md).
 
 After the PR is created (or when the workflow ends early due to error or user abandonment), call the `feature_implement_finished` MCP tool with:
+
 - `session_id`: from `feature_implement_started`
 - `completion_status`: `completed` if PR was created, otherwise `abandoned_at_planning`, `abandoned_at_implementation`, `abandoned_at_review`, or `error`
 - `plan_correction_count`: how many times the user corrected the assessment or plan (0 if confirmed without changes)
@@ -305,14 +240,14 @@ After the PR is created (or when the workflow ends early due to error or user ab
 - `files_created`, `files_modified`, `tasks_completed`
 - `review_iterations`, `audit_result` (`all_pass`, `had_gaps`, or `skipped`), `audit_iterations`
 - `validation_result` (`pass`, `fail`, or `skipped`), `boundary_history_written`, `pr_created`
-- `boundary_history_value`: how useful the boundary history was during pre-planning — `none` means no history existed at pre-read time (so `boundary_history_written=true` paired with `value=none` is a legal combination, e.g. this run created the first entry); `irrelevant` means history was read but nothing applied; `low` means an adjacent entry was grazed but did not shape the plan; `medium` means an entry directly informed pre-planning; `high` means an entry was decisive in shaping the plan. Full anchored rubric lives in `reference.md`.
+- `boundary_history_value`: how useful the boundary history was during pre-planning - `none` means no history existed at pre-read time (so `boundary_history_written=true` paired with `value=none` is a legal combination, e.g. this run created the first entry); `irrelevant` means history was read but nothing applied; `low` means an adjacent entry was grazed but did not shape the plan; `medium` means an entry directly informed pre-planning; `high` means an entry was decisive in shaping the plan. Full anchored rubric lives in `reference.md`.
 - `plan_deviation_notes`: brief note if the plan changed during execution (empty if no deviations)
 - `child_steps`: list of `telemetry_payload` dicts collected from child tools invoked with `orchestrated=true` during the session
 
 For fields not yet reached (early exit), use: 0 for counts, `skipped` for results, false for booleans.
 
-Before or immediately after `feature_implement_finished`, call
-`feature_implement_workflow_update` one final time to:
+Before or immediately after `feature_implement_finished`, call `feature_implement_workflow_update` one final time to:
+
 - mark `finish` as completed for successful runs
 - set `workflow_status` to `completed`, `abandoned`, or `failed`
 - keep `current_step_id` at the step where the workflow stopped
@@ -320,4 +255,4 @@ Before or immediately after `feature_implement_finished`, call
 
 ## Reference
 
-For briefing templates, return-contract schemas, size reference, error recovery, and skills invoked, see [reference.md](reference.md).
+For detailed step instructions, briefing templates, return-contract schemas, size reference, error recovery, and skills invoked, see [reference.md](reference.md).

--- a/skills/bill-feature-implement/content.md
+++ b/skills/bill-feature-implement/content.md
@@ -1,0 +1,127 @@
+# Feature Implement Content
+
+This file is the author-owned execution body for `bill-feature-implement`. The shell contract, workflow-state contract, continuation contract, stable step ids, stable artifact names, and telemetry ownership remain in [SKILL.md](SKILL.md).
+
+## Step 1: Collect Design Doc + Assess Size (orchestrator)
+
+Ask the user for:
+1. **Feature design doc** - inline text, file path, or directory of spec files
+2. **Issue key** (for example `ME-5066`, `SKILL-10`) - required. The issue key prefixes the branch name, spec directory, and commit message. If the user has no issue yet, stop and ask them to create one before continuing; do not invent a placeholder.
+
+Accept PDFs (read in page ranges if >10 pages), markdown, images. If a directory, read all files and synthesize. If spec exceeds about 8,000 words, ask which sections matter most.
+
+### Single-Pass Assessment
+
+Present everything together in one pass:
+1. **Acceptance criteria** - numbered list
+2. **Non-goals** - things explicitly out of scope
+3. **Open questions** - unresolved decisions (if any)
+4. **Feature size** - SMALL / MEDIUM / LARGE
+5. **Feature name** inferred from spec
+6. **Rollout need** - N/A unless spec, user, or repo requires guarded rollout
+
+Then ask: **Confirm or adjust the above before I plan.** Open questions must be resolved before proceeding. The confirmed criteria are the contract for the completeness audit and for every subagent briefing from Step 2 onward.
+
+After the assessment is confirmed, follow the Step 1 transition contract in [SKILL.md](SKILL.md#step-1-collect-design-doc--assess-size-orchestrator) and the workflow-state contract in [SKILL.md](SKILL.md#workflow-state).
+
+## Step 1b: Create Feature Branch (orchestrator)
+
+Create the feature branch with:
+
+`git checkout -b feat/{ISSUE_KEY}-{feature-name}`
+
+After the branch is created, follow the Step 1b workflow-state update contract in [SKILL.md](SKILL.md#step-1b-create-feature-branch-orchestrator).
+
+## Step 2: Pre-Planning (subagent)
+
+Spawn a subagent with the pre-planning briefing defined in [reference.md](reference.md) under `Pre-planning subagent briefing`. The briefing includes: acceptance criteria, non-goals, issue key, feature name, spec content (or saved spec path for MEDIUM/LARGE), feature size, expected affected boundaries (if known), rollout need, and explicit instructions to:
+
+- Read `agent/history.md` in each boundary the feature is likely to touch (newest first; stop when no longer relevant).
+- Read `agent/decisions.md` header lines in each boundary and only open full entries when titles look relevant.
+- For MEDIUM/LARGE, save the spec to `.feature-specs/{ISSUE_KEY}-{feature-name}/spec.md` with status `In Progress`.
+- Read `CLAUDE.md`, `AGENTS.md`, and the matching `bill-feature-implement` section in `.agents/skill-overrides.md` when present.
+- Discover codebase patterns: similar features referenced in the spec, build/runtime dependencies for affected boundaries, reusable components.
+- When `kmp` signals dominate, resolve governed add-ons only after stack routing settles on `kmp`. Start from `Selected add-ons: none`. Let the routed pack own add-on detection and selection, then scan the matching pack-owned add-on supporting files' `## Section index` headings first. If the add-on is split into topic files, open only the linked topic files whose cues match the work during pre-planning and pattern discovery.
+- Confirm `bill-quality-check` can route this repo; if not, pick a repo-native validation command.
+- If the rollout uses a feature flag, read `bill-feature-guard` inline and choose a pattern (Legacy / DI Switch / Simple Conditional).
+
+The subagent returns the pre-planning return contract from [reference.md](reference.md). The orchestrator keeps this digest in context and passes it to later subagents - the raw findings stay in the subagent.
+
+## Step 3: Create Implementation Plan (subagent)
+
+Spawn a subagent with the planning briefing defined in [reference.md](reference.md) under `Planning subagent briefing`. The briefing includes: acceptance criteria, non-goals, feature size, pre-planning digest (from Step 2), rollout info, feature-flag pattern (if any), and validation strategy.
+
+The subagent returns the planning return contract: an ordered task list, each task with description, files to create or modify, which acceptance criteria it satisfies, and test coverage (or `None` when deferred to the final test task). For MEDIUM/LARGE with more than 15 tasks, the plan must be split into phases with checkpoints.
+
+If the plan includes testable logic, the final task must be a dedicated test task. The subagent is responsible for enforcing this rule in the plan it returns.
+
+The orchestrator presents the plan, then proceeds to implementation - the plan is not a second approval gate.
+
+## Step 4: Execute Plan (subagent)
+
+Spawn a subagent with the implementation briefing defined in [reference.md](reference.md) under `Implementation subagent briefing`. The briefing includes: acceptance criteria, plan (from Step 3), pre-planning digest (from Step 2), rollout info, feature-flag pattern (if any), spec path (for MEDIUM/LARGE), and execution rules (project standards, test gate, orphan cleanup, catalog updates for agent-config changes).
+
+The subagent executes the plan atomically (one task per turn), prints per-task progress, writes tests as specified, and stops to re-plan if a task reveals the plan is wrong. On stop-and-re-plan, the subagent returns with `plan_deviation_notes` populated so the orchestrator can decide whether to re-spawn the planning subagent.
+
+The subagent returns the implementation return contract: `files_created`, `files_modified`, `tasks_completed`, `plan_deviation_notes`, `tests_written`, `notes_for_review`.
+
+For MEDIUM/LARGE, the subagent performs the post-implementation compact internally before returning: summarize files, feature flag info, criteria-to-file mapping, deviations; then re-read the saved spec to verify every criterion is mapped.
+
+## Step 5: Code Review (orchestrator)
+
+Run `bill-code-review` inline in the orchestrator. Read its skill file and apply it inline. Scope: current unit of work for SMALL, branch diff for MEDIUM/LARGE. Do not wrap `bill-code-review` in an additional subagent - it already spawns specialist subagents internally.
+
+Review loop:
+
+- Auto-fix Blocker and Major findings by spawning the implementation subagent again with a fix briefing (acceptance criteria + list of findings + pointer to the current diff + instruction to fix only those findings).
+- Before respawning, capture the exact diff pointer the review was run against - the branch name, commit range (for example `main..HEAD`), or explicit file list - and pass it as `{branch_or_commit_range}` in the fix briefing so the subagent knows which diff the findings refer to.
+- Re-run review.
+- Continue past Minor-only findings.
+- Max 3 iterations.
+- Do not pause to ask the user which finding to fix.
+
+Orchestrated child telemetry:
+
+- When this workflow invokes `import_review` and `triage_findings` for the review it owns, pass `orchestrated=true` to both tools.
+- Collect the `telemetry_payload` returned by `triage_findings` (or by `import_review` when the review has no findings) and append it to the local `child_steps` list.
+- The review will not emit `skillbill_review_finished` on its own - its payload will be embedded in the `skillbill_feature_implement_finished` event instead.
+
+## Step 6: Completeness Audit (subagent)
+
+Spawn a subagent with the audit briefing defined in [reference.md](reference.md) under `Completeness audit subagent briefing`. The briefing includes: acceptance criteria, implementation return contract (from Step 4), and - for MEDIUM/LARGE - a pointer to the branch diff.
+
+SMALL: the subagent returns a quick confirmation for each criterion.
+
+MEDIUM/LARGE: the subagent returns a full per-criterion report with evidence paths.
+
+The subagent returns the audit return contract: `pass: bool`, `per_criterion: [...]`, `gaps: [...]`.
+
+If gaps are found: the orchestrator respawns the planning subagent with the gaps, then the implementation subagent, then re-runs code review, then re-spawns the audit subagent. Max 2 audit iterations. When complete, the orchestrator updates the saved spec status to `Complete` (MEDIUM/LARGE only).
+
+## Finalization sequence (Steps 6b -> 9)
+
+Once the audit passes, run Steps 6b through 9 as a continuous sequence without pausing. The only reason to stop is if a step fails.
+
+### Step 6b: Final Validation Gate (subagent)
+
+Spawn a subagent with the quality-check briefing defined in [reference.md](reference.md) under `Quality-check subagent briefing`. The subagent runs `bill-quality-check` (which auto-routes to the matching stack quality-check skill), fixes any issues at their root without using suppressions, and must call `quality_check_finished` with `orchestrated=true` itself. The subagent returns: `validation_result`, `routed_skill`, `detected_stack`, `initial_failure_count`, `final_failure_count`, and the `telemetry_payload` returned by `quality_check_finished`.
+
+If `bill-quality-check` reports no supported stack for the affected repo, the subagent falls back to the closest existing repo-native validation command.
+
+The orchestrator appends the returned `telemetry_payload` to the `child_steps` list.
+
+### Step 7: Write Boundary History (orchestrator)
+
+Run `bill-boundary-history` inline in the orchestrator. Read its skill file and apply it inline. The skill owns write/skip rules and entry format.
+
+### Step 8: Commit and Push (orchestrator)
+
+1. Stage all new and modified files from this feature (do not use `git add -A`)
+2. Commit with message format: `feat: <concise description>` (omit the issue key - the branch name already carries it)
+3. Push the branch to the remote with `-u` to set upstream tracking
+
+### Step 9: Generate PR Description (subagent)
+
+Spawn a subagent with the PR-description briefing defined in [reference.md](reference.md) under `PR-description subagent briefing`. The subagent runs `bill-pr-description` (read its skill file and apply inline), creates the PR, and must call `pr_description_generated` with `orchestrated=true` itself. The subagent returns: PR URL, PR title, and the `telemetry_payload` returned by `pr_description_generated`.
+
+The orchestrator appends the returned `telemetry_payload` to the `child_steps` list.

--- a/skills/bill-feature-implement/reference.md
+++ b/skills/bill-feature-implement/reference.md
@@ -59,7 +59,9 @@ Use these exact step ids when updating workflow state:
 
 ### Canonical artifacts
 
-Persist these named artifacts through `artifacts_patch`:
+The shell-owned source of truth for artifact names lives in [SKILL.md](SKILL.md#stable-artifact-names).
+
+Persist these named artifacts through `artifacts_patch` when the workflow runtime reaches the corresponding phase:
 
 - `assessment`
 - `branch`
@@ -70,6 +72,7 @@ Persist these named artifacts through `artifacts_patch`:
 - `audit_report`
 - `validation_result`
 - `history_result`
+- `commit_push_result` (reserved shell-owned name; Step 8 currently does not persist it)
 - `pr_result`
 
 ### Phase-to-artifact mapping
@@ -86,6 +89,7 @@ has in hand:
 - Step 6 → `audit_report`
 - Step 6b → `validation_result`
 - Step 7 → `history_result`
+- Step 8 → no persisted artifact today; `commit_push_result` remains a shell-documented reserved name until runtime support exists
 - Step 9 → `pr_result`
 
 ### Open sequence

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -38,7 +38,15 @@ def read(relative_path: str) -> str:
   return (ROOT / relative_path).read_text(encoding="utf-8")
 
 
-FEATURE_IMPLEMENT = read("skills/bill-feature-implement/SKILL.md") + "\n" + read("skills/bill-feature-implement/reference.md")
+FEATURE_IMPLEMENT_SHELL = read("skills/bill-feature-implement/SKILL.md")
+FEATURE_IMPLEMENT_CONTENT = read("skills/bill-feature-implement/content.md")
+FEATURE_IMPLEMENT = (
+  FEATURE_IMPLEMENT_SHELL
+  + "\n"
+  + FEATURE_IMPLEMENT_CONTENT
+  + "\n"
+  + read("skills/bill-feature-implement/reference.md")
+)
 CODE_REVIEW = read("skills/bill-code-review/SKILL.md")
 QUALITY_CHECK = read("skills/bill-quality-check/SKILL.md")
 PR_DESCRIPTION = read("skills/bill-pr-description/SKILL.md")
@@ -198,14 +206,30 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("`bill-code-review`", FEATURE_IMPLEMENT)
     self.assertIn("`bill-quality-check`", FEATURE_IMPLEMENT)
 
+  def test_feature_implement_shell_points_to_authored_content(self) -> None:
+    self.assertIn("## Execution", FEATURE_IMPLEMENT_SHELL)
+    self.assertIn("[content.md](content.md)", FEATURE_IMPLEMENT_SHELL)
+    self.assertIn("## Workflow State", FEATURE_IMPLEMENT_SHELL)
+    self.assertIn("## Continuation Mode", FEATURE_IMPLEMENT_SHELL)
+    self.assertIn("## Step 1: Collect Design Doc + Assess Size (orchestrator)", FEATURE_IMPLEMENT_SHELL)
+    self.assertNotIn("## Workflow State", FEATURE_IMPLEMENT_CONTENT)
+    self.assertNotIn("## Continuation Mode", FEATURE_IMPLEMENT_CONTENT)
+    self.assertIn("## Step 1: Collect Design Doc + Assess Size (orchestrator)", FEATURE_IMPLEMENT_CONTENT)
+    self.assertIn("## Finalization sequence (Steps 6b -> 9)", FEATURE_IMPLEMENT_CONTENT)
+
   def test_feature_implement_uses_workflow_state_tools(self) -> None:
     self.assertIn("feature_implement_workflow_open", FEATURE_IMPLEMENT)
     self.assertIn("feature_implement_workflow_update", FEATURE_IMPLEMENT)
     self.assertIn("feature_implement_workflow_continue", FEATURE_IMPLEMENT)
     self.assertIn("## Continuation Mode", FEATURE_IMPLEMENT)
+    self.assertIn("`branch`", FEATURE_IMPLEMENT_SHELL)
     self.assertIn("`assessment`", FEATURE_IMPLEMENT)
     self.assertIn("`preplan_digest`", FEATURE_IMPLEMENT)
     self.assertIn("`implementation_summary`", FEATURE_IMPLEMENT)
+    self.assertIn("`audit_report`", FEATURE_IMPLEMENT_SHELL)
+    self.assertIn("`validation_result`", FEATURE_IMPLEMENT_SHELL)
+    self.assertIn("`history_result`", FEATURE_IMPLEMENT_SHELL)
+    self.assertIn("`commit_push_result`", FEATURE_IMPLEMENT_SHELL)
     self.assertIn("`pr_result`", FEATURE_IMPLEMENT)
 
   def test_pr_description_prefers_repo_native_templates(self) -> None:

--- a/tests/test_validate_agent_configs_e2e.py
+++ b/tests/test_validate_agent_configs_e2e.py
@@ -333,6 +333,24 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       result = self.run_validator(repo_root)
       self.assertEqual(result.returncode, 0, result.stdout)
 
+  def test_rejects_feature_implement_without_content_md(self) -> None:
+    with self.fixture_repo(
+      [("base", "bill-feature-implement")],
+      skill_contents={
+        "bill-feature-implement": (
+          self.skill_markdown("bill-feature-implement")
+          + "\nWhen invoking child MCP tools, pass `orchestrated=true` to every call.\n"
+        ),
+      },
+    ) as repo_root:
+      (repo_root / "skills" / "bill-feature-implement" / "content.md").unlink()
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn(
+        "bill-feature-implement must include sibling content.md",
+        result.stdout,
+      )
+
   def test_rejects_feature_implement_without_workflow_state_contract(self) -> None:
     with self.fixture_repo(
       [("base", "bill-feature-implement")],
@@ -347,7 +365,43 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       result = self.run_validator(repo_root)
       self.assertEqual(result.returncode, 1, result.stdout)
       self.assertIn(
-        "workflow-driven skill must include '## Workflow State'",
+        "bill-feature-implement shell must include '## Workflow State'",
+        result.stdout,
+      )
+
+  def test_rejects_feature_implement_without_continuation_mode_contract(self) -> None:
+    with self.fixture_repo(
+      [("base", "bill-feature-implement")],
+      skill_contents={
+        "bill-feature-implement": (
+          self.skill_markdown("bill-feature-implement")
+          .replace("## Continuation Mode\n\n", "", 1)
+          + "\nWhen invoking child MCP tools, pass `orchestrated=true` to every call.\n"
+        ),
+      },
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn(
+        "bill-feature-implement shell must include '## Continuation Mode'",
+        result.stdout,
+      )
+
+  def test_rejects_feature_implement_without_execution_pointer(self) -> None:
+    with self.fixture_repo(
+      [("base", "bill-feature-implement")],
+      skill_contents={
+        "bill-feature-implement": (
+          self.skill_markdown("bill-feature-implement")
+          .replace("[content.md](content.md)", "[reference.md](reference.md)", 1)
+          + "\nWhen invoking child MCP tools, pass `orchestrated=true` to every call.\n"
+        ),
+      },
+    ) as repo_root:
+      result = self.run_validator(repo_root)
+      self.assertEqual(result.returncode, 1, result.stdout)
+      self.assertIn(
+        "bill-feature-implement shell must include '[content.md](content.md)'",
         result.stdout,
       )
 
@@ -1021,6 +1075,11 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
       path = repo_root / "skills" / package_name / skill_name / "SKILL.md"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content or self.skill_markdown(skill_name), encoding="utf-8")
+    if skill_name == "bill-feature-implement":
+      (path.parent / "content.md").write_text(
+        self.feature_implement_content_markdown(),
+        encoding="utf-8",
+      )
 
   def write_supporting_files(self, repo_root: Path, package_name: str, skill_name: str) -> None:
     targets = supporting_file_targets(repo_root)
@@ -1031,7 +1090,125 @@ class ValidateAgentConfigsE2ETest(unittest.TestCase):
     for file_name in required_supporting_files_for_skill(skill_name):
       (skill_dir / file_name).symlink_to(targets[file_name])
 
+  def feature_implement_content_markdown(self) -> str:
+    return textwrap.dedent(
+      """\
+      # Feature Implement Content
+
+      ## Step 1: Collect Design Doc + Assess Size (orchestrator)
+
+      Fixture execution body for Step 1.
+
+      ## Step 5: Code Review (orchestrator)
+
+      Run `bill-code-review` inline and pass `orchestrated=true`.
+
+      ## Finalization sequence (Steps 6b -> 9)
+
+      Finish the workflow without changing runtime behavior.
+      """
+    )
+
   def skill_markdown(self, skill_name: str) -> str:
+    if skill_name == "bill-feature-implement":
+      lines = [
+        "---",
+        f"name: {skill_name}",
+        f"description: Use when validating fixture taxonomy behavior for {skill_name}.",
+        "---",
+        "",
+        "# bill-feature-implement",
+        "",
+        "## Project Overrides",
+        "",
+        "Follow the shell ceremony in [shell-ceremony.md](shell-ceremony.md).",
+        "",
+        "If `.agents/skill-overrides.md` exists in the project root and contains a matching section, read that section and apply it as the highest-priority instruction for this skill.",
+        "",
+        "## Execution",
+        "",
+        "Follow the instructions in [content.md](content.md).",
+        "",
+        "## Workflow State",
+        "",
+        "- `feature_implement_workflow_open`",
+        "- `feature_implement_workflow_update`",
+        "- `feature_implement_workflow_continue`",
+        "",
+        "### Stable Step Ids",
+        "",
+        "1. `assess`",
+        "2. `create_branch`",
+        "3. `preplan`",
+        "4. `plan`",
+        "5. `implement`",
+        "6. `review`",
+        "7. `audit`",
+        "8. `validate`",
+        "9. `write_history`",
+        "10. `commit_push`",
+        "11. `pr_description`",
+        "12. `finish`",
+        "",
+        "### Stable Artifact Names",
+        "",
+        "- `assessment`",
+        "- `branch`",
+        "- `preplan_digest`",
+        "- `plan`",
+        "- `implementation_summary`",
+        "- `review_result`",
+        "- `audit_report`",
+        "- `validation_result`",
+        "- `history_result`",
+        "- `commit_push_result`",
+        "- `pr_result`",
+        "",
+        "## Continuation Mode",
+        "",
+        "Resume with the persisted workflow artifacts instead of restarting from Step 1.",
+        "",
+        "## Step 1: Collect Design Doc + Assess Size (orchestrator)",
+        "",
+        "Persist `assessment` before advancing.",
+        "",
+        "## Step 1b: Create Feature Branch (orchestrator)",
+        "",
+        "Persist `branch` before advancing.",
+        "",
+        "## Step 2: Pre-Planning (subagent)",
+        "",
+        "Persist `preplan_digest` before advancing.",
+        "",
+        "## Step 3: Create Implementation Plan (subagent)",
+        "",
+        "Persist `plan` before advancing.",
+        "",
+        "## Step 4: Execute Plan (subagent)",
+        "",
+        "Persist `implementation_summary` before advancing.",
+        "",
+        "## Step 5: Code Review (orchestrator)",
+        "",
+        "Persist `review_result` before advancing.",
+        "",
+        "## Step 6: Completeness Audit (subagent)",
+        "",
+        "Persist `audit_report` before advancing.",
+        "",
+        "## Finalization sequence (Steps 6b -> 9)",
+        "",
+        "Persist `validation_result`, `history_result`, `commit_push_result`, and `pr_result` as the shell-owned artifact inventory allows.",
+        "",
+        "## Telemetry: Record Finished",
+        "",
+        "Record the parent-owned finished event after child telemetry collection is complete.",
+        "",
+      ]
+      for sidecar in required_supporting_files_for_skill(skill_name):
+        lines.append(f"[{sidecar}]({sidecar})")
+      return "\n".join(lines) + "\n"
+
     lines = [
       f"---",
       f"name: {skill_name}",


### PR DESCRIPTION
# Summary

This refactor splits `bill-feature-implement` into a shell-owned contract and a sibling authored execution body. `SKILL.md` now keeps the workflow-state and continuation contracts, stable step ids, stable artifact names, telemetry ownership, and the explicit execution pointer, while `content.md` holds the phase-by-phase execution guidance. Runtime behavior is unchanged; this is a contract/docs refactor with validator and test coverage.

- Added `skills/bill-feature-implement/content.md` and updated the shell/reference docs to preserve the split.
- Extended validator coverage so `bill-feature-implement` loud-fails when `content.md` or required shell markers are missing.
- Updated repo docs and tests so the authoring surface no longer implies the workflow is single-file.

## Feature Flags

N/A

# How Has This Been Tested?

- `.venv/bin/python3 -m unittest discover -s tests`
- `npx --yes agnix --strict .`
- `.venv/bin/python3 scripts/validate_agent_configs.py`
