### PR TITLE
feat: expand remote workflow telemetry stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ The workflow runtime now exposes discovery, resume, and continue surfaces throug
 
 - `skill-bill workflow ...` for `bill-feature-implement`
 - `skill-bill verify-workflow ...` for `bill-feature-verify`
+- `skill-bill implement-stats` and `skill-bill verify-stats` for local workflow telemetry summaries
+- `skill-bill telemetry stats <verify|implement>` for org-wide workflow summaries, optionally with `--group-by day|week` trend series, through the configured telemetry proxy
+- `skill-bill telemetry capabilities` to discover relay read/write support before querying remote stats
 - matching MCP tools for each workflow family
 
 Interrupted runs can be reactivated from persisted state instead of being reconstructed from chat history, and each `continue` surface now returns a step-specific continuation contract for the owning top-level skill.
@@ -166,7 +169,7 @@ The point of the shipped inventory is to demonstrate the governance model with r
 
 ## Review telemetry
 
-Skill Bill records review acceptance metrics locally in SQLite and can optionally sync anonymized analytics to a hosted relay or custom proxy. The `skill-bill` MCP server exposes review import, triage, learnings, and stats as native agent tools — no bash commands needed. See [docs/review-telemetry.md](docs/review-telemetry.md) for the full workflow, CLI reference, learnings management, telemetry events, and proxy configuration.
+Skill Bill records review acceptance metrics locally in SQLite and can optionally sync anonymized analytics to a hosted relay or custom proxy. The `skill-bill` MCP server exposes review import, triage, learnings, review stats, local workflow stats, and proxy-backed remote workflow stats as native agent tools — no bash commands needed. See [docs/review-telemetry.md](docs/review-telemetry.md) for the full workflow, CLI reference, learnings management, telemetry events, remote-stats contract, and proxy configuration.
 
 ## Supported agents
 

--- a/docs/cloudflare-telemetry-proxy/README.md
+++ b/docs/cloudflare-telemetry-proxy/README.md
@@ -1,13 +1,17 @@
 # Cloudflare Worker telemetry proxy
 
-This example lets Skill Bill clients send telemetry to a small Cloudflare Worker instead of the default hosted relay while keeping the client payload backend-agnostic.
+This example lets Skill Bill clients send telemetry to a small Cloudflare Worker instead of the default hosted relay while keeping the client payload backend-agnostic. It now also shows one way to expose aggregate remote workflow stats through the same proxy boundary.
 
 ## What it does
 
-1. Accepts `POST` requests containing a JSON body with a `batch` array.
+1. Accepts `POST /` requests containing a JSON body with a `batch` array.
 2. Performs lightweight validation on the incoming batch.
 3. Adds the server-side `POSTHOG_API_KEY` for this example backend.
 4. Forwards the batch to PostHog `/batch/`.
+5. Exposes `GET /capabilities` so clients can discover whether the relay supports ingest and/or stats.
+6. Accepts `POST /stats` requests containing a workflow name plus `date_from` / `date_to`.
+7. Optionally enforces a bearer token for `/stats`.
+8. Queries PostHog through its Query API and returns aggregate workflow metrics.
 
 The client payload stays the same privacy-scoped metadata produced by the `skill-bill` CLI and MCP server:
 
@@ -24,19 +28,32 @@ It excludes:
 
 1. Install Wrangler.
 2. Copy `wrangler.toml.example` to a local `wrangler.toml`. That generated file is intentionally ignored and should stay machine-specific.
-3. From this directory, set the PostHog project key:
+3. From this directory, set the PostHog project key used for event ingestion:
 
    ```bash
    wrangler secret put POSTHOG_API_KEY
    ```
 
-4. Deploy:
+4. If you want `/stats` support, also set:
+
+   ```bash
+   wrangler secret put POSTHOG_PERSONAL_API_KEY
+   wrangler secret put POSTHOG_PROJECT_ID
+   wrangler secret put PROXY_STATS_BEARER_TOKEN
+   ```
+
+   Optional variables:
+
+   - `POSTHOG_APP_HOST` defaults to `https://us.posthog.com` and is used for Query API calls
+   - `POSTHOG_HOST` defaults to `https://us.i.posthog.com` and is used for event ingestion
+
+5. Deploy:
 
    ```bash
    wrangler deploy
    ```
 
-The example defaults `POSTHOG_HOST` to the US Cloud endpoint. If you use EU Cloud or self-hosted PostHog, update `POSTHOG_HOST` in your local `wrangler.toml` before deploying.
+The example defaults `POSTHOG_HOST` to the US ingest endpoint and `POSTHOG_APP_HOST` to the US app/API endpoint. If you use EU Cloud or self-hosted PostHog, update those in your local `wrangler.toml` before deploying.
 
 ## Add the proxy as the telemetry destination
 
@@ -55,8 +72,32 @@ skill-bill telemetry status
 skill-bill telemetry sync
 ```
 
+If you want to query org-wide workflow metrics through the same proxy, also set a stats token on the machine running Skill Bill:
+
+```bash
+export SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN="replace-with-your-worker-token"
+```
+
+Then query remote aggregate stats through the proxy contract:
+
+```bash
+skill-bill telemetry capabilities
+skill-bill telemetry stats verify --since 30d
+skill-bill telemetry stats implement --date-from 2026-04-01 --date-to 2026-04-22
+skill-bill telemetry stats verify --since 30d --group-by day
+skill-bill telemetry stats implement --since 30d --group-by week
+```
+
 ## Notes
 
 - This example is intentionally minimal; it protects the PostHog project key, not the endpoint itself.
 - If you expect public traffic, add Cloudflare rate limiting, bot protection, or other filtering on top of this Worker.
-- The Skill Bill client always emits the same generic `{"batch": [...]}` payload. If you use another analytics backend, adapt this Worker to translate that batch before forwarding it.
+- The Skill Bill client uses three relay operations:
+  - `POST /` with `{"batch": [...]}`
+  - `GET /capabilities`
+  - `POST /stats` with `{"workflow": "...", "date_from": "...", "date_to": "...", "group_by": "day|week"}` (`group_by` optional)
+- If you use another analytics backend, adapt this Worker to translate those payloads before forwarding or querying.
+- The `/stats` route in this example is intentionally PostHog-specific. The Skill Bill CLI and MCP server are not.
+- `in_progress_runs` in the normalized `/stats` response is derived as `max(started_runs - finished_runs, 0)` for the requested date window.
+- for `bill-feature-implement`, `boundary_history_useful_runs` is derived as `boundary_history_value in ('medium', 'high')`
+- grouped `/stats` series are trend-oriented event-window buckets, not session-cohort analytics.

--- a/docs/cloudflare-telemetry-proxy/worker.js
+++ b/docs/cloudflare-telemetry-proxy/worker.js
@@ -1,5 +1,7 @@
-const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const DEFAULT_POSTHOG_INGEST_HOST = "https://us.i.posthog.com";
+const DEFAULT_POSTHOG_APP_HOST = "https://us.posthog.com";
 const MAX_BATCH_SIZE = 100;
+const CONTRACT_VERSION = "1";
 
 function jsonResponse(status, payload) {
   return new Response(JSON.stringify(payload), {
@@ -8,8 +10,8 @@ function jsonResponse(status, payload) {
   });
 }
 
-function normalizeHost(host) {
-  return (host || DEFAULT_POSTHOG_HOST).replace(/\/+$/, "");
+function normalizeHost(host, fallback) {
+  return (host || fallback).replace(/\/+$/, "");
 }
 
 function isValidEvent(event) {
@@ -25,21 +27,865 @@ function isValidEvent(event) {
   );
 }
 
+function isIsoDate(value) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value || "");
+}
+
+function escapeSqlLiteral(value) {
+  return String(value).replace(/'/g, "''");
+}
+
+function nextIsoDate(value) {
+  const next = new Date(`${value}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return next.toISOString().slice(0, 10);
+}
+
+function addDaysIsoDate(value, days) {
+  const next = new Date(`${value}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next.toISOString().slice(0, 10);
+}
+
+function maxIsoDate(left, right) {
+  return left > right ? left : right;
+}
+
+function minIsoDate(left, right) {
+  return left < right ? left : right;
+}
+
+function weekStartIsoDate(value) {
+  const current = new Date(`${value}T00:00:00Z`);
+  const day = current.getUTCDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  current.setUTCDate(current.getUTCDate() + offset);
+  return current.toISOString().slice(0, 10);
+}
+
+function rate(numerator, denominator) {
+  if (!denominator) {
+    return 0;
+  }
+  return Math.round((numerator / denominator) * 1000) / 1000;
+}
+
+function average(value) {
+  const numeric = Number(value || 0);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  return Math.round(numeric * 100) / 100;
+}
+
+function toInt(value) {
+  const numeric = Number(value || 0);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  return Math.trunc(numeric);
+}
+
+function validateStatsRequest(payload) {
+  if (typeof payload !== "object" || payload === null) {
+    return "Request body must be a JSON object.";
+  }
+  if (!["bill-feature-verify", "bill-feature-implement"].includes(payload.workflow)) {
+    return "workflow must be one of: bill-feature-verify, bill-feature-implement.";
+  }
+  if (!isIsoDate(payload.date_from) || !isIsoDate(payload.date_to)) {
+    return "date_from and date_to must use YYYY-MM-DD format.";
+  }
+  if (payload.date_from > payload.date_to) {
+    return "date_from must be on or before date_to.";
+  }
+  if (payload.group_by && !["day", "week"].includes(payload.group_by)) {
+    return "group_by must be one of: day, week.";
+  }
+  return null;
+}
+
+function capabilitiesPayload(env) {
+  const supportsIngest = Boolean(env.POSTHOG_API_KEY);
+  const supportsStats = Boolean(env.POSTHOG_PERSONAL_API_KEY && env.POSTHOG_PROJECT_ID);
+  return {
+    contract_version: CONTRACT_VERSION,
+    source: "remote_proxy",
+    supports_ingest: supportsIngest,
+    supports_stats: supportsStats,
+    supported_workflows: supportsStats
+      ? ["bill-feature-verify", "bill-feature-implement"]
+      : [],
+    stats_auth_required: Boolean(env.PROXY_STATS_BEARER_TOKEN),
+  };
+}
+
+async function readJson(request) {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+async function forwardBatch(env, batch) {
+  if (!env.POSTHOG_API_KEY) {
+    return jsonResponse(500, { error: "POSTHOG_API_KEY is not configured." });
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  let upstreamResponse;
+  try {
+    upstreamResponse = await fetch(`${normalizeHost(env.POSTHOG_HOST, DEFAULT_POSTHOG_INGEST_HOST)}/batch/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: env.POSTHOG_API_KEY,
+        batch,
+      }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!upstreamResponse.ok) {
+    return jsonResponse(502, { error: "Upstream telemetry relay returned an error." });
+  }
+
+  const responseText = await upstreamResponse.text();
+  return new Response(
+    responseText || JSON.stringify({ ok: true }),
+    {
+      status: upstreamResponse.status,
+      headers: {
+        "Content-Type": upstreamResponse.headers.get("Content-Type") || "application/json",
+      },
+    },
+  );
+}
+
+async function runPostHogQuery(env, query) {
+  if (!env.POSTHOG_PERSONAL_API_KEY) {
+    return { error: "POSTHOG_PERSONAL_API_KEY is not configured.", status: 500 };
+  }
+  if (!env.POSTHOG_PROJECT_ID) {
+    return { error: "POSTHOG_PROJECT_ID is not configured.", status: 500 };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  let upstreamResponse;
+  try {
+    upstreamResponse = await fetch(
+      `${normalizeHost(env.POSTHOG_APP_HOST, DEFAULT_POSTHOG_APP_HOST)}/api/projects/${env.POSTHOG_PROJECT_ID}/query/`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${env.POSTHOG_PERSONAL_API_KEY}`,
+        },
+        body: JSON.stringify({
+          query: {
+            kind: "HogQLQuery",
+            query,
+          },
+        }),
+        signal: controller.signal,
+      },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const responseText = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return {
+      error: "Upstream telemetry stats backend returned an error.",
+      status: 502,
+      details: responseText || null,
+    };
+  }
+
+  let payload;
+  try {
+    payload = responseText ? JSON.parse(responseText) : {};
+  } catch {
+    return { error: "Upstream telemetry stats backend returned invalid JSON.", status: 502 };
+  }
+  return { payload, status: 200 };
+}
+
+function buildVerifyStatsQuery(dateFrom, dateToExclusive) {
+  const from = escapeSqlLiteral(`${dateFrom} 00:00:00`);
+  const to = escapeSqlLiteral(`${dateToExclusive} 00:00:00`);
+  return `
+    SELECT
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_started') AS started_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished') AS finished_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_started' AND lower(toString(properties.rollout_relevant)) = 'true') AS rollout_relevant_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND lower(toString(properties.feature_flag_audit_performed)) = 'true') AS feature_flag_audit_performed_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.audit_result) = 'all_pass') AS audit_result_all_pass,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.audit_result) = 'had_gaps') AS audit_result_had_gaps,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.audit_result) = 'skipped') AS audit_result_skipped,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'completed') AS completion_status_completed,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'abandoned_at_review') AS completion_status_abandoned_at_review,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'abandoned_at_audit') AS completion_status_abandoned_at_audit,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'error') AS completion_status_error,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND (
+        toString(properties.history_relevance) IN ('irrelevant', 'low', 'medium', 'high')
+        OR toString(properties.history_helpfulness) IN ('irrelevant', 'low', 'medium', 'high')
+      )) AS history_read_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'none') AS history_relevance_none,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'irrelevant') AS history_relevance_irrelevant,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'low') AS history_relevance_low,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'medium') AS history_relevance_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'high') AS history_relevance_high,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'none') AS history_helpfulness_none,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'irrelevant') AS history_helpfulness_irrelevant,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'low') AS history_helpfulness_low,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'medium') AS history_helpfulness_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'high') AS history_helpfulness_high,
+      avgIf(toFloatOrZero(toString(properties.acceptance_criteria_count)), event = 'skillbill_feature_verify_started') AS average_acceptance_criteria_count,
+      avgIf(toFloatOrZero(toString(properties.review_iterations)), event = 'skillbill_feature_verify_finished') AS average_review_iterations,
+      avgIf(toFloatOrZero(toString(properties.duration_seconds)), event = 'skillbill_feature_verify_finished') AS average_duration_seconds
+    FROM events
+    WHERE event IN ('skillbill_feature_verify_started', 'skillbill_feature_verify_finished')
+      AND timestamp >= toDateTime('${from}')
+      AND timestamp < toDateTime('${to}')
+  `;
+}
+
+function buildImplementStatsQuery(dateFrom, dateToExclusive) {
+  const from = escapeSqlLiteral(`${dateFrom} 00:00:00`);
+  const to = escapeSqlLiteral(`${dateToExclusive} 00:00:00`);
+  return `
+    SELECT
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started') AS started_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished') AS finished_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND toString(properties.feature_size) = 'SMALL') AS feature_size_small,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND toString(properties.feature_size) = 'MEDIUM') AS feature_size_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND toString(properties.feature_size) = 'LARGE') AS feature_size_large,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND lower(toString(properties.rollout_needed)) = 'true') AS rollout_needed_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND lower(toString(properties.feature_flag_used)) = 'true') AS feature_flag_used_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND lower(toString(properties.pr_created)) = 'true') AS pr_created_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND lower(toString(properties.boundary_history_written)) = 'true') AS boundary_history_written_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.audit_result) = 'all_pass') AS audit_result_all_pass,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.audit_result) = 'had_gaps') AS audit_result_had_gaps,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.audit_result) = 'skipped') AS audit_result_skipped,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.validation_result) = 'pass') AS validation_result_pass,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.validation_result) = 'fail') AS validation_result_fail,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.validation_result) = 'skipped') AS validation_result_skipped,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'completed') AS completion_status_completed,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'abandoned_at_planning') AS completion_status_abandoned_at_planning,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'abandoned_at_implementation') AS completion_status_abandoned_at_implementation,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'abandoned_at_review') AS completion_status_abandoned_at_review,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'error') AS completion_status_error,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'none') AS boundary_history_value_none,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'irrelevant') AS boundary_history_value_irrelevant,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'low') AS boundary_history_value_low,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'medium') AS boundary_history_value_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'high') AS boundary_history_value_high,
+      avgIf(toFloatOrZero(toString(properties.acceptance_criteria_count)), event = 'skillbill_feature_implement_started') AS average_acceptance_criteria_count,
+      avgIf(toFloatOrZero(toString(properties.spec_word_count)), event = 'skillbill_feature_implement_started') AS average_spec_word_count,
+      avgIf(toFloatOrZero(toString(properties.review_iterations)), event = 'skillbill_feature_implement_finished') AS average_review_iterations,
+      avgIf(toFloatOrZero(toString(properties.audit_iterations)), event = 'skillbill_feature_implement_finished') AS average_audit_iterations,
+      avgIf(toFloatOrZero(toString(properties.duration_seconds)), event = 'skillbill_feature_implement_finished') AS average_duration_seconds
+    FROM events
+    WHERE event IN ('skillbill_feature_implement_started', 'skillbill_feature_implement_finished')
+      AND timestamp >= toDateTime('${from}')
+      AND timestamp < toDateTime('${to}')
+  `;
+}
+
+function buildVerifySeriesQuery(dateFrom, dateToExclusive) {
+  const from = escapeSqlLiteral(`${dateFrom} 00:00:00`);
+  const to = escapeSqlLiteral(`${dateToExclusive} 00:00:00`);
+  return `
+    SELECT
+      toString(toDate(timestamp)) AS bucket_date,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_started') AS started_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished') AS finished_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_started' AND lower(toString(properties.rollout_relevant)) = 'true') AS rollout_relevant_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND lower(toString(properties.feature_flag_audit_performed)) = 'true') AS feature_flag_audit_performed_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.audit_result) = 'all_pass') AS audit_result_all_pass,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.audit_result) = 'had_gaps') AS audit_result_had_gaps,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.audit_result) = 'skipped') AS audit_result_skipped,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'completed') AS completion_status_completed,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'abandoned_at_review') AS completion_status_abandoned_at_review,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'abandoned_at_audit') AS completion_status_abandoned_at_audit,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.completion_status) = 'error') AS completion_status_error,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND (
+        toString(properties.history_relevance) IN ('irrelevant', 'low', 'medium', 'high')
+        OR toString(properties.history_helpfulness) IN ('irrelevant', 'low', 'medium', 'high')
+      )) AS history_read_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'none') AS history_relevance_none,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'irrelevant') AS history_relevance_irrelevant,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'low') AS history_relevance_low,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'medium') AS history_relevance_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_relevance) = 'high') AS history_relevance_high,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'none') AS history_helpfulness_none,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'irrelevant') AS history_helpfulness_irrelevant,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'low') AS history_helpfulness_low,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'medium') AS history_helpfulness_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_verify_finished' AND toString(properties.history_helpfulness) = 'high') AS history_helpfulness_high
+    FROM events
+    WHERE event IN ('skillbill_feature_verify_started', 'skillbill_feature_verify_finished')
+      AND timestamp >= toDateTime('${from}')
+      AND timestamp < toDateTime('${to}')
+    GROUP BY bucket_date
+    ORDER BY bucket_date
+  `;
+}
+
+function buildImplementSeriesQuery(dateFrom, dateToExclusive) {
+  const from = escapeSqlLiteral(`${dateFrom} 00:00:00`);
+  const to = escapeSqlLiteral(`${dateToExclusive} 00:00:00`);
+  return `
+    SELECT
+      toString(toDate(timestamp)) AS bucket_date,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started') AS started_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished') AS finished_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND toString(properties.feature_size) = 'SMALL') AS feature_size_small,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND toString(properties.feature_size) = 'MEDIUM') AS feature_size_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND toString(properties.feature_size) = 'LARGE') AS feature_size_large,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_started' AND lower(toString(properties.rollout_needed)) = 'true') AS rollout_needed_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND lower(toString(properties.feature_flag_used)) = 'true') AS feature_flag_used_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND lower(toString(properties.pr_created)) = 'true') AS pr_created_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND lower(toString(properties.boundary_history_written)) = 'true') AS boundary_history_written_runs,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.audit_result) = 'all_pass') AS audit_result_all_pass,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.audit_result) = 'had_gaps') AS audit_result_had_gaps,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.audit_result) = 'skipped') AS audit_result_skipped,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.validation_result) = 'pass') AS validation_result_pass,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.validation_result) = 'fail') AS validation_result_fail,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.validation_result) = 'skipped') AS validation_result_skipped,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'completed') AS completion_status_completed,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'abandoned_at_planning') AS completion_status_abandoned_at_planning,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'abandoned_at_implementation') AS completion_status_abandoned_at_implementation,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'abandoned_at_review') AS completion_status_abandoned_at_review,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.completion_status) = 'error') AS completion_status_error,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'none') AS boundary_history_value_none,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'irrelevant') AS boundary_history_value_irrelevant,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'low') AS boundary_history_value_low,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'medium') AS boundary_history_value_medium,
+      uniqExactIf(toString(properties.session_id), event = 'skillbill_feature_implement_finished' AND toString(properties.boundary_history_value) = 'high') AS boundary_history_value_high
+    FROM events
+    WHERE event IN ('skillbill_feature_implement_started', 'skillbill_feature_implement_finished')
+      AND timestamp >= toDateTime('${from}')
+      AND timestamp < toDateTime('${to}')
+    GROUP BY bucket_date
+    ORDER BY bucket_date
+  `;
+}
+
+function rowToObject(columns, row) {
+  const payload = {};
+  columns.forEach((column, index) => {
+    payload[column] = row[index];
+  });
+  return payload;
+}
+
+function queryRowsToObjects(payload) {
+  const columns = Array.isArray(payload?.columns) ? payload.columns : [];
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+  return results
+    .filter((row) => Array.isArray(row))
+    .map((row) => rowToObject(columns, row));
+}
+
+export function normalizeVerifyStats(row, dateFrom, dateTo) {
+  const startedRuns = toInt(row.started_runs);
+  const finishedRuns = toInt(row.finished_runs);
+  const inProgressRuns = Math.max(startedRuns - finishedRuns, 0);
+  const completedRuns = toInt(row.completion_status_completed);
+  const abandonedAtReviewRuns = toInt(row.completion_status_abandoned_at_review);
+  const abandonedAtAuditRuns = toInt(row.completion_status_abandoned_at_audit);
+  const abandonedRuns = abandonedAtReviewRuns + abandonedAtAuditRuns;
+  const historyRelevantRuns = toInt(row.history_relevance_medium) + toInt(row.history_relevance_high);
+  const historyHelpfulRuns = toInt(row.history_helpfulness_medium) + toInt(row.history_helpfulness_high);
+  return {
+    status: "ok",
+    source: "remote_proxy",
+    workflow: "bill-feature-verify",
+    date_from: dateFrom,
+    date_to: dateTo,
+    started_runs: startedRuns,
+    finished_runs: finishedRuns,
+    in_progress_runs: inProgressRuns,
+    in_progress_rate: rate(inProgressRuns, startedRuns),
+    completion_rate: rate(completedRuns, startedRuns),
+    abandonment_rate: rate(abandonedRuns, startedRuns),
+    completion_status_counts: {
+      completed: completedRuns,
+      abandoned_at_review: abandonedAtReviewRuns,
+      abandoned_at_audit: abandonedAtAuditRuns,
+      error: toInt(row.completion_status_error),
+    },
+    audit_result_counts: {
+      all_pass: toInt(row.audit_result_all_pass),
+      had_gaps: toInt(row.audit_result_had_gaps),
+      skipped: toInt(row.audit_result_skipped),
+    },
+    rollout_relevant_runs: toInt(row.rollout_relevant_runs),
+    rollout_relevant_rate: rate(toInt(row.rollout_relevant_runs), startedRuns),
+    feature_flag_audit_performed_runs: toInt(row.feature_flag_audit_performed_runs),
+    feature_flag_audit_performed_rate: rate(toInt(row.feature_flag_audit_performed_runs), finishedRuns),
+    history_read_runs: toInt(row.history_read_runs),
+    history_read_rate: rate(toInt(row.history_read_runs), finishedRuns),
+    history_relevant_runs: historyRelevantRuns,
+    history_relevant_rate: rate(historyRelevantRuns, finishedRuns),
+    history_helpful_runs: historyHelpfulRuns,
+    history_helpful_rate: rate(historyHelpfulRuns, finishedRuns),
+    history_relevance_counts: {
+      none: toInt(row.history_relevance_none),
+      irrelevant: toInt(row.history_relevance_irrelevant),
+      low: toInt(row.history_relevance_low),
+      medium: toInt(row.history_relevance_medium),
+      high: toInt(row.history_relevance_high),
+    },
+    history_helpfulness_counts: {
+      none: toInt(row.history_helpfulness_none),
+      irrelevant: toInt(row.history_helpfulness_irrelevant),
+      low: toInt(row.history_helpfulness_low),
+      medium: toInt(row.history_helpfulness_medium),
+      high: toInt(row.history_helpfulness_high),
+    },
+    average_acceptance_criteria_count: average(row.average_acceptance_criteria_count),
+    average_review_iterations: average(row.average_review_iterations),
+    average_duration_seconds: average(row.average_duration_seconds),
+  };
+}
+
+export function normalizeImplementStats(row, dateFrom, dateTo) {
+  const startedRuns = toInt(row.started_runs);
+  const finishedRuns = toInt(row.finished_runs);
+  const inProgressRuns = Math.max(startedRuns - finishedRuns, 0);
+  const completedRuns = toInt(row.completion_status_completed);
+  const boundaryHistoryUsefulRuns = toInt(row.boundary_history_value_medium) + toInt(row.boundary_history_value_high);
+  return {
+    status: "ok",
+    source: "remote_proxy",
+    workflow: "bill-feature-implement",
+    date_from: dateFrom,
+    date_to: dateTo,
+    started_runs: startedRuns,
+    finished_runs: finishedRuns,
+    in_progress_runs: inProgressRuns,
+    in_progress_rate: rate(inProgressRuns, startedRuns),
+    completion_rate: rate(completedRuns, startedRuns),
+    feature_size_counts: {
+      SMALL: toInt(row.feature_size_small),
+      MEDIUM: toInt(row.feature_size_medium),
+      LARGE: toInt(row.feature_size_large),
+    },
+    completion_status_counts: {
+      completed: completedRuns,
+      abandoned_at_planning: toInt(row.completion_status_abandoned_at_planning),
+      abandoned_at_implementation: toInt(row.completion_status_abandoned_at_implementation),
+      abandoned_at_review: toInt(row.completion_status_abandoned_at_review),
+      error: toInt(row.completion_status_error),
+    },
+    audit_result_counts: {
+      all_pass: toInt(row.audit_result_all_pass),
+      had_gaps: toInt(row.audit_result_had_gaps),
+      skipped: toInt(row.audit_result_skipped),
+    },
+    validation_result_counts: {
+      pass: toInt(row.validation_result_pass),
+      fail: toInt(row.validation_result_fail),
+      skipped: toInt(row.validation_result_skipped),
+    },
+    rollout_needed_runs: toInt(row.rollout_needed_runs),
+    rollout_needed_rate: rate(toInt(row.rollout_needed_runs), startedRuns),
+    feature_flag_used_runs: toInt(row.feature_flag_used_runs),
+    feature_flag_used_rate: rate(toInt(row.feature_flag_used_runs), finishedRuns),
+    pr_created_runs: toInt(row.pr_created_runs),
+    pr_created_rate: rate(toInt(row.pr_created_runs), finishedRuns),
+    boundary_history_written_runs: toInt(row.boundary_history_written_runs),
+    boundary_history_written_rate: rate(toInt(row.boundary_history_written_runs), finishedRuns),
+    boundary_history_useful_runs: boundaryHistoryUsefulRuns,
+    boundary_history_useful_rate: rate(boundaryHistoryUsefulRuns, finishedRuns),
+    boundary_history_value_counts: {
+      none: toInt(row.boundary_history_value_none),
+      irrelevant: toInt(row.boundary_history_value_irrelevant),
+      low: toInt(row.boundary_history_value_low),
+      medium: toInt(row.boundary_history_value_medium),
+      high: toInt(row.boundary_history_value_high),
+    },
+    average_acceptance_criteria_count: average(row.average_acceptance_criteria_count),
+    average_spec_word_count: average(row.average_spec_word_count),
+    average_review_iterations: average(row.average_review_iterations),
+    average_audit_iterations: average(row.average_audit_iterations),
+    average_duration_seconds: average(row.average_duration_seconds),
+  };
+}
+
+export function normalizeVerifySeriesEntry(row, bucketStart, bucketEnd) {
+  const startedRuns = toInt(row.started_runs);
+  const finishedRuns = toInt(row.finished_runs);
+  const inProgressRuns = Math.max(startedRuns - finishedRuns, 0);
+  const completedRuns = toInt(row.completion_status_completed);
+  const abandonedAtReviewRuns = toInt(row.completion_status_abandoned_at_review);
+  const abandonedAtAuditRuns = toInt(row.completion_status_abandoned_at_audit);
+  const abandonedRuns = abandonedAtReviewRuns + abandonedAtAuditRuns;
+  const historyRelevantRuns = toInt(row.history_relevance_medium) + toInt(row.history_relevance_high);
+  const historyHelpfulRuns = toInt(row.history_helpfulness_medium) + toInt(row.history_helpfulness_high);
+  return {
+    bucket_start: bucketStart,
+    bucket_end: bucketEnd,
+    started_runs: startedRuns,
+    finished_runs: finishedRuns,
+    in_progress_runs: inProgressRuns,
+    in_progress_rate: rate(inProgressRuns, startedRuns),
+    completion_rate: rate(completedRuns, startedRuns),
+    abandonment_rate: rate(abandonedRuns, startedRuns),
+    completion_status_counts: {
+      completed: completedRuns,
+      abandoned_at_review: abandonedAtReviewRuns,
+      abandoned_at_audit: abandonedAtAuditRuns,
+      error: toInt(row.completion_status_error),
+    },
+    audit_result_counts: {
+      all_pass: toInt(row.audit_result_all_pass),
+      had_gaps: toInt(row.audit_result_had_gaps),
+      skipped: toInt(row.audit_result_skipped),
+    },
+    rollout_relevant_runs: toInt(row.rollout_relevant_runs),
+    rollout_relevant_rate: rate(toInt(row.rollout_relevant_runs), startedRuns),
+    feature_flag_audit_performed_runs: toInt(row.feature_flag_audit_performed_runs),
+    feature_flag_audit_performed_rate: rate(toInt(row.feature_flag_audit_performed_runs), finishedRuns),
+    history_read_runs: toInt(row.history_read_runs),
+    history_read_rate: rate(toInt(row.history_read_runs), finishedRuns),
+    history_relevant_runs: historyRelevantRuns,
+    history_relevant_rate: rate(historyRelevantRuns, finishedRuns),
+    history_helpful_runs: historyHelpfulRuns,
+    history_helpful_rate: rate(historyHelpfulRuns, finishedRuns),
+    history_relevance_counts: {
+      none: toInt(row.history_relevance_none),
+      irrelevant: toInt(row.history_relevance_irrelevant),
+      low: toInt(row.history_relevance_low),
+      medium: toInt(row.history_relevance_medium),
+      high: toInt(row.history_relevance_high),
+    },
+    history_helpfulness_counts: {
+      none: toInt(row.history_helpfulness_none),
+      irrelevant: toInt(row.history_helpfulness_irrelevant),
+      low: toInt(row.history_helpfulness_low),
+      medium: toInt(row.history_helpfulness_medium),
+      high: toInt(row.history_helpfulness_high),
+    },
+  };
+}
+
+export function normalizeImplementSeriesEntry(row, bucketStart, bucketEnd) {
+  const startedRuns = toInt(row.started_runs);
+  const finishedRuns = toInt(row.finished_runs);
+  const inProgressRuns = Math.max(startedRuns - finishedRuns, 0);
+  const completedRuns = toInt(row.completion_status_completed);
+  const boundaryHistoryUsefulRuns = toInt(row.boundary_history_value_medium) + toInt(row.boundary_history_value_high);
+  return {
+    bucket_start: bucketStart,
+    bucket_end: bucketEnd,
+    started_runs: startedRuns,
+    finished_runs: finishedRuns,
+    in_progress_runs: inProgressRuns,
+    in_progress_rate: rate(inProgressRuns, startedRuns),
+    completion_rate: rate(completedRuns, startedRuns),
+    feature_size_counts: {
+      SMALL: toInt(row.feature_size_small),
+      MEDIUM: toInt(row.feature_size_medium),
+      LARGE: toInt(row.feature_size_large),
+    },
+    completion_status_counts: {
+      completed: completedRuns,
+      abandoned_at_planning: toInt(row.completion_status_abandoned_at_planning),
+      abandoned_at_implementation: toInt(row.completion_status_abandoned_at_implementation),
+      abandoned_at_review: toInt(row.completion_status_abandoned_at_review),
+      error: toInt(row.completion_status_error),
+    },
+    audit_result_counts: {
+      all_pass: toInt(row.audit_result_all_pass),
+      had_gaps: toInt(row.audit_result_had_gaps),
+      skipped: toInt(row.audit_result_skipped),
+    },
+    validation_result_counts: {
+      pass: toInt(row.validation_result_pass),
+      fail: toInt(row.validation_result_fail),
+      skipped: toInt(row.validation_result_skipped),
+    },
+    rollout_needed_runs: toInt(row.rollout_needed_runs),
+    rollout_needed_rate: rate(toInt(row.rollout_needed_runs), startedRuns),
+    feature_flag_used_runs: toInt(row.feature_flag_used_runs),
+    feature_flag_used_rate: rate(toInt(row.feature_flag_used_runs), finishedRuns),
+    pr_created_runs: toInt(row.pr_created_runs),
+    pr_created_rate: rate(toInt(row.pr_created_runs), finishedRuns),
+    boundary_history_written_runs: toInt(row.boundary_history_written_runs),
+    boundary_history_written_rate: rate(toInt(row.boundary_history_written_runs), finishedRuns),
+    boundary_history_useful_runs: boundaryHistoryUsefulRuns,
+    boundary_history_useful_rate: rate(boundaryHistoryUsefulRuns, finishedRuns),
+    boundary_history_value_counts: {
+      none: toInt(row.boundary_history_value_none),
+      irrelevant: toInt(row.boundary_history_value_irrelevant),
+      low: toInt(row.boundary_history_value_low),
+      medium: toInt(row.boundary_history_value_medium),
+      high: toInt(row.boundary_history_value_high),
+    },
+  };
+}
+
+function summarizeVerifySeriesBucket(bucketStart, bucketEnd, entries) {
+  const startedRuns = entries.reduce((sum, entry) => sum + toInt(entry.started_runs), 0);
+  const finishedRuns = entries.reduce((sum, entry) => sum + toInt(entry.finished_runs), 0);
+  const completedRuns = entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.completed), 0);
+  const abandonedAtReviewRuns = entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.abandoned_at_review), 0);
+  const abandonedAtAuditRuns = entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.abandoned_at_audit), 0);
+  const abandonedRuns = abandonedAtReviewRuns + abandonedAtAuditRuns;
+  const inProgressRuns = Math.max(startedRuns - finishedRuns, 0);
+  const historyReadRuns = entries.reduce((sum, entry) => sum + toInt(entry.history_read_runs), 0);
+  const historyRelevantRuns = entries.reduce((sum, entry) => sum + toInt(entry.history_relevant_runs), 0);
+  const historyHelpfulRuns = entries.reduce((sum, entry) => sum + toInt(entry.history_helpful_runs), 0);
+  return {
+    bucket_start: bucketStart,
+    bucket_end: bucketEnd,
+    started_runs: startedRuns,
+    finished_runs: finishedRuns,
+    in_progress_runs: inProgressRuns,
+    in_progress_rate: rate(inProgressRuns, startedRuns),
+    completion_rate: rate(completedRuns, startedRuns),
+    abandonment_rate: rate(abandonedRuns, startedRuns),
+    completion_status_counts: {
+      completed: completedRuns,
+      abandoned_at_review: abandonedAtReviewRuns,
+      abandoned_at_audit: abandonedAtAuditRuns,
+      error: entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.error), 0),
+    },
+    audit_result_counts: {
+      all_pass: entries.reduce((sum, entry) => sum + toInt(entry.audit_result_counts?.all_pass), 0),
+      had_gaps: entries.reduce((sum, entry) => sum + toInt(entry.audit_result_counts?.had_gaps), 0),
+      skipped: entries.reduce((sum, entry) => sum + toInt(entry.audit_result_counts?.skipped), 0),
+    },
+    rollout_relevant_runs: entries.reduce((sum, entry) => sum + toInt(entry.rollout_relevant_runs), 0),
+    rollout_relevant_rate: rate(
+      entries.reduce((sum, entry) => sum + toInt(entry.rollout_relevant_runs), 0),
+      startedRuns,
+    ),
+    feature_flag_audit_performed_runs: entries.reduce((sum, entry) => sum + toInt(entry.feature_flag_audit_performed_runs), 0),
+    feature_flag_audit_performed_rate: rate(
+      entries.reduce((sum, entry) => sum + toInt(entry.feature_flag_audit_performed_runs), 0),
+      finishedRuns,
+    ),
+    history_read_runs: historyReadRuns,
+    history_read_rate: rate(historyReadRuns, finishedRuns),
+    history_relevant_runs: historyRelevantRuns,
+    history_relevant_rate: rate(historyRelevantRuns, finishedRuns),
+    history_helpful_runs: historyHelpfulRuns,
+    history_helpful_rate: rate(historyHelpfulRuns, finishedRuns),
+    history_relevance_counts: {
+      none: entries.reduce((sum, entry) => sum + toInt(entry.history_relevance_counts?.none), 0),
+      irrelevant: entries.reduce((sum, entry) => sum + toInt(entry.history_relevance_counts?.irrelevant), 0),
+      low: entries.reduce((sum, entry) => sum + toInt(entry.history_relevance_counts?.low), 0),
+      medium: entries.reduce((sum, entry) => sum + toInt(entry.history_relevance_counts?.medium), 0),
+      high: entries.reduce((sum, entry) => sum + toInt(entry.history_relevance_counts?.high), 0),
+    },
+    history_helpfulness_counts: {
+      none: entries.reduce((sum, entry) => sum + toInt(entry.history_helpfulness_counts?.none), 0),
+      irrelevant: entries.reduce((sum, entry) => sum + toInt(entry.history_helpfulness_counts?.irrelevant), 0),
+      low: entries.reduce((sum, entry) => sum + toInt(entry.history_helpfulness_counts?.low), 0),
+      medium: entries.reduce((sum, entry) => sum + toInt(entry.history_helpfulness_counts?.medium), 0),
+      high: entries.reduce((sum, entry) => sum + toInt(entry.history_helpfulness_counts?.high), 0),
+    },
+  };
+}
+
+function summarizeImplementSeriesBucket(bucketStart, bucketEnd, entries) {
+  const startedRuns = entries.reduce((sum, entry) => sum + toInt(entry.started_runs), 0);
+  const finishedRuns = entries.reduce((sum, entry) => sum + toInt(entry.finished_runs), 0);
+  const completedRuns = entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.completed), 0);
+  const inProgressRuns = Math.max(startedRuns - finishedRuns, 0);
+  const boundaryHistoryUsefulRuns = entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_useful_runs), 0);
+  return {
+    bucket_start: bucketStart,
+    bucket_end: bucketEnd,
+    started_runs: startedRuns,
+    finished_runs: finishedRuns,
+    in_progress_runs: inProgressRuns,
+    in_progress_rate: rate(inProgressRuns, startedRuns),
+    completion_rate: rate(completedRuns, startedRuns),
+    feature_size_counts: {
+      SMALL: entries.reduce((sum, entry) => sum + toInt(entry.feature_size_counts?.SMALL), 0),
+      MEDIUM: entries.reduce((sum, entry) => sum + toInt(entry.feature_size_counts?.MEDIUM), 0),
+      LARGE: entries.reduce((sum, entry) => sum + toInt(entry.feature_size_counts?.LARGE), 0),
+    },
+    completion_status_counts: {
+      completed: completedRuns,
+      abandoned_at_planning: entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.abandoned_at_planning), 0),
+      abandoned_at_implementation: entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.abandoned_at_implementation), 0),
+      abandoned_at_review: entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.abandoned_at_review), 0),
+      error: entries.reduce((sum, entry) => sum + toInt(entry.completion_status_counts?.error), 0),
+    },
+    audit_result_counts: {
+      all_pass: entries.reduce((sum, entry) => sum + toInt(entry.audit_result_counts?.all_pass), 0),
+      had_gaps: entries.reduce((sum, entry) => sum + toInt(entry.audit_result_counts?.had_gaps), 0),
+      skipped: entries.reduce((sum, entry) => sum + toInt(entry.audit_result_counts?.skipped), 0),
+    },
+    validation_result_counts: {
+      pass: entries.reduce((sum, entry) => sum + toInt(entry.validation_result_counts?.pass), 0),
+      fail: entries.reduce((sum, entry) => sum + toInt(entry.validation_result_counts?.fail), 0),
+      skipped: entries.reduce((sum, entry) => sum + toInt(entry.validation_result_counts?.skipped), 0),
+    },
+    rollout_needed_runs: entries.reduce((sum, entry) => sum + toInt(entry.rollout_needed_runs), 0),
+    rollout_needed_rate: rate(
+      entries.reduce((sum, entry) => sum + toInt(entry.rollout_needed_runs), 0),
+      startedRuns,
+    ),
+    feature_flag_used_runs: entries.reduce((sum, entry) => sum + toInt(entry.feature_flag_used_runs), 0),
+    feature_flag_used_rate: rate(
+      entries.reduce((sum, entry) => sum + toInt(entry.feature_flag_used_runs), 0),
+      finishedRuns,
+    ),
+    pr_created_runs: entries.reduce((sum, entry) => sum + toInt(entry.pr_created_runs), 0),
+    pr_created_rate: rate(
+      entries.reduce((sum, entry) => sum + toInt(entry.pr_created_runs), 0),
+      finishedRuns,
+    ),
+    boundary_history_written_runs: entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_written_runs), 0),
+    boundary_history_written_rate: rate(
+      entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_written_runs), 0),
+      finishedRuns,
+    ),
+    boundary_history_useful_runs: boundaryHistoryUsefulRuns,
+    boundary_history_useful_rate: rate(boundaryHistoryUsefulRuns, finishedRuns),
+    boundary_history_value_counts: {
+      none: entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_value_counts?.none), 0),
+      irrelevant: entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_value_counts?.irrelevant), 0),
+      low: entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_value_counts?.low), 0),
+      medium: entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_value_counts?.medium), 0),
+      high: entries.reduce((sum, entry) => sum + toInt(entry.boundary_history_value_counts?.high), 0),
+    },
+  };
+}
+
+export function buildVerifySeries(rows, groupBy, dateFrom, dateTo) {
+  const dailySeries = rows.map((row) => normalizeVerifySeriesEntry(row, String(row.bucket_date || ""), String(row.bucket_date || "")));
+  if (groupBy !== "week") {
+    return dailySeries;
+  }
+  const grouped = new Map();
+  dailySeries.forEach((entry) => {
+    const naturalWeekStart = weekStartIsoDate(entry.bucket_start);
+    const bucketStart = maxIsoDate(naturalWeekStart, dateFrom);
+    const bucketEnd = minIsoDate(addDaysIsoDate(naturalWeekStart, 6), dateTo);
+    if (!grouped.has(naturalWeekStart)) {
+      grouped.set(naturalWeekStart, {
+        bucket_start: bucketStart,
+        bucket_end: bucketEnd,
+        entries: [],
+      });
+    }
+    grouped.get(naturalWeekStart).entries.push(entry);
+  });
+  return Array.from(grouped.entries())
+    .sort((left, right) => left[0].localeCompare(right[0]))
+    .map(([, bucket]) => summarizeVerifySeriesBucket(bucket.bucket_start, bucket.bucket_end, bucket.entries));
+}
+
+export function buildImplementSeries(rows, groupBy, dateFrom, dateTo) {
+  const dailySeries = rows.map((row) => normalizeImplementSeriesEntry(row, String(row.bucket_date || ""), String(row.bucket_date || "")));
+  if (groupBy !== "week") {
+    return dailySeries;
+  }
+  const grouped = new Map();
+  dailySeries.forEach((entry) => {
+    const naturalWeekStart = weekStartIsoDate(entry.bucket_start);
+    const bucketStart = maxIsoDate(naturalWeekStart, dateFrom);
+    const bucketEnd = minIsoDate(addDaysIsoDate(naturalWeekStart, 6), dateTo);
+    if (!grouped.has(naturalWeekStart)) {
+      grouped.set(naturalWeekStart, {
+        bucket_start: bucketStart,
+        bucket_end: bucketEnd,
+        entries: [],
+      });
+    }
+    grouped.get(naturalWeekStart).entries.push(entry);
+  });
+  return Array.from(grouped.entries())
+    .sort((left, right) => left[0].localeCompare(right[0]))
+    .map(([, bucket]) => summarizeImplementSeriesBucket(bucket.bucket_start, bucket.bucket_end, bucket.entries));
+}
+
 export default {
   async fetch(request, env) {
+    const url = new URL(request.url);
+    const normalizedPath = url.pathname.replace(/\/+$/, "");
+
+    if (
+      request.method === "GET"
+      && (normalizedPath === "/capabilities" || normalizedPath.endsWith("/capabilities"))
+    ) {
+      return jsonResponse(200, capabilitiesPayload(env));
+    }
+
     if (request.method !== "POST") {
       return jsonResponse(405, { error: "Method not allowed." });
     }
 
-    if (!env.POSTHOG_API_KEY) {
-      return jsonResponse(500, { error: "POSTHOG_API_KEY is not configured." });
+    const payload = await readJson(request);
+    if (payload === null) {
+      return jsonResponse(400, { error: "Request body must be valid JSON." });
     }
 
-    let payload;
-    try {
-      payload = await request.json();
-    } catch {
-      return jsonResponse(400, { error: "Request body must be valid JSON." });
+    if (normalizedPath === "/stats" || normalizedPath.endsWith("/stats")) {
+      const validationError = validateStatsRequest(payload);
+      if (validationError) {
+        return jsonResponse(400, { error: validationError });
+      }
+
+      const authToken = env.PROXY_STATS_BEARER_TOKEN;
+      if (authToken) {
+        const header = request.headers.get("Authorization") || "";
+        if (header !== `Bearer ${authToken}`) {
+          return jsonResponse(401, { error: "Missing or invalid proxy stats token." });
+        }
+      }
+
+      const dateToExclusive = nextIsoDate(payload.date_to);
+      const query = payload.workflow === "bill-feature-verify"
+        ? buildVerifyStatsQuery(payload.date_from, dateToExclusive)
+        : buildImplementStatsQuery(payload.date_from, dateToExclusive);
+      const result = await runPostHogQuery(env, query);
+      if (result.error) {
+        const responsePayload = { error: result.error };
+        if (result.details) {
+          responsePayload.details = result.details;
+        }
+        return jsonResponse(result.status, responsePayload);
+      }
+
+      const summaryRows = queryRowsToObjects(result.payload);
+      const row = summaryRows[0] || {};
+      const normalized = payload.workflow === "bill-feature-verify"
+        ? normalizeVerifyStats(row, payload.date_from, payload.date_to)
+        : normalizeImplementStats(row, payload.date_from, payload.date_to);
+      if (payload.group_by) {
+        const seriesQuery = payload.workflow === "bill-feature-verify"
+          ? buildVerifySeriesQuery(payload.date_from, dateToExclusive)
+          : buildImplementSeriesQuery(payload.date_from, dateToExclusive);
+        const seriesResult = await runPostHogQuery(env, seriesQuery);
+        if (seriesResult.error) {
+          const responsePayload = { error: seriesResult.error };
+          if (seriesResult.details) {
+            responsePayload.details = seriesResult.details;
+          }
+          return jsonResponse(seriesResult.status, responsePayload);
+        }
+        const seriesRows = queryRowsToObjects(seriesResult.payload);
+        normalized.group_by = payload.group_by;
+        normalized.series = payload.workflow === "bill-feature-verify"
+          ? buildVerifySeries(seriesRows, payload.group_by, payload.date_from, payload.date_to)
+          : buildImplementSeries(seriesRows, payload.group_by, payload.date_from, payload.date_to);
+      }
+      return jsonResponse(200, normalized);
     }
 
     const batch = payload?.batch;
@@ -53,36 +899,6 @@ export default {
       return jsonResponse(400, { error: "Each batch entry must include event, distinct_id, and properties." });
     }
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 10_000);
-    let upstreamResponse;
-    try {
-      upstreamResponse = await fetch(`${normalizeHost(env.POSTHOG_HOST)}/batch/`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          api_key: env.POSTHOG_API_KEY,
-          batch,
-        }),
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timer);
-    }
-
-    if (!upstreamResponse.ok) {
-      return jsonResponse(502, { error: "Upstream telemetry relay returned an error." });
-    }
-
-    const responseText = await upstreamResponse.text();
-    return new Response(
-      responseText || JSON.stringify({ ok: true }),
-      {
-        status: upstreamResponse.status,
-        headers: {
-          "Content-Type": upstreamResponse.headers.get("Content-Type") || "application/json",
-        },
-      },
-    );
+    return forwardBatch(env, batch);
   },
 };

--- a/docs/cloudflare-telemetry-proxy/wrangler.toml
+++ b/docs/cloudflare-telemetry-proxy/wrangler.toml
@@ -3,4 +3,5 @@ main = "worker.js"
 compatibility_date = "2026-04-03"
 
 [vars]
-POSTHOG_HOST = "https://us.i.posthog.com"
+POSTHOG_HOST = "https://eu.i.posthog.com"
+POSTHOG_APP_HOST = "https://eu.posthog.com"

--- a/docs/cloudflare-telemetry-proxy/wrangler.toml.example
+++ b/docs/cloudflare-telemetry-proxy/wrangler.toml.example
@@ -4,3 +4,4 @@ compatibility_date = "2026-04-03"
 
 [vars]
 POSTHOG_HOST = "https://us.i.posthog.com"
+POSTHOG_APP_HOST = "https://us.posthog.com"

--- a/docs/review-telemetry.md
+++ b/docs/review-telemetry.md
@@ -7,7 +7,7 @@ Skill Bill can record a measurement loop for code-review usefulness. Telemetry u
 - each finding in `### 2. Risk Register` should use `- [F-001] Severity | Confidence | file:line | description`
 - feedback history and learnings stay local in SQLite regardless of telemetry state
 
-The `skill-bill` CLI and MCP server are installed automatically by `./install.sh`. The MCP server exposes `import_review`, `triage_findings`, `resolve_learnings`, `review_stats`, and `doctor` as native agent tools. The CLI provides the same functionality plus learnings CRUD and telemetry management.
+The `skill-bill` CLI and MCP server are installed automatically by `./install.sh`. The MCP server exposes `import_review`, `triage_findings`, `resolve_learnings`, `review_stats`, `feature_implement_stats`, `feature_verify_stats`, and `doctor` as native agent tools. The CLI provides the same functionality plus learnings CRUD and telemetry management.
 
 ```bash
 skill-bill --help
@@ -46,6 +46,8 @@ skill-bill triage --run-id rvw-20260402-001 --decision "fix=[1] reject=[2]"
 skill-bill triage --run-id rvw-20260402-001 --decision "all fix"
 skill-bill learnings resolve --repo Sermilion/skill-bill --skill bill-kotlin-code-review --review-session-id rvs-20260402-001
 skill-bill stats --run-id rvw-20260402-001 --format json
+skill-bill implement-stats --format json
+skill-bill verify-stats --format json
 ```
 
 The `triage` command maps the visible numbers back to the stable `F-001` ids internally. For agent-driven flows, prefer a structured selection string like `fix=[1,3] reject=[2]` so every finding is resolved deterministically in one step. Use `all <action>` to apply the same action to every finding. Supported triage actions are:
@@ -283,6 +285,8 @@ Both levels:
 | `review_iterations` | integer | Code-review iteration count |
 | `audit_result` | string | `all_pass`, `had_gaps`, or `skipped` |
 | `completion_status` | string | `completed`, `abandoned_at_review`, `abandoned_at_audit`, or `error` |
+| `history_relevance` | string | How relevant history-entry reading was: `none`, `irrelevant`, `low`, `medium`, or `high` |
+| `history_helpfulness` | string | How helpful history-entry reading was: `none`, `irrelevant`, `low`, `medium`, or `high` |
 | `duration_seconds` | integer | Wall-clock seconds from started to finished |
 
 `full` adds:
@@ -391,6 +395,193 @@ Both levels also include:
 
 Fields always excluded (both levels): repo name, branch name, raw spec content, raw plan content, file paths, acceptance criteria text.
 
+## PostHog dashboard spec
+
+The local `skill-bill implement-stats` and `skill-bill verify-stats` commands are the source of truth for workflow-summary semantics. PostHog dashboards should mirror those summaries instead of inventing a separate analytics vocabulary.
+
+Recommended global filters:
+
+- date ranges: last 7 days, last 30 days, and rolling quarter
+- use started events for intake/adoption charts
+- use finished events for completion, iteration, and duration charts
+- do not mix started and finished denominators in one chart unless the chart explicitly describes funnel dropoff
+
+### Feature-verify dashboard
+
+Use `skillbill_feature_verify_started` for intake metrics and `skillbill_feature_verify_finished` for outcome metrics.
+
+Recommended tiles:
+
+- `Verify runs started`: count of `skillbill_feature_verify_started`
+- `Verify runs finished`: count of `skillbill_feature_verify_finished`
+- `Verify completion rate`: `completion_status = completed` on finished events divided by all finished events
+- `Verify abandonment rate`: `completion_status != completed` on finished events divided by all finished events
+- `Rollout-relevant rate`: `rollout_relevant = true` on started events divided by all started events
+- `Audit gaps rate`: `audit_result = had_gaps` on finished events divided by all finished events
+- `History read rate`: finished events where history telemetry is not `none` divided by all finished events
+- `History relevant rate`: finished events where `history_relevance in (medium, high)` divided by all finished events
+- `History helpful rate`: finished events where `history_helpfulness in (medium, high)` divided by all finished events
+- `Average review iterations`: average `review_iterations` on finished events
+- `Average verify duration`: average `duration_seconds` on finished events
+- `Acceptance criteria distribution`: histogram or average of `acceptance_criteria_count` on started events
+
+Recommended breakdowns:
+
+- `completion_status`
+- `audit_result`
+- `rollout_relevant`
+- `history_relevance`
+- `history_helpfulness`
+
+Mirror to local stats:
+
+- `total_runs` ~= count of started events
+- `completion_status_counts` = finished breakdown by `completion_status`
+- `audit_result_counts` = finished breakdown by `audit_result`
+- `rollout_relevant_rate` = started filter on `rollout_relevant = true`
+- `history_read_rate` = finished runs where `history_relevance != none` or `history_helpfulness != none`
+- `history_relevant_rate` = finished runs where `history_relevance in (medium, high)`
+- `history_helpful_rate` = finished runs where `history_helpfulness in (medium, high)`
+- `average_review_iterations` = average on finished `review_iterations`
+- `average_duration_seconds` = average on finished `duration_seconds`
+
+### Feature-implement dashboard
+
+Use `skillbill_feature_implement_started` for intake/sizing and `skillbill_feature_implement_finished` for outcome metrics.
+
+Recommended tiles:
+
+- `Implement runs started`: count of `skillbill_feature_implement_started`
+- `Implement runs finished`: count of `skillbill_feature_implement_finished`
+- `Implement completion rate`: `completion_status = completed` on finished events divided by all finished events
+- `Feature size mix`: breakdown of started events by `feature_size`
+- `Rollout-needed rate`: `rollout_needed = true` on started events divided by all started events
+- `Feature-flag usage rate`: `feature_flag_used = true` on finished events divided by all finished events
+- `PR-created rate`: `pr_created = true` on finished events divided by all finished events
+- `Average review iterations`: average `review_iterations` on finished events
+- `Average audit iterations`: average `audit_iterations` on finished events
+- `Average implementation duration`: average `duration_seconds` on finished events
+- `Validation result mix`: breakdown of finished events by `validation_result`
+- `Audit result mix`: breakdown of finished events by `audit_result`
+
+Recommended breakdowns:
+
+- `feature_size`
+- `completion_status`
+- `validation_result`
+- `audit_result`
+- `feature_flag_pattern`
+
+Mirror to local stats:
+
+- `total_runs` ~= count of started events
+- `feature_size_counts` = started breakdown by `feature_size`
+- `completion_status_counts` = finished breakdown by `completion_status`
+- `validation_result_counts` = finished breakdown by `validation_result`
+- `audit_result_counts` = finished breakdown by `audit_result`
+- `rollout_needed_rate` = started filter on `rollout_needed = true`
+- `feature_flag_used_rate` = finished filter on `feature_flag_used = true`
+- `pr_created_rate` = finished filter on `pr_created = true`
+- `average_review_iterations` = average on finished `review_iterations`
+- `average_audit_iterations` = average on finished `audit_iterations`
+- `average_duration_seconds` = average on finished `duration_seconds`
+
+### Alignment rule
+
+If a PostHog chart disagrees with local CLI/MCP stats for the same date range, treat the local stats command as the contract and fix the chart definition first.
+
+## Remote stats contract
+
+For org-wide analysis, Skill Bill can query aggregate workflow metrics through the configured telemetry proxy instead of reading one install's local SQLite database.
+
+CLI:
+
+```bash
+skill-bill telemetry capabilities
+skill-bill telemetry stats verify --since 30d
+skill-bill telemetry stats implement --date-from 2026-04-01 --date-to 2026-04-22
+skill-bill telemetry stats verify --since 30d --group-by day
+skill-bill telemetry stats implement --since 30d --group-by week
+```
+
+MCP:
+
+- `telemetry_proxy_capabilities`
+- `telemetry_remote_stats`
+
+Client capability contract:
+
+```json
+{
+  "contract_version": "1",
+  "supports_ingest": true,
+  "supports_stats": true,
+  "supported_workflows": [
+    "bill-feature-verify",
+    "bill-feature-implement"
+  ]
+}
+```
+
+Client request contract:
+
+```json
+{
+  "workflow": "bill-feature-verify",
+  "date_from": "2026-04-01",
+  "date_to": "2026-04-22",
+  "group_by": "day"
+}
+```
+
+The client sends that payload to:
+
+- `<configured telemetry proxy url>/capabilities`
+- `<configured telemetry proxy url>/stats`
+
+The proxy owns backend-specific query logic. It may answer from PostHog, ClickHouse, BigQuery, or any other analytics store.
+
+Normalized remote stats payloads now include:
+
+- `started_runs`
+- `finished_runs`
+- `in_progress_runs`
+- `in_progress_rate`
+- optional `group_by`
+- optional `series`
+
+For `bill-feature-implement`, normalized remote stats also include:
+
+- `boundary_history_written_runs`
+- `boundary_history_written_rate`
+- `boundary_history_useful_runs`
+- `boundary_history_useful_rate`
+- `boundary_history_value_counts`
+
+For `bill-feature-verify`, normalized remote stats also include:
+
+- `history_read_runs`
+- `history_read_rate`
+- `history_relevant_runs`
+- `history_relevant_rate`
+- `history_helpful_runs`
+- `history_helpful_rate`
+- `history_relevance_counts`
+- `history_helpfulness_counts`
+
+For the proxy contract, `in_progress_runs` is a range-scoped estimate derived from event counts in the selected window: `max(started_runs - finished_runs, 0)`. It is useful for top-level workflow monitoring, but it is not a durable workflow-state query.
+`boundary_history_useful_runs` is defined as `boundary_history_value in ('medium', 'high')`.
+`history_relevant_runs` is defined as `history_relevance in ('medium', 'high')`.
+`history_helpful_runs` is defined as `history_helpfulness in ('medium', 'high')`.
+
+When `group_by` is provided, the proxy returns a `series` array with day or week buckets. Those buckets use the same event-window math as the top-level summary, so they are trend-oriented monitoring data, not cohort/session-complete analytics.
+
+Recommended auth model:
+
+- set `SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN` on the client machine
+- have the proxy require `Authorization: Bearer <token>` for `/stats` and optionally `/capabilities`
+- keep ingest and stats authorization concerns separate if you want public ingest but private aggregate reads
+
 ## Remote sync defaults
 
 Fresh installs default telemetry to `anonymous`, with a level prompt during `./install.sh`. When telemetry level is not `off`, Skill Bill generates an install id, writes telemetry config to `~/.skill-bill/config.json`, and can batch-sync queued telemetry to the hosted Skill Bill relay. If you configure a custom proxy, Skill Bill sends telemetry to that proxy only.
@@ -429,6 +620,7 @@ Proxy configuration:
 
 ```bash
 export SKILL_BILL_TELEMETRY_PROXY_URL="https://your-worker.your-subdomain.workers.dev"
+export SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN="replace-with-your-stats-token"
 export SKILL_BILL_TELEMETRY_LEVEL="full"                   # optional override (off, anonymous, full)
 export SKILL_BILL_TELEMETRY_ENABLED="true"                 # legacy override (maps true→anonymous, false→off)
 export SKILL_BILL_TELEMETRY_BATCH_SIZE="50"                # optional override

--- a/skill_bill/cli.py
+++ b/skill_bill/cli.py
@@ -70,8 +70,14 @@ from skill_bill.review import (
   read_input,
   save_imported_review,
 )
-from skill_bill.stats import stats_payload
+from skill_bill.stats import (
+  feature_implement_stats_payload,
+  feature_verify_stats_payload,
+  stats_payload,
+)
 from skill_bill.sync import (
+  fetch_proxy_capabilities,
+  fetch_remote_stats,
   sync_result_payload,
   sync_telemetry,
   telemetry_status_payload,
@@ -200,6 +206,22 @@ def triage_command(args: argparse.Namespace) -> int:
 def stats_command(args: argparse.Namespace) -> int:
   with open_db(args.db, sync=False) as (connection, db_path):
     payload = stats_payload(connection, args.run_id)
+  payload["db_path"] = str(db_path)
+  emit(payload, args.format)
+  return 0
+
+
+def feature_implement_stats_command(args: argparse.Namespace) -> int:
+  with open_db(args.db, sync=False) as (connection, db_path):
+    payload = feature_implement_stats_payload(connection)
+  payload["db_path"] = str(db_path)
+  emit(payload, args.format)
+  return 0
+
+
+def feature_verify_stats_command(args: argparse.Namespace) -> int:
+  with open_db(args.db, sync=False) as (connection, db_path):
+    payload = feature_verify_stats_payload(connection)
   payload["db_path"] = str(db_path)
   emit(payload, args.format)
   return 0
@@ -342,6 +364,28 @@ def telemetry_sync_command(args: argparse.Namespace) -> int:
   result = sync_telemetry(resolve_db_path(args.db))
   emit(sync_result_payload(result), args.format)
   return 1 if result.status == "failed" else 0
+
+
+def telemetry_capabilities_command(args: argparse.Namespace) -> int:
+  payload = fetch_proxy_capabilities()
+  emit(payload, args.format)
+  return 0
+
+
+def telemetry_remote_stats_command(args: argparse.Namespace) -> int:
+  workflow = {
+    "verify": "bill-feature-verify",
+    "implement": "bill-feature-implement",
+  }[args.workflow]
+  payload = fetch_remote_stats(
+    workflow=workflow,
+    since=args.since,
+    date_from=args.date_from,
+    date_to=args.date_to,
+    group_by=args.group_by,
+  )
+  emit(payload, args.format)
+  return 0
 
 
 def telemetry_toggle_command(args: argparse.Namespace) -> int:
@@ -2187,6 +2231,30 @@ def build_parser() -> argparse.ArgumentParser:
   stats_parser.add_argument("--format", choices=("text", "json"), default="text")
   stats_parser.set_defaults(handler=stats_command)
 
+  feature_implement_stats_parser = subparsers.add_parser(
+    "implement-stats",
+    aliases=["feature-implement-stats"],
+    help="Show aggregate bill-feature-implement metrics from the local SQLite store.",
+  )
+  feature_implement_stats_parser.add_argument(
+    "--format",
+    choices=("text", "json"),
+    default="text",
+  )
+  feature_implement_stats_parser.set_defaults(handler=feature_implement_stats_command)
+
+  feature_verify_stats_parser = subparsers.add_parser(
+    "verify-stats",
+    aliases=["feature-verify-stats"],
+    help="Show aggregate bill-feature-verify metrics from the local SQLite store.",
+  )
+  feature_verify_stats_parser.add_argument(
+    "--format",
+    choices=("text", "json"),
+    default="text",
+  )
+  feature_verify_stats_parser.set_defaults(handler=feature_verify_stats_command)
+
   learnings_parser = subparsers.add_parser(
     "learnings",
     help="Manage local review learnings derived from rejected review findings.",
@@ -2268,6 +2336,47 @@ def build_parser() -> argparse.ArgumentParser:
   telemetry_sync_parser = telemetry_subparsers.add_parser("sync", help="Flush pending telemetry events to the active proxy target.")
   telemetry_sync_parser.add_argument("--format", choices=("text", "json"), default="text")
   telemetry_sync_parser.set_defaults(handler=telemetry_sync_command)
+
+  telemetry_capabilities_parser = telemetry_subparsers.add_parser(
+    "capabilities",
+    help="Show which relay/proxy telemetry operations the configured endpoint supports.",
+  )
+  telemetry_capabilities_parser.add_argument("--format", choices=("text", "json"), default="text")
+  telemetry_capabilities_parser.set_defaults(handler=telemetry_capabilities_command)
+
+  telemetry_remote_stats_parser = telemetry_subparsers.add_parser(
+    "stats",
+    help="Fetch aggregate org-wide workflow metrics from the configured telemetry proxy.",
+  )
+  telemetry_remote_stats_parser.add_argument(
+    "workflow",
+    choices=("verify", "implement"),
+    help="Workflow family to query through the remote telemetry proxy.",
+  )
+  telemetry_remote_stats_window = telemetry_remote_stats_parser.add_mutually_exclusive_group()
+  telemetry_remote_stats_window.add_argument(
+    "--since",
+    default="",
+    help="Relative lookback window in <days>d format. Defaults to 30d.",
+  )
+  telemetry_remote_stats_window.add_argument(
+    "--date-from",
+    default="",
+    help="Inclusive start date in YYYY-MM-DD format.",
+  )
+  telemetry_remote_stats_parser.add_argument(
+    "--date-to",
+    default="",
+    help="Inclusive end date in YYYY-MM-DD format. Defaults to today (UTC).",
+  )
+  telemetry_remote_stats_parser.add_argument(
+    "--group-by",
+    choices=("day", "week"),
+    default="",
+    help="Optional time-bucket series to include alongside the summary.",
+  )
+  telemetry_remote_stats_parser.add_argument("--format", choices=("text", "json"), default="text")
+  telemetry_remote_stats_parser.set_defaults(handler=telemetry_remote_stats_command)
 
   telemetry_enable_parser = telemetry_subparsers.add_parser("enable", help="Enable remote telemetry sync.")
   telemetry_enable_parser.add_argument(

--- a/skill_bill/constants.py
+++ b/skill_bill/constants.py
@@ -12,11 +12,13 @@ CONFIG_ENVIRONMENT_KEY = "SKILL_BILL_CONFIG_PATH"
 TELEMETRY_ENABLED_ENVIRONMENT_KEY = "SKILL_BILL_TELEMETRY_ENABLED"
 TELEMETRY_LEVEL_ENVIRONMENT_KEY = "SKILL_BILL_TELEMETRY_LEVEL"
 TELEMETRY_PROXY_URL_ENVIRONMENT_KEY = "SKILL_BILL_TELEMETRY_PROXY_URL"
+TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY = "SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN"
 INSTALL_ID_ENVIRONMENT_KEY = "SKILL_BILL_INSTALL_ID"
 TELEMETRY_BATCH_SIZE_ENVIRONMENT_KEY = "SKILL_BILL_TELEMETRY_BATCH_SIZE"
 TELEMETRY_LEVELS = ("off", "anonymous", "full")
 DEFAULT_TELEMETRY_PROXY_URL = "https://skill-bill-telemetry-proxy.skillbill.workers.dev"
 DEFAULT_TELEMETRY_BATCH_SIZE = 50
+TELEMETRY_PROXY_CONTRACT_VERSION = "1"
 FINDING_OUTCOME_TYPES = (
   "finding_accepted",
   "fix_applied",
@@ -43,6 +45,7 @@ EVENT_FEATURE_VERIFY_FINISHED = "skillbill_feature_verify_finished"
 EVENT_PR_DESCRIPTION_GENERATED = "skillbill_pr_description_generated"
 EVENT_NEW_SKILL_SCAFFOLD_STARTED = "skillbill_new_skill_scaffold_started"
 EVENT_NEW_SKILL_SCAFFOLD_FINISHED = "skillbill_new_skill_scaffold_finished"
+REMOTE_STATS_WORKFLOWS = ("bill-feature-implement", "bill-feature-verify")
 
 FEATURE_IMPLEMENT_SESSION_PREFIX = "fis"
 FEATURE_IMPLEMENT_WORKFLOW_PREFIX = "wfl"
@@ -117,7 +120,8 @@ FEATURE_SIZES = ("SMALL", "MEDIUM", "LARGE")
 SPEC_INPUT_TYPES = ("raw_text", "pdf", "markdown_file", "image", "directory")
 ISSUE_KEY_TYPES = ("jira", "linear", "github", "other", "none")
 FEATURE_FLAG_PATTERNS = ("simple_conditional", "di_switch", "legacy", "none")
-BOUNDARY_HISTORY_VALUES = ("none", "irrelevant", "low", "medium", "high")
+HISTORY_SIGNAL_VALUES = ("none", "irrelevant", "low", "medium", "high")
+BOUNDARY_HISTORY_VALUES = HISTORY_SIGNAL_VALUES
 AUDIT_RESULTS = ("all_pass", "had_gaps", "skipped")
 VALIDATION_RESULTS = ("pass", "fail", "skipped")
 COMPLETION_STATUSES = (

--- a/skill_bill/db.py
+++ b/skill_bill/db.py
@@ -248,6 +248,18 @@ def ensure_database(path: Path) -> sqlite3.Connection:
     "child_steps_json",
     "TEXT NOT NULL DEFAULT ''",
   )
+  ensure_column(
+    connection,
+    "feature_verify_sessions",
+    "history_relevance",
+    "TEXT NOT NULL DEFAULT 'none'",
+  )
+  ensure_column(
+    connection,
+    "feature_verify_sessions",
+    "history_helpfulness",
+    "TEXT NOT NULL DEFAULT 'none'",
+  )
   migrate_feedback_events_schema(connection)
   return connection
 

--- a/skill_bill/feature_verify.py
+++ b/skill_bill/feature_verify.py
@@ -18,6 +18,7 @@ from skill_bill.constants import (
   FEATURE_VERIFY_WORKFLOW_STEP_IDS,
   FEATURE_VERIFY_WORKFLOW_STEP_STATUSES,
   FEATURE_VERIFY_WORKFLOW_TERMINAL_STATUSES,
+  HISTORY_SIGNAL_VALUES,
 )
 from skill_bill.feature_implement import validate_enum
 from skill_bill.stats import enqueue_telemetry_event
@@ -33,15 +34,23 @@ def validate_finished_params(
   *,
   audit_result: str,
   completion_status: str,
+  history_relevance: str,
+  history_helpfulness: str,
 ) -> str | None:
   error = validate_enum(audit_result, AUDIT_RESULTS, "audit_result")
   if error:
     return error
-  return validate_enum(
+  error = validate_enum(
     completion_status,
     FEATURE_VERIFY_COMPLETION_STATUSES,
     "completion_status",
   )
+  if error:
+    return error
+  error = validate_enum(history_relevance, HISTORY_SIGNAL_VALUES, "history_relevance")
+  if error:
+    return error
+  return validate_enum(history_helpfulness, HISTORY_SIGNAL_VALUES, "history_helpfulness")
 
 
 def save_started(
@@ -76,6 +85,8 @@ def save_finished(
   review_iterations: int,
   audit_result: str,
   completion_status: str,
+  history_relevance: str,
+  history_helpfulness: str,
   gaps_found: list[str],
 ) -> None:
   exists = connection.execute(
@@ -92,6 +103,8 @@ def save_finished(
           review_iterations = ?,
           audit_result = ?,
           completion_status = ?,
+          history_relevance = ?,
+          history_helpfulness = ?,
           gaps_found = ?,
           finished_at = CURRENT_TIMESTAMP
         WHERE session_id = ?
@@ -101,6 +114,8 @@ def save_finished(
           review_iterations,
           audit_result,
           completion_status,
+          history_relevance,
+          history_helpfulness,
           json.dumps(gaps_found),
           session_id,
         ),
@@ -111,8 +126,9 @@ def save_finished(
         """
         INSERT INTO feature_verify_sessions (
           session_id, feature_flag_audit_performed, review_iterations,
-          audit_result, completion_status, gaps_found, finished_at
-        ) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+          audit_result, completion_status, history_relevance,
+          history_helpfulness, gaps_found, finished_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
         """,
         (
           session_id,
@@ -120,6 +136,8 @@ def save_finished(
           review_iterations,
           audit_result,
           completion_status,
+          history_relevance,
+          history_helpfulness,
           json.dumps(gaps_found),
         ),
       )
@@ -196,6 +214,8 @@ def build_finished_payload(
     "review_iterations": row["review_iterations"] or 0,
     "audit_result": row["audit_result"] or "skipped",
     "completion_status": row["completion_status"] or "",
+    "history_relevance": row["history_relevance"] or "none",
+    "history_helpfulness": row["history_helpfulness"] or "none",
     "duration_seconds": duration_seconds,
   })
 
@@ -215,6 +235,8 @@ def build_finished_payload_from_fields(
   review_iterations: int,
   audit_result: str,
   completion_status: str,
+  history_relevance: str,
+  history_helpfulness: str,
   gaps_found: list[str],
   duration_seconds: int,
   level: str,
@@ -231,6 +253,8 @@ def build_finished_payload_from_fields(
     "review_iterations": review_iterations,
     "audit_result": audit_result,
     "completion_status": completion_status,
+    "history_relevance": history_relevance,
+    "history_helpfulness": history_helpfulness,
     "duration_seconds": duration_seconds,
   })
   if level == "full":

--- a/skill_bill/mcp_server.py
+++ b/skill_bill/mcp_server.py
@@ -46,7 +46,13 @@ from skill_bill.review import (
   parse_review,
   save_imported_review,
 )
-from skill_bill.stats import stats_payload, update_review_finished_telemetry_state
+from skill_bill.stats import (
+  feature_implement_stats_payload,
+  feature_verify_stats_payload,
+  stats_payload,
+  update_review_finished_telemetry_state,
+)
+from skill_bill.sync import fetch_proxy_capabilities, fetch_remote_stats
 from skill_bill.triage import (
   parse_triage_decisions,
   record_feedback,
@@ -245,6 +251,48 @@ def review_stats(review_run_id: str | None = None) -> dict:
     payload = stats_payload(connection, review_run_id)
   payload["db_path"] = str(db_path)
   return payload
+
+
+@mcp.tool()
+def feature_implement_stats() -> dict:
+  """Show aggregate bill-feature-implement metrics from the local SQLite store."""
+  with open_db(sync=False) as (connection, db_path):
+    payload = feature_implement_stats_payload(connection)
+  payload["db_path"] = str(db_path)
+  return payload
+
+
+@mcp.tool()
+def feature_verify_stats() -> dict:
+  """Show aggregate bill-feature-verify metrics from the local SQLite store."""
+  with open_db(sync=False) as (connection, db_path):
+    payload = feature_verify_stats_payload(connection)
+  payload["db_path"] = str(db_path)
+  return payload
+
+
+@mcp.tool()
+def telemetry_remote_stats(
+  workflow: str,
+  since: str = "",
+  date_from: str = "",
+  date_to: str = "",
+  group_by: str = "",
+) -> dict:
+  """Fetch aggregate org-wide workflow metrics from the configured telemetry proxy."""
+  return fetch_remote_stats(
+    workflow=workflow,
+    since=since,
+    date_from=date_from,
+    date_to=date_to,
+    group_by=group_by,
+  )
+
+
+@mcp.tool()
+def telemetry_proxy_capabilities() -> dict:
+  """Show which relay/proxy telemetry operations the configured endpoint supports."""
+  return fetch_proxy_capabilities()
 
 
 @mcp.tool()
@@ -735,6 +783,8 @@ def feature_verify_finished(
   review_iterations: int,
   audit_result: str,
   completion_status: str,
+  history_relevance: str = "none",
+  history_helpfulness: str = "none",
   session_id: str = "",
   gaps_found: list[str] | None = None,
   orchestrated: bool = False,
@@ -755,6 +805,8 @@ def feature_verify_finished(
   validation_error = _fv.validate_finished_params(
     audit_result=audit_result,
     completion_status=completion_status,
+    history_relevance=history_relevance,
+    history_helpfulness=history_helpfulness,
   )
   if validation_error:
     return {"status": "error", "session_id": session_id, "error": validation_error}
@@ -775,6 +827,8 @@ def feature_verify_finished(
       review_iterations=review_iterations,
       audit_result=audit_result,
       completion_status=completion_status,
+      history_relevance=history_relevance,
+      history_helpfulness=history_helpfulness,
       gaps_found=gaps_found_list,
       duration_seconds=duration_seconds,
       level=level,
@@ -794,6 +848,8 @@ def feature_verify_finished(
       review_iterations=review_iterations,
       audit_result=audit_result,
       completion_status=completion_status,
+      history_relevance=history_relevance,
+      history_helpfulness=history_helpfulness,
       gaps_found=gaps_found_list,
     )
     settings = load_telemetry_settings()

--- a/skill_bill/stats.py
+++ b/skill_bill/stats.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+from datetime import datetime
 import json
 import sqlite3
 
 from skill_bill.config import load_telemetry_settings, telemetry_is_enabled
 from skill_bill.constants import (
   ACCEPTED_FINDING_OUTCOME_TYPES,
+  AUDIT_RESULTS,
+  BOUNDARY_HISTORY_VALUES,
+  COMPLETION_STATUSES,
+  FEATURE_FLAG_PATTERNS,
+  FEATURE_SIZES,
+  FEATURE_VERIFY_COMPLETION_STATUSES,
   FINDING_OUTCOME_TYPES,
+  HISTORY_SIGNAL_VALUES,
   REJECTED_FINDING_OUTCOME_TYPES,
+  VALIDATION_RESULTS,
 )
 from skill_bill.db import review_exists
 
@@ -20,6 +29,252 @@ def stats_payload(connection: sqlite3.Connection, review_run_id: str | None) -> 
   payload = summarize_finding_rows(finding_rows)
   payload["review_run_id"] = review_run_id
   return payload
+
+
+def _rate(count: int, total: int) -> float:
+  return round(count / total, 3) if total else 0.0
+
+
+def _average(values: list[int]) -> float:
+  return round(sum(values) / len(values), 2) if values else 0.0
+
+
+def _parse_json_list(raw_value: object) -> list[object]:
+  if not raw_value:
+    return []
+  try:
+    decoded = json.loads(str(raw_value))
+  except json.JSONDecodeError:
+    return []
+  return decoded if isinstance(decoded, list) else []
+
+
+def _duration_seconds(row: sqlite3.Row) -> int:
+  started_at = str(row["started_at"] or "")
+  finished_at = str(row["finished_at"] or "")
+  if not started_at or not finished_at:
+    return 0
+  try:
+    start_dt = datetime.fromisoformat(started_at)
+    end_dt = datetime.fromisoformat(finished_at)
+  except (ValueError, TypeError):
+    return 0
+  return max(0, int((end_dt - start_dt).total_seconds()))
+
+
+def _count_values(
+  rows: list[sqlite3.Row],
+  column_name: str,
+  expected_values: tuple[str, ...],
+) -> dict[str, int]:
+  counts = {value: 0 for value in expected_values}
+  for row in rows:
+    raw_value = str(row[column_name] or "")
+    if raw_value in counts:
+      counts[raw_value] += 1
+  return counts
+
+
+def feature_verify_stats_payload(connection: sqlite3.Connection) -> dict[str, object]:
+  rows = connection.execute(
+    """
+    SELECT *
+    FROM feature_verify_sessions
+    ORDER BY started_at, session_id
+    """
+  ).fetchall()
+  finished_rows = [row for row in rows if row["finished_at"]]
+
+  rollout_relevant_runs = sum(1 for row in rows if bool(row["rollout_relevant"]))
+  audit_performed_runs = sum(1 for row in finished_rows if bool(row["feature_flag_audit_performed"]))
+  history_read_runs = sum(
+    1
+    for row in finished_rows
+    if str(row["history_relevance"] or "none") != "none"
+    or str(row["history_helpfulness"] or "none") != "none"
+  )
+  history_relevant_runs = sum(
+    1 for row in finished_rows if str(row["history_relevance"] or "none") in ("medium", "high")
+  )
+  history_helpful_runs = sum(
+    1 for row in finished_rows if str(row["history_helpfulness"] or "none") in ("medium", "high")
+  )
+  runs_with_gaps_found = sum(
+    1 for row in finished_rows if len(_parse_json_list(row["gaps_found"])) > 0
+  )
+  review_iterations = [
+    int(row["review_iterations"])
+    for row in finished_rows
+    if row["review_iterations"] is not None
+  ]
+  durations = [
+    duration
+    for row in finished_rows
+    for duration in [_duration_seconds(row)]
+    if duration > 0
+  ]
+  acceptance_criteria_counts = [
+    int(row["acceptance_criteria_count"])
+    for row in rows
+    if row["acceptance_criteria_count"] is not None
+  ]
+
+  return {
+    "workflow": "bill-feature-verify",
+    "total_runs": len(rows),
+    "finished_runs": len(finished_rows),
+    "in_progress_runs": len(rows) - len(finished_rows),
+    "completion_status_counts": _count_values(
+      finished_rows,
+      "completion_status",
+      FEATURE_VERIFY_COMPLETION_STATUSES,
+    ),
+    "audit_result_counts": _count_values(
+      finished_rows,
+      "audit_result",
+      AUDIT_RESULTS,
+    ),
+    "rollout_relevant_runs": rollout_relevant_runs,
+    "rollout_relevant_rate": _rate(rollout_relevant_runs, len(rows)),
+    "feature_flag_audit_performed_runs": audit_performed_runs,
+    "feature_flag_audit_performed_rate": _rate(audit_performed_runs, len(finished_rows)),
+    "history_read_runs": history_read_runs,
+    "history_read_rate": _rate(history_read_runs, len(finished_rows)),
+    "history_relevant_runs": history_relevant_runs,
+    "history_relevant_rate": _rate(history_relevant_runs, len(finished_rows)),
+    "history_helpful_runs": history_helpful_runs,
+    "history_helpful_rate": _rate(history_helpful_runs, len(finished_rows)),
+    "history_relevance_counts": _count_values(
+      finished_rows,
+      "history_relevance",
+      HISTORY_SIGNAL_VALUES,
+    ),
+    "history_helpfulness_counts": _count_values(
+      finished_rows,
+      "history_helpfulness",
+      HISTORY_SIGNAL_VALUES,
+    ),
+    "runs_with_gaps_found": runs_with_gaps_found,
+    "average_acceptance_criteria_count": _average(acceptance_criteria_counts),
+    "average_review_iterations": _average(review_iterations),
+    "average_duration_seconds": _average(durations),
+  }
+
+
+def feature_implement_stats_payload(connection: sqlite3.Connection) -> dict[str, object]:
+  rows = connection.execute(
+    """
+    SELECT *
+    FROM feature_implement_sessions
+    ORDER BY started_at, session_id
+    """
+  ).fetchall()
+  finished_rows = [row for row in rows if row["finished_at"]]
+
+  rollout_needed_runs = sum(1 for row in rows if bool(row["rollout_needed"]))
+  feature_flag_used_runs = sum(1 for row in finished_rows if bool(row["feature_flag_used"]))
+  pr_created_runs = sum(1 for row in finished_rows if bool(row["pr_created"]))
+  boundary_history_written_runs = sum(
+    1 for row in finished_rows if bool(row["boundary_history_written"])
+  )
+
+  acceptance_criteria_counts = [
+    int(row["acceptance_criteria_count"])
+    for row in rows
+    if row["acceptance_criteria_count"] is not None
+  ]
+  spec_word_counts = [
+    int(row["spec_word_count"])
+    for row in rows
+    if row["spec_word_count"] is not None
+  ]
+  review_iterations = [
+    int(row["review_iterations"])
+    for row in finished_rows
+    if row["review_iterations"] is not None
+  ]
+  audit_iterations = [
+    int(row["audit_iterations"])
+    for row in finished_rows
+    if row["audit_iterations"] is not None
+  ]
+  files_created = [
+    int(row["files_created"])
+    for row in finished_rows
+    if row["files_created"] is not None
+  ]
+  files_modified = [
+    int(row["files_modified"])
+    for row in finished_rows
+    if row["files_modified"] is not None
+  ]
+  tasks_completed = [
+    int(row["tasks_completed"])
+    for row in finished_rows
+    if row["tasks_completed"] is not None
+  ]
+  durations = [
+    duration
+    for row in finished_rows
+    for duration in [_duration_seconds(row)]
+    if duration > 0
+  ]
+
+  return {
+    "workflow": "bill-feature-implement",
+    "total_runs": len(rows),
+    "finished_runs": len(finished_rows),
+    "in_progress_runs": len(rows) - len(finished_rows),
+    "feature_size_counts": _count_values(
+      rows,
+      "feature_size",
+      FEATURE_SIZES,
+    ),
+    "completion_status_counts": _count_values(
+      finished_rows,
+      "completion_status",
+      COMPLETION_STATUSES,
+    ),
+    "audit_result_counts": _count_values(
+      finished_rows,
+      "audit_result",
+      AUDIT_RESULTS,
+    ),
+    "validation_result_counts": _count_values(
+      finished_rows,
+      "validation_result",
+      VALIDATION_RESULTS,
+    ),
+    "feature_flag_pattern_counts": _count_values(
+      finished_rows,
+      "feature_flag_pattern",
+      FEATURE_FLAG_PATTERNS,
+    ),
+    "boundary_history_value_counts": _count_values(
+      finished_rows,
+      "boundary_history_value",
+      BOUNDARY_HISTORY_VALUES,
+    ),
+    "rollout_needed_runs": rollout_needed_runs,
+    "rollout_needed_rate": _rate(rollout_needed_runs, len(rows)),
+    "feature_flag_used_runs": feature_flag_used_runs,
+    "feature_flag_used_rate": _rate(feature_flag_used_runs, len(finished_rows)),
+    "pr_created_runs": pr_created_runs,
+    "pr_created_rate": _rate(pr_created_runs, len(finished_rows)),
+    "boundary_history_written_runs": boundary_history_written_runs,
+    "boundary_history_written_rate": _rate(
+      boundary_history_written_runs,
+      len(finished_rows),
+    ),
+    "average_acceptance_criteria_count": _average(acceptance_criteria_counts),
+    "average_spec_word_count": _average(spec_word_counts),
+    "average_review_iterations": _average(review_iterations),
+    "average_audit_iterations": _average(audit_iterations),
+    "average_files_created": _average(files_created),
+    "average_files_modified": _average(files_modified),
+    "average_tasks_completed": _average(tasks_completed),
+    "average_duration_seconds": _average(durations),
+  }
 
 
 def count_rows(

--- a/skill_bill/sync.py
+++ b/skill_bill/sync.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 import json
+import os
 import sqlite3
 import sys
 import urllib.error
 import urllib.request
 
 from skill_bill.config import load_telemetry_settings
-from skill_bill.constants import SyncResult, TelemetrySettings
+from skill_bill.constants import (
+  REMOTE_STATS_WORKFLOWS,
+  SyncResult,
+  TELEMETRY_PROXY_CONTRACT_VERSION,
+  TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY,
+  TelemetrySettings,
+)
 from skill_bill.db import ensure_database
 from skill_bill.stats import (
   fetch_pending_telemetry_events,
@@ -45,6 +53,93 @@ def build_telemetry_batch(settings: TelemetrySettings, rows: list[sqlite3.Row]) 
   return batch
 
 
+def _json_request(
+  url: str,
+  payload: dict[str, object],
+  *,
+  error_context: str,
+  headers: dict[str, str] | None = None,
+) -> dict[str, object]:
+  request_headers = {
+    "Content-Type": "application/json",
+    "User-Agent": "skill-bill-telemetry/1.0",
+  }
+  if headers:
+    request_headers.update(headers)
+  request = urllib.request.Request(
+    url=url,
+    data=json.dumps(payload).encode("utf-8"),
+    headers=request_headers,
+    method="POST",
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=10) as response:
+      status_code = getattr(response, "status", response.getcode())
+      body = response.read().decode("utf-8", errors="replace").strip()
+      if status_code < 200 or status_code >= 300:
+        raise ValueError(f"{error_context} failed with HTTP {status_code}.")
+  except urllib.error.HTTPError as error:
+    response_body = error.read().decode("utf-8", errors="replace").strip()
+    message = f"{error_context} failed with HTTP {error.code}."
+    if response_body:
+      message = f"{message} {response_body}"
+    raise ValueError(message) from error
+  except urllib.error.URLError as error:
+    raise
+
+  if not body:
+    return {}
+  try:
+    decoded = json.loads(body)
+  except json.JSONDecodeError as error:
+    raise ValueError(f"{error_context} returned invalid JSON.") from error
+  if not isinstance(decoded, dict):
+    raise ValueError(f"{error_context} returned a non-object JSON payload.")
+  return decoded
+
+
+def _json_get(
+  url: str,
+  *,
+  error_context: str,
+  headers: dict[str, str] | None = None,
+) -> dict[str, object]:
+  request_headers = {
+    "User-Agent": "skill-bill-telemetry/1.0",
+  }
+  if headers:
+    request_headers.update(headers)
+  request = urllib.request.Request(
+    url=url,
+    headers=request_headers,
+    method="GET",
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=10) as response:
+      status_code = getattr(response, "status", response.getcode())
+      body = response.read().decode("utf-8", errors="replace").strip()
+      if status_code < 200 or status_code >= 300:
+        raise ValueError(f"{error_context} failed with HTTP {status_code}.")
+  except urllib.error.HTTPError as error:
+    response_body = error.read().decode("utf-8", errors="replace").strip()
+    message = f"{error_context} failed with HTTP {error.code}."
+    if response_body:
+      message = f"{message} {response_body}"
+    raise ValueError(message) from error
+  except urllib.error.URLError:
+    raise
+
+  if not body:
+    return {}
+  try:
+    decoded = json.loads(body)
+  except json.JSONDecodeError as error:
+    raise ValueError(f"{error_context} returned invalid JSON.") from error
+  if not isinstance(decoded, dict):
+    raise ValueError(f"{error_context} returned a non-object JSON payload.")
+  return decoded
+
+
 def post_json(url: str, payload: dict[str, object], *, error_context: str) -> None:
   request = urllib.request.Request(
     url=url,
@@ -68,6 +163,54 @@ def post_json(url: str, payload: dict[str, object], *, error_context: str) -> No
     raise ValueError(message) from error
 
 
+def _proxy_auth_headers() -> dict[str, str]:
+  stats_token = os.environ.get(TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY, "").strip()
+  headers: dict[str, str] = {}
+  if stats_token:
+    headers["Authorization"] = f"Bearer {stats_token}"
+  return headers
+
+
+def _default_proxy_capabilities(proxy_url: str, capabilities_url: str) -> dict[str, object]:
+  return {
+    "contract_version": "0",
+    "source": "remote_proxy",
+    "proxy_url": proxy_url,
+    "capabilities_url": capabilities_url,
+    "supports_ingest": True,
+    "supports_stats": False,
+    "supported_workflows": [],
+  }
+
+
+def fetch_proxy_capabilities() -> dict[str, object]:
+  settings = load_telemetry_settings()
+  if not settings.proxy_url:
+    raise ValueError("Telemetry relay URL is not configured.")
+
+  capabilities_url = settings.proxy_url.rstrip("/") + "/capabilities"
+  headers = _proxy_auth_headers()
+  try:
+    payload = _json_get(
+      capabilities_url,
+      error_context="Telemetry proxy capabilities request",
+      headers=headers,
+    )
+  except ValueError as error:
+    if "HTTP 404" in str(error) or "HTTP 405" in str(error):
+      return _default_proxy_capabilities(settings.proxy_url, capabilities_url)
+    raise
+
+  payload.setdefault("contract_version", TELEMETRY_PROXY_CONTRACT_VERSION)
+  payload.setdefault("source", "remote_proxy")
+  payload.setdefault("proxy_url", settings.proxy_url)
+  payload.setdefault("capabilities_url", capabilities_url)
+  payload.setdefault("supports_ingest", True)
+  payload.setdefault("supports_stats", False)
+  payload.setdefault("supported_workflows", [])
+  return payload
+
+
 def send_proxy_batch(settings: TelemetrySettings, rows: list[sqlite3.Row]) -> str | None:
   if not settings.proxy_url:
     raise ValueError("Telemetry relay URL is not configured.")
@@ -79,6 +222,114 @@ def send_proxy_batch(settings: TelemetrySettings, rows: list[sqlite3.Row]) -> st
     error_context=error_context,
   )
   return None
+
+
+def parse_remote_stats_window(
+  *,
+  since: str = "",
+  date_from: str = "",
+  date_to: str = "",
+  today: date | None = None,
+) -> tuple[str, str]:
+  if date_from and since:
+    raise ValueError("Use either since or date_from/date_to, not both.")
+
+  today_value = today or datetime.now(timezone.utc).date()
+  if date_to:
+    try:
+      end_date = date.fromisoformat(date_to)
+    except ValueError as error:
+      raise ValueError("date_to must use YYYY-MM-DD format.") from error
+  else:
+    end_date = today_value
+
+  if date_from:
+    try:
+      start_date = date.fromisoformat(date_from)
+    except ValueError as error:
+      raise ValueError("date_from must use YYYY-MM-DD format.") from error
+  else:
+    normalized = (since or "30d").strip().lower()
+    if not normalized.endswith("d"):
+      raise ValueError("since must use <days>d format, for example 7d or 30d.")
+    try:
+      days = int(normalized[:-1])
+    except ValueError as error:
+      raise ValueError("since must use <days>d format, for example 7d or 30d.") from error
+    if days <= 0:
+      raise ValueError("since must be greater than zero days.")
+    start_date = end_date - timedelta(days=days - 1)
+
+  if start_date > end_date:
+    raise ValueError("date_from must be on or before date_to.")
+  return (start_date.isoformat(), end_date.isoformat())
+
+
+def fetch_remote_stats(
+  *,
+  workflow: str,
+  since: str = "",
+  date_from: str = "",
+  date_to: str = "",
+  group_by: str = "",
+) -> dict[str, object]:
+  if workflow not in REMOTE_STATS_WORKFLOWS:
+    raise ValueError(
+      f"workflow must be one of: {', '.join(REMOTE_STATS_WORKFLOWS)}."
+    )
+  if group_by and group_by not in ("day", "week"):
+    raise ValueError("group_by must be one of: day, week.")
+  settings = load_telemetry_settings()
+  if not settings.proxy_url:
+    raise ValueError("Telemetry relay URL is not configured.")
+
+  resolved_date_from, resolved_date_to = parse_remote_stats_window(
+    since=since,
+    date_from=date_from,
+    date_to=date_to,
+  )
+  capabilities = fetch_proxy_capabilities()
+  supports_stats = bool(capabilities.get("supports_stats"))
+  supported_workflows_raw = capabilities.get("supported_workflows", [])
+  supported_workflows = [
+    str(value)
+    for value in supported_workflows_raw
+    if isinstance(value, str) and value
+  ]
+  if not supports_stats:
+    raise ValueError(
+      "Configured telemetry proxy does not support remote stats yet. "
+      f"Capabilities URL: {capabilities.get('capabilities_url', settings.proxy_url.rstrip('/') + '/capabilities')}"
+    )
+  if supported_workflows and workflow not in supported_workflows:
+    raise ValueError(
+      f"Configured telemetry proxy does not support workflow '{workflow}'. "
+      f"Supported workflows: {', '.join(supported_workflows)}."
+    )
+  stats_url = settings.proxy_url.rstrip("/") + "/stats"
+  headers = _proxy_auth_headers()
+  request_payload: dict[str, object] = {
+    "workflow": workflow,
+    "date_from": resolved_date_from,
+    "date_to": resolved_date_to,
+  }
+  if group_by:
+    request_payload["group_by"] = group_by
+  payload = _json_request(
+    stats_url,
+    request_payload,
+    error_context="Remote telemetry stats request",
+    headers=headers,
+  )
+  payload.setdefault("workflow", workflow)
+  payload.setdefault("date_from", resolved_date_from)
+  payload.setdefault("date_to", resolved_date_to)
+  payload.setdefault("source", "remote_proxy")
+  payload.setdefault("stats_url", stats_url)
+  payload.setdefault("capabilities", capabilities)
+  if group_by:
+    payload.setdefault("group_by", group_by)
+  return payload
 
 
 def sync_telemetry(db_path: Path) -> SyncResult:

--- a/skills/bill-feature-verify/SKILL.md
+++ b/skills/bill-feature-verify/SKILL.md
@@ -191,7 +191,7 @@ For the shared telemetry contract including the `orchestrated` flag semantics, f
 
 **Standalone invocation:**
 1. Call `feature_verify_started` after Step 2 (criteria confirmed) with `acceptance_criteria_count`, `rollout_relevant`, and `spec_summary`. Save the returned `session_id`.
-2. Call `feature_verify_finished` after Step 7 (verdict delivered) with `session_id`, `feature_flag_audit_performed`, `review_iterations`, `audit_result` (`all_pass` / `had_gaps` / `skipped`), `completion_status` (`completed` / `abandoned_at_review` / `abandoned_at_audit` / `error`), and optional `gaps_found` list.
+2. Call `feature_verify_finished` after Step 7 (verdict delivered) with `session_id`, `feature_flag_audit_performed`, `review_iterations`, `audit_result` (`all_pass` / `had_gaps` / `skipped`), `completion_status` (`completed` / `abandoned_at_review` / `abandoned_at_audit` / `error`), `history_relevance` (`none` / `irrelevant` / `low` / `medium` / `high`), `history_helpfulness` (`none` / `irrelevant` / `low` / `medium` / `high`), and optional `gaps_found` list.
 
 **Orchestrated invocation** (when called from another workflow that passes `orchestrated=true`):
 1. Skip `feature_verify_started`.

--- a/tests/test_feature_verify_telemetry.py
+++ b/tests/test_feature_verify_telemetry.py
@@ -29,6 +29,8 @@ FINISHED_PARAMS = {
   "review_iterations": 2,
   "audit_result": "had_gaps",
   "completion_status": "completed",
+  "history_relevance": "high",
+  "history_helpfulness": "medium",
   "gaps_found": ["rollout toggle missing in admin UI"],
 }
 
@@ -105,6 +107,8 @@ class FeatureVerifyEnabledTest(unittest.TestCase):
     payload = json.loads(rows[0]["payload_json"])
     self.assertEqual(payload["completion_status"], "completed")
     self.assertEqual(payload["audit_result"], "had_gaps")
+    self.assertEqual(payload["history_relevance"], "high")
+    self.assertEqual(payload["history_helpfulness"], "medium")
     self.assertNotIn("gaps_found", payload)  # full-only
     self.assertNotIn("spec_summary", payload)
 
@@ -115,6 +119,14 @@ class FeatureVerifyEnabledTest(unittest.TestCase):
     result = feature_verify_finished(session_id=started["session_id"], **params)
     self.assertEqual(result["status"], "error")
     self.assertIn("completion_status", result["error"])
+
+  def test_finished_validates_history_signal_values(self) -> None:
+    started = feature_verify_started(**STARTED_PARAMS)
+    params = dict(FINISHED_PARAMS)
+    params["history_helpfulness"] = "wildly"
+    result = feature_verify_finished(session_id=started["session_id"], **params)
+    self.assertEqual(result["status"], "error")
+    self.assertIn("history_helpfulness", result["error"])
 
   def test_full_level_includes_redacted_fields(self) -> None:
     Path(self.config_path).write_text(
@@ -159,6 +171,8 @@ class FeatureVerifyEnabledTest(unittest.TestCase):
     self.assertEqual(payload["skill"], "bill-feature-verify")
     self.assertEqual(payload["audit_result"], "had_gaps")
     self.assertEqual(payload["duration_seconds"], 300)
+    self.assertEqual(payload["history_relevance"], "high")
+    self.assertEqual(payload["history_helpfulness"], "medium")
     self.assertNotIn("session_id", payload)
     started_rows = self._outbox_rows("skillbill_feature_verify_started")
     finished_rows = self._outbox_rows("skillbill_feature_verify_finished")

--- a/tests/test_mcp_stdio.py
+++ b/tests/test_mcp_stdio.py
@@ -32,6 +32,7 @@ Reason: kotlin signals dominate
 EXPECTED_TOOLS = {
   "doctor",
   "feature_implement_finished",
+  "feature_implement_stats",
   "feature_implement_started",
   "feature_implement_workflow_get",
   "feature_implement_workflow_latest",
@@ -41,6 +42,7 @@ EXPECTED_TOOLS = {
   "feature_implement_workflow_resume",
   "feature_implement_workflow_update",
   "feature_verify_finished",
+  "feature_verify_stats",
   "feature_verify_started",
   "feature_verify_workflow_get",
   "feature_verify_workflow_latest",
@@ -56,6 +58,8 @@ EXPECTED_TOOLS = {
   "quality_check_started",
   "resolve_learnings",
   "review_stats",
+  "telemetry_proxy_capabilities",
+  "telemetry_remote_stats",
   "triage_findings",
 }
 

--- a/tests/test_remote_telemetry_stats.py
+++ b/tests/test_remote_telemetry_stats.py
@@ -1,0 +1,749 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+import urllib.error
+import urllib.request
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from skill_bill.cli import main  # noqa: E402
+from skill_bill.constants import (  # noqa: E402
+  CONFIG_ENVIRONMENT_KEY,
+  TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY,
+  TELEMETRY_PROXY_URL_ENVIRONMENT_KEY,
+)
+from skill_bill.mcp_server import (  # noqa: E402
+  telemetry_proxy_capabilities,
+  telemetry_remote_stats,
+)
+
+
+class RemoteTelemetryStatsTest(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir = tempfile.mkdtemp()
+    self.config_path = os.path.join(self.temp_dir, "config.json")
+    Path(self.config_path).write_text(
+      json.dumps({
+        "install_id": "test-install-id",
+        "telemetry": {"level": "off", "proxy_url": "", "batch_size": 50},
+      }),
+      encoding="utf-8",
+    )
+    self._original_env: dict[str, str | None] = {}
+    env_overrides = {
+      CONFIG_ENVIRONMENT_KEY: self.config_path,
+      TELEMETRY_PROXY_URL_ENVIRONMENT_KEY: "https://telemetry.example.dev/ingest",
+      TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY: "stats-token-123",
+    }
+    for key, value in env_overrides.items():
+      self._original_env[key] = os.environ.get(key)
+      os.environ[key] = value
+
+  def tearDown(self) -> None:
+    for key, value in self._original_env.items():
+      if value is None:
+        os.environ.pop(key, None)
+      else:
+        os.environ[key] = value
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def test_cli_telemetry_stats_verify_posts_proxy_contract(self) -> None:
+    captured_requests: list[dict[str, object]] = []
+
+    class FakeResponse:
+      def __init__(self, payload: dict[str, object]) -> None:
+        self.status = 200
+        self.payload = payload
+
+      def __enter__(self):
+        return self
+
+      def __exit__(self, exc_type, exc, tb):
+        return False
+
+      def getcode(self) -> int:
+        return 200
+
+      def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+    def fake_urlopen(request, timeout=10):
+      body = None
+      if request.data is not None:
+        body = json.loads(request.data.decode("utf-8"))
+      captured_requests.append({
+        "url": request.full_url,
+        "method": request.get_method(),
+        "body": body,
+        "authorization": request.headers.get("Authorization"),
+      })
+      if request.full_url.endswith("/capabilities"):
+        return FakeResponse({
+          "contract_version": "1",
+          "supports_ingest": True,
+          "supports_stats": True,
+          "supported_workflows": [
+            "bill-feature-verify",
+            "bill-feature-implement",
+          ],
+        })
+      return FakeResponse({
+        "status": "ok",
+        "workflow": "bill-feature-verify",
+        "source": "remote_proxy",
+        "started_runs": 14,
+        "finished_runs": 12,
+        "in_progress_runs": 2,
+        "in_progress_rate": 0.143,
+        "completion_rate": 0.75,
+        "history_read_runs": 9,
+        "history_read_rate": 0.75,
+        "history_relevant_runs": 7,
+        "history_relevant_rate": 0.583,
+        "history_helpful_runs": 6,
+        "history_helpful_rate": 0.5,
+        "history_relevance_counts": {
+          "none": 3,
+          "irrelevant": 2,
+          "low": 0,
+          "medium": 4,
+          "high": 3,
+        },
+        "history_helpfulness_counts": {
+          "none": 3,
+          "irrelevant": 1,
+          "low": 2,
+          "medium": 4,
+          "high": 2,
+        },
+      })
+
+    stdout = io.StringIO()
+    with patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+      with contextlib.redirect_stdout(stdout):
+        exit_code = main([
+          "telemetry",
+          "stats",
+          "verify",
+          "--date-from",
+          "2026-04-01",
+          "--date-to",
+          "2026-04-22",
+          "--format",
+          "json",
+        ])
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["workflow"], "bill-feature-verify")
+    self.assertEqual(payload["started_runs"], 14)
+    self.assertEqual(payload["finished_runs"], 12)
+    self.assertEqual(payload["in_progress_runs"], 2)
+    self.assertEqual(payload["in_progress_rate"], 0.143)
+    self.assertEqual(payload["history_relevant_runs"], 7)
+    self.assertEqual(payload["history_helpful_rate"], 0.5)
+    self.assertEqual(payload["source"], "remote_proxy")
+    self.assertEqual(
+      captured_requests,
+      [
+        {
+          "url": "https://telemetry.example.dev/ingest/capabilities",
+          "method": "GET",
+          "body": None,
+          "authorization": "Bearer stats-token-123",
+        },
+        {
+          "url": "https://telemetry.example.dev/ingest/stats",
+          "method": "POST",
+          "body": {
+            "workflow": "bill-feature-verify",
+            "date_from": "2026-04-01",
+            "date_to": "2026-04-22",
+          },
+          "authorization": "Bearer stats-token-123",
+        },
+      ],
+    )
+    self.assertEqual(
+      payload["capabilities"]["supports_stats"],
+      True,
+    )
+
+  def test_cli_telemetry_stats_verify_posts_group_by_when_requested(self) -> None:
+    captured_requests: list[dict[str, object]] = []
+
+    class FakeResponse:
+      def __init__(self, payload: dict[str, object]) -> None:
+        self.status = 200
+        self.payload = payload
+
+      def __enter__(self):
+        return self
+
+      def __exit__(self, exc_type, exc, tb):
+        return False
+
+      def getcode(self) -> int:
+        return 200
+
+      def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+    def fake_urlopen(request, timeout=10):
+      body = None
+      if request.data is not None:
+        body = json.loads(request.data.decode("utf-8"))
+      captured_requests.append({
+        "url": request.full_url,
+        "method": request.get_method(),
+        "body": body,
+      })
+      if request.full_url.endswith("/capabilities"):
+        return FakeResponse({
+          "contract_version": "1",
+          "supports_ingest": True,
+          "supports_stats": True,
+          "supported_workflows": [
+            "bill-feature-verify",
+            "bill-feature-implement",
+          ],
+        })
+      return FakeResponse({
+        "status": "ok",
+        "workflow": "bill-feature-verify",
+        "source": "remote_proxy",
+        "group_by": "day",
+        "series": [
+          {
+            "bucket_start": "2026-04-01",
+            "bucket_end": "2026-04-01",
+            "started_runs": 2,
+            "finished_runs": 1,
+            "in_progress_runs": 1,
+            "in_progress_rate": 0.5,
+            "completion_rate": 0.5,
+            "abandonment_rate": 0,
+          },
+        ],
+      })
+
+    stdout = io.StringIO()
+    with patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+      with contextlib.redirect_stdout(stdout):
+        exit_code = main([
+          "telemetry",
+          "stats",
+          "verify",
+          "--since",
+          "7d",
+          "--group-by",
+          "day",
+          "--format",
+          "json",
+        ])
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["group_by"], "day")
+    self.assertEqual(payload["series"][0]["bucket_start"], "2026-04-01")
+    self.assertEqual(
+      captured_requests[1]["body"],
+      {
+        "workflow": "bill-feature-verify",
+        "date_from": payload["date_from"],
+        "date_to": payload["date_to"],
+        "group_by": "day",
+      },
+    )
+
+  def test_cli_telemetry_stats_rejects_invalid_since_format(self) -> None:
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+      exit_code = main(["telemetry", "stats", "verify", "--since", "month"])
+
+    self.assertEqual(exit_code, 1)
+    self.assertIn("since must use <days>d format", stderr.getvalue())
+
+  def test_mcp_tool_fetches_remote_implement_stats(self) -> None:
+    captured_requests: list[dict[str, object]] = []
+
+    class FakeResponse:
+      def __init__(self, payload: dict[str, object]) -> None:
+        self.status = 200
+        self.payload = payload
+
+      def __enter__(self):
+        return self
+
+      def __exit__(self, exc_type, exc, tb):
+        return False
+
+      def getcode(self) -> int:
+        return 200
+
+      def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+    def fake_urlopen(request, timeout=10):
+      body = None
+      if request.data is not None:
+        body = json.loads(request.data.decode("utf-8"))
+      captured_requests.append({
+        "url": request.full_url,
+        "method": request.get_method(),
+        "body": body,
+      })
+      if request.full_url.endswith("/capabilities"):
+        return FakeResponse({
+          "contract_version": "1",
+          "supports_ingest": True,
+          "supports_stats": True,
+          "supported_workflows": [
+            "bill-feature-verify",
+            "bill-feature-implement",
+          ],
+        })
+      return FakeResponse({
+        "status": "ok",
+        "workflow": "bill-feature-implement",
+        "source": "remote_proxy",
+        "started_runs": 20,
+        "finished_runs": 18,
+        "in_progress_runs": 2,
+        "in_progress_rate": 0.1,
+        "pr_created_rate": 0.61,
+        "boundary_history_written_runs": 12,
+        "boundary_history_written_rate": 0.667,
+        "boundary_history_useful_runs": 12,
+        "boundary_history_useful_rate": 0.667,
+        "boundary_history_value_counts": {
+          "none": 3,
+          "irrelevant": 1,
+          "low": 2,
+          "medium": 7,
+          "high": 5,
+        },
+      })
+
+    with patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+      payload = telemetry_remote_stats(
+        workflow="bill-feature-implement",
+        date_from="2026-04-01",
+        date_to="2026-04-22",
+        since="",
+      )
+
+    self.assertEqual(payload["workflow"], "bill-feature-implement")
+    self.assertEqual(payload["started_runs"], 20)
+    self.assertEqual(payload["in_progress_runs"], 2)
+    self.assertEqual(payload["pr_created_rate"], 0.61)
+    self.assertEqual(payload["boundary_history_written_runs"], 12)
+    self.assertEqual(payload["boundary_history_useful_runs"], 12)
+    self.assertEqual(payload["boundary_history_useful_rate"], 0.667)
+    self.assertEqual(payload["boundary_history_value_counts"]["medium"], 7)
+    self.assertEqual(captured_requests[0]["url"], "https://telemetry.example.dev/ingest/capabilities")
+    self.assertEqual(captured_requests[0]["method"], "GET")
+    self.assertEqual(captured_requests[1]["url"], "https://telemetry.example.dev/ingest/stats")
+    self.assertEqual(captured_requests[1]["method"], "POST")
+    self.assertEqual(
+      captured_requests[1]["body"],
+      {
+        "workflow": "bill-feature-implement",
+        "date_from": "2026-04-01",
+        "date_to": "2026-04-22",
+      },
+    )
+
+  def test_mcp_tool_fetches_grouped_remote_implement_stats(self) -> None:
+    captured_requests: list[dict[str, object]] = []
+
+    class FakeResponse:
+      def __init__(self, payload: dict[str, object]) -> None:
+        self.status = 200
+        self.payload = payload
+
+      def __enter__(self):
+        return self
+
+      def __exit__(self, exc_type, exc, tb):
+        return False
+
+      def getcode(self) -> int:
+        return 200
+
+      def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+    def fake_urlopen(request, timeout=10):
+      body = None
+      if request.data is not None:
+        body = json.loads(request.data.decode("utf-8"))
+      captured_requests.append({
+        "url": request.full_url,
+        "method": request.get_method(),
+        "body": body,
+      })
+      if request.full_url.endswith("/capabilities"):
+        return FakeResponse({
+          "contract_version": "1",
+          "supports_ingest": True,
+          "supports_stats": True,
+          "supported_workflows": [
+            "bill-feature-verify",
+            "bill-feature-implement",
+          ],
+        })
+      return FakeResponse({
+        "status": "ok",
+        "workflow": "bill-feature-implement",
+        "source": "remote_proxy",
+        "group_by": "week",
+        "series": [
+          {
+            "bucket_start": "2026-03-30",
+            "bucket_end": "2026-04-05",
+            "started_runs": 4,
+            "finished_runs": 3,
+            "in_progress_runs": 1,
+            "in_progress_rate": 0.25,
+            "completion_rate": 0.5,
+          },
+        ],
+      })
+
+    with patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+      payload = telemetry_remote_stats(
+        workflow="bill-feature-implement",
+        date_from="2026-04-01",
+        date_to="2026-04-22",
+        since="",
+        group_by="week",
+      )
+
+    self.assertEqual(payload["group_by"], "week")
+    self.assertEqual(payload["series"][0]["bucket_end"], "2026-04-05")
+    self.assertEqual(
+      captured_requests[1]["body"],
+      {
+        "workflow": "bill-feature-implement",
+        "date_from": "2026-04-01",
+        "date_to": "2026-04-22",
+        "group_by": "week",
+      },
+    )
+
+  def test_capabilities_command_and_mcp_tool_use_proxy_contract(self) -> None:
+    class FakeResponse:
+      status = 200
+
+      def __enter__(self):
+        return self
+
+      def __exit__(self, exc_type, exc, tb):
+        return False
+
+      def getcode(self) -> int:
+        return 200
+
+      def read(self) -> bytes:
+        return json.dumps({
+          "contract_version": "1",
+          "supports_ingest": True,
+          "supports_stats": True,
+          "supported_workflows": [
+            "bill-feature-verify",
+            "bill-feature-implement",
+          ],
+        }).encode("utf-8")
+
+    with patch.object(urllib.request, "urlopen", return_value=FakeResponse()):
+      stdout = io.StringIO()
+      with contextlib.redirect_stdout(stdout):
+        exit_code = main(["telemetry", "capabilities", "--format", "json"])
+      self.assertEqual(exit_code, 0)
+      cli_payload = json.loads(stdout.getvalue())
+      mcp_payload = telemetry_proxy_capabilities()
+
+    self.assertEqual(cli_payload["contract_version"], "1")
+    self.assertTrue(cli_payload["supports_stats"])
+    self.assertEqual(
+      cli_payload["supported_workflows"],
+      ["bill-feature-verify", "bill-feature-implement"],
+    )
+    self.assertEqual(mcp_payload["contract_version"], "1")
+    self.assertTrue(mcp_payload["supports_ingest"])
+
+  def test_remote_stats_fails_cleanly_when_proxy_is_ingest_only(self) -> None:
+    class NotFoundError(urllib.error.HTTPError):
+      def __init__(self) -> None:
+        super().__init__(
+          url="https://telemetry.example.dev/ingest/capabilities",
+          code=404,
+          msg="Not Found",
+          hdrs=None,
+          fp=None,
+        )
+
+      def read(self) -> bytes:
+        return b'{"error":"Not found."}'
+
+    def fake_urlopen(request, timeout=10):
+      if request.full_url.endswith("/capabilities"):
+        raise NotFoundError()
+      raise AssertionError("stats should not be called when capabilities say unsupported")
+
+    stderr = io.StringIO()
+    with patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+      with contextlib.redirect_stderr(stderr):
+        exit_code = main(["telemetry", "stats", "verify"])
+
+    self.assertEqual(exit_code, 1)
+    self.assertIn("does not support remote stats yet", stderr.getvalue())
+
+  def test_worker_normalize_verify_stats_uses_started_runs_for_completion_rate(self) -> None:
+    worker_path = ROOT / "docs" / "cloudflare-telemetry-proxy" / "worker.js"
+    temp_dir = tempfile.mkdtemp()
+    temp_worker = Path(temp_dir) / "worker.mjs"
+    shutil.copyfile(worker_path, temp_worker)
+    script = f"""
+import {{ normalizeVerifyStats }} from {json.dumps(temp_worker.as_uri())};
+const payload = normalizeVerifyStats({{
+  started_runs: 10,
+  finished_runs: 6,
+  completion_status_completed: 4,
+  completion_status_abandoned_at_review: 1,
+  completion_status_abandoned_at_audit: 1,
+  completion_status_error: 0,
+  history_read_runs: 5,
+  history_relevance_none: 1,
+  history_relevance_irrelevant: 1,
+  history_relevance_low: 1,
+  history_relevance_medium: 2,
+  history_relevance_high: 1,
+  history_helpfulness_none: 1,
+  history_helpfulness_irrelevant: 1,
+  history_helpfulness_low: 2,
+  history_helpfulness_medium: 1,
+  history_helpfulness_high: 1,
+  audit_result_all_pass: 3,
+  audit_result_had_gaps: 2,
+  audit_result_skipped: 1,
+  rollout_relevant_runs: 7,
+  feature_flag_audit_performed_runs: 5,
+  average_acceptance_criteria_count: 4.25,
+  average_review_iterations: 1.5,
+  average_duration_seconds: 42.0,
+}}, "2026-04-01", "2026-04-22");
+console.log(JSON.stringify(payload));
+"""
+    try:
+      result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        check=True,
+        capture_output=True,
+        text=True,
+      )
+    finally:
+      shutil.rmtree(temp_dir, ignore_errors=True)
+
+    payload = json.loads(result.stdout)
+    self.assertEqual(payload["started_runs"], 10)
+    self.assertEqual(payload["finished_runs"], 6)
+    self.assertEqual(payload["in_progress_runs"], 4)
+    self.assertEqual(payload["in_progress_rate"], 0.4)
+    self.assertEqual(payload["completion_rate"], 0.4)
+    self.assertEqual(payload["abandonment_rate"], 0.2)
+    self.assertEqual(payload["history_read_rate"], 0.833)
+    self.assertEqual(payload["history_relevant_runs"], 3)
+    self.assertEqual(payload["history_helpful_runs"], 2)
+    self.assertEqual(payload["feature_flag_audit_performed_rate"], 0.833)
+
+  def test_worker_normalize_implement_stats_uses_started_runs_for_completion_rate(self) -> None:
+    worker_path = ROOT / "docs" / "cloudflare-telemetry-proxy" / "worker.js"
+    temp_dir = tempfile.mkdtemp()
+    temp_worker = Path(temp_dir) / "worker.mjs"
+    shutil.copyfile(worker_path, temp_worker)
+    script = f"""
+import {{ normalizeImplementStats }} from {json.dumps(temp_worker.as_uri())};
+const payload = normalizeImplementStats({{
+  started_runs: 12,
+  finished_runs: 9,
+  completion_status_completed: 6,
+  completion_status_abandoned_at_planning: 1,
+  completion_status_abandoned_at_implementation: 1,
+  completion_status_abandoned_at_review: 1,
+  completion_status_error: 0,
+  feature_size_small: 4,
+  feature_size_medium: 5,
+  feature_size_large: 3,
+  audit_result_all_pass: 5,
+  audit_result_had_gaps: 3,
+  audit_result_skipped: 1,
+  validation_result_pass: 7,
+  validation_result_fail: 1,
+  validation_result_skipped: 1,
+  rollout_needed_runs: 8,
+  feature_flag_used_runs: 7,
+  pr_created_runs: 5,
+  boundary_history_written_runs: 6,
+  boundary_history_value_none: 1,
+  boundary_history_value_irrelevant: 1,
+  boundary_history_value_low: 1,
+  boundary_history_value_medium: 3,
+  boundary_history_value_high: 3,
+  average_acceptance_criteria_count: 3.0,
+  average_spec_word_count: 1200,
+  average_review_iterations: 1.8,
+  average_audit_iterations: 1.2,
+  average_duration_seconds: 88.5,
+}}, "2026-04-01", "2026-04-22");
+console.log(JSON.stringify(payload));
+"""
+    try:
+      result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        check=True,
+        capture_output=True,
+        text=True,
+      )
+    finally:
+      shutil.rmtree(temp_dir, ignore_errors=True)
+
+    payload = json.loads(result.stdout)
+    self.assertEqual(payload["started_runs"], 12)
+    self.assertEqual(payload["finished_runs"], 9)
+    self.assertEqual(payload["in_progress_runs"], 3)
+    self.assertEqual(payload["in_progress_rate"], 0.25)
+    self.assertEqual(payload["completion_rate"], 0.5)
+    self.assertEqual(payload["feature_flag_used_rate"], 0.778)
+    self.assertEqual(payload["pr_created_rate"], 0.556)
+    self.assertEqual(payload["boundary_history_written_rate"], 0.667)
+    self.assertEqual(payload["boundary_history_useful_runs"], 6)
+    self.assertEqual(payload["boundary_history_useful_rate"], 0.667)
+    self.assertEqual(payload["boundary_history_value_counts"]["medium"], 3)
+
+  def test_worker_builds_weekly_verify_series(self) -> None:
+    worker_path = ROOT / "docs" / "cloudflare-telemetry-proxy" / "worker.js"
+    temp_dir = tempfile.mkdtemp()
+    temp_worker = Path(temp_dir) / "worker.mjs"
+    shutil.copyfile(worker_path, temp_worker)
+    script = f"""
+import {{ buildVerifySeries }} from {json.dumps(temp_worker.as_uri())};
+const payload = buildVerifySeries([
+  {{
+    bucket_date: "2026-04-01",
+    started_runs: 2,
+    finished_runs: 1,
+    rollout_relevant_runs: 2,
+    feature_flag_audit_performed_runs: 1,
+    history_read_runs: 1,
+    history_relevance_none: 0,
+    history_relevance_irrelevant: 0,
+    history_relevance_low: 0,
+    history_relevance_medium: 1,
+    history_relevance_high: 0,
+    history_helpfulness_none: 0,
+    history_helpfulness_irrelevant: 0,
+    history_helpfulness_low: 0,
+    history_helpfulness_medium: 1,
+    history_helpfulness_high: 0,
+    audit_result_all_pass: 0,
+    audit_result_had_gaps: 1,
+    audit_result_skipped: 0,
+    completion_status_completed: 1,
+    completion_status_abandoned_at_review: 0,
+    completion_status_abandoned_at_audit: 0,
+    completion_status_error: 0,
+  }},
+  {{
+    bucket_date: "2026-04-03",
+    started_runs: 1,
+    finished_runs: 1,
+    rollout_relevant_runs: 1,
+    feature_flag_audit_performed_runs: 1,
+    history_read_runs: 1,
+    history_relevance_none: 0,
+    history_relevance_irrelevant: 0,
+    history_relevance_low: 0,
+    history_relevance_medium: 0,
+    history_relevance_high: 1,
+    history_helpfulness_none: 0,
+    history_helpfulness_irrelevant: 0,
+    history_helpfulness_low: 0,
+    history_helpfulness_medium: 0,
+    history_helpfulness_high: 1,
+    audit_result_all_pass: 0,
+    audit_result_had_gaps: 1,
+    audit_result_skipped: 0,
+    completion_status_completed: 1,
+    completion_status_abandoned_at_review: 0,
+    completion_status_abandoned_at_audit: 0,
+    completion_status_error: 0,
+  }},
+  {{
+    bucket_date: "2026-04-08",
+    started_runs: 1,
+    finished_runs: 0,
+    rollout_relevant_runs: 1,
+    feature_flag_audit_performed_runs: 0,
+    history_read_runs: 0,
+    history_relevance_none: 0,
+    history_relevance_irrelevant: 0,
+    history_relevance_low: 0,
+    history_relevance_medium: 0,
+    history_relevance_high: 0,
+    history_helpfulness_none: 0,
+    history_helpfulness_irrelevant: 0,
+    history_helpfulness_low: 0,
+    history_helpfulness_medium: 0,
+    history_helpfulness_high: 0,
+    audit_result_all_pass: 0,
+    audit_result_had_gaps: 0,
+    audit_result_skipped: 0,
+    completion_status_completed: 0,
+    completion_status_abandoned_at_review: 0,
+    completion_status_abandoned_at_audit: 0,
+    completion_status_error: 0,
+  }},
+], "week", "2026-04-01", "2026-04-10");
+console.log(JSON.stringify(payload));
+"""
+    try:
+      result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        check=True,
+        capture_output=True,
+        text=True,
+      )
+    finally:
+      shutil.rmtree(temp_dir, ignore_errors=True)
+
+    payload = json.loads(result.stdout)
+    self.assertEqual(len(payload), 2)
+    self.assertEqual(payload[0]["bucket_start"], "2026-04-01")
+    self.assertEqual(payload[0]["bucket_end"], "2026-04-05")
+    self.assertEqual(payload[0]["started_runs"], 3)
+    self.assertEqual(payload[0]["finished_runs"], 2)
+    self.assertEqual(payload[0]["in_progress_runs"], 1)
+    self.assertEqual(payload[0]["completion_rate"], 0.667)
+    self.assertEqual(payload[0]["history_relevant_runs"], 2)
+    self.assertEqual(payload[0]["history_helpful_runs"], 2)
+    self.assertEqual(payload[1]["bucket_start"], "2026-04-06")
+    self.assertEqual(payload[1]["bucket_end"], "2026-04-10")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_workflow_stats.py
+++ b/tests/test_workflow_stats.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from skill_bill.cli import main  # noqa: E402
+from skill_bill.db import ensure_database  # noqa: E402
+from skill_bill.mcp_server import (  # noqa: E402
+  feature_implement_stats,
+  feature_verify_stats,
+)
+
+
+class WorkflowStatsTest(unittest.TestCase):
+
+  def setUp(self) -> None:
+    self.temp_dir = tempfile.mkdtemp()
+    self.db_path = os.path.join(self.temp_dir, "metrics.db")
+    self.resolved_db_path = str(Path(self.db_path).resolve())
+    self._original_env: dict[str, str | None] = {}
+    env_overrides = {
+      "SKILL_BILL_REVIEW_DB": self.db_path,
+      "SKILL_BILL_CONFIG_PATH": os.path.join(self.temp_dir, "config.json"),
+      "SKILL_BILL_TELEMETRY_ENABLED": "false",
+      "SKILL_BILL_TELEMETRY_PROXY_URL": "http://127.0.0.1:0",
+    }
+    for key, value in env_overrides.items():
+      self._original_env[key] = os.environ.get(key)
+      os.environ[key] = value
+    self.seed_workflow_sessions()
+
+  def tearDown(self) -> None:
+    for key, value in self._original_env.items():
+      if value is None:
+        os.environ.pop(key, None)
+      else:
+        os.environ[key] = value
+    shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+  def seed_workflow_sessions(self) -> None:
+    connection = ensure_database(Path(self.db_path))
+    try:
+      with connection:
+        connection.executemany(
+          """
+          INSERT INTO feature_verify_sessions (
+            session_id,
+            acceptance_criteria_count,
+            rollout_relevant,
+            spec_summary,
+            started_at,
+            feature_flag_audit_performed,
+            review_iterations,
+            audit_result,
+            completion_status,
+            history_relevance,
+            history_helpfulness,
+            gaps_found,
+            finished_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """,
+          [
+            (
+              "fvr-20260422-100000-aa11",
+              4,
+              1,
+              "Verify a telemetry-backed payment retry flow.",
+              "2026-04-22 10:00:00",
+              1,
+              2,
+              "had_gaps",
+              "completed",
+              "high",
+              "medium",
+              json.dumps(["rollout toggle missing"]),
+              "2026-04-22 10:05:00",
+            ),
+            (
+              "fvr-20260422-110000-bb22",
+              6,
+              0,
+              "Verify an abandoned audit flow.",
+              "2026-04-22 11:00:00",
+              0,
+              1,
+              "skipped",
+              "abandoned_at_audit",
+              "irrelevant",
+              "low",
+              json.dumps([]),
+              "2026-04-22 11:10:00",
+            ),
+            (
+              "fvr-20260422-120000-cc33",
+              5,
+              1,
+              "Verify a still-running workflow.",
+              "2026-04-22 12:00:00",
+              None,
+              None,
+              None,
+              None,
+              "none",
+              "none",
+              "",
+              None,
+            ),
+          ],
+        )
+        connection.executemany(
+          """
+          INSERT INTO feature_implement_sessions (
+            session_id,
+            issue_key_provided,
+            issue_key_type,
+            spec_input_types,
+            spec_word_count,
+            feature_size,
+            feature_name,
+            rollout_needed,
+            acceptance_criteria_count,
+            open_questions_count,
+            spec_summary,
+            started_at,
+            completion_status,
+            plan_correction_count,
+            plan_task_count,
+            plan_phase_count,
+            feature_flag_used,
+            feature_flag_pattern,
+            files_created,
+            files_modified,
+            tasks_completed,
+            review_iterations,
+            audit_result,
+            audit_iterations,
+            validation_result,
+            boundary_history_written,
+            boundary_history_value,
+            pr_created,
+            plan_deviation_notes,
+            finished_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """,
+          [
+            (
+              "fis-20260422-100000-aa11",
+              1,
+              "jira",
+              json.dumps(["markdown_file"]),
+              2000,
+              "MEDIUM",
+              "payment-retry",
+              1,
+              5,
+              1,
+              "Retry failed payments with backoff.",
+              "2026-04-22 10:00:00",
+              "completed",
+              0,
+              8,
+              1,
+              1,
+              "legacy",
+              3,
+              5,
+              8,
+              2,
+              "all_pass",
+              1,
+              "pass",
+              1,
+              "medium",
+              1,
+              "Split one task for quality-check follow-up.",
+              "2026-04-22 10:20:00",
+            ),
+            (
+              "fis-20260422-110000-bb22",
+              0,
+              "none",
+              json.dumps(["raw_text"]),
+              400,
+              "SMALL",
+              "copy tweak",
+              0,
+              2,
+              0,
+              "Tweak wording in one screen.",
+              "2026-04-22 11:00:00",
+              "abandoned_at_review",
+              1,
+              2,
+              1,
+              0,
+              "none",
+              0,
+              2,
+              1,
+              1,
+              "skipped",
+              0,
+              "skipped",
+              0,
+              "none",
+              0,
+              "",
+              "2026-04-22 11:05:00",
+            ),
+            (
+              "fis-20260422-120000-cc33",
+              1,
+              "linear",
+              json.dumps(["pdf"]),
+              3000,
+              "LARGE",
+              "billing migration",
+              1,
+              7,
+              2,
+              "Large migration still in progress.",
+              "2026-04-22 12:00:00",
+              "",
+              None,
+              None,
+              None,
+              None,
+              "",
+              None,
+              None,
+              None,
+              None,
+              None,
+              None,
+              None,
+              None,
+              "none",
+              None,
+              "",
+              None,
+            ),
+          ],
+        )
+    finally:
+      connection.close()
+
+  def test_verify_stats_command_reports_aggregate_metrics(self) -> None:
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+      exit_code = main(["verify-stats", "--format", "json"])
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["workflow"], "bill-feature-verify")
+    self.assertEqual(payload["total_runs"], 3)
+    self.assertEqual(payload["finished_runs"], 2)
+    self.assertEqual(payload["in_progress_runs"], 1)
+    self.assertEqual(payload["completion_status_counts"]["completed"], 1)
+    self.assertEqual(payload["completion_status_counts"]["abandoned_at_audit"], 1)
+    self.assertEqual(payload["audit_result_counts"]["had_gaps"], 1)
+    self.assertEqual(payload["audit_result_counts"]["skipped"], 1)
+    self.assertEqual(payload["rollout_relevant_runs"], 2)
+    self.assertEqual(payload["rollout_relevant_rate"], 0.667)
+    self.assertEqual(payload["feature_flag_audit_performed_runs"], 1)
+    self.assertEqual(payload["feature_flag_audit_performed_rate"], 0.5)
+    self.assertEqual(payload["history_read_runs"], 2)
+    self.assertEqual(payload["history_read_rate"], 1.0)
+    self.assertEqual(payload["history_relevant_runs"], 1)
+    self.assertEqual(payload["history_relevant_rate"], 0.5)
+    self.assertEqual(payload["history_helpful_runs"], 1)
+    self.assertEqual(payload["history_helpful_rate"], 0.5)
+    self.assertEqual(payload["history_relevance_counts"]["high"], 1)
+    self.assertEqual(payload["history_relevance_counts"]["irrelevant"], 1)
+    self.assertEqual(payload["history_helpfulness_counts"]["medium"], 1)
+    self.assertEqual(payload["history_helpfulness_counts"]["low"], 1)
+    self.assertEqual(payload["runs_with_gaps_found"], 1)
+    self.assertEqual(payload["average_acceptance_criteria_count"], 5.0)
+    self.assertEqual(payload["average_review_iterations"], 1.5)
+    self.assertEqual(payload["average_duration_seconds"], 450.0)
+    self.assertEqual(payload["db_path"], self.resolved_db_path)
+
+  def test_implement_stats_command_reports_aggregate_metrics(self) -> None:
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+      exit_code = main(["implement-stats", "--format", "json"])
+
+    self.assertEqual(exit_code, 0)
+    payload = json.loads(stdout.getvalue())
+    self.assertEqual(payload["workflow"], "bill-feature-implement")
+    self.assertEqual(payload["total_runs"], 3)
+    self.assertEqual(payload["finished_runs"], 2)
+    self.assertEqual(payload["in_progress_runs"], 1)
+    self.assertEqual(payload["feature_size_counts"]["SMALL"], 1)
+    self.assertEqual(payload["feature_size_counts"]["MEDIUM"], 1)
+    self.assertEqual(payload["feature_size_counts"]["LARGE"], 1)
+    self.assertEqual(payload["completion_status_counts"]["completed"], 1)
+    self.assertEqual(payload["completion_status_counts"]["abandoned_at_review"], 1)
+    self.assertEqual(payload["audit_result_counts"]["all_pass"], 1)
+    self.assertEqual(payload["audit_result_counts"]["skipped"], 1)
+    self.assertEqual(payload["validation_result_counts"]["pass"], 1)
+    self.assertEqual(payload["validation_result_counts"]["skipped"], 1)
+    self.assertEqual(payload["feature_flag_pattern_counts"]["legacy"], 1)
+    self.assertEqual(payload["feature_flag_pattern_counts"]["none"], 1)
+    self.assertEqual(payload["rollout_needed_runs"], 2)
+    self.assertEqual(payload["rollout_needed_rate"], 0.667)
+    self.assertEqual(payload["feature_flag_used_runs"], 1)
+    self.assertEqual(payload["feature_flag_used_rate"], 0.5)
+    self.assertEqual(payload["pr_created_runs"], 1)
+    self.assertEqual(payload["pr_created_rate"], 0.5)
+    self.assertEqual(payload["boundary_history_written_runs"], 1)
+    self.assertEqual(payload["boundary_history_written_rate"], 0.5)
+    self.assertEqual(payload["average_acceptance_criteria_count"], 4.67)
+    self.assertEqual(payload["average_spec_word_count"], 1800.0)
+    self.assertEqual(payload["average_review_iterations"], 1.5)
+    self.assertEqual(payload["average_audit_iterations"], 0.5)
+    self.assertEqual(payload["average_files_created"], 1.5)
+    self.assertEqual(payload["average_files_modified"], 3.5)
+    self.assertEqual(payload["average_tasks_completed"], 4.5)
+    self.assertEqual(payload["average_duration_seconds"], 750.0)
+    self.assertEqual(payload["db_path"], self.resolved_db_path)
+
+  def test_verify_stats_mcp_tool_reports_same_shape(self) -> None:
+    payload = feature_verify_stats()
+    self.assertEqual(payload["workflow"], "bill-feature-verify")
+    self.assertEqual(payload["total_runs"], 3)
+    self.assertEqual(payload["runs_with_gaps_found"], 1)
+    self.assertEqual(payload["db_path"], self.resolved_db_path)
+
+  def test_implement_stats_mcp_tool_reports_same_shape(self) -> None:
+    payload = feature_implement_stats()
+    self.assertEqual(payload["workflow"], "bill-feature-implement")
+    self.assertEqual(payload["total_runs"], 3)
+    self.assertEqual(payload["pr_created_runs"], 1)
+    self.assertEqual(payload["db_path"], self.resolved_db_path)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- add proxy-backed remote workflow stats for feature implement and feature verify, including relay capability checks and grouped day/week series
- extend remote implement stats with boundary history metrics and derived usefulness rates
- add feature-verify history relevance/helpfulness telemetry, local stats, and remote relay aggregation
- document the relay contract and cover the new stats surfaces with focused tests

## Validation
- `.venv/bin/python3 -m unittest tests.test_feature_verify_telemetry tests.test_workflow_stats tests.test_remote_telemetry_stats`
- `.venv/bin/python3 -m unittest tests.test_mcp_server tests.test_cli tests.test_mcp_stdio`
- `python3 -m py_compile skill_bill/constants.py skill_bill/db.py skill_bill/feature_verify.py skill_bill/mcp_server.py skill_bill/stats.py skill_bill/sync.py tests/test_feature_verify_telemetry.py tests/test_workflow_stats.py tests/test_remote_telemetry_stats.py`
- `node --check` on `docs/cloudflare-telemetry-proxy/worker.js`
