### PR TITLE
feat: [SKILL-28] Add runtime persistence ports

### DIFF
--- a/runtime-kotlin/ARCHITECTURE.md
+++ b/runtime-kotlin/ARCHITECTURE.md
@@ -29,6 +29,10 @@ di
 - `skillbill.application`: reusable runtime use cases for CLI, MCP, and future
   entry points.
 - `skillbill.di`: Kotlin-Inject composition roots and providers.
+- `skillbill.ports`: internal port contracts for persistence sessions,
+  repositories, and later filesystem/HTTP/time abstractions.
+- `skillbill.infrastructure`: concrete adapters for port contracts. SQLite
+  adapters own JDBC connection/session behavior.
 - `skillbill.db`: SQLite schema, migrations, connection bootstrap, and current
   JDBC stores.
 - `skillbill.review`: review parsing, triage, review metrics, review telemetry
@@ -59,6 +63,9 @@ These are the stable dependency rules the runtime should converge toward.
    required to wire the graph.
 6. JSON maps and terminal strings are boundary concerns. Internal use cases
    should move toward typed input and output models.
+7. Application use cases must access SQLite through repository and unit-of-work
+   ports. Read use cases call a read session; write use cases call an explicit
+   transaction session.
 
 ## Architecture Guardrails
 
@@ -75,6 +82,10 @@ useful for the next refactors:
   stores
 - learning application use cases return typed results; CLI and MCP map those
   results to JSON-compatible payloads at their adapter boundaries
+- application services use persistence ports rather than opening SQLite
+  databases, importing JDBC, or checking database files directly
+- repository and unit-of-work ports are the required application persistence
+  boundary
 - future `skillbill.domain.*` packages are protected from infrastructure
   imports as soon as they appear
 
@@ -82,9 +93,9 @@ useful for the next refactors:
 
 1. Continue replacing non-learning application-layer `Map<String, Any?>`
    results with typed results.
-2. Introduce repository and unit-of-work ports.
-3. Move pure domain models/rules away from JDBC-shaped runtime objects.
-4. Put telemetry config, HTTP, and filesystem behavior behind explicit ports.
-5. Add versioned database migrations.
-6. Add contract DTOs and golden output fixtures.
-7. Split Gradle modules only after package boundaries are proven.
+2. Move remaining pure domain models/rules away from JDBC-shaped runtime
+   objects.
+3. Put telemetry config, HTTP, and filesystem behavior behind explicit ports.
+4. Add versioned database migrations.
+5. Add contract DTOs and golden output fixtures.
+6. Split Gradle modules only after package boundaries are proven.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-04-24] runtime-repository-unit-of-work
+Areas: skillbill.application, skillbill.ports.persistence, skillbill.infrastructure.sqlite, skillbill.db, architecture tests
+- Added persistence ports for database sessions, unit-of-work access, review repositories, learning repositories, telemetry outbox, and workflow state.
+- Added SQLite adapters that wrap existing JDBC review/learning/store helpers; application services now call `read` or `transaction` on `DatabaseSessionFactory`.
+- Reusable pattern: write use cases should own transaction choice in application services, while SQLite adapters call no-transaction repository helpers inside the active unit of work.
+- Reusable tests: application use cases can be tested with fake repositories via `ApplicationPersistencePortTest`; SQLite transaction behavior is covered in `SQLiteDatabaseSessionFactoryTest`.
+- Known limitation: review/learnings domain objects still contain JDBC-shaped helpers until the next domain-separation phase.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented
+
 ## [2026-04-24] runtime-typed-learning-results
 Areas: skillbill.application, skillbill.learnings, skillbill.cli, skillbill.mcp, architecture tests
 - Added typed learning result models for list, show, resolve, mutations, and delete; `LearningService` no longer returns map payloads for learning use cases.

--- a/runtime-kotlin/src/main/kotlin/skillbill/RuntimeModule.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/RuntimeModule.kt
@@ -16,6 +16,8 @@ object RuntimeModule {
       "skillbill.telemetry",
       "skillbill.review",
       "skillbill.learnings",
+      "skillbill.ports",
+      "skillbill.infrastructure",
       "skillbill.workflow.implement",
       "skillbill.workflow.verify",
       "skillbill.scaffold",

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/LearningService.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/LearningService.kt
@@ -1,54 +1,44 @@
 package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
-import skillbill.RuntimeContext
-import skillbill.db.DatabaseRuntime
 import skillbill.learnings.CreateLearningRequest
 import skillbill.learnings.LearningScope
-import skillbill.learnings.LearningStore
-import skillbill.learnings.LearningsRuntime
 import skillbill.learnings.learningEntry
 import skillbill.learnings.learningEntrySessionJson
+import skillbill.ports.persistence.DatabaseSessionFactory
 
 @Inject
-class LearningService(private val context: RuntimeContext) {
-  fun list(status: String, dbOverride: String?): LearningListResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      val entries = LearningStore.listLearnings(openDb.connection, status).map(::learningEntry)
-      return LearningListResult(openDb.dbPath.toString(), entries)
-    }
+class LearningService(private val database: DatabaseSessionFactory) {
+  fun list(status: String, dbOverride: String?): LearningListResult = database.read(dbOverride) { unitOfWork ->
+    val entries = unitOfWork.learnings.list(status).map(::learningEntry)
+    LearningListResult(unitOfWork.dbPath.toString(), entries)
   }
 
-  fun show(id: Int, dbOverride: String?): LearningRecordResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      val record = LearningStore.getLearning(openDb.connection, id)
-      return LearningRecordResult(openDb.dbPath.toString(), learningEntry(record))
-    }
+  fun show(id: Int, dbOverride: String?): LearningRecordResult = database.read(dbOverride) { unitOfWork ->
+    LearningRecordResult(unitOfWork.dbPath.toString(), learningEntry(unitOfWork.learnings.get(id)))
   }
 
-  fun resolve(repo: String?, skill: String?, reviewSessionId: String?, dbOverride: String?): LearningResolveResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      val (repoScopeKey, skillName, rows) = LearningsRuntime.resolveLearnings(openDb.connection, repo, skill)
-      val entries = rows.map(::learningEntry)
+  fun resolve(repo: String?, skill: String?, reviewSessionId: String?, dbOverride: String?): LearningResolveResult =
+    database.transaction(dbOverride) { unitOfWork ->
+      val resolution = unitOfWork.learnings.resolve(repo, skill)
+      val entries = resolution.records.map(::learningEntry)
       reviewSessionId?.takeIf(String::isNotBlank)?.let {
-        LearningsRuntime.saveSessionLearnings(openDb.connection, it, learningEntrySessionJson(skillName, entries))
+        unitOfWork.learnings.saveSessionLearnings(it, learningEntrySessionJson(resolution.skillName, entries))
       }
-      return LearningResolveResult(
-        dbPath = openDb.dbPath.toString(),
-        repoScopeKey = repoScopeKey,
-        skillName = skillName,
+      LearningResolveResult(
+        dbPath = unitOfWork.dbPath.toString(),
+        repoScopeKey = resolution.repoScopeKey,
+        skillName = resolution.skillName,
         reviewSessionId = reviewSessionId,
         scopePrecedence = LearningScope.precedence,
         learnings = entries,
       )
     }
-  }
 
-  fun add(request: AddLearningInput, dbOverride: String?): LearningRecordResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
+  fun add(request: AddLearningInput, dbOverride: String?): LearningRecordResult =
+    database.transaction(dbOverride) { unitOfWork ->
       val learningId =
-        LearningStore.addLearning(
-          openDb.connection,
+        unitOfWork.learnings.add(
           CreateLearningRequest(
             request.scope,
             request.scopeKey,
@@ -59,18 +49,16 @@ class LearningService(private val context: RuntimeContext) {
             request.fromFinding,
           ),
         )
-      return LearningRecordResult(
-        openDb.dbPath.toString(),
-        learningEntry(LearningStore.getLearning(openDb.connection, learningId)),
+      LearningRecordResult(
+        unitOfWork.dbPath.toString(),
+        learningEntry(unitOfWork.learnings.get(learningId)),
       )
     }
-  }
 
-  fun edit(request: EditLearningInput, dbOverride: String?): LearningRecordResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
+  fun edit(request: EditLearningInput, dbOverride: String?): LearningRecordResult =
+    database.transaction(dbOverride) { unitOfWork ->
       val record =
-        LearningStore.editLearning(
-          openDb.connection,
+        unitOfWork.learnings.edit(
           skillbill.learnings.UpdateLearningRequest(
             request.id,
             request.scope,
@@ -80,22 +68,18 @@ class LearningService(private val context: RuntimeContext) {
             request.reason,
           ),
         )
-      return LearningRecordResult(openDb.dbPath.toString(), learningEntry(record))
+      LearningRecordResult(unitOfWork.dbPath.toString(), learningEntry(record))
     }
-  }
 
-  fun setStatus(id: Int, status: String, dbOverride: String?): LearningRecordResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      val record = LearningStore.setLearningStatus(openDb.connection, id, status)
-      return LearningRecordResult(openDb.dbPath.toString(), learningEntry(record))
+  fun setStatus(id: Int, status: String, dbOverride: String?): LearningRecordResult =
+    database.transaction(dbOverride) { unitOfWork ->
+      val record = unitOfWork.learnings.setStatus(id, status)
+      LearningRecordResult(unitOfWork.dbPath.toString(), learningEntry(record))
     }
-  }
 
-  fun delete(id: Int, dbOverride: String?): LearningDeleteResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      LearningStore.deleteLearning(openDb.connection, id)
-      return LearningDeleteResult(openDb.dbPath.toString(), id)
-    }
+  fun delete(id: Int, dbOverride: String?): LearningDeleteResult = database.transaction(dbOverride) { unitOfWork ->
+    unitOfWork.learnings.delete(id)
+    LearningDeleteResult(unitOfWork.dbPath.toString(), id)
   }
 }
 

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/ReviewService.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/ReviewService.kt
@@ -2,16 +2,18 @@ package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
 import skillbill.RuntimeContext
-import skillbill.db.DatabaseRuntime
+import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.persistence.ReviewRepository
 import skillbill.review.FeedbackRequest
 import skillbill.review.NumberedFinding
 import skillbill.review.ReviewRuntime
-import skillbill.review.ReviewStatsRuntime
 import skillbill.review.TriageRuntime
-import java.sql.Connection
 
 @Inject
-class ReviewService(private val context: RuntimeContext) {
+class ReviewService(
+  private val context: RuntimeContext,
+  private val database: DatabaseSessionFactory,
+) {
   fun previewImport(input: String): Map<String, Any?> {
     val (text) = ReviewRuntime.readInput(input, context.stdinText)
     val review = ReviewRuntime.parseReview(text)
@@ -29,19 +31,18 @@ class ReviewService(private val context: RuntimeContext) {
   fun importReview(input: String, dbOverride: String?, finishZeroFindingTelemetry: Boolean = true): Map<String, Any?> {
     val (text, sourcePath) = ReviewRuntime.readInput(input, context.stdinText)
     val review = ReviewRuntime.parseReview(text)
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      ReviewRuntime.saveImportedReview(openDb.connection, review, sourcePath)
+    return database.transaction(dbOverride) { unitOfWork ->
+      unitOfWork.reviews.saveImportedReview(review, sourcePath)
       if (finishZeroFindingTelemetry && review.findings.isEmpty()) {
         val settings = telemetrySettingsOrNull(context)
-        ReviewStatsRuntime.updateReviewFinishedTelemetryState(
-          openDb.connection,
-          review.reviewRunId,
+        unitOfWork.reviews.updateReviewFinishedTelemetryState(
+          runId = review.reviewRunId,
           enabled = settings?.enabled ?: false,
           level = settings?.level ?: "off",
         )
       }
-      return linkedMapOf(
-        "db_path" to openDb.dbPath.toString(),
+      linkedMapOf(
+        "db_path" to unitOfWork.dbPath.toString(),
         "review_run_id" to review.reviewRunId,
         "review_session_id" to review.reviewSessionId,
         "finding_count" to review.findings.size,
@@ -54,27 +55,20 @@ class ReviewService(private val context: RuntimeContext) {
   }
 
   fun markOrchestrated(runId: String, dbOverride: String?) {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      openDb.connection.prepareStatement(
-        "UPDATE review_runs SET orchestrated_run = 1 WHERE review_run_id = ?",
-      ).use { statement ->
-        statement.setString(1, runId)
-        statement.executeUpdate()
-      }
+    database.transaction(dbOverride) { unitOfWork ->
+      unitOfWork.reviews.markOrchestrated(runId)
     }
   }
 
-  fun reviewFinishedTelemetryPayload(runId: String, dbOverride: String?): Map<String, Any?>? {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
+  fun reviewFinishedTelemetryPayload(runId: String, dbOverride: String?): Map<String, Any?>? =
+    database.transaction(dbOverride) { unitOfWork ->
       val settings = telemetrySettingsOrNull(context)
-      return ReviewStatsRuntime.updateReviewFinishedTelemetryState(
-        openDb.connection,
-        runId,
+      unitOfWork.reviews.updateReviewFinishedTelemetryState(
+        runId = runId,
         enabled = settings?.enabled ?: false,
         level = settings?.level ?: "off",
       )
     }
-  }
 
   fun recordFeedback(
     runId: String,
@@ -82,20 +76,17 @@ class ReviewService(private val context: RuntimeContext) {
     findings: List<String>,
     note: String,
     dbOverride: String?,
-  ): Map<String, Any?> {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      TriageRuntime.recordFeedback(
-        openDb.connection,
-        FeedbackRequest(runId, findings, event, note),
-        feedbackTelemetryOptions(context),
-      )
-      return linkedMapOf(
-        "db_path" to openDb.dbPath.toString(),
-        "review_run_id" to runId,
-        "outcome_type" to event,
-        "recorded_findings" to findings.size,
-      )
-    }
+  ): Map<String, Any?> = database.transaction(dbOverride) { unitOfWork ->
+    unitOfWork.reviews.recordFeedback(
+      FeedbackRequest(runId, findings, event, note),
+      feedbackTelemetryOptions(context),
+    )
+    linkedMapOf(
+      "db_path" to unitOfWork.dbPath.toString(),
+      "review_run_id" to runId,
+      "outcome_type" to event,
+      "recorded_findings" to findings.size,
+    )
   }
 
   fun triage(
@@ -104,26 +95,28 @@ class ReviewService(private val context: RuntimeContext) {
     listOnly: Boolean,
     dbOverride: String?,
     listWhenNoDecisions: Boolean = true,
-  ): TriageResult {
-    DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
-      val numberedFindings = ReviewRuntime.fetchNumberedFindings(openDb.connection, runId)
-      if (listOnly || (decisions.isEmpty() && listWhenNoDecisions)) {
-        val findings = numberedFindings.map(::findingPayload)
-        return TriageResult(
-          payload =
-          linkedMapOf(
-            "db_path" to openDb.dbPath.toString(),
-            "review_run_id" to runId,
-            "findings" to findings,
-          ),
-          findings = findings,
-        )
-      }
-      val applied = applyTriageDecisions(openDb.connection, runId, numberedFindings, decisions)
-      return TriageResult(
+  ): TriageResult = if (listOnly || (decisions.isEmpty() && listWhenNoDecisions)) {
+    database.read(dbOverride) { unitOfWork ->
+      val numberedFindings = unitOfWork.reviews.fetchNumberedFindings(runId)
+      val findings = numberedFindings.map(::findingPayload)
+      TriageResult(
         payload =
         linkedMapOf(
-          "db_path" to openDb.dbPath.toString(),
+          "db_path" to unitOfWork.dbPath.toString(),
+          "review_run_id" to runId,
+          "findings" to findings,
+        ),
+        findings = findings,
+      )
+    }
+  } else {
+    database.transaction(dbOverride) { unitOfWork ->
+      val numberedFindings = unitOfWork.reviews.fetchNumberedFindings(runId)
+      val applied = applyTriageDecisions(unitOfWork.reviews, runId, numberedFindings, decisions)
+      TriageResult(
+        payload =
+        linkedMapOf(
+          "db_path" to unitOfWork.dbPath.toString(),
           "review_run_id" to runId,
           "recorded" to applied.recorded,
         ),
@@ -134,16 +127,16 @@ class ReviewService(private val context: RuntimeContext) {
   }
 
   fun reviewStats(runId: String?, dbOverride: String?): Map<String, Any?> =
-    statsPayload(context, dbOverride) { connection -> ReviewStatsRuntime.statsPayload(connection, runId) }
+    statsPayload(database, dbOverride) { reviewRepository -> reviewRepository.reviewStatsPayload(runId) }
 
   fun featureImplementStats(dbOverride: String?): Map<String, Any?> =
-    statsPayload(context, dbOverride, ReviewStatsRuntime::featureImplementStatsPayload)
+    statsPayload(database, dbOverride, ReviewRepository::featureImplementStatsPayload)
 
   fun featureVerifyStats(dbOverride: String?): Map<String, Any?> =
-    statsPayload(context, dbOverride, ReviewStatsRuntime::featureVerifyStatsPayload)
+    statsPayload(database, dbOverride, ReviewRepository::featureVerifyStatsPayload)
 
   private fun applyTriageDecisions(
-    connection: Connection,
+    reviewRepository: ReviewRepository,
     runId: String,
     numberedFindings: List<NumberedFinding>,
     decisions: List<String>,
@@ -152,8 +145,7 @@ class ReviewService(private val context: RuntimeContext) {
     var telemetryPayload: Map<String, Any?>? = null
     parsedDecisions.forEach { decision ->
       val returnedPayload =
-        TriageRuntime.recordFeedback(
-          connection,
+        reviewRepository.recordFeedback(
           FeedbackRequest(runId, listOf(decision.findingId), decision.outcomeType, decision.note),
           feedbackTelemetryOptions(context),
         )
@@ -177,13 +169,13 @@ class ReviewService(private val context: RuntimeContext) {
 }
 
 private fun statsPayload(
-  context: RuntimeContext,
+  database: DatabaseSessionFactory,
   dbOverride: String?,
-  payloadBuilder: (Connection) -> Map<String, Any?>,
-): Map<String, Any?> = DatabaseRuntime.openDb(dbOverride, context.environment, context.userHome).use { openDb ->
+  payloadBuilder: (ReviewRepository) -> Map<String, Any?>,
+): Map<String, Any?> = database.read(dbOverride) { unitOfWork ->
   linkedMapOf<String, Any?>().apply {
-    putAll(payloadBuilder(openDb.connection))
-    put("db_path", openDb.dbPath.toString())
+    putAll(payloadBuilder(unitOfWork.reviews))
+    put("db_path", unitOfWork.dbPath.toString())
   }
 }
 

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/SystemService.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/SystemService.kt
@@ -3,20 +3,22 @@ package skillbill.application
 import me.tatarka.inject.annotations.Inject
 import skillbill.RuntimeContext
 import skillbill.SkillBillVersion
-import skillbill.db.DatabaseRuntime
-import java.nio.file.Files
+import skillbill.ports.persistence.DatabaseSessionFactory
 
 @Inject
-class SystemService(private val context: RuntimeContext) {
+class SystemService(
+  private val context: RuntimeContext,
+  private val database: DatabaseSessionFactory,
+) {
   fun version(): Map<String, Any?> = linkedMapOf("version" to SkillBillVersion.VALUE)
 
   fun doctor(dbOverride: String?): Map<String, Any?> {
-    val dbPath = DatabaseRuntime.resolveDbPath(dbOverride, context.environment, context.userHome)
+    val dbPath = database.resolveDbPath(dbOverride)
     val settings = telemetrySettingsOrNull(context)
     return linkedMapOf(
       "version" to SkillBillVersion.VALUE,
       "db_path" to dbPath.toString(),
-      "db_exists" to Files.exists(dbPath),
+      "db_exists" to database.databaseExists(dbOverride),
       "telemetry_enabled" to (settings?.enabled ?: false),
       "telemetry_level" to (settings?.level ?: "off"),
     )

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/TelemetryService.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/TelemetryService.kt
@@ -2,7 +2,7 @@ package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
 import skillbill.RuntimeContext
-import skillbill.db.DatabaseRuntime
+import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.telemetry.RemoteStatsRequest
 import skillbill.telemetry.TelemetryConfigMutationRuntime
 import skillbill.telemetry.TelemetryHttpRuntime
@@ -10,16 +10,19 @@ import skillbill.telemetry.TelemetryRemoteStatsRuntime
 import skillbill.telemetry.TelemetrySyncRuntime
 
 @Inject
-class TelemetryService(private val context: RuntimeContext) {
+class TelemetryService(
+  private val context: RuntimeContext,
+  private val database: DatabaseSessionFactory,
+) {
   fun isEnabled(): Boolean = telemetrySettingsOrNull(context)?.enabled ?: false
 
   fun status(dbOverride: String?): Map<String, Any?> {
-    val dbPath = DatabaseRuntime.resolveDbPath(dbOverride, context.environment, context.userHome)
+    val dbPath = database.resolveDbPath(dbOverride)
     return TelemetrySyncRuntime.telemetryStatusPayload(dbPath, loadTelemetrySettings(context))
   }
 
   fun sync(dbOverride: String?): TelemetrySyncPayload {
-    val dbPath = DatabaseRuntime.resolveDbPath(dbOverride, context.environment, context.userHome)
+    val dbPath = database.resolveDbPath(dbOverride)
     val result = TelemetrySyncRuntime.syncTelemetry(dbPath, loadTelemetrySettings(context), context.requester)
     return TelemetrySyncPayload(
       exitCode = if (result.status == "failed") 1 else 0,
@@ -28,7 +31,7 @@ class TelemetryService(private val context: RuntimeContext) {
   }
 
   fun setLevel(level: String, dbOverride: String?): Map<String, Any?> {
-    val dbPath = DatabaseRuntime.resolveDbPath(dbOverride, context.environment, context.userHome)
+    val dbPath = database.resolveDbPath(dbOverride)
     val (settings, clearedEvents) =
       TelemetryConfigMutationRuntime.setTelemetryLevel(
         level = level,

--- a/runtime-kotlin/src/main/kotlin/skillbill/db/TelemetryOutboxStore.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/db/TelemetryOutboxStore.kt
@@ -1,20 +1,15 @@
 package skillbill.db
 
+import skillbill.ports.persistence.TelemetryOutboxRecord
+import skillbill.ports.persistence.TelemetryOutboxRepository
 import java.sql.Connection
 
-data class TelemetryOutboxRow(
-  val id: Long,
-  val eventName: String,
-  val payloadJson: String,
-  val createdAt: String,
-  val syncedAt: String?,
-  val lastError: String,
-)
+typealias TelemetryOutboxRow = TelemetryOutboxRecord
 
 class TelemetryOutboxStore(
   private val connection: Connection,
-) {
-  fun enqueue(eventName: String, payloadJson: String): Long {
+) : TelemetryOutboxRepository {
+  override fun enqueue(eventName: String, payloadJson: String): Long {
     connection.prepareStatement(
       """
       INSERT INTO telemetry_outbox (event_name, payload_json)
@@ -33,7 +28,7 @@ class TelemetryOutboxStore(
     }
   }
 
-  fun listPending(limit: Int? = null): List<TelemetryOutboxRow> {
+  override fun listPending(limit: Int?): List<TelemetryOutboxRecord> {
     val sql =
       buildString {
         appendLine("SELECT id, event_name, payload_json, created_at, synced_at, last_error")
@@ -52,7 +47,7 @@ class TelemetryOutboxStore(
         buildList {
           while (resultSet.next()) {
             add(
-              TelemetryOutboxRow(
+              TelemetryOutboxRecord(
                 id = resultSet.getLong("id"),
                 eventName = resultSet.getString("event_name"),
                 payloadJson = resultSet.getString("payload_json"),
@@ -67,7 +62,7 @@ class TelemetryOutboxStore(
     }
   }
 
-  fun pendingCount(): Int = connection.prepareStatement(
+  override fun pendingCount(): Int = connection.prepareStatement(
     """
       SELECT COUNT(*)
       FROM telemetry_outbox
@@ -80,7 +75,7 @@ class TelemetryOutboxStore(
     }
   }
 
-  fun latestError(): String? = connection.prepareStatement(
+  override fun latestError(): String? = connection.prepareStatement(
     """
       SELECT last_error
       FROM telemetry_outbox
@@ -97,7 +92,7 @@ class TelemetryOutboxStore(
     }
   }
 
-  fun markSynced(id: Long, syncedAt: String) {
+  override fun markSynced(id: Long, syncedAt: String) {
     connection.prepareStatement(
       """
       UPDATE telemetry_outbox
@@ -111,7 +106,7 @@ class TelemetryOutboxStore(
     }
   }
 
-  fun markSynced(eventIds: List<Long>) {
+  override fun markSynced(eventIds: List<Long>) {
     if (eventIds.isEmpty()) {
       return
     }
@@ -130,7 +125,7 @@ class TelemetryOutboxStore(
     }
   }
 
-  fun markFailed(id: Long, lastError: String) {
+  override fun markFailed(id: Long, lastError: String) {
     connection.prepareStatement(
       """
       UPDATE telemetry_outbox
@@ -144,7 +139,7 @@ class TelemetryOutboxStore(
     }
   }
 
-  fun markFailed(eventIds: List<Long>, lastError: String) {
+  override fun markFailed(eventIds: List<Long>, lastError: String) {
     if (eventIds.isEmpty()) {
       return
     }

--- a/runtime-kotlin/src/main/kotlin/skillbill/db/WorkflowStateStore.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/db/WorkflowStateStore.kt
@@ -1,24 +1,14 @@
 package skillbill.db
 
+import skillbill.ports.persistence.WorkflowStateRecord
+import skillbill.ports.persistence.WorkflowStateRepository
 import java.sql.Connection
 
-data class WorkflowStateRow(
-  val workflowId: String,
-  val sessionId: String,
-  val workflowName: String,
-  val contractVersion: String,
-  val workflowStatus: String,
-  val currentStepId: String,
-  val stepsJson: String,
-  val artifactsJson: String,
-  val startedAt: String?,
-  val updatedAt: String?,
-  val finishedAt: String?,
-)
+typealias WorkflowStateRow = WorkflowStateRecord
 
 class WorkflowStateStore(
   private val connection: Connection,
-) {
+) : WorkflowStateRepository {
   private companion object {
     const val WORKFLOW_ID_PARAMETER_INDEX: Int = 1
     const val SESSION_ID_PARAMETER_INDEX: Int = 2
@@ -31,7 +21,7 @@ class WorkflowStateStore(
     const val FINISHED_AT_PARAMETER_INDEX: Int = 9
   }
 
-  fun saveFeatureImplementWorkflow(row: WorkflowStateRow) {
+  override fun saveFeatureImplementWorkflow(row: WorkflowStateRecord) {
     upsert(
       tableName = "feature_implement_workflows",
       row = row,
@@ -39,7 +29,7 @@ class WorkflowStateStore(
     )
   }
 
-  fun saveFeatureVerifyWorkflow(row: WorkflowStateRow) {
+  override fun saveFeatureVerifyWorkflow(row: WorkflowStateRecord) {
     upsert(
       tableName = "feature_verify_workflows",
       row = row,
@@ -47,14 +37,15 @@ class WorkflowStateStore(
     )
   }
 
-  fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRow? = get(
+  override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? = get(
     "feature_implement_workflows",
     workflowId,
   )
 
-  fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRow? = get("feature_verify_workflows", workflowId)
+  override fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord? =
+    get("feature_verify_workflows", workflowId)
 
-  private fun upsert(tableName: String, row: WorkflowStateRow, defaultContractVersion: String) {
+  private fun upsert(tableName: String, row: WorkflowStateRecord, defaultContractVersion: String) {
     connection.prepareStatement(
       """
       INSERT INTO $tableName (
@@ -96,7 +87,7 @@ class WorkflowStateStore(
     }
   }
 
-  private fun get(tableName: String, workflowId: String): WorkflowStateRow? = connection.prepareStatement(
+  private fun get(tableName: String, workflowId: String): WorkflowStateRecord? = connection.prepareStatement(
     """
       SELECT
         workflow_id,
@@ -119,7 +110,7 @@ class WorkflowStateStore(
       if (!resultSet.next()) {
         return null
       }
-      WorkflowStateRow(
+      WorkflowStateRecord(
         workflowId = resultSet.getString("workflow_id"),
         sessionId = resultSet.getString("session_id"),
         workflowName = resultSet.getString("workflow_name"),

--- a/runtime-kotlin/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -7,11 +7,16 @@ import skillbill.application.LearningService
 import skillbill.application.ReviewService
 import skillbill.application.SystemService
 import skillbill.application.TelemetryService
+import skillbill.infrastructure.sqlite.SQLiteDatabaseSessionFactory
+import skillbill.ports.persistence.DatabaseSessionFactory
 
 @Component
 abstract class RuntimeComponent(
   @get:Provides val runtimeContext: RuntimeContext,
 ) {
+  @Provides
+  fun databaseSessionFactory(factory: SQLiteDatabaseSessionFactory): DatabaseSessionFactory = factory
+
   abstract val learningService: LearningService
   abstract val reviewService: ReviewService
   abstract val systemService: SystemService

--- a/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteDatabaseSessionFactory.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteDatabaseSessionFactory.kt
@@ -1,0 +1,56 @@
+package skillbill.infrastructure.sqlite
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.RuntimeContext
+import skillbill.db.DatabaseRuntime
+import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.persistence.UnitOfWork
+import java.nio.file.Files
+import java.sql.Connection
+
+@Inject
+class SQLiteDatabaseSessionFactory(
+  private val context: RuntimeContext,
+) : DatabaseSessionFactory {
+  override fun resolveDbPath(dbOverride: String?) = DatabaseRuntime.resolveDbPath(
+    cliValue = dbOverride ?: context.dbPathOverride,
+    environment = context.environment,
+    userHome = context.userHome,
+  )
+
+  override fun databaseExists(dbOverride: String?): Boolean = Files.exists(resolveDbPath(dbOverride))
+
+  override fun <T> read(dbOverride: String?, block: (UnitOfWork) -> T): T = DatabaseRuntime.openDb(
+    cliValue = dbOverride ?: context.dbPathOverride,
+    environment = context.environment,
+    userHome = context.userHome,
+  ).use { openDb ->
+    block(SQLiteUnitOfWork(openDb.connection, openDb.dbPath))
+  }
+
+  override fun <T> transaction(dbOverride: String?, block: (UnitOfWork) -> T): T = DatabaseRuntime.openDb(
+    cliValue = dbOverride ?: context.dbPathOverride,
+    environment = context.environment,
+    userHome = context.userHome,
+  ).use { openDb ->
+    openDb.connection.inTransaction {
+      block(SQLiteUnitOfWork(openDb.connection, openDb.dbPath))
+    }
+  }
+}
+
+private fun <T> Connection.inTransaction(block: () -> T): T {
+  val previousAutoCommit = autoCommit
+  autoCommit = false
+  try {
+    val outcome = runCatching(block)
+    if (outcome.isSuccess) {
+      commit()
+    } else {
+      rollback()
+    }
+    return outcome.getOrThrow()
+  } finally {
+    autoCommit = previousAutoCommit
+  }
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteRepositories.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteRepositories.kt
@@ -1,0 +1,121 @@
+package skillbill.infrastructure.sqlite
+
+import skillbill.db.TelemetryOutboxStore
+import skillbill.db.WorkflowStateStore
+import skillbill.learnings.CreateLearningRequest
+import skillbill.learnings.LearningStore
+import skillbill.learnings.LearningsRuntime
+import skillbill.learnings.UpdateLearningRequest
+import skillbill.ports.persistence.LearningRepository
+import skillbill.ports.persistence.LearningResolution
+import skillbill.ports.persistence.ReviewRepository
+import skillbill.ports.persistence.TelemetryOutboxRepository
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.review.FeedbackRequest
+import skillbill.review.FeedbackTelemetryOptions
+import skillbill.review.ImportedReview
+import skillbill.review.LearningRecord
+import skillbill.review.NumberedFinding
+import skillbill.review.ReviewRuntime
+import skillbill.review.ReviewStatsRuntime
+import skillbill.review.TriageRuntime
+import skillbill.review.existingReviewSummary
+import skillbill.review.replaceFindings
+import skillbill.review.reviewSummaryChanged
+import skillbill.review.upsertReviewRun
+import java.nio.file.Path
+import java.sql.Connection
+
+class SQLiteUnitOfWork(
+  private val connection: Connection,
+  override val dbPath: Path,
+) : UnitOfWork {
+  override val reviews: ReviewRepository = SQLiteReviewRepository(connection)
+  override val learnings: LearningRepository = SQLiteLearningRepository(connection)
+  override val telemetryOutbox: TelemetryOutboxRepository = TelemetryOutboxStore(connection)
+  override val workflowStates: WorkflowStateRepository = WorkflowStateStore(connection)
+}
+
+class SQLiteReviewRepository(
+  private val connection: Connection,
+) : ReviewRepository {
+  override fun saveImportedReview(review: ImportedReview, sourcePath: String?) {
+    val existingReviewSummary = existingReviewSummary(connection, review.reviewRunId)
+    val existingFindings = ReviewRuntime.fetchImportedFindings(connection, review.reviewRunId)
+    val summarySnapshotChanged = reviewSummaryChanged(existingReviewSummary, review, existingFindings)
+    upsertReviewRun(connection, review, sourcePath)
+    if (summarySnapshotChanged) {
+      ReviewStatsRuntime.clearReviewFinishedTelemetryState(connection, review.reviewRunId)
+    }
+    if (existingFindings != review.findings) {
+      replaceFindings(connection, review)
+    }
+  }
+
+  override fun markOrchestrated(runId: String) {
+    connection.prepareStatement(
+      "UPDATE review_runs SET orchestrated_run = 1 WHERE review_run_id = ?",
+    ).use { statement ->
+      statement.setString(1, runId)
+      statement.executeUpdate()
+    }
+  }
+
+  override fun updateReviewFinishedTelemetryState(runId: String, enabled: Boolean, level: String): Map<String, Any?>? =
+    ReviewStatsRuntime.updateReviewFinishedTelemetryState(
+      connection = connection,
+      reviewRunId = runId,
+      enabled = enabled,
+      level = level,
+    )
+
+  override fun recordFeedback(
+    request: FeedbackRequest,
+    telemetryOptions: FeedbackTelemetryOptions,
+  ): Map<String, Any?>? = TriageRuntime.recordFeedbackWithoutTransaction(connection, request, telemetryOptions)
+
+  override fun fetchNumberedFindings(runId: String): List<NumberedFinding> =
+    ReviewRuntime.fetchNumberedFindings(connection, runId)
+
+  override fun reviewStatsPayload(runId: String?): Map<String, Any?> =
+    ReviewStatsRuntime.statsPayload(connection, runId)
+
+  override fun featureImplementStatsPayload(): Map<String, Any?> =
+    ReviewStatsRuntime.featureImplementStatsPayload(connection)
+
+  override fun featureVerifyStatsPayload(): Map<String, Any?> = ReviewStatsRuntime.featureVerifyStatsPayload(connection)
+}
+
+class SQLiteLearningRepository(
+  private val connection: Connection,
+) : LearningRepository {
+  override fun list(status: String): List<LearningRecord> = LearningStore.listLearnings(connection, status)
+
+  override fun get(id: Int): LearningRecord = LearningStore.getLearning(connection, id)
+
+  override fun resolve(repoScopeKey: String?, skillName: String?): LearningResolution {
+    val (resolvedRepoScopeKey, resolvedSkillName, rows) =
+      LearningsRuntime.resolveLearnings(connection, repoScopeKey, skillName)
+    return LearningResolution(
+      repoScopeKey = resolvedRepoScopeKey,
+      skillName = resolvedSkillName,
+      records = rows,
+    )
+  }
+
+  override fun saveSessionLearnings(reviewSessionId: String, learningsJson: String) {
+    LearningsRuntime.saveSessionLearnings(connection, reviewSessionId, learningsJson)
+  }
+
+  override fun add(request: CreateLearningRequest): Int = LearningStore.addLearning(connection, request)
+
+  override fun edit(request: UpdateLearningRequest): LearningRecord = LearningStore.editLearning(connection, request)
+
+  override fun setStatus(id: Int, status: String): LearningRecord =
+    LearningStore.setLearningStatus(connection, id, status)
+
+  override fun delete(id: Int) {
+    LearningStore.deleteLearning(connection, id)
+  }
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/DatabaseSessionFactory.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/DatabaseSessionFactory.kt
@@ -1,0 +1,21 @@
+package skillbill.ports.persistence
+
+import java.nio.file.Path
+
+interface DatabaseSessionFactory {
+  fun resolveDbPath(dbOverride: String? = null): Path
+
+  fun databaseExists(dbOverride: String? = null): Boolean
+
+  fun <T> read(dbOverride: String? = null, block: (UnitOfWork) -> T): T
+
+  fun <T> transaction(dbOverride: String? = null, block: (UnitOfWork) -> T): T
+}
+
+interface UnitOfWork {
+  val dbPath: Path
+  val reviews: ReviewRepository
+  val learnings: LearningRepository
+  val telemetryOutbox: TelemetryOutboxRepository
+  val workflowStates: WorkflowStateRepository
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/LearningRepository.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/LearningRepository.kt
@@ -1,0 +1,29 @@
+package skillbill.ports.persistence
+
+import skillbill.learnings.CreateLearningRequest
+import skillbill.learnings.UpdateLearningRequest
+import skillbill.review.LearningRecord
+
+data class LearningResolution(
+  val repoScopeKey: String?,
+  val skillName: String?,
+  val records: List<LearningRecord>,
+)
+
+interface LearningRepository {
+  fun list(status: String): List<LearningRecord>
+
+  fun get(id: Int): LearningRecord
+
+  fun resolve(repoScopeKey: String?, skillName: String?): LearningResolution
+
+  fun saveSessionLearnings(reviewSessionId: String, learningsJson: String)
+
+  fun add(request: CreateLearningRequest): Int
+
+  fun edit(request: UpdateLearningRequest): LearningRecord
+
+  fun setStatus(id: Int, status: String): LearningRecord
+
+  fun delete(id: Int)
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/ReviewRepository.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/ReviewRepository.kt
@@ -1,0 +1,24 @@
+package skillbill.ports.persistence
+
+import skillbill.review.FeedbackRequest
+import skillbill.review.FeedbackTelemetryOptions
+import skillbill.review.ImportedReview
+import skillbill.review.NumberedFinding
+
+interface ReviewRepository {
+  fun saveImportedReview(review: ImportedReview, sourcePath: String?)
+
+  fun markOrchestrated(runId: String)
+
+  fun updateReviewFinishedTelemetryState(runId: String, enabled: Boolean, level: String): Map<String, Any?>?
+
+  fun recordFeedback(request: FeedbackRequest, telemetryOptions: FeedbackTelemetryOptions): Map<String, Any?>?
+
+  fun fetchNumberedFindings(runId: String): List<NumberedFinding>
+
+  fun reviewStatsPayload(runId: String?): Map<String, Any?>
+
+  fun featureImplementStatsPayload(): Map<String, Any?>
+
+  fun featureVerifyStatsPayload(): Map<String, Any?>
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/TelemetryOutboxRepository.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/TelemetryOutboxRepository.kt
@@ -1,0 +1,28 @@
+package skillbill.ports.persistence
+
+data class TelemetryOutboxRecord(
+  val id: Long,
+  val eventName: String,
+  val payloadJson: String,
+  val createdAt: String,
+  val syncedAt: String?,
+  val lastError: String,
+)
+
+interface TelemetryOutboxRepository {
+  fun enqueue(eventName: String, payloadJson: String): Long
+
+  fun listPending(limit: Int? = null): List<TelemetryOutboxRecord>
+
+  fun pendingCount(): Int
+
+  fun latestError(): String?
+
+  fun markSynced(id: Long, syncedAt: String)
+
+  fun markSynced(eventIds: List<Long>)
+
+  fun markFailed(id: Long, lastError: String)
+
+  fun markFailed(eventIds: List<Long>, lastError: String)
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/WorkflowStateRepository.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/WorkflowStateRepository.kt
@@ -1,0 +1,25 @@
+package skillbill.ports.persistence
+
+data class WorkflowStateRecord(
+  val workflowId: String,
+  val sessionId: String,
+  val workflowName: String,
+  val contractVersion: String,
+  val workflowStatus: String,
+  val currentStepId: String,
+  val stepsJson: String,
+  val artifactsJson: String,
+  val startedAt: String?,
+  val updatedAt: String?,
+  val finishedAt: String?,
+)
+
+interface WorkflowStateRepository {
+  fun saveFeatureImplementWorkflow(row: WorkflowStateRecord)
+
+  fun saveFeatureVerifyWorkflow(row: WorkflowStateRecord)
+
+  fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord?
+
+  fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord?
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/review/TriageRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/review/TriageRuntime.kt
@@ -2,7 +2,6 @@ package skillbill.review
 
 import skillbill.telemetry.TelemetryConfigRuntime
 import java.sql.Connection
-import java.sql.SQLException
 
 data class FeedbackRequest(
   val reviewRunId: String,
@@ -96,31 +95,25 @@ object TriageRuntime {
     connection: Connection,
     request: FeedbackRequest,
     telemetryOptions: FeedbackTelemetryOptions = FeedbackTelemetryOptions(),
+  ): Map<String, Any?>? = connection.inTransaction {
+    recordFeedbackWithoutTransaction(connection, request, telemetryOptions)
+  }
+
+  fun recordFeedbackWithoutTransaction(
+    connection: Connection,
+    request: FeedbackRequest,
+    telemetryOptions: FeedbackTelemetryOptions = FeedbackTelemetryOptions(),
   ): Map<String, Any?>? {
     validateFeedbackRequest(connection, request)
-    connection.autoCommit = false
-    try {
-      request.findingIds.forEach { findingId ->
-        insertFeedbackEvent(connection, request.reviewRunId, findingId, request.eventType, request.note)
-      }
-      val telemetryPayload =
-        ReviewStatsRuntime.updateReviewFinishedTelemetryState(
-          connection = connection,
-          reviewRunId = request.reviewRunId,
-          enabled = telemetryOptions.enabled ?: TelemetryConfigRuntime.telemetryIsEnabled(),
-          level = telemetryOptions.level,
-        )
-      connection.commit()
-      return telemetryPayload
-    } catch (error: SQLException) {
-      rollbackAndRethrow(connection, error)
-    } catch (error: IllegalArgumentException) {
-      rollbackAndRethrow(connection, error)
-    } catch (error: IllegalStateException) {
-      rollbackAndRethrow(connection, error)
-    } finally {
-      connection.autoCommit = true
+    request.findingIds.forEach { findingId ->
+      insertFeedbackEvent(connection, request.reviewRunId, findingId, request.eventType, request.note)
     }
+    return ReviewStatsRuntime.updateReviewFinishedTelemetryState(
+      connection = connection,
+      reviewRunId = request.reviewRunId,
+      enabled = telemetryOptions.enabled ?: TelemetryConfigRuntime.telemetryIsEnabled(),
+      level = telemetryOptions.level,
+    )
   }
 }
 
@@ -211,7 +204,18 @@ private fun insertFeedbackEvent(
   }
 }
 
-private fun rollbackAndRethrow(connection: Connection, error: Throwable): Nothing {
-  connection.rollback()
-  throw error
+private fun <T> Connection.inTransaction(block: () -> T): T {
+  val previousAutoCommit = autoCommit
+  autoCommit = false
+  try {
+    val outcome = runCatching(block)
+    if (outcome.isSuccess) {
+      commit()
+    } else {
+      rollback()
+    }
+    return outcome.getOrThrow()
+  } finally {
+    autoCommit = previousAutoCommit
+  }
 }

--- a/runtime-kotlin/src/test/kotlin/skillbill/RuntimeModuleSmokeTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/RuntimeModuleSmokeTest.kt
@@ -29,6 +29,8 @@ class RuntimeModuleSmokeTest {
         "skillbill.telemetry",
         "skillbill.review",
         "skillbill.learnings",
+        "skillbill.ports",
+        "skillbill.infrastructure",
         "skillbill.workflow.implement",
         "skillbill.workflow.verify",
         "skillbill.scaffold",
@@ -60,7 +62,14 @@ class RuntimeModuleSmokeTest {
     assertEquals(expectedSubsystemPackages, RuntimeModule.declaredSubsystemPackages.toSet())
     assertEquals(
       expectedSubsystemPackages -
-        setOf("skillbill.application", "skillbill.contracts", "skillbill.di", "skillbill.error"),
+        setOf(
+          "skillbill.application",
+          "skillbill.contracts",
+          "skillbill.di",
+          "skillbill.error",
+          "skillbill.infrastructure",
+          "skillbill.ports",
+        ),
       runtimeSurfacePackages,
     )
     assertTrue(runtimeSurfaces.all { it.qualifiedName?.startsWith("skillbill.") == true })

--- a/runtime-kotlin/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -1,0 +1,259 @@
+package skillbill.application
+
+import skillbill.RuntimeContext
+import skillbill.learnings.CreateLearningRequest
+import skillbill.learnings.LearningScope
+import skillbill.learnings.UpdateLearningRequest
+import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.persistence.LearningRepository
+import skillbill.ports.persistence.LearningResolution
+import skillbill.ports.persistence.ReviewRepository
+import skillbill.ports.persistence.TelemetryOutboxRecord
+import skillbill.ports.persistence.TelemetryOutboxRepository
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.ports.persistence.WorkflowStateRecord
+import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.review.FeedbackRequest
+import skillbill.review.FeedbackTelemetryOptions
+import skillbill.review.ImportedReview
+import skillbill.review.LearningRecord
+import skillbill.review.NumberedFinding
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ApplicationPersistencePortTest {
+  @Test
+  fun `learning list can run with fake repositories through a read unit of work`() {
+    val learningRepository =
+      FakeLearningRepository(
+        records =
+        mutableMapOf(
+          1 to learningRecord(id = 1, title = "Keep prompts stable"),
+        ),
+      )
+    val database = FakeDatabaseSessionFactory(learnings = learningRepository)
+    val service = LearningService(database)
+
+    val result = service.list(status = "active", dbOverride = null)
+
+    assertEquals(listOf("read"), database.calls)
+    assertEquals("/fake/metrics.db", result.dbPath)
+    assertEquals(listOf("Keep prompts stable"), result.learnings.map { it.title })
+  }
+
+  @Test
+  fun `learning add owns a write transaction at the application boundary`() {
+    val learningRepository = FakeLearningRepository()
+    val database = FakeDatabaseSessionFactory(learnings = learningRepository)
+    val service = LearningService(database)
+
+    val result =
+      service.add(
+        AddLearningInput(
+          scope = LearningScope.SKILL,
+          scopeKey = "bill-kotlin-code-review",
+          title = "Prefer ports",
+          rule = "Application services should depend on persistence ports.",
+          reason = "Keeps use cases testable.",
+          fromRun = "rvw-1",
+          fromFinding = "F-1",
+        ),
+        dbOverride = null,
+      )
+
+    assertEquals(listOf("transaction"), database.calls)
+    assertEquals("Prefer ports", result.learning.title)
+    assertEquals("bill-kotlin-code-review", learningRepository.addedRequests.single().scopeKey)
+  }
+
+  @Test
+  fun `review triage records decisions inside one application transaction`() {
+    val reviewRepository =
+      FakeReviewRepository(
+        numberedFindings =
+        listOf(
+          numberedFinding(1, "F-001"),
+          numberedFinding(2, "F-002"),
+        ),
+      )
+    val database = FakeDatabaseSessionFactory(reviews = reviewRepository)
+    val service =
+      ReviewService(
+        RuntimeContext(environment = emptyMap(), userHome = Files.createTempDirectory("skillbill-app-fake")),
+        database,
+      )
+
+    val result =
+      service.triage(
+        runId = "rvw-1",
+        decisions = listOf("all fix - patched"),
+        listOnly = false,
+        dbOverride = null,
+      )
+
+    assertEquals(listOf("transaction"), database.calls)
+    assertEquals(listOf("F-001", "F-002"), reviewRepository.feedbackRequests.map { it.findingIds.single() })
+    assertEquals(listOf("fix_applied", "fix_applied"), result.recorded.map { it["outcome_type"] })
+  }
+}
+
+private class FakeDatabaseSessionFactory(
+  private val reviews: ReviewRepository = FakeReviewRepository(),
+  private val learnings: LearningRepository = FakeLearningRepository(),
+) : DatabaseSessionFactory {
+  val calls = mutableListOf<String>()
+  private val dbPath = Path.of("/fake/metrics.db")
+
+  override fun resolveDbPath(dbOverride: String?): Path = dbPath
+
+  override fun databaseExists(dbOverride: String?): Boolean = true
+
+  override fun <T> read(dbOverride: String?, block: (UnitOfWork) -> T): T {
+    calls += "read"
+    return block(fakeUnitOfWork())
+  }
+
+  override fun <T> transaction(dbOverride: String?, block: (UnitOfWork) -> T): T {
+    calls += "transaction"
+    return block(fakeUnitOfWork())
+  }
+
+  private fun fakeUnitOfWork(): UnitOfWork = object : UnitOfWork {
+    override val dbPath: Path = this@FakeDatabaseSessionFactory.dbPath
+    override val reviews: ReviewRepository = this@FakeDatabaseSessionFactory.reviews
+    override val learnings: LearningRepository = this@FakeDatabaseSessionFactory.learnings
+    override val telemetryOutbox: TelemetryOutboxRepository = NoopTelemetryOutboxRepository
+    override val workflowStates: WorkflowStateRepository = NoopWorkflowStateRepository
+  }
+}
+
+private class FakeLearningRepository(
+  private val records: MutableMap<Int, LearningRecord> = mutableMapOf(),
+) : LearningRepository {
+  val addedRequests = mutableListOf<CreateLearningRequest>()
+
+  override fun list(status: String): List<LearningRecord> =
+    records.values.filter { status == "all" || it.status == status }.sortedBy { it.id }
+
+  override fun get(id: Int): LearningRecord = records.getValue(id)
+
+  override fun resolve(repoScopeKey: String?, skillName: String?): LearningResolution =
+    LearningResolution(repoScopeKey = repoScopeKey, skillName = skillName, records = list(status = "active"))
+
+  override fun saveSessionLearnings(reviewSessionId: String, learningsJson: String) = Unit
+
+  override fun add(request: CreateLearningRequest): Int {
+    addedRequests += request
+    val id = (records.keys.maxOrNull() ?: 0) + 1
+    records[id] =
+      learningRecord(id = id, title = request.title).copy(
+        scope = request.scope.wireName,
+        scopeKey = request.scopeKey,
+        ruleText = request.ruleText,
+        rationale = request.rationale,
+        sourceReviewRunId = request.sourceReviewRunId,
+        sourceFindingId = request.sourceFindingId,
+      )
+    return id
+  }
+
+  override fun edit(request: UpdateLearningRequest): LearningRecord =
+    records.getValue(request.learningId).let { current ->
+      current.copy(
+        scope = request.scope?.wireName ?: current.scope,
+        scopeKey = request.scopeKey ?: current.scopeKey,
+        title = request.title ?: current.title,
+        ruleText = request.ruleText ?: current.ruleText,
+        rationale = request.rationale ?: current.rationale,
+      ).also { records[request.learningId] = it }
+    }
+
+  override fun setStatus(id: Int, status: String): LearningRecord =
+    records.getValue(id).copy(status = status).also { records[id] = it }
+
+  override fun delete(id: Int) {
+    records.remove(id)
+  }
+}
+
+private class FakeReviewRepository(
+  private val numberedFindings: List<NumberedFinding> = emptyList(),
+) : ReviewRepository {
+  val feedbackRequests = mutableListOf<FeedbackRequest>()
+
+  override fun saveImportedReview(review: ImportedReview, sourcePath: String?) = error("Unexpected saveImportedReview")
+
+  override fun markOrchestrated(runId: String) = error("Unexpected markOrchestrated")
+
+  override fun updateReviewFinishedTelemetryState(runId: String, enabled: Boolean, level: String): Map<String, Any?>? =
+    null
+
+  override fun recordFeedback(
+    request: FeedbackRequest,
+    telemetryOptions: FeedbackTelemetryOptions,
+  ): Map<String, Any?>? {
+    feedbackRequests += request
+    return null
+  }
+
+  override fun fetchNumberedFindings(runId: String): List<NumberedFinding> = numberedFindings
+
+  override fun reviewStatsPayload(runId: String?): Map<String, Any?> = error("Unexpected reviewStatsPayload")
+
+  override fun featureImplementStatsPayload(): Map<String, Any?> = error("Unexpected featureImplementStatsPayload")
+
+  override fun featureVerifyStatsPayload(): Map<String, Any?> = error("Unexpected featureVerifyStatsPayload")
+}
+
+private object NoopTelemetryOutboxRepository : TelemetryOutboxRepository {
+  override fun enqueue(eventName: String, payloadJson: String): Long = error("Unexpected enqueue")
+
+  override fun listPending(limit: Int?): List<TelemetryOutboxRecord> = emptyList()
+
+  override fun pendingCount(): Int = 0
+
+  override fun latestError(): String? = null
+
+  override fun markSynced(id: Long, syncedAt: String) = Unit
+
+  override fun markSynced(eventIds: List<Long>) = Unit
+
+  override fun markFailed(id: Long, lastError: String) = Unit
+
+  override fun markFailed(eventIds: List<Long>, lastError: String) = Unit
+}
+
+private object NoopWorkflowStateRepository : WorkflowStateRepository {
+  override fun saveFeatureImplementWorkflow(row: WorkflowStateRecord) = Unit
+
+  override fun saveFeatureVerifyWorkflow(row: WorkflowStateRecord) = Unit
+
+  override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? = null
+
+  override fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord? = null
+}
+
+private fun learningRecord(id: Int, title: String = "Learning $id"): LearningRecord = LearningRecord(
+  id = id,
+  scope = "global",
+  scopeKey = "global",
+  title = title,
+  ruleText = "Rule $id",
+  rationale = "",
+  status = "active",
+  sourceReviewRunId = "rvw-1",
+  sourceFindingId = "F-$id",
+  createdAt = "2026-04-24 00:00:00",
+  updatedAt = "2026-04-24 00:00:00",
+)
+
+private fun numberedFinding(number: Int, findingId: String): NumberedFinding = NumberedFinding(
+  number = number,
+  findingId = findingId,
+  severity = "Major",
+  confidence = "High",
+  location = "README.md:1",
+  description = "Example finding",
+)

--- a/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
@@ -22,6 +22,7 @@ class RuntimeArchitectureTest {
     assertContains(architecture, "Boundary Rules")
     assertContains(architecture, "MCP workflow calls must use application services")
     assertContains(architecture, "learning application use cases return typed results")
+    assertContains(architecture, "repository and unit-of-work ports")
   }
 
   @Test
@@ -35,9 +36,11 @@ class RuntimeArchitectureTest {
         "skillbill.di",
         "skillbill.error",
         "skillbill.install",
+        "skillbill.infrastructure",
         "skillbill.launcher",
         "skillbill.learnings",
         "skillbill.mcp",
+        "skillbill.ports",
         "skillbill.review",
         "skillbill.scaffold",
         "skillbill.telemetry",
@@ -57,6 +60,20 @@ class RuntimeArchitectureTest {
         "com.github.ajalt.clikt",
         "skillbill.cli",
         "skillbill.mcp",
+      ),
+    )
+  }
+
+  @Test
+  fun `application services use persistence ports instead of sqlite infrastructure`() {
+    assertNoBannedImports(
+      files = sourceFiles().filter { it.packageName.startsWith("skillbill.application") },
+      bannedImports =
+      listOf(
+        "java.sql",
+        "java.nio.file.Files",
+        "skillbill.db",
+        "skillbill.infrastructure",
       ),
     )
   }

--- a/runtime-kotlin/src/test/kotlin/skillbill/infrastructure/sqlite/SQLiteDatabaseSessionFactoryTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/infrastructure/sqlite/SQLiteDatabaseSessionFactoryTest.kt
@@ -1,0 +1,57 @@
+package skillbill.infrastructure.sqlite
+
+import skillbill.RuntimeContext
+import skillbill.ports.persistence.WorkflowStateRecord
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class SQLiteDatabaseSessionFactoryTest {
+  @Test
+  fun `transaction rolls back repository writes when the use case fails`() {
+    val tempDir = Files.createTempDirectory("skillbill-sqlite-session")
+    val dbPath = tempDir.resolve("metrics.db")
+    val database = SQLiteDatabaseSessionFactory(RuntimeContext(userHome = tempDir))
+
+    assertFailsWith<IllegalStateException> {
+      database.transaction(dbPath.toString()) { unitOfWork ->
+        unitOfWork.workflowStates.saveFeatureImplementWorkflow(
+          WorkflowStateRecord(
+            workflowId = "wfl-rollback",
+            sessionId = "fis-rollback",
+            workflowName = "bill-feature-implement",
+            contractVersion = "",
+            workflowStatus = "running",
+            currentStepId = "implement",
+            stepsJson = "[]",
+            artifactsJson = "{}",
+            startedAt = null,
+            updatedAt = null,
+            finishedAt = null,
+          ),
+        )
+        error("force rollback")
+      }
+    }
+
+    val saved =
+      database.read(dbPath.toString()) { unitOfWork ->
+        unitOfWork.workflowStates.getFeatureImplementWorkflow("wfl-rollback")
+      }
+    assertNull(saved)
+  }
+
+  @Test
+  fun `resolve path and existence are provided by the database session factory`() {
+    val tempDir = Files.createTempDirectory("skillbill-sqlite-session-path")
+    val dbPath = tempDir.resolve("metrics.db")
+    val database = SQLiteDatabaseSessionFactory(RuntimeContext(userHome = tempDir))
+
+    assertEquals(dbPath.toAbsolutePath().normalize(), database.resolveDbPath(dbPath.toString()))
+    assertEquals(false, database.databaseExists(dbPath.toString()))
+    database.read(dbPath.toString()) { Unit }
+    assertEquals(true, database.databaseExists(dbPath.toString()))
+  }
+}


### PR DESCRIPTION
# Summary

Implements SKILL-28 Phase 3 by moving runtime application services off direct SQLite access and onto explicit persistence ports.

- Added `DatabaseSessionFactory`, `UnitOfWork`, and repository ports for review, learning, telemetry outbox, and workflow state persistence.
- Added SQLite adapters that wrap the existing JDBC stores/runtime helpers behind those ports and wire them through Kotlin-Inject.
- Refactored learning, review, telemetry, and system application services to use read or transaction sessions instead of opening databases directly.
- Added architecture guardrails plus fake-repository application tests and SQLite transaction rollback coverage.

## Feature Flags

N/A

# How Has This Been Tested?

- `./gradlew check --no-configuration-cache`

1. `cd runtime-kotlin`
2. `./gradlew check --no-configuration-cache`
3. Expect the Kotlin quality gate and all runtime tests to pass.
