### PR TITLE
[codex] Refine docs and quiet operator noise

### DIFF
--- a/.feature-specs/project-assessment-2026-04-22/spec.md
+++ b/.feature-specs/project-assessment-2026-04-22/spec.md
@@ -1,0 +1,101 @@
+# Feature: project-assessment-2026-04-22
+Created: 2026-04-22
+Status: Reference
+Sources: repo assessment requested in chat on 2026-04-22 after reviewing README, roadmap, runtime modules, packs, validators, and test suite
+
+## Purpose
+
+Preserve a grounded assessment of Skill Bill's current state so strategy decisions do not depend on memory or re-deriving the same conclusions later.
+
+## Assessment Summary
+
+Skill Bill has moved beyond "prompt repo" territory. It now looks like an early infrastructure product for governed AI-agent behavior, with a real product thesis, coherent architecture, runtime code, validation, workflow state, cross-agent installation, and maintained reference packs.
+
+The project is worth continued investment. The right next phase is not broader surface area for its own sake. The priority should be reliability, proof of usefulness, and external adoption pressure.
+
+## Strong Points
+
+- The product thesis is clear and differentiated: cross-agent portability plus governance is a stronger and more defensible idea than "better prompts."
+- The architecture is coherent: shell/content split, manifest-driven packs, governed add-ons, workflow contracts, loud-fail validation, and stable entry points fit together.
+- The repository contains real product surface, not only docs: CLI, MCP server, scaffolder, installer, telemetry, workflow state, validators, and maintained platform packs.
+- Validation depth is already serious. At the time of this assessment, `scripts/validate_agent_configs.py` passed and the full unit suite passed with `386` tests and `18` skips.
+- The Kotlin/KMP slice is deep enough to function as a real reference implementation rather than a thin demo.
+
+## Weak Points And Risks
+
+- The main strategic risk is over-building governance and framework machinery before proving repeatable user value with external users.
+- The system is increasingly maintainer-friendly, but not yet clearly team-friendly for first-time adopters or first-time platform authors.
+- Proof of usefulness is still mostly internal. The project needs an external author and a real team using it in normal engineering work.
+- Some product metadata and packaging still undersell the current scope, which can confuse adoption and prioritization.
+- Operator ergonomics still need work in places, including noisy telemetry/network failure output and interactive/test chatter.
+- Reference-platform breadth is intentionally narrow, so current usefulness is concentrated in teams that care about Kotlin/KMP and cross-agent consistency.
+
+## Feasibility
+
+Feasibility is high. The repo already demonstrates that the hardest architectural step has been taken: the project has been turned into a coherent governed system rather than a loose set of prompts.
+
+The remaining challenge is not whether the system can exist. The challenge is whether it can become trusted process infrastructure for real teams.
+
+## Usefulness
+
+Skill Bill is likely most useful for:
+
+- teams using more than one coding agent
+- teams that want stable review, verification, and quality workflows
+- teams that care about process consistency and portable engineering standards
+
+Skill Bill is less compelling for:
+
+- solo users who only need lightweight prompt helpers
+- teams standardized on one first-party vendor with low demand for governance
+
+## Investment Recommendation
+
+Continue investing.
+
+Do not prioritize more platform packs as the main near-term strategy. Prioritize making the existing stable entry points dependable enough that one lighthouse team would want to use them repeatedly.
+
+## Recommended Direction
+
+### 1. Reliability First
+
+Deepen the quality of the current stable entry points:
+
+- `bill-code-review`
+- `bill-quality-check`
+- `bill-feature-implement`
+- `bill-feature-verify`
+- `bill-pr-description`
+
+The goal is to make reported behavior match actual behavior consistently, especially around routing, execution mode, resume semantics, and failure handling.
+
+### 2. External Authoring Test
+
+Treat external pack authoring as a first-class product test. If a non-maintainer cannot add or extend a pack successfully using the scaffolder, validator, and docs, the framework is not complete yet.
+
+### 3. Lighthouse Team Adoption
+
+Use one real team as the main validation target. The project needs evidence from normal engineering usage, not only internal polish.
+
+### 4. Framework vs Examples Separation
+
+Keep sharpening the separation between governance/framework code and reference packs so teams can adopt the system without being forced to adopt the shipped examples unchanged.
+
+### 5. Process Routing After Reliability
+
+The next meaningful strategic expansion is routing by work type, not only by stack. Examples include migrations, auth/session changes, rollout-sensitive work, incident fixes, and behavior-preserving refactors. This should come after the current core flows are dependable.
+
+## Concrete Next Steps
+
+1. Get one real team to use the Kotlin/KMP path for 2-4 weeks and capture where trust breaks, where it saves time, and where output quality is genuinely high-signal.
+2. Run an external-author test in which someone unfamiliar with the internals attempts to create or extend a platform pack using only the scaffolder, validator, and docs.
+3. Reduce operator noise in telemetry and test output so failures are easier to interpret and routine runs feel less rough.
+4. Make guarantees explicit: what is deterministic, what is best-effort, what loud-fails, and what should never silently degrade.
+5. Align packaging and metadata with the real product so installation, repo description, and docs present Skill Bill as governed agent infrastructure rather than a narrow telemetry helper.
+6. Add lightweight measurement around review usefulness, authoring success, repeat usage, and cross-agent parity before expanding platform coverage.
+
+## Bottom Line
+
+Skill Bill is past the "interesting side project" stage. It has enough rigor and coherence to justify continued work.
+
+The main trap to avoid is polishing the framework in isolation. The project should now be pressured by external usage, external authoring, and repeated team workflows so the next round of work is guided by evidence rather than maintainers' intuition alone.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Skill Bill
 
-A governed system for portable AI-agent behavior: stable base commands, shared orchestration, validator-backed contracts, cross-agent installers, scaffolding, and local-first telemetry that keep one source of truth from drifting as the repo grows.
+A governed system for portable AI-agent behavior: stable skill entry points, shared orchestration, validator-backed contracts, cross-agent installers, scaffolding, workflow state, and local-first telemetry that keep one source of truth from drifting as the repo grows.
 
-Skill Bill is a governance product, not a prompt dump. This repo ships the shared orchestration playbooks under `orchestration/`, validators and CLI/MCP runtime under `skill_bill/` and `scripts/`, cross-agent installers, the `bill-create-skill` authoring path, SQLite-backed telemetry, and stable base shells such as `bill-code-review` and `bill-quality-check`. Governed pack skills now use a thin `SKILL.md` wrapper plus sibling `content.md` and `shell-ceremony.md` sidecars. `bill-feature-implement` and `bill-feature-verify` now follow the same split as top-level workflow shells: the workflow contract and telemetry ownership stay in `SKILL.md`, while the detailed execution body lives in sibling `content.md`. For humans, `content.md` is the real working surface where authored skill behavior lives; `SKILL.md` is scaffold-managed wiring that points the runtime at the right authored content and shared ceremony. The shell+content contract is versioned at `orchestration/shell-content-contract/PLAYBOOK.md`, and top-level orchestrators can additionally adopt the workflow contract at `orchestration/workflow-contract/PLAYBOOK.md`.
+Skill Bill is a governance product, not a prompt dump. The product is the framework:
 
-Shipped platform packs live under `platform-packs/`. Routing, validation, and installation are manifest-driven, so any conforming platform pack can live here without changing the shell.
+- stable user-facing commands such as `/bill-code-review` and `/bill-quality-check`
+- manifest-driven platform packs under `platform-packs/`
+- shell/content contracts under `orchestration/`
+- runtime surfaces in the `skill-bill` CLI and `skill-bill-mcp` server
+- validator-backed authoring and scaffolding flows
 
-Rolling out to a team? Start with [Getting Started for Teams](docs/getting-started-for-teams.md) — it covers customization, expectations, and when to trust vs. verify output.
-
-## Why this exists
+## Why it exists
 
 Most prompt or skill repos degrade over time:
 
@@ -20,384 +22,101 @@ Most prompt or skill repos degrade over time:
 Skill Bill treats skills more like software:
 
 - stable base capabilities
-- platform-specific overrides
-- shared routing logic
-- CI-enforced naming and structure
-- one repo synced to every supported agent
+- platform-specific overrides behind routers
+- shared contracts instead of prompt folklore
+- loud-fail validation instead of silent fallback
+- one repo synced across multiple coding agents
 
-## What it looks like
+## Core experience
 
-You interact through a handful of stable base commands. They auto-detect your stack and route to the right specialists.
+Most daily use comes through a small set of stable commands:
 
-**Code review** — one command, stack-aware specialist reviews:
+- `/bill-code-review` routes to the matching platform review stack
+- `/bill-quality-check` routes to the matching stack-specific checker
+- `/bill-feature-implement` orchestrates spec-to-PR work
+- `/bill-feature-verify` verifies a PR against a spec or design doc
+- `/bill-pr-description` generates PR text and QA steps
 
-```
-/bill-code-review
+Skill Bill also ships:
 
-Review session ID: rvs-20260402-221530
-Review run ID: rvw-20260402-221530
-Detected stack: kotlin
-Routed to: bill-kotlin-code-review
-Execution mode: inline
-Applied learnings: none
-Specialist reviews: architecture, platform-correctness, testing
+- authoring and maintenance skills such as `/bill-create-skill`, `/bill-boundary-decisions`, and `/bill-boundary-history`
+- a local CLI for telemetry, learnings, workflow resume, validation, scaffolding, and install primitives
+- an MCP server that exposes the same review, workflow, telemetry, and scaffolding primitives as agent tools
 
-### 2. Risk Register
-- [F-001] Major | High | app/src/main/java/...:42 | Shared state mutation is not protected by synchronization.
-- [F-002] Major | Medium | app/src/main/java/...:88 | ViewModel scope is used from the wrong thread context.
-- [F-003] Minor | High | app/src/test/...:17 | Error-path coverage is missing for the new branch.
-```
-
-**Feature implementation** — end-to-end from design doc to PR:
-
-```
-/bill-feature-implement
-
-1. Collects design doc, creates acceptance criteria
-2. Creates branch, plans implementation tasks
-3. Implements each task atomically
-4. Runs /bill-code-review (auto-routed to your stack)
-5. Completeness audit against acceptance criteria
-6. Runs /bill-quality-check (auto-routed)
-7. Generates PR description
-```
-
-**Quality check** — auto-routed to your stack's toolchain:
-
-```
-/bill-quality-check
-
-Detected stack: kotlin
-Routed to: bill-kotlin-quality-check
-
-Running ./gradlew check...
-Build: PASS
-Tests: 247 passed
-Lint: PASS
-```
-
-## How routing works
-
-A single `feature-implement` run chains 10-12 skill invocations:
-
-```
-/bill-feature-implement
-├── plan + acceptance criteria
-├── implementation (atomic tasks)
-├── /bill-code-review (auto-routed)
-│   └── e.g. bill-kotlin-code-review
-│       ├── execution mode: inline or delegated
-│       ├── architecture (inline pass or subagent)
-│       ├── platform-correctness (inline pass or subagent)
-│       ├── security (inline pass or subagent, if applicable)
-│       ├── testing (inline pass or subagent, if applicable)
-│       └── api-contracts / persistence / reliability (inline pass or subagent, when backend signals are present)
-├── /bill-quality-check (auto-routed)
-│   └── e.g. bill-kotlin-quality-check
-├── completeness audit
-└── /bill-pr-description
-```
-
-Small, low-risk review scopes may stay inline in one thread. Larger or higher-risk scopes use delegated review passes and report the chosen execution mode explicitly.
-
-After stack routing, a platform pack may apply governed add-ons from `platform-packs/<platform>/addons/`. These are pack-owned supporting files, not standalone skills or extra slash commands. Routed platform skills in that same pack may reference them from their sibling `content.md` files to enrich the already-selected skill, and they continue to surface as metadata such as `Selected add-ons: android-compose, android-navigation, android-interop, android-design-system, android-r8` for KMP Android work.
-
-The current `kmp` pilot uses:
-- `android-compose-implementation.md`
-- `android-compose-review.md`
-- `android-compose-edge-to-edge.md`
-- `android-compose-adaptive-layouts.md`
-- `android-navigation-implementation.md`
-- `android-navigation-review.md`
-- `android-interop-implementation.md`
-- `android-interop-review.md`
-- `android-design-system-implementation.md`
-- `android-design-system-review.md`
-- `android-r8-implementation.md`
-- `android-r8-review.md`
-
-Runtime skills scan the add-on index first, then open only the linked topic files whose cues match the current work so Android-specific depth stays available without paying the token cost on every KMP run.
-
-The intent is for these pack-owned add-ons to be the apex Android reference layer inside Skill Bill for transferable Android development guidance: Compose edge-to-edge and adaptive surfaces, Android navigation/state patterns, host-boundary interoperability, design-system/theming work, and Android shrinker/R8 behavior. Android-specific upgrade playbooks such as AGP migrations or Play Billing version bumps stay out of runtime add-ons unless they are intentionally modeled as their own governed assets.
-
-Base entry points stay stable for users:
-
-- `/bill-code-review` routes to the matching `bill-<platform>-code-review` discovered from `platform-packs/`
-- `/bill-quality-check` routes to the matching stack-specific quality checker
-- `/bill-feature-implement` orchestrates the full workflow
-
-## Skills vs workflows
-
-Skill Bill keeps **skills** and **workflows** separate on purpose:
-
-- skills are the reusable user-facing units: routing, rubrics, stack depth, and standalone execution
-- workflows are the small set of top-level orchestrators that need durable step state, explicit artifact handoff, retry/resume rules, and parent-owned telemetry
-
-Current top-level workflow adopters:
-
-- `bill-feature-implement`
-- `bill-feature-verify`
-
-Both still present as stable user-facing skills, but their internal step graphs now have a governed home under `orchestration/workflow-contract/PLAYBOOK.md` instead of living only in skill prose.
-
-The workflow runtime now exposes discovery, resume, and continue surfaces through:
-
-- `skill-bill workflow ...` for `bill-feature-implement`
-- `skill-bill verify-workflow ...` for `bill-feature-verify`
-- `skill-bill implement-stats` and `skill-bill verify-stats` for local workflow telemetry summaries
-- `skill-bill telemetry stats <verify|implement>` for org-wide workflow summaries, optionally with `--group-by day|week` trend series, through the configured telemetry proxy
-- `skill-bill telemetry capabilities` to discover relay read/write support before querying remote stats
-- matching MCP tools for each workflow family
-
-Interrupted runs can be reactivated from persisted state instead of being reconstructed from chat history, and each `continue` surface now returns a step-specific continuation contract for the owning top-level skill.
-
-## Reference platform packs
-
-Skill Bill's governed architecture lives in `platform-packs/<slug>/`. Any platform is allowed as long as it follows the governed pack contract.
-
-| Tier     | Platforms   | What you get                                                                                                                                                                           | Skill count            |
-|----------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
-| **Deep** | Kotlin, KMP | Multi-layer specialist routing (KMP → Kotlin baseline), 12 governed Android add-ons (Compose, navigation, interop, design-system, R8), inline/delegated execution modes, quality-check | 13 skills + 12 add-ons |
-
-The point of the shipped inventory is to demonstrate the governance model with real maintained packs.
-
-**What "Deep" means here:**
-
-- Deep platforms have multi-layer routing, governed add-ons for framework-specific guidance, and specialist areas that compose across packages.
-- Kotlin provides the baseline review and quality-check path.
-- KMP layers Android/KMP-specific review depth and governed Android add-ons on top of the Kotlin baseline.
-
-## Review telemetry
-
-Skill Bill records review acceptance metrics locally in SQLite and can optionally sync anonymized analytics to a hosted relay or custom proxy. The `skill-bill` MCP server exposes review import, triage, learnings, review stats, local workflow stats, and proxy-backed remote workflow stats as native agent tools — no bash commands needed. See [docs/review-telemetry.md](docs/review-telemetry.md) for the full workflow, CLI reference, learnings management, telemetry events, remote-stats contract, and proxy configuration.
-
-## Supported agents
-
-| Agent          | Install path                              |
-|----------------|-------------------------------------------|
-| GitHub Copilot | `~/.copilot/skills/`                      |
-| Claude Code    | `~/.claude/commands/`                     |
-| GLM            | `~/.glm/commands/`                        |
-| OpenAI Codex   | `~/.codex/skills/` or `~/.agents/skills/` |
-| OpenCode       | `~/.config/opencode/skills/`              |
-
-The installer links all selected agents to the same repo so updates stay in sync, and registers the local Skill Bill MCP server for agents with config-based MCP support.
-
-## Installation
+## Quick install
 
 ```bash
 git clone https://github.com/Sermilion/skill-bill.git ~/Development/skill-bill
 cd ~/Development/skill-bill
-chmod +x install.sh
 ./install.sh
 ```
 
-If you want a stable install target instead of tracking `main`, clone a release tag and install from that checkout:
+The installer:
 
-```bash
-TAG=v0.x.y
-git clone --branch "$TAG" --depth 1 https://github.com/Sermilion/skill-bill.git ~/Development/skill-bill
-cd ~/Development/skill-bill
-./install.sh
-```
+- detects supported agents
+- installs selected skills as symlinks back to this repo
+- installs selected platform packs
+- registers the local Skill Bill MCP server for agents that support MCP config
 
-The installer first asks which agent targets to install to. You can choose one or more entries, including `all`:
+Supported install targets today:
 
-```text
-all
-```
+- GitHub Copilot
+- Claude Code
+- GLM
+- OpenAI Codex
+- OpenCode
 
-It then shows the available platform packs discovered under `platform-packs/` and asks which ones to install. Canonical skills in `skills/` are always installed. Governed add-ons under `platform-packs/<platform>/addons/` ship with their owning platform pack and do not appear as separate install targets or slash commands. The primary input path is **comma-separated numbers**, though platform names still work too.
+## Start here
 
-Available options depend on the packs present in your checkout. For example, a checkout with the Kotlin and KMP reference packs shows:
-
-```text
-1. Kotlin
-2. KMP
-3. all
-```
-
-Example platform selections:
-
-```text
-1
-1,2
-2
-3
-```
-
-Each installer run replaces the existing Skill Bill installs and reinstalls only the agent and platform selections from that run.
-
-The installer always removes existing Skill Bill installs before reinstalling the selected agents and platforms. Installed skills are symlinks back to `skills/` in this repo, so edits to skill files are picked up immediately without re-running `./install.sh`.
-
-## Uninstallation
-
-To remove Skill Bill skill installs from the supported agent install paths:
-
-```bash
-chmod +x uninstall.sh
-./uninstall.sh
-```
-
-The uninstaller is idempotent. It removes current Skill Bill installs, generated alias installs, and known legacy install names when they are present, and skips unrelated non-symlink paths.
+- [Getting Started](docs/getting-started.md): primary onboarding guide, install flow, skill surfaces, full `skill-bill` CLI coverage, and full MCP tool coverage
+- [Getting Started for Teams](docs/getting-started-for-teams.md): rollout guidance, customization strategy, trust-vs-verify guidance, and adoption patterns
+- [Review Telemetry](docs/review-telemetry.md): telemetry contract, learnings, local DB usage, and remote proxy stats
+- [Roadmap](docs/ROADMAP.md): product direction, priorities, and strategic framing
 
 ## Reference skill catalog
 
-The skills below ship in this repo as the built-in governance system plus the currently maintained platform packs. Install them via `./install.sh` or extend them via `/bill-create-skill`.
-
-### Code Review (1 skills)
+### Canonical Skills (13 skills)
 
 | Skill | Purpose |
 |-------|---------|
-| `/bill-code-review` | Shell-owned code-review router; routes to the matching platform pack based on manifest-declared signals |
+| `/bill-boundary-decisions` | Record architectural and implementation decisions in `agent/decisions.md` |
+| `/bill-boundary-history` | Record reusable feature history in `agent/history.md` |
+| `/bill-code-review` | Stable code-review entry point that routes to the matching platform pack |
+| `/bill-create-skill` | Scaffold and bootstrap governed skills and platform packs |
+| `/bill-feature-guard` | Add feature-flag rollout safety to an implementation |
+| `/bill-feature-guard-cleanup` | Remove feature flags and legacy code after rollout |
+| `/bill-feature-implement` | End-to-end feature workflow from spec through review and validation |
+| `/bill-feature-verify` | Verify a PR against a task spec or design doc |
+| `/bill-grill-plan` | Stress-test a plan or design by walking the decision tree |
+| `/bill-pr-description` | Generate a PR title, description, and QA steps |
+| `/bill-quality-check` | Stable quality-check entry point that routes to the matching checker |
+| `/bill-skill-remove` | Remove an existing skill or platform skill set and clean up installs |
+| `/bill-unit-test-value-check` | Review unit tests for low-value or tautological coverage |
 
-### Platform Packs — Kotlin (9 skills)
+## Architecture snapshot
 
-Reference pack at `platform-packs/kotlin/`. Covers shared Kotlin plus backend/server Kotlin code and acts as the baseline layer for the KMP pack.
+The main governed layers are:
 
-| Skill | Purpose |
-|-------|---------|
-| `/bill-kotlin-code-review` | Kotlin baseline review orchestrator |
-| `/bill-kotlin-code-review-architecture` | Kotlin architecture and boundaries review |
-| `/bill-kotlin-code-review-platform-correctness` | Kotlin lifecycle, coroutine, threading, and logic review |
-| `/bill-kotlin-code-review-performance` | Kotlin performance review |
-| `/bill-kotlin-code-review-security` | Kotlin security review |
-| `/bill-kotlin-code-review-testing` | Kotlin test quality review |
-| `/bill-kotlin-code-review-api-contracts` | Kotlin backend API contract review |
-| `/bill-kotlin-code-review-persistence` | Kotlin backend persistence review |
-| `/bill-kotlin-code-review-reliability` | Kotlin backend reliability review |
+- `skills/`: canonical user-facing skills and pre-shell platform overrides
+- `platform-packs/`: manifest-driven platform review and quality-check depth
+- `orchestration/`: routing, delegation, workflow, telemetry, and shell-content contracts
+- `skill_bill/`: Python CLI, MCP server, workflow state, telemetry, scaffolding, and install primitives
+- `scripts/`: repo validators and migration helpers
 
-### Platform Packs — KMP (3 skills)
+Governed pack skills use a thin `SKILL.md` wrapper plus sibling `content.md` and `shell-ceremony.md`. Workflow shells such as `bill-feature-implement` and `bill-feature-verify` follow the same split: shell-owned orchestration and telemetry in `SKILL.md`, authored execution guidance in `content.md`.
 
-Reference pack at `platform-packs/kmp/`. Layers Android/KMP-specific reviewers on the Kotlin baseline. Also owns governed Android add-ons.
+## Reference packs
 
-| Skill | Purpose |
-|-------|---------|
-| `/bill-kmp-code-review` | Android/KMP review override |
-| `/bill-kmp-code-review-ui` | KMP UI review |
-| `/bill-kmp-code-review-ux-accessibility` | KMP UX and accessibility review |
+The shipped reference inventory is intentionally narrow and deep:
 
-### Feature Lifecycle (4 skills)
+- `kotlin`: baseline Kotlin review and quality-check behavior
+- `kmp`: Kotlin baseline plus Android/KMP depth and governed add-ons
 
-| Skill | Purpose |
-|-------|---------|
-| `/bill-feature-implement` | Spec-to-verified implementation workflow shell - heavy phases run in subagents, with authored execution guidance in sibling `content.md` |
-| `/bill-feature-verify` | Spec-to-PR verification workflow shell - durable workflow state in `SKILL.md`, authored execution guidance in sibling `content.md` |
-| `/bill-feature-guard` | Add feature-flag rollout safety |
-| `/bill-feature-guard-cleanup` | Remove feature flags after rollout |
-
-### Utilities (9 skills)
-
-| Skill | Purpose |
-|-------|---------|
-| `/bill-quality-check` | Shared quality-check router |
-| `/bill-kotlin-quality-check` | Gradle/Kotlin quality-check implementation |
-| `/bill-boundary-history` | Maintain `agent/history.md` at module/package/area boundaries |
-| `/bill-boundary-decisions` | Record architectural/implementation decisions in `agent/decisions.md` |
-| `/bill-unit-test-value-check` | Audit unit tests for real value |
-| `/bill-pr-description` | Generate PR title, description, and QA steps, preferring repo PR templates when present |
-| `/bill-grill-plan` | Stress-test a plan or design by walking every decision branch |
-| `/bill-create-skill` | Scaffold a new skill or platform skill set and sync it to all agents |
-| `/bill-skill-remove` | Remove an existing skill or platform skill set and clean up installs and wiring |
-
-## Project customization
-
-Use `AGENTS.md` for repo-wide guidance.
-
-Use `.agents/skill-overrides.md` for per-skill customization without editing this plugin. The file is intentionally strict:
-
-- first line must be `# Skill Overrides`
-- each section must be `## <existing-skill-name>`
-- each section body must be a bullet list
-- freeform text outside sections is invalid
-
-Precedence:
-
-1. matching `.agents/skill-overrides.md` section
-2. `AGENTS.md`
-3. built-in skill defaults
-
-Example:
-
-```md
-# Skill Overrides
-
-## bill-kotlin-quality-check
-- Treat warnings as blocking work.
-
-## bill-pr-description
-- Keep QA steps concise.
-```
-
-## Architecture
-
-### Core model
-
-The repo is organized around a strict four-layer model:
-
-- `skills/` — canonical, user-facing capabilities such as `bill-code-review` (a governed shell), `bill-quality-check` (also a governed shell), and `bill-feature-implement` / `bill-feature-verify` (top-level workflow shells with sibling `content.md`)
-- `skills/<platform>/` — platform-specific overrides for skills that have not been piloted onto the shell+content contract yet (today: the platform-specific `feature-implement` and `feature-verify` overrides; code-review and quality-check are shelled)
-- `platform-packs/<platform>/` — user-owned platform packs consumed by the `bill-code-review` shell via the shell+content contract. Each pack ships a `platform.yaml` manifest plus per-area reviewer content
-- `orchestration/` — single source of truth for shared routing, review, delegation, telemetry, and shell+content contracts
-
-Think of it as markdown with inheritance:
-
-- canonical skills define the stable contracts
-- platform skills specialize them
-- orchestration files are the canonical shared contracts for routing, review, delegation, and telemetry; skills link to them via sibling symlinks, so changes propagate to every linked skill immediately
-
-### Fast mental model
-
-If you only remember four things, remember these:
-
-1. Users enter through stable skills in `skills/`.
-2. Platform depth lives in `skills/<platform>/`.
-3. Governed add-ons live under `platform-packs/<platform>/addons/` and apply only after stack routing.
-4. Shared logic is documented in `orchestration/`, but runtimes consume it through sibling sidecars such as `stack-routing.md`, `review-orchestrator.md`, `review-delegation.md`, and `telemetry-contract.md`.
-5. Topology changes should start in `scripts/skill_repo_contracts.py`, then flow into skills, tests, and docs.
-
-That last file is the canonical map for:
-
-- which shared playbook snapshots exist
-- which runtime-facing skills require which sidecars
-- which review skills are governed by the shared review/delegation contract
-
-Current shipped platform packs (under `platform-packs/`):
-
-- `kotlin` — reference pack with 9 code-review skills plus `bill-kotlin-quality-check`
-- `kmp` — reference pack with 3 code-review skills and 12 governed Android add-ons; quality-check currently falls back to `kotlin`
-
-Additional stacks can be added as conforming platform packs under `platform-packs/`.
-
-### Naming and enforcement
-
-Naming is intentionally strict:
-
-- canonical skills may use any neutral `bill-<capability>` name
-- platform overrides must use `bill-<platform>-<base-capability>`
-- deeper specialization is only allowed for code review:
-  - `bill-<platform>-code-review-<area>`
-
-Approved `code-review` areas:
-
-- `architecture`
-- `performance`
-- `platform-correctness`
-- `security`
-- `testing`
-- `api-contracts`
-- `persistence`
-- `reliability`
-- `ui`
-- `ux-accessibility`
-
-That means new stacks can extend the system, but they cannot invent random new naming shapes without intentionally updating the validator and docs.
+Routing, validation, and installation are manifest-driven, so the system is designed to accept any conforming pack rather than a hardcoded shortlist.
 
 ## Validation
 
-This repo validates both content quality and taxonomy rules.
-
-Local checks:
+Core validation commands:
 
 ```bash
 .venv/bin/python3 -m unittest discover -s tests
@@ -405,179 +124,6 @@ npx --yes agnix --strict .
 .venv/bin/python3 scripts/validate_agent_configs.py
 ```
 
-## Test runs
-
-For everyday development, use the smallest test slice that proves the change:
-
-- full repo suite: `.venv/bin/python3 -m unittest discover -s tests`
-- focused workflow/runtime coverage: run the specific `tests.test_<area>` modules you touched
-- opt-in subprocess workflow E2E coverage: set `SKILL_BILL_RUN_WORKFLOW_E2E=1`
-
-Example focused run for the verify workflow runtime:
-
-```bash
-.venv/bin/python3 -m unittest \
-  tests.test_feature_verify_workflow_state \
-  tests.test_feature_verify_agent_resume \
-  tests.test_feature_verify_workflow_contract \
-  tests.test_feature_verify_telemetry \
-  tests.test_cli \
-  tests.test_mcp_stdio
-```
-
-Example opt-in workflow E2E run:
-
-```bash
-SKILL_BILL_RUN_WORKFLOW_E2E=1 .venv/bin/python3 -m unittest tests.test_feature_verify_workflow_e2e
-```
-
-CI runs the same checks.
-
-## Versioning and releases
-
-Skill Bill uses tag-driven GitHub Releases.
-
-- stable releases use SemVer tags such as `v0.4.0`
-- prereleases use SemVer prerelease tags such as `v0.5.0-rc.1`
-- pushing a release tag reruns validation and publishes a GitHub Release with generated notes
-
-See `RELEASING.md` for the maintainer checklist and versioning policy.
-
-The validator enforces:
-
-- package location rules
-- naming rules
-- README catalog drift
-- cross-skill references
-- required routing playbook references
-- plugin metadata
-
-## Skill taxonomy
-
-The repo now has three distinct layers, and it helps to read them in that order:
-
-- `content.md` is the authored working surface for a governed skill. This is where maintainers put the actual execution guidance, rubrics, routing cues, add-on selection rules, and specialist-specific judgment.
-- `SKILL.md` is the scaffold-managed entry wrapper. Agents enter through it, but it is intentionally thin: descriptor metadata, a pointer to `content.md`, and pointers to governed sidecars such as `shell-ceremony.md`.
-- sibling supporting files such as `shell-ceremony.md`, `stack-routing.md`, `review-orchestrator.md`, and `telemetry-contract.md` provide shared behavior when that family needs it. These are contract surfaces, not the place for day-to-day authored skill logic.
-
-In practice: if you are changing what a skill tells an agent to do, you almost always want `content.md`. If you are changing shared runtime ceremony, reporting, routing, or telemetry behavior, you are usually in a governed sidecar or orchestration playbook instead.
-
-That now includes `skills/bill-feature-implement/` and `skills/bill-feature-verify/`: keep workflow-state markers, continuation behavior, stable artifact names, and telemetry ownership in `SKILL.md`, but edit the detailed execution flow in sibling `content.md`.
-
-## Authoring a skill
-
-Skill Bill v1.1 splits every governed skill into two sibling files:
-
-- **`content.md`** — the actual authoring surface. Put the skill's real
-  behavior here: execution guidance, rubrics, routing cues,
-  project-specific rules, classification signals, add-on selection
-  rules, and specialist heuristics. When maintainers say "edit the
-  skill", this is usually the file they mean. Open it with
-  `skill-bill edit <skill-name>`; by default it walks each authored H2
-  section in the terminal with replace / append / clear / skip actions.
-  Pass `--section <heading>` to target one section, `--editor` to hand
-  off to `$VISUAL` or `$EDITOR`, or `--body-file` to replace the full
-  body (or one targeted section) from stdin or another path. For scripted
-  or agent-authored writes, use `skill-bill fill <skill-name> --body-file`
-  or `--body`; it writes `content.md`, regenerates the wrapper, and
-  reruns validation without manual file editing.
-- **`SKILL.md`** — generated governance shell. Agents execute through
-  this file, but authors normally should not edit it directly. It carries
-  frontmatter (`name`, `description`), the required governed H2 set, a
-  template-owned `## Execution` pointer to the sibling `content.md`, and
-  the shell-owned ceremony such as overrides precedence
-  (`.agents/skill-overrides.md` > `AGENTS.md` > built-in defaults).
-- **shared sidecars** — files such as `shell-ceremony.md`,
-  `stack-routing.md`, `review-orchestrator.md`, `review-delegation.md`,
-  and `telemetry-contract.md`. These hold governed cross-skill behavior
-  when needed. They are part of the execution contract, but they are not
-  the normal authoring surface for skill-specific logic.
-
-The shell owns output contracts (session/run IDs, severity/confidence
-scales, risk-register format), orchestration (delegation/inline mode,
-scope-determination bullet lists), telemetry and learnings pointers,
-sidecar-file references, and `## Project Overrides` — none of that
-belongs in `content.md`. See
-`orchestration/shell-content-contract/PLAYBOOK.md` for the full taxonomy
-and ceremony blacklist.
-
-Example shape:
-
-```
-platform-packs/kotlin/code-review/bill-kotlin-code-review/
-├── SKILL.md            # generated, contract-enforced shell
-├── content.md          # author-owned skill body
-├── stack-routing.md    # sibling supporting files (sym-linked)
-├── review-orchestrator.md
-├── review-delegation.md
-└── telemetry-contract.md
-```
-
-When the shared wrapper template changes, regenerate scaffold-managed
-wrappers with `skill-bill render` (alias: `skill-bill upgrade`). Use
-`--skill-name <skill>` to target a single skill; omit it to refresh the
-full repo. Wrapper regeneration leaves the authored `content.md` working
-surface alone and reruns `scripts/validate_agent_configs.py`.
-
-Legacy v1.0 skills migrate through the one-shot script
-`.venv/bin/python3 scripts/migrate_to_content_md.py`. The migration is
-idempotent, writes `_migration_backup/<timestamp>/` before the first
-rewrite, rolls back per-skill on validator failure, and never commits.
-This is a maintainer-only bulk workflow; normal skill edits should go
-through `skill-bill edit`.
-
-## Adding skills
-
-Preferred path:
-
-- from inside an AI agent, run `/bill-create-skill`. The skill starts with plain-language intake, gathers only the missing authoring details, previews the inferred scaffold, then subprocess-calls `skill-bill new --payload <tempfile>` to materialize it.
-- outside an agent (scripts, CI, teams piloting a new platform), run `skill-bill new --interactive` for the same plain-language bootstrap flow, or pass a JSON payload file with `skill-bill new --payload ./payload.json`.
-- when you want one command that scaffolds and drops directly into authoring, use `skill-bill create-and-fill --interactive` (or `--payload`). It is only for one content-managed skill at a time; use `skill-bill new` for platform-pack bootstrap flows.
-
-Terminal-first loop for one concrete skill:
-
-1. `skill-bill new --interactive`
-2. `skill-bill show <skill-name>`
-3. `skill-bill edit <skill-name>` or `skill-bill fill <skill-name> --body-file -`
-4. `skill-bill doctor skill <skill-name>`
-5. `skill-bill validate --skill-name <skill-name>`
-6. `skill-bill render --skill-name <skill-name>` when wrapper templates change
-
-`skill-bill new-skill` and `skill-bill upgrade` remain supported as the
-lower-level command names behind `new` and `render`.
-
-Additional authoring helpers:
-
-- `skill-bill show <skill-name>` gives a stable read path for humans and agents: section headings, completion status, drift status, and recommended next commands.
-- `skill-bill explain [<skill-name>]` explains the governed boundary between `content.md`, generated `SKILL.md`, and shared sidecars.
-- `skill-bill doctor skill <skill-name>` runs isolated validation and returns a plain-language diagnosis plus the next commands to run.
-
-For governed skills, the interactive flow can seed an initial `content.md`
-body so the authored behavior is captured at scaffold time instead of being
-backfilled by editing `SKILL.md`. New platform packs are scaffolded as a
-bootstrap set: pack root, baseline `code-review`, and baseline
-`quality-check`. Known platforms such as `java` use built-in routing
-presets; only unknown or custom platforms need manual `routing_signals`.
-`platform-pack` supports `skeleton_mode=full` for approved specialist stubs
-or `starter` for the baseline pair only.
-
-The payload schema, the loud-fail exception catalog, and one worked example per kind live in `orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md`.
-
-The scaffolder is atomic: it creates files, edits manifests with best-effort comment preservation, wires sibling supporting-file symlinks, runs `scripts/validate_agent_configs.py`, and auto-installs into detected agents. Any failure rolls back every staged change and prints the validator's error verbatim.
-
-When the shared wrapper template changes, run `skill-bill render` from the
-repo root. It regenerates scaffold-managed `SKILL.md` wrappers in place,
-then reruns `scripts/validate_agent_configs.py`. Authored `content.md`
-files and the shared `shell-ceremony.md` sidecar stay untouched.
-
-Manual path (discouraged — prefer the scaffolder):
-
-1. create the governed skill directory in the correct taxonomy location
-2. add the scaffold-managed `SKILL.md`, the authored `content.md`, and any required governed sidecars or symlinks
-3. follow the naming rules above
-4. run `./install.sh`
-5. update docs and validation if you intentionally add a new package or naming shape
-
 ## License
 
-MIT — free to use, copy, modify, merge, publish, distribute, sublicense, and sell, provided the license notice is retained.
+[MIT](LICENSE)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,9 +58,11 @@ Skill Bill is succeeding when most of the following are true:
 
 - **Workflow contract pilot (shipped):** Added `orchestration/workflow-contract/PLAYBOOK.md` to define when a top-level command becomes a workflow, what durable state and artifacts it owns, and how child telemetry rolls up into one parent lifecycle. `bill-feature-implement` is the first pilot; leaf skills remain standalone and reusable.
 - **SKILL-14 (shipped):** Piloted the shell + content architectural split on `bill-code-review`. The shell at `skills/bill-code-review/` is now platform-independent and owns routing, telemetry, output structure, and contract enforcement; platform-specific reviewer content lives under `platform-packs/<platform>/` and is discovered through the versioned contract at `orchestration/shell-content-contract/PLAYBOOK.md`.
-- **SKILL-15 (in progress):** New-skill scaffolder + auto-installer. Turns the shell+content contract into a one-shot authoring flow so first-time authors — including forks — succeed without hand-wiring directories, sidecars, and manifests. Treated as a core product feature, not tooling; external authoring is a success metric the project needs to validate.
-- **SKILL-14 follow-up:** Apply the same shell + content split to `bill-quality-check`, `bill-feature-implement`, and `bill-feature-verify` so every stable command benefits from the same governance.
-- **Upcoming — examples extraction:** Separate framework from reference packs even more aggressively. The long-term architectural move is to keep example packs cleanly separable from the governance system so adoption, forking, and adding new maintained packs stay distinct.
+- **SKILL-15 and follow-ons (shipped):** The new-skill scaffolder, auto-installer, and terminal-first authoring loop now exist as real product surface. Governed skill creation, editing, rendering, validation, add-on creation, and install primitives are available through `skill-bill`, with contract-backed tests and rollback behavior.
+- **Shell/content split follow-through (shipped):** The shell + content architecture now covers the stable core surfaces that matter most: `bill-code-review`, `bill-quality-check`, `bill-feature-implement`, and `bill-feature-verify`. The repo is now much closer to one consistent governed model instead of mixed prompt layouts.
+- **Workflow runtime and resume surfaces (shipped):** Durable workflow state, resume, continue, local stats, and matching MCP tools now exist for both `bill-feature-implement` and `bill-feature-verify`, so long-running orchestrators no longer depend only on chat history.
+- **Operator docs split (shipped):** The documentation surface is now split into a shorter `README.md`, a primary `docs/getting-started.md`, and a team-focused `docs/getting-started-for-teams.md`, which is a healthier structure for adoption than a single overloaded README.
+- **Next architectural move:** Separate framework from reference packs even more aggressively so adoption, forking, and adding maintained packs stay distinct from the governance system itself.
 
 ## Current position
 
@@ -71,14 +73,17 @@ Today, Skill Bill is strongest in these areas:
 - stack-aware routing for code review and quality-check flows
 - layered review orchestration with shared and platform-specific contracts
 - validation coverage that prevents many forms of repository drift
+- local operator surfaces: CLI, MCP, workflow state, telemetry, and governed authoring
+- documentation structure that now distinguishes landing-page, getting-started, and team-rollout concerns
 
 Today, Skill Bill is still relatively early in these areas:
 
-- reliability under real-world runtime behavior
-- organization-level rollout and override strategy
-- measurement of review quality and usefulness
+- reliability under real-world runtime behavior across different agents and repos
+- organization-level rollout and override strategy beyond maintainer intuition
+- measurement of review quality, repeat usage, and external usefulness
+- external authoring validation for new packs and governed extensions
 - deeper process routing beyond stack detection
-- broader team adoption patterns, documentation, and change management
+- broader team adoption patterns and lighthouse-team evidence
 
 ## Strategic priorities
 
@@ -160,7 +165,21 @@ Key outcome:
 
 **Teams should be able to operationalize Skill Bill without each team inventing its own model from scratch.**
 
-### 5. Add measurement and feedback loops
+### 5. Validate external authoring and adoption
+
+The framework is only complete if someone other than the maintainer can use it successfully.
+
+The highest-value validation now is:
+
+- can a non-maintainer author or extend a platform pack using the scaffolder, docs, and validator?
+- can a team install the system and keep using it for several weeks?
+- do the current stable entry points hold up under normal engineering usage rather than maintainer demos?
+
+Key outcome:
+
+**Skill Bill should prove itself with external authors and one lighthouse team before it spends much more energy on breadth.**
+
+### 6. Add measurement and feedback loops
 
 A governed framework needs evidence, not only intuition. Because the shipped skills are reference examples rather than the product, measurement should favor framework-level signals over per-skill output quality.
 
@@ -179,7 +198,7 @@ Key outcome:
 
 **The project should learn from real authoring and adoption patterns, not only from its maintainer's instincts.**
 
-### 6. Expand from stack routing to process routing
+### 7. Expand from stack routing to process routing
 
 Right now, Skill Bill is strong at answering:
 
@@ -207,7 +226,7 @@ Key outcome:
 
 **Routing should eventually reflect both technical stack and work type.**
 
-### 7. Build reusable organizational memory
+### 8. Build reusable organizational memory
 
 One of the most promising directions for Skill Bill is encoding engineering judgment once and reusing it everywhere.
 
@@ -291,7 +310,7 @@ Focus:
 
 Examples of work:
 
-- write team adoption docs and examples
+- pressure-test the new getting-started and team-rollout docs with real users
 - define recommended repo-local override strategy
 - document a minimal process integration model for reviews and PRs
 - make install/update flows friendlier for non-maintainers
@@ -339,7 +358,18 @@ Prioritize:
 
 This horizon is about turning the current stable commands into genuinely strong daily tools.
 
-### Horizon 3: Operationalize for teams
+### Horizon 3: Prove external adoption
+
+Prioritize:
+
+- external authoring of at least one new or forked pack
+- one lighthouse team using the core flows in normal work
+- measurement around repeat usage, trust, and usefulness
+- evidence-driven fixes from real rollout friction
+
+This horizon is about validating that the framework works outside the maintainer's own loop.
+
+### Horizon 4: Operationalize for teams
 
 Prioritize:
 
@@ -350,7 +380,7 @@ Prioritize:
 
 This horizon is about moving from "useful to an advanced individual" to "safe and valuable for a team."
 
-### Horizon 4: Expand carefully
+### Horizon 5: Expand carefully
 
 Prioritize:
 

--- a/docs/getting-started-for-teams.md
+++ b/docs/getting-started-for-teams.md
@@ -1,25 +1,40 @@
 # Getting Started for Teams
 
-A practical guide for teams evaluating or rolling out Skill Bill. For install mechanics and the full skill catalog, see the [README](../README.md).
+A practical guide for teams evaluating or rolling out Skill Bill.
+
+Use this document for:
+
+- rollout strategy
+- customization boundaries
+- trust-vs-verify guidance
+- adoption patterns and expectations
+
+Use [Getting Started](getting-started.md) for:
+
+- installation
+- supported agents
+- stable skill surfaces
+- full `skill-bill` CLI coverage
+- full MCP tool coverage
 
 ## Who this is for
 
 Engineers and tech leads deciding whether to adopt Skill Bill on a team. It focuses on **what to expect**, **how to customize**, and **when to trust the output** — the parts that matter once install is done.
 
-## Install in one minute
+## Before you roll it out
 
-Follow the [Installation section of README.md](../README.md#installation). The short version:
+Complete install and operator setup live in [Getting Started](getting-started.md).
 
-1. Clone the repo somewhere stable (e.g. `~/Development/skill-bill`).
-2. Run `./install.sh`.
-3. Select your agents (Claude Code / Copilot / Codex / OpenCode / GLM).
-4. Select the platform packs you want — check the [reference platform packs](../README.md#reference-platform-packs) first so you know what the currently shipped packs include.
+Before involving a team, one person should:
 
-Installed skills are symlinks back to the repo, so `git pull` updates everything without re-running install.
+1. Install Skill Bill locally.
+2. Run the stable commands on recent real work.
+3. Decide which shipped platform packs are relevant.
+4. Decide whether the team will start with defaults, override files, or a forked platform pack.
 
 ## The three commands that matter
 
-99% of daily use comes down to three base commands. They auto-detect your stack and route to the specialist skills.
+Most daily use still comes down to three base commands. They auto-detect your stack and route to specialist skills.
 
 | Command | Use it when | Expected output |
 |---------|-------------|-----------------|
@@ -124,7 +139,7 @@ The scaffolder:
 - applies the built-in Java routing preset automatically, including the governed manifest fields and required H2 sections.
 - wires the sibling supporting files needed by the generated skills.
 - installs the new skills into every detected agent.
-- does not require a manual README platform catalog update.
+- does not require a manual docs catalog update.
 
 If you want a bare-bones Java skill set up front instead of just the starter pack, use:
 
@@ -240,7 +255,7 @@ A suggested sequence:
 
 ## Getting unstuck
 
-- The skill catalog drifted from README? Run `.venv/bin/python3 scripts/validate_agent_configs.py` — it fails loudly on catalog drift.
+- Need to verify repo docs and governed metadata still line up? Run `.venv/bin/python3 scripts/validate_agent_configs.py` — it fails loudly on catalog and contract drift.
 - Review output won't parse into telemetry? See the exact required format in [review-telemetry.md](review-telemetry.md).
 - A skill routed to the wrong stack? Open an issue with the detected signals and scope; stack routing is the most commonly tuned part of the system.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,311 @@
+# Getting Started
+
+A practical guide to installing Skill Bill, understanding the shipped surfaces, and using the full local CLI and MCP server without having to reverse-engineer the repo.
+
+## What Skill Bill ships
+
+Skill Bill has three primary operator surfaces:
+
+- slash-command skills installed into your coding agent
+- the local `skill-bill` CLI
+- the local `skill-bill-mcp` server
+
+Those surfaces sit on top of the same governed system:
+
+- canonical skills in `skills/`
+- manifest-driven platform packs in `platform-packs/`
+- shared contracts in `orchestration/`
+- runtime code in `skill_bill/`
+
+## Install
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/Sermilion/skill-bill.git ~/Development/skill-bill
+cd ~/Development/skill-bill
+```
+
+For a pinned install instead of `main`:
+
+```bash
+TAG=v0.x.y
+git clone --branch "$TAG" --depth 1 https://github.com/Sermilion/skill-bill.git ~/Development/skill-bill
+cd ~/Development/skill-bill
+```
+
+### 2. Run the installer
+
+```bash
+./install.sh
+```
+
+The installer asks for:
+
+- which agents to install into
+- which platform packs to install
+
+Canonical skills in `skills/` are always installed. Platform packs are selected from the manifests discovered under `platform-packs/`.
+
+### 3. Supported agent targets
+
+| Agent | Install path |
+|-------|--------------|
+| GitHub Copilot | `~/.copilot/skills/` |
+| Claude Code | `~/.claude/commands/` |
+| GLM | `~/.glm/commands/` |
+| OpenAI Codex | `~/.codex/skills/` or `~/.agents/skills/` |
+| OpenCode | `~/.config/opencode/skills/` |
+
+Installed skills are symlinks back to this repo, so a `git pull` updates installed behavior without reinstalling.
+
+### 4. Optional local Python entry points
+
+The package exposes:
+
+- `skill-bill`
+- `skill-bill-mcp`
+
+If you want the local Python entry points available directly, install the package in your environment:
+
+```bash
+pip install -e .
+```
+
+## First run
+
+The fastest way to confirm the install is healthy:
+
+```bash
+skill-bill doctor
+skill-bill telemetry status --format json
+```
+
+Then use the stable skill entry points from your agent:
+
+- `/bill-code-review`
+- `/bill-quality-check`
+- `/bill-feature-implement`
+- `/bill-feature-verify`
+
+## Shipped skill surfaces
+
+### Stable base skills
+
+These are the main user-facing entry points:
+
+- `/bill-code-review`
+- `/bill-quality-check`
+- `/bill-feature-implement`
+- `/bill-feature-verify`
+- `/bill-pr-description`
+- `/bill-create-skill`
+- `/bill-grill-plan`
+- `/bill-boundary-decisions`
+- `/bill-boundary-history`
+- `/bill-feature-guard`
+- `/bill-feature-guard-cleanup`
+- `/bill-unit-test-value-check`
+- `/bill-skill-remove`
+
+### Reference platform packs
+
+The shipped reference packs are:
+
+- `kotlin`: Kotlin baseline review and quality-check behavior
+- `kmp`: KMP review depth layered on top of Kotlin, including Android/KMP add-ons
+
+The platform-specific skill implementations live under `platform-packs/<platform>/`.
+
+### Skills vs workflows
+
+Skill Bill keeps these separate on purpose:
+
+- skills are reusable, user-facing units such as routed code review or quality check
+- workflows are top-level orchestrators that need durable step state, artifact handoff, and resume semantics
+
+Current workflow families:
+
+- `bill-feature-implement`
+- `bill-feature-verify`
+
+Those workflows are exposed both as skills and through local CLI/MCP workflow-state surfaces.
+
+## The `skill-bill` CLI
+
+The local CLI is the operator and maintainer surface for telemetry, workflow state, learnings, governed skill authoring, validation, and install primitives.
+
+### Review import and triage
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill import-review` | Import a review output file or stdin into the local SQLite store |
+| `skill-bill record-feedback` | Record explicit feedback for one or more imported findings |
+| `skill-bill triage` | List numbered findings and record triage decisions |
+| `skill-bill stats` | Show aggregate or per-run review acceptance metrics |
+| `skill-bill implement-stats` | Show aggregate `bill-feature-implement` local metrics |
+| `skill-bill verify-stats` | Show aggregate `bill-feature-verify` local metrics |
+
+### Learnings management
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill learnings add` | Create a learning from a rejected review finding |
+| `skill-bill learnings list` | List stored learnings |
+| `skill-bill learnings show` | Show one learning entry |
+| `skill-bill learnings resolve` | Resolve active learnings for a repo or skill context |
+| `skill-bill learnings edit` | Edit a learning entry |
+| `skill-bill learnings disable` | Disable a learning entry |
+| `skill-bill learnings enable` | Re-enable a learning entry |
+| `skill-bill learnings delete` | Delete a learning entry |
+
+### Telemetry
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill telemetry status` | Show local telemetry configuration and pending sync state |
+| `skill-bill telemetry sync` | Flush pending telemetry events to the active proxy target |
+| `skill-bill telemetry capabilities` | Show proxy/relay read-write capabilities |
+| `skill-bill telemetry stats verify` | Fetch remote org-wide `bill-feature-verify` metrics |
+| `skill-bill telemetry stats implement` | Fetch remote org-wide `bill-feature-implement` metrics |
+| `skill-bill telemetry enable` | Enable telemetry at `anonymous` or `full` level |
+| `skill-bill telemetry disable` | Disable telemetry |
+| `skill-bill telemetry set-level` | Set telemetry to `off`, `anonymous`, or `full` |
+
+### Workflow state
+
+`bill-feature-implement` workflow state:
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill workflow list` | List recent persisted implement workflows |
+| `skill-bill workflow show` | Show raw persisted workflow state |
+| `skill-bill workflow resume` | Explain how to resume or recover a workflow |
+| `skill-bill workflow continue` | Reopen a resumable workflow and emit a continuation brief |
+
+`bill-feature-verify` workflow state:
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill verify-workflow list` | List recent persisted verify workflows |
+| `skill-bill verify-workflow show` | Show raw persisted verify workflow state |
+| `skill-bill verify-workflow resume` | Explain how to resume or recover a verify workflow |
+| `skill-bill verify-workflow continue` | Reopen a resumable verify workflow and emit a continuation brief |
+
+### Governed skill authoring and maintenance
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill list` | List content-managed skills and authoring status |
+| `skill-bill show <skill>` | Show one governed skill, its content status, and next commands |
+| `skill-bill explain [skill]` | Explain the governed authoring boundary and workflow |
+| `skill-bill validate` | Run full repo validation or targeted skill validation |
+| `skill-bill upgrade` | Regenerate scaffold-managed wrappers without touching sidecars |
+| `skill-bill render` | Alias for `upgrade` |
+| `skill-bill edit <skill>` | Edit `content.md` and regenerate the wrapper |
+| `skill-bill fill <skill>` | Write authored body text into `content.md` and validate |
+| `skill-bill new-skill` | Scaffold a new skill from JSON payload or interactive prompts |
+| `skill-bill new` | Alias for `new-skill` |
+| `skill-bill create-and-fill` | Scaffold one skill, then immediately author `content.md` |
+| `skill-bill new-addon` | Create a governed add-on file in an existing platform pack |
+
+### Install and health primitives
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill doctor` | Show local install and telemetry health |
+| `skill-bill version` | Show the installed Skill Bill version |
+| `skill-bill install agent-path <agent>` | Print the canonical install path for one agent |
+| `skill-bill install detect-agents` | List detected agents and install paths |
+| `skill-bill install link-skill` | Symlink one skill directory into a target agent path |
+
+## The `skill-bill-mcp` server
+
+The MCP server exposes Skill Bill’s local primitives as agent tools. This is the primary integration path when an agent can call local MCP tools directly.
+
+### Review telemetry and learnings tools
+
+| MCP tool | Purpose |
+|----------|---------|
+| `import_review` | Import code-review output into the local store |
+| `triage_findings` | Record triage decisions for imported findings |
+| `resolve_learnings` | Resolve active learnings for a repo or skill context |
+| `review_stats` | Show aggregate or per-run review metrics |
+| `feature_implement_stats` | Show aggregate local implement metrics |
+| `feature_verify_stats` | Show aggregate local verify metrics |
+| `telemetry_remote_stats` | Fetch remote org-wide workflow metrics |
+| `telemetry_proxy_capabilities` | Show proxy/relay capability support |
+| `doctor` | Show local install and telemetry health |
+
+### `bill-feature-implement` workflow tools
+
+| MCP tool | Purpose |
+|----------|---------|
+| `feature_implement_started` | Emit the started lifecycle event |
+| `feature_implement_workflow_open` | Create a persisted workflow record |
+| `feature_implement_workflow_update` | Update workflow state, steps, and artifacts |
+| `feature_implement_workflow_get` | Get one workflow by id |
+| `feature_implement_workflow_list` | List recent implement workflows |
+| `feature_implement_workflow_latest` | Fetch the most recently updated implement workflow |
+| `feature_implement_workflow_resume` | Build a resume/recovery payload |
+| `feature_implement_workflow_continue` | Reopen a resumable workflow and build a continuation brief |
+| `feature_implement_finished` | Emit the finished lifecycle event |
+
+### Quality-check, verify, and PR-description tools
+
+| MCP tool | Purpose |
+|----------|---------|
+| `quality_check_started` | Emit quality-check started telemetry |
+| `quality_check_finished` | Emit quality-check finished telemetry |
+| `feature_verify_started` | Emit feature-verify started telemetry |
+| `feature_verify_finished` | Emit feature-verify finished telemetry |
+| `feature_verify_workflow_open` | Create a persisted verify workflow record |
+| `feature_verify_workflow_update` | Update verify workflow state |
+| `feature_verify_workflow_get` | Get one verify workflow by id |
+| `feature_verify_workflow_list` | List recent verify workflows |
+| `feature_verify_workflow_latest` | Fetch the most recently updated verify workflow |
+| `feature_verify_workflow_resume` | Build a verify resume/recovery payload |
+| `feature_verify_workflow_continue` | Reopen a resumable verify workflow and build a continuation brief |
+| `pr_description_generated` | Emit PR-description telemetry |
+
+### Scaffolding tool
+
+| MCP tool | Purpose |
+|----------|---------|
+| `new_skill_scaffold` | Scaffold a new governed skill from a validated payload |
+
+## When to use each surface
+
+Use slash-command skills when:
+
+- you want the stable end-user workflow inside your coding agent
+- you want routed platform behavior rather than raw local primitives
+
+Use the CLI when:
+
+- you are operating on local files, telemetry, validation, or workflow state directly
+- you are authoring, editing, scaffolding, or validating governed skills
+- you want text or JSON output outside the agent runtime
+
+Use MCP when:
+
+- your agent can call local tools directly
+- you want agent-accessible workflow state, telemetry, or scaffolding without shelling out
+- you want orchestration code to consume structured tool outputs rather than parsing CLI text
+
+## Customization
+
+Project-local customization flows through:
+
+- `AGENTS.md` for repo-wide guidance
+- `.agents/skill-overrides.md` for skill-specific overrides
+
+For rollout strategy, trust-vs-verify guidance, and team customization patterns, use [Getting Started for Teams](getting-started-for-teams.md).
+
+## Reference docs
+
+- [Getting Started for Teams](getting-started-for-teams.md)
+- [Review Telemetry](review-telemetry.md)
+- [Roadmap](ROADMAP.md)
+- `orchestration/shell-content-contract/PLAYBOOK.md`
+- `orchestration/workflow-contract/PLAYBOOK.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "skill-bill"
 version = "0.1.0"
-description = "Local-first review telemetry CLI for Skill Bill."
+description = "Governed cross-agent skills, workflows, validation, and telemetry for AI-assisted engineering."
 requires-python = ">=3.10"
 dependencies = ["mcp", "pyyaml>=6"]
 

--- a/skill_bill/sync.py
+++ b/skill_bill/sync.py
@@ -481,12 +481,17 @@ def telemetry_status_payload(db_path: Path) -> dict[str, object]:
     connection.close()
 
 
-def auto_sync_telemetry(db_path: Path) -> SyncResult | None:
+def auto_sync_telemetry(
+  db_path: Path,
+  *,
+  report_failures: bool = False,
+) -> SyncResult | None:
   try:
     result = sync_telemetry(db_path)
   except ValueError as error:
-    print(f"Telemetry sync skipped: {error}", file=sys.stderr)
+    if report_failures:
+      print(f"Telemetry sync skipped: {error}", file=sys.stderr)
     return None
-  if result.status == "failed" and result.message:
+  if report_failures and result.status == "failed" and result.message:
     print(f"Telemetry sync failed: {result.message}", file=sys.stderr)
   return result

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -10,6 +10,8 @@ codes.
 
 from __future__ import annotations
 
+import contextlib
+import io
 from pathlib import Path
 import shutil
 import sys
@@ -266,7 +268,9 @@ class MigrationCoverageTest(unittest.TestCase):
       "assert_execution_body_matches",
       side_effect=always_fail,
     ):
-      code = migrate_to_content_md.main(["--yes", "--repo-root", str(self.repo)])
+      stdout = io.StringIO()
+      with contextlib.redirect_stdout(stdout):
+        code = migrate_to_content_md.main(["--yes", "--repo-root", str(self.repo)])
     self.assertNotEqual(code, 0)
     _ = original
 

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -23,6 +23,8 @@ Covered cases (SKILL-15 AC16 + SKILL-19 follow-on):
 from __future__ import annotations
 
 from pathlib import Path
+import contextlib
+import io
 import sys
 import tempfile
 import unittest
@@ -1261,24 +1263,35 @@ class NewSkillCliErrorMappingTest(unittest.TestCase):
       dry_run=False,
       format="json",
     )
-    code = new_skill_command(args)
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+      code = new_skill_command(args)
     self.assertEqual(code, 2)
 
 
 class NewSkillInteractivePromptTest(unittest.TestCase):
+  @contextlib.contextmanager
+  def _quiet_prompt_output(self):
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+      yield
+
   def test_platform_pack_prompt_defaults_new_platform_to_full(self) -> None:
     from skill_bill.cli import _prompt_new_skill_interactively
 
     with tempfile.TemporaryDirectory() as tmpdir:
       repo_root = Path(tmpdir)
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "java",   # platform
-          "",       # specialist mode -> all
-          "",       # display name
-          "",       # description
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "java",   # platform
+            "",       # specialist mode -> all
+            "",       # display name
+            "",       # description
+          ],
+        ),
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
 
@@ -1291,14 +1304,17 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
 
     with tempfile.TemporaryDirectory() as tmpdir:
       repo_root = Path(tmpdir)
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "php",    # platform
-          "",       # specialist mode -> all
-          "",       # display name
-          "",       # description
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "php",    # platform
+            "",       # specialist mode -> all
+            "",       # display name
+            "",       # description
+          ],
+        ),
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
 
@@ -1312,16 +1328,19 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
 
     with tempfile.TemporaryDirectory() as tmpdir:
       repo_root = Path(tmpdir)
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "python",    # platform
-          "",          # specialist mode -> all
-          "Python",    # display name
-          "",          # description
-          "pyproject.toml,setup.py",  # strong signals
-          "",          # tie-breakers
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "python",    # platform
+            "",          # specialist mode -> all
+            "Python",    # display name
+            "",          # description
+            "pyproject.toml,setup.py",  # strong signals
+            "",          # tie-breakers
+          ],
+        ),
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
 
@@ -1338,15 +1357,18 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
 
     with tempfile.TemporaryDirectory() as tmpdir:
       repo_root = Path(tmpdir)
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "php",                  # platform
-          "2",                    # specialist mode -> custom
-          "architecture,security,testing,reliability",
-          "",                     # display name
-          "",                     # description
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "php",                  # platform
+            "2",                    # specialist mode -> custom
+            "architecture,security,testing,reliability",
+            "",                     # display name
+            "",                     # description
+          ],
+        ),
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
 
@@ -1363,14 +1385,17 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
 
     with tempfile.TemporaryDirectory() as tmpdir:
       repo_root = Path(tmpdir)
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "php",    # platform
-          "1",      # specialist mode -> none
-          "",       # display name
-          "",       # description
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "php",    # platform
+            "1",      # specialist mode -> none
+            "",       # display name
+            "",       # description
+          ],
+        ),
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
 
@@ -1389,16 +1414,19 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
         "shell_contract_version: '1.0'\n",
         encoding="utf-8",
       )
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "php",           # platform
-          "1",             # code-review specialist
-          "security",      # area
-          "",              # derived name
-          "Review PHP security risks.",  # description
-          "END",           # optional content body
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "php",           # platform
+            "1",             # code-review specialist
+            "security",      # area
+            "",              # derived name
+            "Review PHP security risks.",  # description
+            "END",           # optional content body
+          ],
+        ),
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
 
@@ -1417,16 +1445,19 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
         "shell_contract_version: '1.0'\n",
         encoding="utf-8",
       )
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "php",            # platform
-          "2",              # platform override
-          "quality-check",  # family
-          "",               # derived name
-          "Run PHP quality checks.",  # description
-          "END",            # optional content body
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "php",            # platform
+            "2",              # platform override
+            "quality-check",  # family
+            "",               # derived name
+            "Run PHP quality checks.",  # description
+            "END",            # optional content body
+          ],
+        ),
       ):
         payload = _prompt_new_skill_interactively(repo_root=repo_root)
 
@@ -1445,16 +1476,19 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
         "contract_version: '1.1'\n",
         encoding="utf-8",
       )
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "kmp",                 # platform
-          "android-compose",     # add-on slug
-          "Compose guidance.",   # description
-          "First body line.",    # body
-          "Second body line.",   # body
-          "END",                 # terminator
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "kmp",                 # platform
+            "android-compose",     # add-on slug
+            "Compose guidance.",   # description
+            "First body line.",    # body
+            "Second body line.",   # body
+            "END",                 # terminator
+          ],
+        ),
       ):
         payload = _prompt_new_addon_interactively(repo_root=repo_root)
 
@@ -1476,16 +1510,19 @@ class NewSkillInteractivePromptTest(unittest.TestCase):
         "contract_version: '1.1'\n",
         encoding="utf-8",
       )
-      with mock.patch(
-        "builtins.input",
-        side_effect=[
-          "kmp",              # platform
-          "android-compose",  # add-on slug
-          "",                 # description
-          "END",              # empty body attempt
-          "Real body line.",  # second body attempt
-          "END",              # terminator
-        ],
+      with (
+        self._quiet_prompt_output(),
+        mock.patch(
+          "builtins.input",
+          side_effect=[
+            "kmp",              # platform
+            "android-compose",  # add-on slug
+            "",                 # description
+            "END",              # empty body attempt
+            "Real body line.",  # second body attempt
+            "END",              # terminator
+          ],
+        ),
       ):
         payload = _prompt_new_addon_interactively(repo_root=repo_root)
 


### PR DESCRIPTION
## Summary

- tighten Skill Bill positioning and split onboarding docs into a shorter README plus a full Getting Started guide
- refresh the roadmap so shipped milestones, current product surface, and near-term priorities match the repo state
- quiet background telemetry/test harness noise and save the latest project assessment in repo spec form

## Validation

- `.venv/bin/python3 scripts/validate_agent_configs.py`
- `.venv/bin/python3 -m unittest discover -s tests`
