### PR TITLE
feat: [SKILL-28] Port telemetry subsystem

### DIFF
--- a/runtime-kotlin/ARCHITECTURE.md
+++ b/runtime-kotlin/ARCHITECTURE.md
@@ -30,10 +30,12 @@ di
   entry points.
 - `skillbill.di`: Kotlin-Inject composition roots and providers.
 - `skillbill.ports`: internal port contracts for persistence sessions,
-  repositories, and later filesystem/HTTP/time abstractions.
+  repositories, telemetry settings/config/client abstractions, and later
+  filesystem/time abstractions.
 - `skillbill.infrastructure`: concrete adapters for port contracts. SQLite
   adapters own JDBC connection/session behavior and table-shaped repository
-  implementations.
+  implementations; HTTP adapters own telemetry relay request/response details;
+  filesystem adapters own telemetry config file reads and writes.
 - `skillbill.db`: SQLite schema, migrations, connection bootstrap, and current
   JDBC stores.
 - `skillbill.review`: pure review parsing and triage decision normalization
@@ -42,9 +44,10 @@ di
 - `skillbill.learnings`: learning records, learning scope rules, learning
   source validation rules, and learning payload helpers. It must stay free of
   JDBC.
-- `skillbill.telemetry`: telemetry config, sync orchestration, HTTP contracts,
-  and current telemetry adapter code.
-- `skillbill.contracts`: shared JSON and runtime contract helpers.
+- `skillbill.telemetry`: telemetry settings normalization, sync orchestration,
+  config mutation rules, sync result models, and compatibility facades.
+- `skillbill.contracts`: shared JSON and runtime contract helpers, including
+  telemetry proxy DTO/payload mappers.
 - `skillbill.error`: runtime exception taxonomy.
 - `skillbill.workflow.*`, `skillbill.install`, `skillbill.launcher`, and
   `skillbill.scaffold`: placeholder or early runtime surfaces for later
@@ -69,6 +72,10 @@ These are the stable dependency rules the runtime should converge toward.
 7. Application use cases must access SQLite through repository and unit-of-work
    ports. Read use cases call a read session; write use cases call an explicit
    transaction session.
+8. Telemetry application use cases must depend on `TelemetrySettingsProvider`,
+   `TelemetryConfigStore`, `TelemetryClient`, and `TelemetryOutboxRepository`.
+   HTTP request mechanics belong in `infrastructure/http`; config file IO
+   belongs in `infrastructure/fs`; telemetry proxy DTOs belong in `contracts`.
 
 ## Architecture Guardrails
 
@@ -93,6 +100,12 @@ useful for the next refactors:
   for learnings lives in infrastructure adapters
 - review parsing and triage decision normalization are pure surfaces that do
   not import JDBC or persistence adapters
+- telemetry sync orchestration depends on telemetry ports and the outbox
+  repository, not on SQLite, filesystem IO, or Java HTTP APIs
+- telemetry HTTP request/response details live under `skillbill.infrastructure.http`
+  and telemetry config file IO lives under `skillbill.infrastructure.fs`
+- telemetry proxy batch and stats wire payloads are explicit contract helpers,
+  separate from sync orchestration
 - future `skillbill.domain.*` packages are protected from infrastructure
   imports as soon as they appear
 
@@ -102,7 +115,7 @@ useful for the next refactors:
    results with typed results.
 2. Move remaining pure domain models/rules away from JDBC-shaped runtime
    objects.
-3. Put telemetry config, HTTP, and filesystem behavior behind explicit ports.
-4. Add versioned database migrations.
-5. Add contract DTOs and golden output fixtures.
-6. Split Gradle modules only after package boundaries are proven.
+3. Add versioned database migrations.
+4. Add contract DTOs and golden output fixtures for the remaining JSON
+   surfaces.
+5. Split Gradle modules only after package boundaries are proven.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-04-24] runtime-telemetry-ported-subsystem
+Areas: skillbill.application, skillbill.telemetry, skillbill.ports.telemetry, skillbill.infrastructure.http, skillbill.infrastructure.fs, skillbill.contracts.telemetry, architecture tests
+- Added telemetry settings/config/client ports and wired them through Kotlin-Inject; application telemetry/status/sync/mutation paths now use ports plus `TelemetryOutboxRepository`.
+- Moved telemetry config file reads/writes/deletes into `FileTelemetryConfigStore` and relay HTTP request/response mechanics into `HttpTelemetryClient`.
+- Reusable contract surface: telemetry proxy batch and remote-stats payload mapping now lives in `contracts/telemetry`, outside sync orchestration.
+- Reusable sync pattern: `TelemetrySyncRuntime` accepts outbox and client ports directly, with behavior coverage for disabled, noop, synced, failed, and unconfigured paths.
+- Known limitation: legacy telemetry runtime objects remain as compatibility facades while review telemetry helpers are ported in later phases.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented
+
 ## [2026-04-24] runtime-domain-persistence-separation
 Areas: skillbill.learnings, skillbill.review, skillbill.application, skillbill.ports.persistence, skillbill.infrastructure.sqlite, architecture tests
 - Moved `LearningRecord` and learning request/source-validation rules into the learnings domain; `skillbill.learnings` now stays free of JDBC and review runtime imports.

--- a/runtime-kotlin/src/main/kotlin/skillbill/RuntimeContext.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/RuntimeContext.kt
@@ -1,7 +1,7 @@
 package skillbill
 
-import skillbill.telemetry.HttpRequester
-import skillbill.telemetry.TelemetryHttpRuntime
+import skillbill.infrastructure.http.JdkHttpRequester
+import skillbill.ports.telemetry.HttpRequester
 import java.nio.file.Path
 
 data class RuntimeContext(
@@ -9,5 +9,5 @@ data class RuntimeContext(
   val stdinText: String? = null,
   val environment: Map<String, String> = System.getenv(),
   val userHome: Path = Path.of(System.getProperty("user.home")),
-  val requester: HttpRequester = TelemetryHttpRuntime.defaultHttpRequester,
+  val requester: HttpRequester = JdkHttpRequester,
 )

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/ReviewService.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/ReviewService.kt
@@ -4,6 +4,7 @@ import me.tatarka.inject.annotations.Inject
 import skillbill.RuntimeContext
 import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.persistence.ReviewRepository
+import skillbill.ports.telemetry.TelemetrySettingsProvider
 import skillbill.review.FeedbackRequest
 import skillbill.review.NumberedFinding
 import skillbill.review.ReviewInputReader
@@ -14,6 +15,7 @@ import skillbill.review.TriageDecisionParser
 class ReviewService(
   private val context: RuntimeContext,
   private val database: DatabaseSessionFactory,
+  private val settingsProvider: TelemetrySettingsProvider,
 ) {
   fun previewImport(input: String): Map<String, Any?> {
     val (text) = ReviewInputReader.readInput(input, context.stdinText)
@@ -35,7 +37,7 @@ class ReviewService(
     return database.transaction(dbOverride) { unitOfWork ->
       unitOfWork.reviews.saveImportedReview(review, sourcePath)
       if (finishZeroFindingTelemetry && review.findings.isEmpty()) {
-        val settings = telemetrySettingsOrNull(context)
+        val settings = telemetrySettingsOrNull(settingsProvider)
         unitOfWork.reviews.updateReviewFinishedTelemetryState(
           runId = review.reviewRunId,
           enabled = settings?.enabled ?: false,
@@ -63,7 +65,7 @@ class ReviewService(
 
   fun reviewFinishedTelemetryPayload(runId: String, dbOverride: String?): Map<String, Any?>? =
     database.transaction(dbOverride) { unitOfWork ->
-      val settings = telemetrySettingsOrNull(context)
+      val settings = telemetrySettingsOrNull(settingsProvider)
       unitOfWork.reviews.updateReviewFinishedTelemetryState(
         runId = runId,
         enabled = settings?.enabled ?: false,
@@ -80,7 +82,7 @@ class ReviewService(
   ): Map<String, Any?> = database.transaction(dbOverride) { unitOfWork ->
     unitOfWork.reviews.recordFeedback(
       FeedbackRequest(runId, findings, event, note),
-      feedbackTelemetryOptions(context),
+      feedbackTelemetryOptions(settingsProvider),
     )
     linkedMapOf(
       "db_path" to unitOfWork.dbPath.toString(),
@@ -148,7 +150,7 @@ class ReviewService(
       val returnedPayload =
         reviewRepository.recordFeedback(
           FeedbackRequest(runId, listOf(decision.findingId), decision.outcomeType, decision.note),
-          feedbackTelemetryOptions(context),
+          feedbackTelemetryOptions(settingsProvider),
         )
       if (returnedPayload != null) {
         telemetryPayload = returnedPayload

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/SystemService.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/SystemService.kt
@@ -1,20 +1,20 @@
 package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
-import skillbill.RuntimeContext
 import skillbill.SkillBillVersion
 import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.telemetry.TelemetrySettingsProvider
 
 @Inject
 class SystemService(
-  private val context: RuntimeContext,
   private val database: DatabaseSessionFactory,
+  private val settingsProvider: TelemetrySettingsProvider,
 ) {
   fun version(): Map<String, Any?> = linkedMapOf("version" to SkillBillVersion.VALUE)
 
   fun doctor(dbOverride: String?): Map<String, Any?> {
     val dbPath = database.resolveDbPath(dbOverride)
-    val settings = telemetrySettingsOrNull(context)
+    val settings = telemetrySettingsOrNull(settingsProvider)
     return linkedMapOf(
       "version" to SkillBillVersion.VALUE,
       "db_path" to dbPath.toString(),

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/TelemetryService.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/TelemetryService.kt
@@ -1,29 +1,50 @@
 package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
-import skillbill.RuntimeContext
 import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.telemetry.TelemetryClient
+import skillbill.ports.telemetry.TelemetryConfigStore
+import skillbill.ports.telemetry.TelemetrySettingsProvider
 import skillbill.telemetry.RemoteStatsRequest
-import skillbill.telemetry.TelemetryConfigMutationRuntime
-import skillbill.telemetry.TelemetryHttpRuntime
-import skillbill.telemetry.TelemetryRemoteStatsRuntime
+import skillbill.telemetry.TelemetryConfigMutations
+import skillbill.telemetry.TelemetrySettings
 import skillbill.telemetry.TelemetrySyncRuntime
 
 @Inject
 class TelemetryService(
-  private val context: RuntimeContext,
   private val database: DatabaseSessionFactory,
+  private val settingsProvider: TelemetrySettingsProvider,
+  private val configStore: TelemetryConfigStore,
+  private val telemetryClient: TelemetryClient,
 ) {
-  fun isEnabled(): Boolean = telemetrySettingsOrNull(context)?.enabled ?: false
+  fun isEnabled(): Boolean = telemetrySettingsOrNull(settingsProvider)?.enabled ?: false
 
   fun status(dbOverride: String?): Map<String, Any?> {
     val dbPath = database.resolveDbPath(dbOverride)
-    return TelemetrySyncRuntime.telemetryStatusPayload(dbPath, loadTelemetrySettings(context))
+    val settings = loadTelemetrySettings(settingsProvider)
+    if (!settings.enabled) {
+      return TelemetrySyncRuntime.telemetryStatusPayload(dbPath, settings)
+    }
+    return database.read(dbOverride) { unitOfWork ->
+      TelemetrySyncRuntime.telemetryStatusPayload(
+        dbPath = unitOfWork.dbPath,
+        settings = settings,
+        pendingEvents = unitOfWork.telemetryOutbox.pendingCount(),
+        latestError = unitOfWork.telemetryOutbox.latestError(),
+      )
+    }
   }
 
   fun sync(dbOverride: String?): TelemetrySyncPayload {
-    val dbPath = database.resolveDbPath(dbOverride)
-    val result = TelemetrySyncRuntime.syncTelemetry(dbPath, loadTelemetrySettings(context), context.requester)
+    val settings = loadTelemetrySettings(settingsProvider)
+    val result =
+      if (!settings.enabled) {
+        TelemetrySyncRuntime.disabledSync(settings)
+      } else {
+        database.transaction(dbOverride) { unitOfWork ->
+          TelemetrySyncRuntime.syncTelemetry(settings, unitOfWork.telemetryOutbox, telemetryClient)
+        }
+      }
     return TelemetrySyncPayload(
       exitCode = if (result.status == "failed") 1 else 0,
       payload = TelemetrySyncRuntime.syncResultPayload(result),
@@ -31,25 +52,12 @@ class TelemetryService(
   }
 
   fun setLevel(level: String, dbOverride: String?): Map<String, Any?> {
-    val dbPath = database.resolveDbPath(dbOverride)
-    val (settings, clearedEvents) =
-      TelemetryConfigMutationRuntime.setTelemetryLevel(
-        level = level,
-        dbPath = dbPath,
-        environment = context.environment,
-        userHome = context.userHome,
-      )
+    val (settings, clearedEvents) = setTelemetryLevel(level, dbOverride)
     return telemetryMutationPayload(settings, clearedEvents)
   }
 
   fun capabilities(): Map<String, Any?> = linkedMapOf<String, Any?>().apply {
-    putAll(
-      TelemetryHttpRuntime.fetchProxyCapabilities(
-        settings = loadTelemetrySettings(context),
-        requester = context.requester,
-        environment = context.environment,
-      ),
-    )
+    putAll(telemetryClient.fetchProxyCapabilities(loadTelemetrySettings(settingsProvider)))
   }
 
   fun remoteStats(
@@ -63,15 +71,26 @@ class TelemetryService(
   )
 
   fun remoteStats(request: RemoteStatsRequest): Map<String, Any?> = linkedMapOf<String, Any?>().apply {
-    putAll(
-      TelemetryRemoteStatsRuntime.fetchRemoteStats(
-        request = request,
-        settings = loadTelemetrySettings(context),
-        requester = context.requester,
-        environment = context.environment,
-      ),
-    )
+    putAll(telemetryClient.fetchRemoteStats(loadTelemetrySettings(settingsProvider), request))
   }
+
+  private fun setTelemetryLevel(level: String, dbOverride: String?): Pair<TelemetrySettings, Int> =
+    if (level == "off" && database.databaseExists(dbOverride)) {
+      database.transaction(dbOverride) { unitOfWork ->
+        TelemetryConfigMutations.setTelemetryLevel(
+          level = level,
+          configStore = configStore,
+          settingsProvider = settingsProvider,
+          outbox = unitOfWork.telemetryOutbox,
+        )
+      }
+    } else {
+      TelemetryConfigMutations.setTelemetryLevel(
+        level = level,
+        configStore = configStore,
+        settingsProvider = settingsProvider,
+      )
+    }
 }
 
 data class TelemetrySyncPayload(

--- a/runtime-kotlin/src/main/kotlin/skillbill/application/TelemetrySupport.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/application/TelemetrySupport.kt
@@ -1,22 +1,18 @@
 package skillbill.application
 
-import skillbill.RuntimeContext
+import skillbill.ports.telemetry.TelemetrySettingsProvider
 import skillbill.review.FeedbackTelemetryOptions
-import skillbill.telemetry.TelemetryConfigRuntime
 import skillbill.telemetry.TelemetrySettings
 import skillbill.telemetry.telemetrySyncTarget
 
-internal fun loadTelemetrySettings(context: RuntimeContext): TelemetrySettings =
-  TelemetryConfigRuntime.loadTelemetrySettings(
-    environment = context.environment,
-    userHome = context.userHome,
-  )
+internal fun loadTelemetrySettings(settingsProvider: TelemetrySettingsProvider): TelemetrySettings =
+  settingsProvider.load()
 
-internal fun telemetrySettingsOrNull(context: RuntimeContext): TelemetrySettings? =
-  runCatching { loadTelemetrySettings(context) }.getOrNull()
+internal fun telemetrySettingsOrNull(settingsProvider: TelemetrySettingsProvider): TelemetrySettings? =
+  settingsProvider.loadOrNull()
 
-internal fun feedbackTelemetryOptions(context: RuntimeContext): FeedbackTelemetryOptions {
-  val settings = telemetrySettingsOrNull(context)
+internal fun feedbackTelemetryOptions(settingsProvider: TelemetrySettingsProvider): FeedbackTelemetryOptions {
+  val settings = telemetrySettingsOrNull(settingsProvider)
   return FeedbackTelemetryOptions(
     enabled = settings?.enabled ?: false,
     level = settings?.level ?: "off",

--- a/runtime-kotlin/src/main/kotlin/skillbill/cli/models/CliRuntimeContext.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/cli/models/CliRuntimeContext.kt
@@ -1,8 +1,8 @@
 package skillbill.cli.models
 
 import skillbill.RuntimeContext
-import skillbill.telemetry.HttpRequester
-import skillbill.telemetry.TelemetryHttpRuntime
+import skillbill.infrastructure.http.JdkHttpRequester
+import skillbill.ports.telemetry.HttpRequester
 import java.nio.file.Path
 
 data class CliRuntimeContext(
@@ -10,7 +10,7 @@ data class CliRuntimeContext(
   val stdinText: String? = null,
   val environment: Map<String, String> = System.getenv(),
   val userHome: Path = Path.of(System.getProperty("user.home")),
-  val requester: HttpRequester = TelemetryHttpRuntime.defaultHttpRequester,
+  val requester: HttpRequester = JdkHttpRequester,
 ) {
   fun toRuntimeContext(): RuntimeContext = RuntimeContext(
     dbPathOverride = dbPathOverride,

--- a/runtime-kotlin/src/main/kotlin/skillbill/contracts/telemetry/TelemetryProxyContracts.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/contracts/telemetry/TelemetryProxyContracts.kt
@@ -1,0 +1,75 @@
+package skillbill.contracts.telemetry
+
+import skillbill.contracts.JsonSupport
+import skillbill.ports.persistence.TelemetryOutboxRecord
+import skillbill.telemetry.TelemetrySettings
+
+data class TelemetryProxyBatchEvent(
+  val event: String,
+  val distinctId: String,
+  val properties: Map<String, Any?>,
+  val timestamp: String,
+) {
+  fun toPayload(): Map<String, Any?> = mapOf(
+    "event" to event,
+    "distinct_id" to distinctId,
+    "properties" to properties,
+    "timestamp" to timestamp,
+  )
+}
+
+data class TelemetryProxyBatchPayload(
+  val batch: List<TelemetryProxyBatchEvent>,
+) {
+  fun toPayload(): Map<String, Any?> = mapOf("batch" to batch.map { it.toPayload() })
+}
+
+data class RemoteStatsQueryPayload(
+  val workflow: String,
+  val dateFrom: String,
+  val dateTo: String,
+  val groupBy: String = "",
+) {
+  fun toPayload(): Map<String, Any?> = buildMap {
+    put("workflow", workflow)
+    put("date_from", dateFrom)
+    put("date_to", dateTo)
+    if (groupBy.isNotBlank()) {
+      put("group_by", groupBy)
+    }
+  }
+}
+
+fun telemetryProxyBatchPayload(
+  settings: TelemetrySettings,
+  rows: List<TelemetryOutboxRecord>,
+): TelemetryProxyBatchPayload = TelemetryProxyBatchPayload(
+  batch =
+  rows.map { row ->
+    TelemetryProxyBatchEvent(
+      event = row.eventName,
+      distinctId = settings.installId,
+      properties = telemetryProperties(row.payloadJson, settings.installId),
+      timestamp = row.createdAt,
+    )
+  },
+)
+
+fun defaultProxyCapabilities(proxyUrl: String, capabilitiesUrl: String): Map<String, Any?> = mapOf(
+  "contract_version" to "0",
+  "source" to "remote_proxy",
+  "proxy_url" to proxyUrl,
+  "capabilities_url" to capabilitiesUrl,
+  "supports_ingest" to true,
+  "supports_stats" to false,
+  "supported_workflows" to emptyList<String>(),
+)
+
+private fun telemetryProperties(payloadJson: String, installId: String): MutableMap<String, Any?> = (
+  JsonSupport.parseObjectOrNull(payloadJson)?.let {
+    JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(it))
+  } ?: emptyMap()
+  ).toMutableMap().apply {
+  this["install_id"] = installId
+  this["\$process_person_profile"] = false
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/db/TelemetryOutboxStore.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/db/TelemetryOutboxStore.kt
@@ -158,4 +158,17 @@ class TelemetryOutboxStore(
       statement.executeUpdate()
     }
   }
+
+  override fun clear(): Int {
+    val count = connection.createStatement().use { statement ->
+      statement.executeQuery("SELECT COUNT(*) FROM telemetry_outbox").use { resultSet ->
+        resultSet.next()
+        resultSet.getInt(1)
+      }
+    }
+    connection.createStatement().use { statement ->
+      statement.executeUpdate("DELETE FROM telemetry_outbox")
+    }
+    return count
+  }
 }

--- a/runtime-kotlin/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -7,8 +7,14 @@ import skillbill.application.LearningService
 import skillbill.application.ReviewService
 import skillbill.application.SystemService
 import skillbill.application.TelemetryService
+import skillbill.infrastructure.fs.FileTelemetryConfigStore
+import skillbill.infrastructure.http.HttpTelemetryClient
 import skillbill.infrastructure.sqlite.SQLiteDatabaseSessionFactory
 import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.telemetry.TelemetryClient
+import skillbill.ports.telemetry.TelemetryConfigStore
+import skillbill.ports.telemetry.TelemetrySettingsProvider
+import skillbill.telemetry.DefaultTelemetrySettingsProvider
 
 @Component
 abstract class RuntimeComponent(
@@ -16,6 +22,15 @@ abstract class RuntimeComponent(
 ) {
   @Provides
   fun databaseSessionFactory(factory: SQLiteDatabaseSessionFactory): DatabaseSessionFactory = factory
+
+  @Provides
+  fun telemetryConfigStore(store: FileTelemetryConfigStore): TelemetryConfigStore = store
+
+  @Provides
+  fun telemetrySettingsProvider(provider: DefaultTelemetrySettingsProvider): TelemetrySettingsProvider = provider
+
+  @Provides
+  fun telemetryClient(client: HttpTelemetryClient): TelemetryClient = client
 
   abstract val learningService: LearningService
   abstract val reviewService: ReviewService

--- a/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
@@ -1,0 +1,107 @@
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.RuntimeContext
+import skillbill.contracts.JsonSupport
+import skillbill.ports.telemetry.TelemetryConfigStore
+import skillbill.telemetry.CONFIG_ENVIRONMENT_KEY
+import skillbill.telemetry.STATE_DIR_ENVIRONMENT_KEY
+import skillbill.telemetry.TelemetryConfigRuntime
+import skillbill.telemetry.expandAndNormalizeTelemetryPath
+import java.nio.file.Files
+import java.nio.file.Path
+
+@Inject
+class FileTelemetryConfigStore(
+  private val context: RuntimeContext,
+) : TelemetryConfigStore {
+  override fun stateDir(): Path = resolveTelemetryStateDir(context.environment, context.userHome)
+
+  override fun configPath(): Path = resolveTelemetryConfigPath(context.environment, context.userHome)
+
+  override fun read(): Map<String, Any?>? = readTelemetryConfigFile(configPath())
+
+  override fun ensure(): Map<String, Any?> = ensureTelemetryConfigFile(configPath())
+
+  override fun write(payload: Map<String, Any?>) = writeTelemetryConfigFile(configPath(), payload)
+
+  override fun delete(): Boolean = Files.deleteIfExists(configPath())
+}
+
+internal fun resolveTelemetryStateDir(
+  environment: Map<String, String> = System.getenv(),
+  userHome: Path = Path.of(System.getProperty("user.home")),
+): Path = environment[STATE_DIR_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
+  expandAndNormalizeTelemetryPath(it, userHome)
+} ?: userHome.resolve(".skill-bill").toAbsolutePath().normalize()
+
+internal fun resolveTelemetryConfigPath(
+  environment: Map<String, String> = System.getenv(),
+  userHome: Path = Path.of(System.getProperty("user.home")),
+): Path = environment[CONFIG_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
+  expandAndNormalizeTelemetryPath(it, userHome)
+} ?: userHome.resolve(".skill-bill").resolve("config.json").toAbsolutePath().normalize()
+
+internal fun readTelemetryConfigFile(path: Path): Map<String, Any?>? {
+  if (!Files.exists(path)) {
+    return null
+  }
+  val rawPayload = JsonSupport.parseObjectOrNull(Files.readString(path))
+    ?: throw IllegalArgumentException("Telemetry config at '$path' is not valid JSON.")
+  return JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(rawPayload))
+    ?: throw IllegalArgumentException("Telemetry config at '$path' must contain a JSON object.")
+}
+
+internal fun ensureTelemetryConfigFile(path: Path): Map<String, Any?> {
+  path.parent?.let(Files::createDirectories)
+  val existing = readTelemetryConfigFile(path)
+  val payload = (existing?.toMutableMap() ?: mutableMapOf())
+  val defaults = TelemetryConfigRuntime.defaultLocalConfig()
+  val telemetry = normalizedTelemetryMap(payload, defaults)
+  payload["install_id"] = normalizedInstallId(payload, defaults)
+  payload["telemetry"] = telemetry
+  if (!Files.exists(path) || existing != payload) {
+    writeTelemetryConfigFile(path, payload)
+  }
+  return payload
+}
+
+internal fun writeTelemetryConfigFile(path: Path, payload: Map<String, Any?>) {
+  path.parent?.let(Files::createDirectories)
+  Files.writeString(path, JsonSupport.mapToJsonString(payload) + "\n")
+}
+
+private fun normalizedInstallId(payload: MutableMap<String, Any?>, defaults: Map<String, Any?>): String =
+  (payload["install_id"] as? String)?.takeIf(String::isNotBlank)
+    ?: defaults.getValue("install_id").toString()
+
+private fun normalizedTelemetryMap(payload: MutableMap<String, Any?>, defaults: Map<String, Any?>): Map<String, Any?> {
+  val telemetryRaw = payload["telemetry"]
+  val telemetry =
+    (telemetryRaw as? Map<*, *>)
+      ?.entries
+      ?.filter { it.key is String }
+      ?.associate { it.key as String to it.value }
+      ?.toMutableMap() ?: mutableMapOf()
+  val defaultTelemetry = defaults.getValue("telemetry") as Map<*, *>
+  normalizeLegacyEnabledFlag(telemetry)
+  listOf("level", "proxy_url", "batch_size").forEach { key ->
+    telemetry.putIfAbsent(key, defaultTelemetry[key])
+  }
+  return telemetry
+}
+
+private fun normalizeLegacyEnabledFlag(telemetry: MutableMap<String, Any?>) {
+  if (!telemetry.containsKey("level") && telemetry.containsKey("enabled")) {
+    val enabledRaw = telemetry.remove("enabled")
+    telemetry["level"] = legacyEnabledLevel(enabledRaw)
+  } else {
+    telemetry.remove("enabled")
+  }
+}
+
+private fun legacyEnabledLevel(enabledRaw: Any?): String = when (enabledRaw) {
+  is Boolean -> if (enabledRaw) "anonymous" else "off"
+  is String -> if (TelemetryConfigRuntime.parseBoolValue(enabledRaw, "telemetry.enabled")) "anonymous" else "off"
+  else -> if (enabledRaw == true) "anonymous" else "off"
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/http/HttpTelemetryClient.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/http/HttpTelemetryClient.kt
@@ -1,0 +1,233 @@
+package skillbill.infrastructure.http
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.RuntimeContext
+import skillbill.contracts.JsonSupport
+import skillbill.contracts.telemetry.RemoteStatsQueryPayload
+import skillbill.contracts.telemetry.defaultProxyCapabilities
+import skillbill.contracts.telemetry.telemetryProxyBatchPayload
+import skillbill.ports.persistence.TelemetryOutboxRecord
+import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.telemetry.HttpResponse
+import skillbill.ports.telemetry.TelemetryClient
+import skillbill.telemetry.HTTP_METHOD_NOT_ALLOWED
+import skillbill.telemetry.HTTP_NOT_FOUND
+import skillbill.telemetry.RemoteStatsRequest
+import skillbill.telemetry.TELEMETRY_PROXY_CONTRACT_VERSION
+import skillbill.telemetry.TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY
+import skillbill.telemetry.TelemetrySettings
+import skillbill.telemetry.parseRemoteStatsWindow
+import skillbill.telemetry.validateRemoteStatsCapabilities
+import skillbill.telemetry.validateRemoteStatsRequest
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+
+object JdkHttpRequester : HttpRequester {
+  override fun execute(method: String, url: String, bodyJson: String?, headers: Map<String, String>): HttpResponse {
+    val requestBuilder =
+      HttpRequest
+        .newBuilder(URI.create(url))
+        .method(method, bodyPublisher(bodyJson))
+    headers.forEach(requestBuilder::header)
+    val response = HttpClient.newHttpClient().send(requestBuilder.build(), BodyHandlers.ofString())
+    return HttpResponse(statusCode = response.statusCode(), body = response.body().orEmpty())
+  }
+}
+
+@Inject
+class HttpTelemetryClient(
+  private val context: RuntimeContext,
+) : TelemetryClient {
+  constructor(
+    requester: HttpRequester,
+    environment: Map<String, String> = System.getenv(),
+  ) : this(RuntimeContext(environment = environment, requester = requester))
+
+  override fun sendBatch(settings: TelemetrySettings, rows: List<TelemetryOutboxRecord>) {
+    require(settings.proxyUrl.isNotBlank()) { "Telemetry relay URL is not configured." }
+    val errorContext =
+      if (settings.customProxyUrl != null) {
+        "Telemetry custom proxy sync"
+      } else {
+        "Telemetry relay sync"
+      }
+    postJson(
+      url = settings.proxyUrl,
+      payload = telemetryProxyBatchPayload(settings, rows).toPayload(),
+      errorContext = errorContext,
+      requester = context.requester,
+    )
+  }
+
+  override fun fetchProxyCapabilities(settings: TelemetrySettings): Map<String, Any?> {
+    require(settings.proxyUrl.isNotBlank()) { "Telemetry relay URL is not configured." }
+    val capabilitiesUrl = settings.proxyUrl.trimEnd('/') + "/capabilities"
+    return try {
+      requestJsonGet(
+        url = capabilitiesUrl,
+        errorContext = "Telemetry proxy capabilities request",
+        headers = proxyAuthHeaders(context.environment),
+        requester = context.requester,
+      ).toMutableMap().apply {
+        putIfAbsent("contract_version", TELEMETRY_PROXY_CONTRACT_VERSION)
+        putIfAbsent("source", "remote_proxy")
+        putIfAbsent("proxy_url", settings.proxyUrl)
+        putIfAbsent("capabilities_url", capabilitiesUrl)
+        putIfAbsent("supports_ingest", true)
+        putIfAbsent("supports_stats", false)
+        putIfAbsent("supported_workflows", emptyList<String>())
+      }
+    } catch (error: HttpFailureException) {
+      if (error.statusCode == HTTP_NOT_FOUND || error.statusCode == HTTP_METHOD_NOT_ALLOWED) {
+        defaultProxyCapabilities(settings.proxyUrl, capabilitiesUrl)
+      } else {
+        throw IllegalArgumentException(
+          error.message ?: "Telemetry proxy capabilities request failed.",
+          error,
+        )
+      }
+    }
+  }
+
+  override fun fetchRemoteStats(settings: TelemetrySettings, request: RemoteStatsRequest): Map<String, Any?> {
+    validateRemoteStatsRequest(request)
+    require(settings.proxyUrl.isNotBlank()) {
+      "Telemetry relay URL is not configured."
+    }
+    val (resolvedDateFrom, resolvedDateTo) =
+      parseRemoteStatsWindow(request.since, request.dateFrom, request.dateTo)
+    val capabilities = fetchProxyCapabilities(settings)
+    validateRemoteStatsCapabilities(
+      request = request,
+      settings = settings,
+      capabilities = capabilities,
+    )
+    val statsUrl = settings.proxyUrl.trimEnd('/') + "/stats"
+    val payload =
+      requestJson(
+        url = statsUrl,
+        payload =
+        RemoteStatsQueryPayload(
+          workflow = request.workflow,
+          dateFrom = resolvedDateFrom,
+          dateTo = resolvedDateTo,
+          groupBy = request.groupBy,
+        ).toPayload(),
+        errorContext = "Remote telemetry stats request",
+        headers = proxyAuthHeaders(context.environment),
+        requester = context.requester,
+      ).toMutableMap()
+    payload.putIfAbsent("workflow", request.workflow)
+    payload.putIfAbsent("date_from", resolvedDateFrom)
+    payload.putIfAbsent("date_to", resolvedDateTo)
+    payload.putIfAbsent("source", "remote_proxy")
+    payload.putIfAbsent("stats_url", statsUrl)
+    payload.putIfAbsent("capabilities", capabilities)
+    if (request.groupBy.isNotBlank()) {
+      payload.putIfAbsent("group_by", request.groupBy)
+    }
+    return payload
+  }
+}
+
+private fun requestJson(
+  url: String,
+  payload: Map<String, Any?>,
+  errorContext: String,
+  headers: Map<String, String>,
+  requester: HttpRequester,
+): Map<String, Any?> {
+  val response =
+    requester.execute(
+      "POST",
+      url,
+      JsonSupport.mapToJsonString(payload),
+      defaultJsonHeaders() + headers,
+    )
+  ensureSuccessfulResponse(response, errorContext)
+  return decodeJsonObject(response.body, errorContext)
+}
+
+private fun requestJsonGet(
+  url: String,
+  errorContext: String,
+  headers: Map<String, String>,
+  requester: HttpRequester,
+): Map<String, Any?> {
+  val response =
+    requester.execute(
+      "GET",
+      url,
+      null,
+      mapOf("User-Agent" to "skill-bill-telemetry/1.0") + headers,
+    )
+  ensureSuccessfulResponse(response, errorContext)
+  return decodeJsonObject(response.body, errorContext)
+}
+
+private fun postJson(url: String, payload: Map<String, Any?>, errorContext: String, requester: HttpRequester) {
+  val response =
+    requester.execute(
+      "POST",
+      url,
+      JsonSupport.mapToJsonString(payload),
+      defaultJsonHeaders(),
+    )
+  ensureSuccessfulResponse(response, errorContext)
+}
+
+private fun ensureSuccessfulResponse(response: HttpResponse, errorContext: String) {
+  if (response.statusCode !in HTTP_OK_MIN..HTTP_OK_MAX) {
+    throw HttpFailureException(
+      response.statusCode,
+      httpFailureMessage(response, errorContext),
+    )
+  }
+}
+
+private fun decodeJsonObject(body: String, errorContext: String): Map<String, Any?> {
+  if (body.isBlank()) {
+    return emptyMap()
+  }
+  val decoded =
+    JsonSupport.parseObjectOrNull(body)
+      ?: throw IllegalArgumentException("$errorContext returned invalid JSON.")
+  return JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(decoded))
+    ?: throw IllegalArgumentException(
+      "$errorContext returned a non-object JSON payload.",
+    )
+}
+
+private fun httpFailureMessage(response: HttpResponse, errorContext: String): String = if (response.body.isBlank()) {
+  "$errorContext failed with HTTP ${response.statusCode}."
+} else {
+  "$errorContext failed with HTTP ${response.statusCode}. ${response.body.trim()}"
+}
+
+private fun proxyAuthHeaders(environment: Map<String, String>): Map<String, String> =
+  environment[TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY]
+    ?.trim()
+    ?.takeIf(String::isNotBlank)
+    ?.let { mapOf("Authorization" to "Bearer $it") }
+    ?: emptyMap()
+
+private fun defaultJsonHeaders(): Map<String, String> = mapOf(
+  "Content-Type" to "application/json",
+  "User-Agent" to "skill-bill-telemetry/1.0",
+)
+
+private fun bodyPublisher(bodyJson: String?): HttpRequest.BodyPublisher = if (bodyJson == null) {
+  HttpRequest.BodyPublishers.noBody()
+} else {
+  HttpRequest.BodyPublishers.ofString(bodyJson)
+}
+
+private const val HTTP_OK_MIN: Int = 200
+private const val HTTP_OK_MAX: Int = 299
+
+private class HttpFailureException(
+  val statusCode: Int,
+  message: String,
+) : IllegalArgumentException(message)

--- a/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteTelemetryOutboxPurger.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteTelemetryOutboxPurger.kt
@@ -1,0 +1,17 @@
+package skillbill.infrastructure.sqlite
+
+import skillbill.db.DatabaseRuntime
+import skillbill.db.TelemetryOutboxStore
+import java.nio.file.Files
+import java.nio.file.Path
+
+object SQLiteTelemetryOutboxPurger {
+  fun clearIfDatabaseExists(dbPath: Path): Int {
+    if (!Files.exists(dbPath)) {
+      return 0
+    }
+    return DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      TelemetryOutboxStore(connection).clear()
+    }
+  }
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/mcp/McpRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/mcp/McpRuntime.kt
@@ -3,13 +3,13 @@ package skillbill.mcp
 import skillbill.RuntimeContext
 import skillbill.di.RuntimeComponent
 import skillbill.di.create
-import skillbill.telemetry.HttpRequester
+import skillbill.infrastructure.http.JdkHttpRequester
+import skillbill.ports.telemetry.HttpRequester
 import skillbill.telemetry.RemoteStatsRequest
-import skillbill.telemetry.TelemetryHttpRuntime
 import java.nio.file.Path
 
 data class McpRuntimeContext(
-  val requester: HttpRequester = TelemetryHttpRuntime.defaultHttpRequester,
+  val requester: HttpRequester = JdkHttpRequester,
   val environment: Map<String, String> = System.getenv(),
   val userHome: Path = Path.of(System.getProperty("user.home")),
 ) {

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/TelemetryOutboxRepository.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/persistence/TelemetryOutboxRepository.kt
@@ -25,4 +25,6 @@ interface TelemetryOutboxRepository {
   fun markFailed(id: Long, lastError: String)
 
   fun markFailed(eventIds: List<Long>, lastError: String)
+
+  fun clear(): Int
 }

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/HttpRequester.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/HttpRequester.kt
@@ -1,0 +1,10 @@
+package skillbill.ports.telemetry
+
+data class HttpResponse(
+  val statusCode: Int,
+  val body: String,
+)
+
+fun interface HttpRequester {
+  fun execute(method: String, url: String, bodyJson: String?, headers: Map<String, String>): HttpResponse
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/TelemetryClient.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/TelemetryClient.kt
@@ -1,0 +1,13 @@
+package skillbill.ports.telemetry
+
+import skillbill.ports.persistence.TelemetryOutboxRecord
+import skillbill.telemetry.RemoteStatsRequest
+import skillbill.telemetry.TelemetrySettings
+
+interface TelemetryClient {
+  fun sendBatch(settings: TelemetrySettings, rows: List<TelemetryOutboxRecord>)
+
+  fun fetchProxyCapabilities(settings: TelemetrySettings): Map<String, Any?>
+
+  fun fetchRemoteStats(settings: TelemetrySettings, request: RemoteStatsRequest): Map<String, Any?>
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/TelemetryConfigStore.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/TelemetryConfigStore.kt
@@ -1,0 +1,17 @@
+package skillbill.ports.telemetry
+
+import java.nio.file.Path
+
+interface TelemetryConfigStore {
+  fun stateDir(): Path
+
+  fun configPath(): Path
+
+  fun read(): Map<String, Any?>?
+
+  fun ensure(): Map<String, Any?>
+
+  fun write(payload: Map<String, Any?>)
+
+  fun delete(): Boolean
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/TelemetrySettingsProvider.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/ports/telemetry/TelemetrySettingsProvider.kt
@@ -1,0 +1,9 @@
+package skillbill.ports.telemetry
+
+import skillbill.telemetry.TelemetrySettings
+
+interface TelemetrySettingsProvider {
+  fun load(materialize: Boolean = false): TelemetrySettings
+
+  fun loadOrNull(materialize: Boolean = false): TelemetrySettings? = runCatching { load(materialize) }.getOrNull()
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/DefaultTelemetrySettingsProvider.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/DefaultTelemetrySettingsProvider.kt
@@ -1,0 +1,130 @@
+package skillbill.telemetry
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.RuntimeContext
+import skillbill.ports.telemetry.TelemetryConfigStore
+import skillbill.ports.telemetry.TelemetrySettingsProvider
+
+@Inject
+class DefaultTelemetrySettingsProvider(
+  private val context: RuntimeContext,
+  private val configStore: TelemetryConfigStore,
+) : TelemetrySettingsProvider {
+  override fun load(materialize: Boolean): TelemetrySettings = loadTelemetrySettingsFromStore(
+    materialize = materialize,
+    environment = context.environment,
+    configStore = configStore,
+  )
+}
+
+internal fun loadTelemetrySettingsFromStore(
+  materialize: Boolean,
+  environment: Map<String, String>,
+  configStore: TelemetryConfigStore,
+): TelemetrySettings {
+  val configPath = configStore.configPath()
+  val config = if (materialize) configStore.ensure() else configStore.read()
+  val baseSettings = configBackedSettings(configPath, config)
+  val envSettings = applyEnvironmentOverrides(baseSettings, environment)
+  val enabled = envSettings.level != "off"
+  val (proxyUrl, customProxyUrl) = telemetryProxyUrl(envSettings.customProxyUrl)
+  require(!enabled || envSettings.installId.isNotBlank()) {
+    "Telemetry is enabled but no install_id is configured at '$configPath'. " +
+      "Run 'skill-bill telemetry enable' to create one."
+  }
+  return TelemetrySettings(
+    configPath = configPath,
+    level = envSettings.level,
+    enabled = enabled,
+    installId = envSettings.installId,
+    proxyUrl = proxyUrl,
+    customProxyUrl = customProxyUrl,
+    batchSize = envSettings.batchSize,
+  )
+}
+
+private data class MutableTelemetrySettings(
+  val level: String,
+  val customProxyUrl: String,
+  val batchSize: Int,
+  val installId: String,
+)
+
+private fun configBackedSettings(configPath: java.nio.file.Path, config: Map<String, Any?>?): MutableTelemetrySettings {
+  if (config == null) {
+    return MutableTelemetrySettings(
+      level = "off",
+      customProxyUrl = "",
+      batchSize = DEFAULT_TELEMETRY_BATCH_SIZE,
+      installId = "",
+    )
+  }
+  val telemetryRaw = config["telemetry"]
+  val telemetry =
+    when (telemetryRaw) {
+      null -> emptyMap()
+      is Map<*, *> -> telemetryRaw.entries.filter { it.key is String }.associate { it.key as String to it.value }
+      else -> throw IllegalArgumentException("Telemetry config at '$configPath' must contain a 'telemetry' object.")
+    }
+  return MutableTelemetrySettings(
+    level = telemetryLevelFromConfig(telemetry),
+    customProxyUrl = telemetry["proxy_url"]?.toString()?.trim().orEmpty(),
+    batchSize = telemetryBatchSize(telemetry),
+    installId = config["install_id"]?.toString()?.trim().orEmpty(),
+  )
+}
+
+private fun telemetryLevelFromConfig(telemetry: Map<String, Any?>): String {
+  val levelRaw = telemetry["level"]
+  val enabledRaw = telemetry["enabled"]
+  return when {
+    levelRaw != null -> TelemetryConfigRuntime.parseTelemetryLevel(levelRaw.toString(), "telemetry.level")
+    enabledRaw is Boolean -> if (enabledRaw) "anonymous" else "off"
+    enabledRaw is String ->
+      if (TelemetryConfigRuntime.parseBoolValue(enabledRaw, "telemetry.enabled")) {
+        "anonymous"
+      } else {
+        "off"
+      }
+    enabledRaw != null -> if (enabledRaw == true) "anonymous" else "off"
+    else -> "anonymous"
+  }
+}
+
+private fun telemetryBatchSize(telemetry: Map<String, Any?>): Int = when (val batchSizeRaw = telemetry["batch_size"]) {
+  is Int -> batchSizeRaw
+  is Number -> batchSizeRaw.toInt()
+  null -> DEFAULT_TELEMETRY_BATCH_SIZE
+  else -> TelemetryConfigRuntime.parsePositiveInt(batchSizeRaw.toString(), "telemetry.batch_size")
+}
+
+private fun applyEnvironmentOverrides(
+  settings: MutableTelemetrySettings,
+  environment: Map<String, String>,
+): MutableTelemetrySettings {
+  var level = settings.level
+  var customProxyUrl = settings.customProxyUrl
+  var batchSize = settings.batchSize
+  var installId = settings.installId
+
+  environment[TELEMETRY_LEVEL_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
+    level = TelemetryConfigRuntime.parseTelemetryLevel(it, TELEMETRY_LEVEL_ENVIRONMENT_KEY)
+  } ?: environment[TELEMETRY_ENABLED_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
+    level = if (TelemetryConfigRuntime.parseBoolValue(it, TELEMETRY_ENABLED_ENVIRONMENT_KEY)) "anonymous" else "off"
+  }
+  environment[TELEMETRY_PROXY_URL_ENVIRONMENT_KEY]
+    ?.takeIf(String::isNotBlank)
+    ?.let { customProxyUrl = it.trim() }
+  environment[INSTALL_ID_ENVIRONMENT_KEY]
+    ?.takeIf(String::isNotBlank)
+    ?.let { installId = it.trim() }
+  environment[TELEMETRY_BATCH_SIZE_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
+    batchSize = TelemetryConfigRuntime.parsePositiveInt(it, TELEMETRY_BATCH_SIZE_ENVIRONMENT_KEY)
+  }
+  return MutableTelemetrySettings(
+    level = level,
+    customProxyUrl = customProxyUrl,
+    batchSize = batchSize,
+    installId = installId,
+  )
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryConfigMutationRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryConfigMutationRuntime.kt
@@ -1,10 +1,9 @@
 package skillbill.telemetry
 
-import skillbill.contracts.JsonSupport
-import java.nio.file.Files
+import skillbill.RuntimeContext
+import skillbill.infrastructure.fs.FileTelemetryConfigStore
+import skillbill.infrastructure.sqlite.SQLiteTelemetryOutboxPurger
 import java.nio.file.Path
-import java.sql.Connection
-import java.sql.DriverManager
 
 object TelemetryConfigMutationRuntime {
   fun setTelemetryLevel(
@@ -13,14 +12,22 @@ object TelemetryConfigMutationRuntime {
     environment: Map<String, String> = System.getenv(),
     userHome: Path = Path.of(System.getProperty("user.home")),
   ): Pair<TelemetrySettings, Int> {
-    require(level in telemetryLevels) {
-      "Telemetry level must be one of: ${telemetryLevels.joinToString(", ")}."
-    }
-    val configPath = TelemetryConfigRuntime.resolveConfigPath(environment, userHome)
+    val context = RuntimeContext(environment = environment, userHome = userHome)
+    val configStore = FileTelemetryConfigStore(context)
+    val settingsProvider = DefaultTelemetrySettingsProvider(context, configStore)
     return if (level == "off") {
-      disableTelemetry(configPath, dbPath, environment, userHome)
+      require(level in telemetryLevels) {
+        "Telemetry level must be one of: ${telemetryLevels.joinToString(", ")}."
+      }
+      configStore.delete()
+      val clearedEvents = dbPath?.let(SQLiteTelemetryOutboxPurger::clearIfDatabaseExists).orEmpty()
+      settingsProvider.load(materialize = false) to clearedEvents
     } else {
-      enableTelemetry(configPath, level, environment, userHome)
+      TelemetryConfigMutations.setTelemetryLevel(
+        level = level,
+        configStore = configStore,
+        settingsProvider = settingsProvider,
+      )
     }
   }
 
@@ -37,91 +44,4 @@ object TelemetryConfigMutationRuntime {
   )
 }
 
-private fun enableTelemetry(
-  configPath: Path,
-  level: String,
-  environment: Map<String, String>,
-  userHome: Path,
-): Pair<TelemetrySettings, Int> {
-  val payload = TelemetryConfigRuntime.ensureLocalConfig(configPath).toMutableMap()
-  val telemetry =
-    (
-      (payload["telemetry"] as? Map<*, *>)
-        ?.entries
-        ?.filter { it.key is String }
-        ?.associate { it.key as String to it.value }
-        ?.toMutableMap()
-      )
-      ?: throw IllegalArgumentException(
-        "Telemetry config at '$configPath' must contain a 'telemetry' object.",
-      )
-  telemetry["level"] = level
-  telemetry.remove("enabled")
-  payload["telemetry"] = telemetry
-  Files.writeString(configPath, JsonSupport.mapToJsonString(payload) + "\n")
-  return TelemetryConfigRuntime.loadTelemetrySettings(
-    materialize = true,
-    environment = environment,
-    userHome = userHome,
-  ) to 0
-}
-
-private fun disableTelemetry(
-  configPath: Path,
-  dbPath: Path?,
-  environment: Map<String, String>,
-  userHome: Path,
-): Pair<TelemetrySettings, Int> {
-  Files.deleteIfExists(configPath)
-  val clearedEvents = dbPath?.let(::purgeTelemetryOutbox).orEmpty()
-  return TelemetryConfigRuntime.loadTelemetrySettings(
-    materialize = false,
-    environment = environment,
-    userHome = userHome,
-  ) to clearedEvents
-}
-
-private fun purgeTelemetryOutbox(dbPath: Path): Int {
-  if (!Files.exists(dbPath)) {
-    return 0
-  }
-  val jdbcUrl = "jdbc:sqlite:${dbPath.toAbsolutePath().normalize()}"
-  return DriverManager.getConnection(jdbcUrl).use(::purgeTelemetryOutboxRows)
-}
-
 private fun Int?.orEmpty(): Int = this ?: 0
-
-private fun purgeTelemetryOutboxRows(connection: Connection): Int {
-  if (!hasTelemetryOutbox(connection)) {
-    return 0
-  }
-  val pendingEvents = countPendingTelemetryEvents(connection)
-  deleteTelemetryOutboxRows(connection)
-  return pendingEvents
-}
-
-private fun hasTelemetryOutbox(connection: Connection): Boolean = connection.createStatement().use { statement ->
-  statement.executeQuery(
-    """
-    SELECT 1
-    FROM sqlite_master
-    WHERE type = 'table' AND name = 'telemetry_outbox'
-    """.trimIndent(),
-  ).use { resultSet -> resultSet.next() }
-}
-
-private fun countPendingTelemetryEvents(connection: Connection): Int = connection.createStatement().use { statement ->
-  statement.executeQuery("SELECT COUNT(*) FROM telemetry_outbox").use { resultSet ->
-    if (resultSet.next()) {
-      resultSet.getInt(1)
-    } else {
-      0
-    }
-  }
-}
-
-private fun deleteTelemetryOutboxRows(connection: Connection) {
-  connection.createStatement().use { statement ->
-    statement.executeUpdate("DELETE FROM telemetry_outbox")
-  }
-}

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryConfigMutations.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryConfigMutations.kt
@@ -1,0 +1,71 @@
+package skillbill.telemetry
+
+import skillbill.ports.persistence.TelemetryOutboxRepository
+import skillbill.ports.telemetry.TelemetryConfigStore
+import skillbill.ports.telemetry.TelemetrySettingsProvider
+
+object TelemetryConfigMutations {
+  fun setTelemetryLevel(
+    level: String,
+    configStore: TelemetryConfigStore,
+    settingsProvider: TelemetrySettingsProvider,
+    outbox: TelemetryOutboxRepository? = null,
+  ): Pair<TelemetrySettings, Int> {
+    require(level in telemetryLevels) {
+      "Telemetry level must be one of: ${telemetryLevels.joinToString(", ")}."
+    }
+    return if (level == "off") {
+      disableTelemetry(configStore, settingsProvider, outbox)
+    } else {
+      enableTelemetry(configStore, settingsProvider, level)
+    }
+  }
+
+  fun setTelemetryEnabled(
+    enabled: Boolean,
+    configStore: TelemetryConfigStore,
+    settingsProvider: TelemetrySettingsProvider,
+    outbox: TelemetryOutboxRepository? = null,
+  ): Pair<TelemetrySettings, Int> = setTelemetryLevel(
+    level = if (enabled) "anonymous" else "off",
+    configStore = configStore,
+    settingsProvider = settingsProvider,
+    outbox = outbox,
+  )
+}
+
+private fun enableTelemetry(
+  configStore: TelemetryConfigStore,
+  settingsProvider: TelemetrySettingsProvider,
+  level: String,
+): Pair<TelemetrySettings, Int> {
+  val payload = configStore.ensure().toMutableMap()
+  val telemetry =
+    (
+      (payload["telemetry"] as? Map<*, *>)
+        ?.entries
+        ?.filter { it.key is String }
+        ?.associate { it.key as String to it.value }
+        ?.toMutableMap()
+      )
+      ?: throw IllegalArgumentException(
+        "Telemetry config at '${configStore.configPath()}' must contain a 'telemetry' object.",
+      )
+  telemetry["level"] = level
+  telemetry.remove("enabled")
+  payload["telemetry"] = telemetry
+  configStore.write(payload)
+  return settingsProvider.load(materialize = true) to 0
+}
+
+private fun disableTelemetry(
+  configStore: TelemetryConfigStore,
+  settingsProvider: TelemetrySettingsProvider,
+  outbox: TelemetryOutboxRepository?,
+): Pair<TelemetrySettings, Int> {
+  configStore.delete()
+  val clearedEvents = outbox?.clear().orEmpty()
+  return settingsProvider.load(materialize = false) to clearedEvents
+}
+
+private fun Int?.orEmpty(): Int = this ?: 0

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryConfigRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryConfigRuntime.kt
@@ -1,7 +1,11 @@
 package skillbill.telemetry
 
-import skillbill.contracts.JsonSupport
-import java.nio.file.Files
+import skillbill.RuntimeContext
+import skillbill.infrastructure.fs.FileTelemetryConfigStore
+import skillbill.infrastructure.fs.ensureTelemetryConfigFile
+import skillbill.infrastructure.fs.readTelemetryConfigFile
+import skillbill.infrastructure.fs.resolveTelemetryConfigPath
+import skillbill.infrastructure.fs.resolveTelemetryStateDir
 import java.nio.file.Path
 import java.util.UUID
 
@@ -9,16 +13,12 @@ object TelemetryConfigRuntime {
   fun stateDir(
     environment: Map<String, String> = System.getenv(),
     userHome: Path = Path.of(System.getProperty("user.home")),
-  ): Path = environment[STATE_DIR_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
-    expandAndNormalizeTelemetryPath(it, userHome)
-  } ?: userHome.resolve(".skill-bill").toAbsolutePath().normalize()
+  ): Path = resolveTelemetryStateDir(environment, userHome)
 
   fun resolveConfigPath(
     environment: Map<String, String> = System.getenv(),
     userHome: Path = Path.of(System.getProperty("user.home")),
-  ): Path = environment[CONFIG_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
-    expandAndNormalizeTelemetryPath(it, userHome)
-  } ?: userHome.resolve(".skill-bill").resolve("config.json").toAbsolutePath().normalize()
+  ): Path = resolveTelemetryConfigPath(environment, userHome)
 
   fun defaultLocalConfig(): Map<String, Any?> = mapOf(
     "install_id" to UUID.randomUUID().toString(),
@@ -30,28 +30,9 @@ object TelemetryConfigRuntime {
       ),
   )
 
-  fun readLocalConfig(path: Path): Map<String, Any?>? {
-    if (!Files.exists(path)) {
-      return null
-    }
-    val rawPayload = JsonSupport.parseObjectOrNull(Files.readString(path))
-      ?: throw IllegalArgumentException("Telemetry config at '$path' is not valid JSON.")
-    return JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(rawPayload))
-      ?: throw IllegalArgumentException("Telemetry config at '$path' must contain a JSON object.")
-  }
+  fun readLocalConfig(path: Path): Map<String, Any?>? = readTelemetryConfigFile(path)
 
-  fun ensureLocalConfig(path: Path): Map<String, Any?> {
-    path.parent?.let(Files::createDirectories)
-    val payload = (readLocalConfig(path)?.toMutableMap() ?: mutableMapOf())
-    val defaults = defaultLocalConfig()
-    val telemetry = normalizedTelemetryMap(payload, defaults)
-    payload["install_id"] = normalizedInstallId(payload, defaults)
-    payload["telemetry"] = telemetry
-    if (!Files.exists(path) || readLocalConfig(path) != payload) {
-      Files.writeString(path, JsonSupport.mapToJsonString(payload) + "\n")
-    }
-    return payload
-  }
+  fun ensureLocalConfig(path: Path): Map<String, Any?> = ensureTelemetryConfigFile(path)
 
   fun parseBoolValue(rawValue: String, name: String): Boolean = when (rawValue.trim().lowercase()) {
     "1", "true", "yes", "on" -> true
@@ -77,27 +58,11 @@ object TelemetryConfigRuntime {
     materialize: Boolean = false,
     environment: Map<String, String> = System.getenv(),
     userHome: Path = Path.of(System.getProperty("user.home")),
-  ): TelemetrySettings {
-    val configPath = resolveConfigPath(environment, userHome)
-    val config = if (materialize) ensureLocalConfig(configPath) else readLocalConfig(configPath)
-    val baseSettings = configBackedSettings(configPath, config)
-    val envSettings = applyEnvironmentOverrides(baseSettings, environment)
-    val enabled = envSettings.level != "off"
-    val (proxyUrl, customProxyUrl) = telemetryProxyUrl(envSettings.customProxyUrl)
-    require(!enabled || envSettings.installId.isNotBlank()) {
-      "Telemetry is enabled but no install_id is configured at '$configPath'. " +
-        "Run 'skill-bill telemetry enable' to create one."
-    }
-    return TelemetrySettings(
-      configPath = configPath,
-      level = envSettings.level,
-      enabled = enabled,
-      installId = envSettings.installId,
-      proxyUrl = proxyUrl,
-      customProxyUrl = customProxyUrl,
-      batchSize = envSettings.batchSize,
-    )
-  }
+  ): TelemetrySettings = loadTelemetrySettingsFromStore(
+    materialize = materialize,
+    environment = environment,
+    configStore = FileTelemetryConfigStore(RuntimeContext(environment = environment, userHome = userHome)),
+  )
 
   fun telemetryIsEnabled(
     environment: Map<String, String> = System.getenv(),
@@ -105,125 +70,4 @@ object TelemetryConfigRuntime {
   ): Boolean = runCatching {
     loadTelemetrySettings(environment = environment, userHome = userHome).enabled
   }.getOrDefault(false)
-}
-
-private data class MutableTelemetrySettings(
-  val level: String,
-  val customProxyUrl: String,
-  val batchSize: Int,
-  val installId: String,
-)
-
-private fun normalizedInstallId(payload: MutableMap<String, Any?>, defaults: Map<String, Any?>): String =
-  (payload["install_id"] as? String)?.takeIf(String::isNotBlank)
-    ?: defaults.getValue("install_id").toString()
-
-private fun normalizedTelemetryMap(payload: MutableMap<String, Any?>, defaults: Map<String, Any?>): Map<String, Any?> {
-  val telemetryRaw = payload["telemetry"]
-  val telemetry =
-    (telemetryRaw as? Map<*, *>)
-      ?.entries
-      ?.filter { it.key is String }
-      ?.associate { it.key as String to it.value }
-      ?.toMutableMap() ?: mutableMapOf()
-  val defaultTelemetry = defaults.getValue("telemetry") as Map<*, *>
-  normalizeLegacyEnabledFlag(telemetry)
-  listOf("level", "proxy_url", "batch_size").forEach { key ->
-    telemetry.putIfAbsent(key, defaultTelemetry[key])
-  }
-  return telemetry
-}
-
-private fun normalizeLegacyEnabledFlag(telemetry: MutableMap<String, Any?>) {
-  if (!telemetry.containsKey("level") && telemetry.containsKey("enabled")) {
-    val enabledRaw = telemetry.remove("enabled")
-    telemetry["level"] = legacyEnabledLevel(enabledRaw)
-  } else {
-    telemetry.remove("enabled")
-  }
-}
-
-private fun legacyEnabledLevel(enabledRaw: Any?): String = when (enabledRaw) {
-  is Boolean -> if (enabledRaw) "anonymous" else "off"
-  is String -> if (TelemetryConfigRuntime.parseBoolValue(enabledRaw, "telemetry.enabled")) "anonymous" else "off"
-  else -> if (enabledRaw == true) "anonymous" else "off"
-}
-
-private fun configBackedSettings(configPath: Path, config: Map<String, Any?>?): MutableTelemetrySettings {
-  if (config == null) {
-    return MutableTelemetrySettings(
-      level = "off",
-      customProxyUrl = "",
-      batchSize = DEFAULT_TELEMETRY_BATCH_SIZE,
-      installId = "",
-    )
-  }
-  val telemetryRaw = config["telemetry"]
-  val telemetry =
-    when (telemetryRaw) {
-      null -> emptyMap()
-      is Map<*, *> -> telemetryRaw.entries.filter { it.key is String }.associate { it.key as String to it.value }
-      else -> throw IllegalArgumentException("Telemetry config at '$configPath' must contain a 'telemetry' object.")
-    }
-  return MutableTelemetrySettings(
-    level = telemetryLevelFromConfig(telemetry),
-    customProxyUrl = telemetry["proxy_url"]?.toString()?.trim().orEmpty(),
-    batchSize = telemetryBatchSize(telemetry),
-    installId = config["install_id"]?.toString()?.trim().orEmpty(),
-  )
-}
-
-private fun telemetryLevelFromConfig(telemetry: Map<String, Any?>): String {
-  val levelRaw = telemetry["level"]
-  val enabledRaw = telemetry["enabled"]
-  return when {
-    levelRaw != null -> TelemetryConfigRuntime.parseTelemetryLevel(levelRaw.toString(), "telemetry.level")
-    enabledRaw is Boolean -> if (enabledRaw) "anonymous" else "off"
-    enabledRaw is String ->
-      if (TelemetryConfigRuntime.parseBoolValue(enabledRaw, "telemetry.enabled")) {
-        "anonymous"
-      } else {
-        "off"
-      }
-    enabledRaw != null -> if (enabledRaw == true) "anonymous" else "off"
-    else -> "anonymous"
-  }
-}
-
-private fun telemetryBatchSize(telemetry: Map<String, Any?>): Int = when (val batchSizeRaw = telemetry["batch_size"]) {
-  is Int -> batchSizeRaw
-  is Number -> batchSizeRaw.toInt()
-  null -> DEFAULT_TELEMETRY_BATCH_SIZE
-  else -> TelemetryConfigRuntime.parsePositiveInt(batchSizeRaw.toString(), "telemetry.batch_size")
-}
-
-private fun applyEnvironmentOverrides(
-  settings: MutableTelemetrySettings,
-  environment: Map<String, String>,
-): MutableTelemetrySettings {
-  var level = settings.level
-  var customProxyUrl = settings.customProxyUrl
-  var batchSize = settings.batchSize
-  var installId = settings.installId
-
-  environment[TELEMETRY_LEVEL_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
-    level = TelemetryConfigRuntime.parseTelemetryLevel(it, TELEMETRY_LEVEL_ENVIRONMENT_KEY)
-  } ?: environment[TELEMETRY_ENABLED_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
-    level = if (TelemetryConfigRuntime.parseBoolValue(it, TELEMETRY_ENABLED_ENVIRONMENT_KEY)) "anonymous" else "off"
-  }
-  environment[TELEMETRY_PROXY_URL_ENVIRONMENT_KEY]
-    ?.takeIf(String::isNotBlank)
-    ?.let { customProxyUrl = it.trim() }
-  environment[INSTALL_ID_ENVIRONMENT_KEY]
-    ?.takeIf(String::isNotBlank)
-    ?.let { installId = it.trim() }
-  environment[TELEMETRY_BATCH_SIZE_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
-    batchSize = TelemetryConfigRuntime.parsePositiveInt(it, TELEMETRY_BATCH_SIZE_ENVIRONMENT_KEY)
-  }
-  return MutableTelemetrySettings(
-    level = level,
-    customProxyUrl = customProxyUrl,
-    batchSize = batchSize,
-    installId = installId,
-  )
 }

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryHttpRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryHttpRuntime.kt
@@ -1,178 +1,27 @@
 package skillbill.telemetry
 
-import skillbill.contracts.JsonSupport
-import skillbill.db.TelemetryOutboxRow
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse.BodyHandlers
+import skillbill.contracts.telemetry.telemetryProxyBatchPayload
+import skillbill.infrastructure.http.HttpTelemetryClient
+import skillbill.infrastructure.http.JdkHttpRequester
+import skillbill.ports.persistence.TelemetryOutboxRecord
 
 object TelemetryHttpRuntime {
-  val defaultHttpRequester: HttpRequester =
-    HttpRequester { method, url, bodyJson, headers ->
-      val requestBuilder =
-        HttpRequest
-          .newBuilder(URI.create(url))
-          .method(method, bodyPublisher(bodyJson))
-      headers.forEach(requestBuilder::header)
-      val response = HttpClient.newHttpClient().send(requestBuilder.build(), BodyHandlers.ofString())
-      HttpResponse(statusCode = response.statusCode(), body = response.body().orEmpty())
-    }
+  val defaultHttpRequester: HttpRequester = JdkHttpRequester
 
-  fun buildTelemetryBatch(settings: TelemetrySettings, rows: List<TelemetryOutboxRow>): List<Map<String, Any?>> =
-    rows.map { row ->
-      val properties = telemetryProperties(row.payloadJson, settings.installId)
-      mapOf(
-        "event" to row.eventName,
-        "distinct_id" to settings.installId,
-        "properties" to properties,
-        "timestamp" to row.createdAt,
-      )
-    }
+  fun buildTelemetryBatch(settings: TelemetrySettings, rows: List<TelemetryOutboxRecord>): List<Map<String, Any?>> =
+    telemetryProxyBatchPayload(settings, rows).batch.map { it.toPayload() }
 
   fun fetchProxyCapabilities(
     settings: TelemetrySettings = TelemetryConfigRuntime.loadTelemetrySettings(),
     requester: HttpRequester = defaultHttpRequester,
     environment: Map<String, String> = System.getenv(),
-  ): Map<String, Any?> {
-    require(settings.proxyUrl.isNotBlank()) { "Telemetry relay URL is not configured." }
-    val capabilitiesUrl = settings.proxyUrl.trimEnd('/') + "/capabilities"
-    return try {
-      requestJsonGet(
-        url = capabilitiesUrl,
-        errorContext = "Telemetry proxy capabilities request",
-        headers = proxyAuthHeaders(environment),
-        requester = requester,
-      ).toMutableMap().apply {
-        putIfAbsent("contract_version", TELEMETRY_PROXY_CONTRACT_VERSION)
-        putIfAbsent("source", "remote_proxy")
-        putIfAbsent("proxy_url", settings.proxyUrl)
-        putIfAbsent("capabilities_url", capabilitiesUrl)
-        putIfAbsent("supports_ingest", true)
-        putIfAbsent("supports_stats", false)
-        putIfAbsent("supported_workflows", emptyList<String>())
-      }
-    } catch (error: HttpFailureException) {
-      if (error.statusCode == HTTP_NOT_FOUND || error.statusCode == HTTP_METHOD_NOT_ALLOWED) {
-        defaultProxyCapabilities(settings.proxyUrl, capabilitiesUrl)
-      } else {
-        throw IllegalArgumentException(
-          error.message ?: "Telemetry proxy capabilities request failed.",
-          error,
-        )
-      }
-    }
-  }
+  ): Map<String, Any?> = HttpTelemetryClient(requester, environment).fetchProxyCapabilities(settings)
 
   fun sendProxyBatch(
     settings: TelemetrySettings,
-    rows: List<TelemetryOutboxRow>,
+    rows: List<TelemetryOutboxRecord>,
     requester: HttpRequester = defaultHttpRequester,
   ) {
-    require(settings.proxyUrl.isNotBlank()) { "Telemetry relay URL is not configured." }
-    val payload = mapOf("batch" to buildTelemetryBatch(settings, rows))
-    val errorContext =
-      if (settings.customProxyUrl != null) {
-        "Telemetry custom proxy sync"
-      } else {
-        "Telemetry relay sync"
-      }
-    postJson(
-      url = settings.proxyUrl,
-      payload = payload,
-      errorContext = errorContext,
-      requester = requester,
-    )
+    HttpTelemetryClient(requester).sendBatch(settings, rows)
   }
 }
-
-internal fun requestJson(
-  url: String,
-  payload: Map<String, Any?>,
-  errorContext: String,
-  headers: Map<String, String>,
-  requester: HttpRequester,
-): Map<String, Any?> {
-  val response =
-    requester.execute(
-      "POST",
-      url,
-      JsonSupport.mapToJsonString(payload),
-      defaultJsonHeaders() + headers,
-    )
-  ensureSuccessfulResponse(response, errorContext)
-  return decodeJsonObject(response.body, errorContext)
-}
-
-internal fun requestJsonGet(
-  url: String,
-  errorContext: String,
-  headers: Map<String, String>,
-  requester: HttpRequester,
-): Map<String, Any?> {
-  val response =
-    requester.execute(
-      "GET",
-      url,
-      null,
-      mapOf("User-Agent" to "skill-bill-telemetry/1.0") + headers,
-    )
-  ensureSuccessfulResponse(response, errorContext)
-  return decodeJsonObject(response.body, errorContext)
-}
-
-private fun postJson(url: String, payload: Map<String, Any?>, errorContext: String, requester: HttpRequester) {
-  val response =
-    requester.execute(
-      "POST",
-      url,
-      JsonSupport.mapToJsonString(payload),
-      defaultJsonHeaders(),
-    )
-  ensureSuccessfulResponse(response, errorContext)
-}
-
-private fun ensureSuccessfulResponse(response: HttpResponse, errorContext: String) {
-  if (response.statusCode !in HTTP_OK_MIN..HTTP_OK_MAX) {
-    throw HttpFailureException(
-      response.statusCode,
-      httpFailureMessage(response, errorContext),
-    )
-  }
-}
-
-private fun decodeJsonObject(body: String, errorContext: String): Map<String, Any?> {
-  if (body.isBlank()) {
-    return emptyMap()
-  }
-  val decoded =
-    JsonSupport.parseObjectOrNull(body)
-      ?: throw IllegalArgumentException("$errorContext returned invalid JSON.")
-  return JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(decoded))
-    ?: throw IllegalArgumentException(
-      "$errorContext returned a non-object JSON payload.",
-    )
-}
-
-private fun httpFailureMessage(response: HttpResponse, errorContext: String): String = if (response.body.isBlank()) {
-  "$errorContext failed with HTTP ${response.statusCode}."
-} else {
-  "$errorContext failed with HTTP ${response.statusCode}. ${response.body.trim()}"
-}
-
-internal fun proxyAuthHeaders(environment: Map<String, String>): Map<String, String> =
-  environment[TELEMETRY_PROXY_STATS_TOKEN_ENVIRONMENT_KEY]
-    ?.trim()
-    ?.takeIf(String::isNotBlank)
-    ?.let { mapOf("Authorization" to "Bearer $it") }
-    ?: emptyMap()
-
-private fun defaultJsonHeaders(): Map<String, String> = mapOf(
-  "Content-Type" to "application/json",
-  "User-Agent" to "skill-bill-telemetry/1.0",
-)
-
-internal class HttpFailureException(
-  val statusCode: Int,
-  message: String,
-) : IllegalArgumentException(message)

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryHttpSupport.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryHttpSupport.kt
@@ -1,32 +1,4 @@
 package skillbill.telemetry
 
-import skillbill.contracts.JsonSupport
-import java.net.http.HttpRequest
-
 internal const val HTTP_NOT_FOUND: Int = 404
 internal const val HTTP_METHOD_NOT_ALLOWED: Int = 405
-
-internal fun telemetryProperties(payloadJson: String, installId: String): MutableMap<String, Any?> = (
-  JsonSupport.parseObjectOrNull(payloadJson)?.let {
-    JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(it))
-  } ?: emptyMap()
-  ).toMutableMap().apply {
-  this["install_id"] = installId
-  this["\$process_person_profile"] = false
-}
-
-internal fun defaultProxyCapabilities(proxyUrl: String, capabilitiesUrl: String): Map<String, Any?> = mapOf(
-  "contract_version" to "0",
-  "source" to "remote_proxy",
-  "proxy_url" to proxyUrl,
-  "capabilities_url" to capabilitiesUrl,
-  "supports_ingest" to true,
-  "supports_stats" to false,
-  "supported_workflows" to emptyList<String>(),
-)
-
-internal fun bodyPublisher(bodyJson: String?): HttpRequest.BodyPublisher = if (bodyJson == null) {
-  HttpRequest.BodyPublishers.noBody()
-} else {
-  HttpRequest.BodyPublishers.ofString(bodyJson)
-}

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryModels.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryModels.kt
@@ -2,6 +2,10 @@ package skillbill.telemetry
 
 import java.nio.file.Path
 
+typealias HttpResponse = skillbill.ports.telemetry.HttpResponse
+
+typealias HttpRequester = skillbill.ports.telemetry.HttpRequester
+
 data class TelemetrySettings(
   val configPath: Path,
   val level: String,
@@ -26,12 +30,3 @@ data class SyncResult(
   val customProxyUrl: String? = null,
   val message: String? = null,
 )
-
-data class HttpResponse(
-  val statusCode: Int,
-  val body: String,
-)
-
-fun interface HttpRequester {
-  fun execute(method: String, url: String, bodyJson: String?, headers: Map<String, String>): HttpResponse
-}

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryRemoteStatsRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetryRemoteStatsRuntime.kt
@@ -17,64 +17,27 @@ object TelemetryRemoteStatsRuntime {
     dateFrom: String = "",
     dateTo: String = "",
     today: LocalDate = LocalDate.now(ZoneOffset.UTC),
-  ): Pair<String, String> {
-    require(dateFrom.isBlank() || since.isBlank()) {
-      "Use either since or date_from/date_to, not both."
-    }
-    val endDate = resolvedEndDate(dateTo, today)
-    val startDate = resolvedStartDate(since, dateFrom, endDate)
-    require(!startDate.isAfter(endDate)) {
-      "date_from must be on or before date_to."
-    }
-    return startDate.toString() to endDate.toString()
-  }
-
-  fun fetchRemoteStats(
-    request: RemoteStatsRequest,
-    settings: TelemetrySettings = TelemetryConfigRuntime.loadTelemetrySettings(),
-    requester: HttpRequester = TelemetryHttpRuntime.defaultHttpRequester,
-    environment: Map<String, String> = System.getenv(),
-  ): Map<String, Any?> {
-    validateRemoteStatsRequest(request)
-    require(settings.proxyUrl.isNotBlank()) {
-      "Telemetry relay URL is not configured."
-    }
-    val (resolvedDateFrom, resolvedDateTo) =
-      parseRemoteStatsWindow(request.since, request.dateFrom, request.dateTo)
-    val capabilities =
-      TelemetryHttpRuntime.fetchProxyCapabilities(
-        settings = settings,
-        requester = requester,
-        environment = environment,
-      )
-    validateRemoteStatsCapabilities(
-      request = request,
-      settings = settings,
-      capabilities = capabilities,
-    )
-    val statsUrl = settings.proxyUrl.trimEnd('/') + "/stats"
-    val payload =
-      requestJson(
-        url = statsUrl,
-        payload = remoteStatsPayload(request, resolvedDateFrom, resolvedDateTo),
-        errorContext = "Remote telemetry stats request",
-        headers = proxyAuthHeaders(environment),
-        requester = requester,
-      ).toMutableMap()
-    payload.putIfAbsent("workflow", request.workflow)
-    payload.putIfAbsent("date_from", resolvedDateFrom)
-    payload.putIfAbsent("date_to", resolvedDateTo)
-    payload.putIfAbsent("source", "remote_proxy")
-    payload.putIfAbsent("stats_url", statsUrl)
-    payload.putIfAbsent("capabilities", capabilities)
-    if (request.groupBy.isNotBlank()) {
-      payload.putIfAbsent("group_by", request.groupBy)
-    }
-    return payload
-  }
+  ): Pair<String, String> = skillbill.telemetry.parseRemoteStatsWindow(since, dateFrom, dateTo, today)
 }
 
-private fun validateRemoteStatsRequest(request: RemoteStatsRequest) {
+internal fun parseRemoteStatsWindow(
+  since: String = "",
+  dateFrom: String = "",
+  dateTo: String = "",
+  today: LocalDate = LocalDate.now(ZoneOffset.UTC),
+): Pair<String, String> {
+  require(dateFrom.isBlank() || since.isBlank()) {
+    "Use either since or date_from/date_to, not both."
+  }
+  val endDate = resolvedEndDate(dateTo, today)
+  val startDate = resolvedStartDate(since, dateFrom, endDate)
+  require(!startDate.isAfter(endDate)) {
+    "date_from must be on or before date_to."
+  }
+  return startDate.toString() to endDate.toString()
+}
+
+internal fun validateRemoteStatsRequest(request: RemoteStatsRequest) {
   require(request.workflow in remoteStatsWorkflows) {
     "workflow must be one of: ${remoteStatsWorkflows.joinToString(", ")}."
   }
@@ -83,7 +46,7 @@ private fun validateRemoteStatsRequest(request: RemoteStatsRequest) {
   }
 }
 
-private fun validateRemoteStatsCapabilities(
+internal fun validateRemoteStatsCapabilities(
   request: RemoteStatsRequest,
   settings: TelemetrySettings,
   capabilities: Map<String, Any?>,
@@ -101,19 +64,6 @@ private fun validateRemoteStatsCapabilities(
   require(supportedWorkflows.isEmpty() || request.workflow in supportedWorkflows) {
     "Configured telemetry proxy does not support workflow '${request.workflow}'. " +
       "Supported workflows: ${supportedWorkflows.joinToString(", ")}."
-  }
-}
-
-private fun remoteStatsPayload(
-  request: RemoteStatsRequest,
-  resolvedDateFrom: String,
-  resolvedDateTo: String,
-): Map<String, Any?> = buildMap {
-  put("workflow", request.workflow)
-  put("date_from", resolvedDateFrom)
-  put("date_to", resolvedDateTo)
-  if (request.groupBy.isNotBlank()) {
-    put("group_by", request.groupBy)
   }
 }
 

--- a/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetrySyncRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/telemetry/TelemetrySyncRuntime.kt
@@ -1,20 +1,22 @@
 package skillbill.telemetry
 
-import skillbill.db.DatabaseRuntime
-import skillbill.db.TelemetryOutboxRow
-import skillbill.db.TelemetryOutboxStore
+import skillbill.ports.persistence.TelemetryOutboxRecord
+import skillbill.ports.persistence.TelemetryOutboxRepository
+import skillbill.ports.telemetry.TelemetryClient
 import java.io.IOException
 import java.nio.file.Path
 
 object TelemetrySyncRuntime {
+  fun disabledSync(settings: TelemetrySettings): SyncResult = disabledSyncResult(settings)
+
   fun syncTelemetry(
-    dbPath: Path,
-    settings: TelemetrySettings = TelemetryConfigRuntime.loadTelemetrySettings(),
-    requester: HttpRequester = TelemetryHttpRuntime.defaultHttpRequester,
+    settings: TelemetrySettings,
+    outboxRepository: TelemetryOutboxRepository,
+    client: TelemetryClient,
   ): SyncResult = if (!settings.enabled) {
     disabledSyncResult(settings)
   } else {
-    syncEnabledTelemetry(dbPath, settings, requester)
+    syncEnabledTelemetry(settings, outboxRepository, client)
   }
 
   fun syncResultPayload(result: SyncResult): Map<String, Any?> = buildMap {
@@ -34,31 +36,29 @@ object TelemetrySyncRuntime {
 
   fun telemetryStatusPayload(
     dbPath: Path,
-    settings: TelemetrySettings = TelemetryConfigRuntime.loadTelemetrySettings(),
+    settings: TelemetrySettings,
+    pendingEvents: Int = 0,
+    latestError: String? = null,
   ): Map<String, Any?> {
     val payload = baseStatusPayload(dbPath, settings)
     if (!settings.enabled) {
       return payload
     }
-
-    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
-      val outboxStore = TelemetryOutboxStore(connection)
-      payload["pending_events"] = outboxStore.pendingCount()
-      outboxStore.latestError()?.let { payload["latest_error"] = it }
-    }
+    payload["pending_events"] = pendingEvents
+    latestError?.let { payload["latest_error"] = it }
     return payload
   }
 
   fun autoSyncTelemetry(
-    dbPath: Path,
+    settings: TelemetrySettings,
+    outboxRepository: TelemetryOutboxRepository,
+    client: TelemetryClient,
     reportFailures: Boolean = false,
     stderr: (String) -> Unit = {},
-    settings: TelemetrySettings = TelemetryConfigRuntime.loadTelemetrySettings(),
-    requester: HttpRequester = TelemetryHttpRuntime.defaultHttpRequester,
   ): SyncResult? {
     val result =
       try {
-        syncTelemetry(dbPath, settings, requester)
+        syncTelemetry(settings, outboxRepository, client)
       } catch (error: IllegalArgumentException) {
         if (reportFailures) {
           stderr("Telemetry sync skipped: ${error.message}")
@@ -78,27 +78,29 @@ fun telemetrySyncTarget(settings: TelemetrySettings): String = when {
   else -> "hosted_relay"
 }
 
-private fun syncEnabledTelemetry(dbPath: Path, settings: TelemetrySettings, requester: HttpRequester): SyncResult =
-  DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
-    val outboxStore = TelemetryOutboxStore(connection)
-    val pendingBefore = outboxStore.pendingCount()
-    val syncContext = syncContext(settings, pendingBefore)
-    when {
-      !syncContext.remoteConfigured -> unconfiguredSyncResult(syncContext)
-      pendingBefore == 0 -> noopSyncResult(syncContext)
-      else -> syncPendingBatches(outboxStore, settings, requester, syncContext)
-    }
+private fun syncEnabledTelemetry(
+  settings: TelemetrySettings,
+  outboxRepository: TelemetryOutboxRepository,
+  client: TelemetryClient,
+): SyncResult {
+  val pendingBefore = outboxRepository.pendingCount()
+  val syncContext = syncContext(settings, pendingBefore)
+  return when {
+    !syncContext.remoteConfigured -> unconfiguredSyncResult(syncContext)
+    pendingBefore == 0 -> noopSyncResult(syncContext)
+    else -> syncPendingBatches(outboxRepository, settings, client, syncContext)
   }
+}
 
 private fun syncPendingBatches(
-  outboxStore: TelemetryOutboxStore,
+  outboxRepository: TelemetryOutboxRepository,
   settings: TelemetrySettings,
-  requester: HttpRequester,
+  client: TelemetryClient,
   syncContext: SyncContext,
 ): SyncResult {
   var syncedTotal = 0
   while (true) {
-    val rows = outboxStore.listPending(limit = settings.batchSize)
+    val rows = outboxRepository.listPending(limit = settings.batchSize)
     if (rows.isEmpty()) {
       break
     }
@@ -106,9 +108,9 @@ private fun syncPendingBatches(
     val failureResult =
       trySyncBatch(
         PendingBatch(
-          outboxStore = outboxStore,
+          outboxRepository = outboxRepository,
           settings = settings,
-          requester = requester,
+          client = client,
           eventIds = eventIds,
           rows = rows,
           syncedTotal = syncedTotal,
@@ -120,12 +122,12 @@ private fun syncPendingBatches(
     }
     syncedTotal += eventIds.size
   }
-  return completedSyncResult(syncContext, syncedTotal, outboxStore.pendingCount())
+  return completedSyncResult(syncContext, syncedTotal, outboxRepository.pendingCount())
 }
 
 private fun trySyncBatch(batch: PendingBatch): SyncResult? = try {
-  TelemetryHttpRuntime.sendProxyBatch(batch.settings, batch.rows, batch.requester)
-  batch.outboxStore.markSynced(batch.eventIds)
+  batch.client.sendBatch(batch.settings, batch.rows)
+  batch.outboxRepository.markSynced(batch.eventIds)
   null
 } catch (error: IOException) {
   failedSyncResult(batch, error.message.orEmpty())
@@ -134,21 +136,21 @@ private fun trySyncBatch(batch: PendingBatch): SyncResult? = try {
 }
 
 private data class PendingBatch(
-  val outboxStore: TelemetryOutboxStore,
+  val outboxRepository: TelemetryOutboxRepository,
   val settings: TelemetrySettings,
-  val requester: HttpRequester,
+  val client: TelemetryClient,
   val eventIds: List<Long>,
-  val rows: List<TelemetryOutboxRow>,
+  val rows: List<TelemetryOutboxRecord>,
   val syncedTotal: Int,
   val syncContext: SyncContext,
 )
 
 private fun failedSyncResult(batch: PendingBatch, message: String): SyncResult {
-  batch.outboxStore.markFailed(batch.eventIds, message)
+  batch.outboxRepository.markFailed(batch.eventIds, message)
   return syncResult(
     status = "failed",
     syncedEvents = batch.syncedTotal,
-    pendingEvents = batch.outboxStore.pendingCount(),
+    pendingEvents = batch.outboxRepository.pendingCount(),
     syncContext = batch.syncContext,
     message = message,
   )

--- a/runtime-kotlin/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -16,10 +16,15 @@ import skillbill.ports.persistence.TelemetryOutboxRepository
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.persistence.WorkflowStateRecord
 import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.ports.telemetry.TelemetryClient
+import skillbill.ports.telemetry.TelemetryConfigStore
+import skillbill.ports.telemetry.TelemetrySettingsProvider
 import skillbill.review.FeedbackRequest
 import skillbill.review.FeedbackTelemetryOptions
 import skillbill.review.ImportedReview
 import skillbill.review.NumberedFinding
+import skillbill.telemetry.RemoteStatsRequest
+import skillbill.telemetry.TelemetrySettings
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -112,6 +117,7 @@ class ApplicationPersistencePortTest {
       ReviewService(
         RuntimeContext(environment = emptyMap(), userHome = Files.createTempDirectory("skillbill-app-fake")),
         database,
+        FakeTelemetrySettingsProvider(enabled = false),
       )
 
     val result =
@@ -126,11 +132,45 @@ class ApplicationPersistencePortTest {
     assertEquals(listOf("F-001", "F-002"), reviewRepository.feedbackRequests.map { it.findingIds.single() })
     assertEquals(listOf("fix_applied", "fix_applied"), result.recorded.map { it["outcome_type"] })
   }
+
+  @Test
+  fun `telemetry sync uses outbox repository and client ports inside transaction`() {
+    val outboxRepository =
+      InMemoryTelemetryOutboxRepository(
+        mutableListOf(
+          TelemetryOutboxRecord(
+            id = 1,
+            eventName = "skillbill_feature_implement_started",
+            payloadJson = """{"name":"ok"}""",
+            createdAt = "2026-04-24 00:00:00",
+            syncedAt = null,
+            lastError = "",
+          ),
+        ),
+      )
+    val database = FakeDatabaseSessionFactory(telemetryOutbox = outboxRepository)
+    val client = FakeTelemetryClient()
+    val service =
+      TelemetryService(
+        database = database,
+        settingsProvider = FakeTelemetrySettingsProvider(enabled = true),
+        configStore = FakeTelemetryConfigStore,
+        telemetryClient = client,
+      )
+
+    val result = service.sync(dbOverride = null)
+
+    assertEquals(listOf("transaction"), database.calls)
+    assertEquals("synced", result.payload["sync_status"])
+    assertEquals(listOf(listOf(1L)), client.sentBatchIds)
+    assertEquals(0, outboxRepository.pendingCount())
+  }
 }
 
 private class FakeDatabaseSessionFactory(
   private val reviews: ReviewRepository = FakeReviewRepository(),
   private val learnings: LearningRepository = FakeLearningRepository(),
+  private val telemetryOutbox: TelemetryOutboxRepository = NoopTelemetryOutboxRepository,
 ) : DatabaseSessionFactory {
   val calls = mutableListOf<String>()
   private val dbPath = Path.of("/fake/metrics.db")
@@ -153,7 +193,7 @@ private class FakeDatabaseSessionFactory(
     override val dbPath: Path = this@FakeDatabaseSessionFactory.dbPath
     override val reviews: ReviewRepository = this@FakeDatabaseSessionFactory.reviews
     override val learnings: LearningRepository = this@FakeDatabaseSessionFactory.learnings
-    override val telemetryOutbox: TelemetryOutboxRepository = NoopTelemetryOutboxRepository
+    override val telemetryOutbox: TelemetryOutboxRepository = this@FakeDatabaseSessionFactory.telemetryOutbox
     override val workflowStates: WorkflowStateRepository = NoopWorkflowStateRepository
   }
 }
@@ -263,6 +303,91 @@ private object NoopTelemetryOutboxRepository : TelemetryOutboxRepository {
   override fun markFailed(id: Long, lastError: String) = Unit
 
   override fun markFailed(eventIds: List<Long>, lastError: String) = Unit
+
+  override fun clear(): Int = 0
+}
+
+private class InMemoryTelemetryOutboxRepository(
+  private val rows: MutableList<TelemetryOutboxRecord> = mutableListOf(),
+) : TelemetryOutboxRepository {
+  override fun enqueue(eventName: String, payloadJson: String): Long = error("Unexpected enqueue")
+
+  override fun listPending(limit: Int?): List<TelemetryOutboxRecord> =
+    rows.filter { it.syncedAt == null }.let { pending ->
+      if (limit == null) pending else pending.take(limit)
+    }
+
+  override fun pendingCount(): Int = rows.count { it.syncedAt == null }
+
+  override fun latestError(): String? = rows.lastOrNull { it.syncedAt == null && it.lastError.isNotBlank() }?.lastError
+
+  override fun markSynced(id: Long, syncedAt: String) {
+    markSynced(listOf(id))
+  }
+
+  override fun markSynced(eventIds: List<Long>) {
+    rows.replaceAll { row ->
+      if (row.id in eventIds) row.copy(syncedAt = "2026-04-24 00:00:01", lastError = "") else row
+    }
+  }
+
+  override fun markFailed(id: Long, lastError: String) {
+    markFailed(listOf(id), lastError)
+  }
+
+  override fun markFailed(eventIds: List<Long>, lastError: String) {
+    rows.replaceAll { row ->
+      if (row.id in eventIds) row.copy(lastError = lastError) else row
+    }
+  }
+
+  override fun clear(): Int {
+    val count = rows.size
+    rows.clear()
+    return count
+  }
+}
+
+private class FakeTelemetrySettingsProvider(
+  private val enabled: Boolean,
+) : TelemetrySettingsProvider {
+  override fun load(materialize: Boolean): TelemetrySettings = TelemetrySettings(
+    configPath = Path.of("/fake/config.json"),
+    level = if (enabled) "anonymous" else "off",
+    enabled = enabled,
+    installId = if (enabled) "fake-install-id" else "",
+    proxyUrl = if (enabled) "https://telemetry.example.dev/ingest" else "",
+    customProxyUrl = if (enabled) "https://telemetry.example.dev/ingest" else null,
+    batchSize = 50,
+  )
+}
+
+private object FakeTelemetryConfigStore : TelemetryConfigStore {
+  override fun stateDir(): Path = Path.of("/fake")
+
+  override fun configPath(): Path = Path.of("/fake/config.json")
+
+  override fun read(): Map<String, Any?>? = null
+
+  override fun ensure(): Map<String, Any?> = emptyMap()
+
+  override fun write(payload: Map<String, Any?>) = Unit
+
+  override fun delete(): Boolean = true
+}
+
+private class FakeTelemetryClient : TelemetryClient {
+  val sentBatchIds = mutableListOf<List<Long>>()
+
+  override fun sendBatch(settings: TelemetrySettings, rows: List<TelemetryOutboxRecord>) {
+    sentBatchIds += rows.map { it.id }
+  }
+
+  override fun fetchProxyCapabilities(settings: TelemetrySettings): Map<String, Any?> =
+    error("Unexpected fetchProxyCapabilities")
+
+  override fun fetchRemoteStats(settings: TelemetrySettings, request: RemoteStatsRequest): Map<String, Any?> =
+    error("Unexpected fetchRemoteStats")
 }
 
 private object NoopWorkflowStateRepository : WorkflowStateRepository {

--- a/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
@@ -25,6 +25,10 @@ class RuntimeArchitectureTest {
     assertContains(architecture, "repository and unit-of-work ports")
     assertContains(architecture, "LearningRecord is owned by the learnings domain")
     assertContains(architecture, "review parsing and triage decision normalization are pure surfaces")
+    assertContains(architecture, "TelemetrySettingsProvider")
+    assertContains(architecture, "TelemetryConfigStore")
+    assertContains(architecture, "TelemetryClient")
+    assertContains(architecture, "telemetry proxy DTO/payload mappers")
   }
 
   @Test
@@ -78,6 +82,10 @@ class RuntimeArchitectureTest {
         "skillbill.infrastructure",
         "skillbill.review.ReviewRuntime",
         "skillbill.review.TriageRuntime",
+        "skillbill.telemetry.TelemetryConfigRuntime",
+        "skillbill.telemetry.TelemetryConfigMutationRuntime",
+        "skillbill.telemetry.TelemetryHttpRuntime",
+        "skillbill.telemetry.TelemetryRemoteStatsRuntime",
       ),
     )
   }
@@ -188,6 +196,54 @@ class RuntimeArchitectureTest {
         "skillbill.cli",
         "skillbill.db",
         "skillbill.mcp",
+      ),
+    )
+  }
+
+  @Test
+  fun `telemetry ports and adapters are explicit package surfaces`() {
+    val portFiles =
+      listOf(
+        sourceRoot.resolve("skillbill/ports/telemetry/TelemetrySettingsProvider.kt"),
+        sourceRoot.resolve("skillbill/ports/telemetry/TelemetryConfigStore.kt"),
+        sourceRoot.resolve("skillbill/ports/telemetry/TelemetryClient.kt"),
+        sourceRoot.resolve("skillbill/ports/persistence/TelemetryOutboxRepository.kt"),
+      )
+    portFiles.forEach { path ->
+      assertTrue(Files.exists(path), "Missing telemetry port: ${sourceRoot.relativize(path)}")
+    }
+
+    assertContains(
+      Files.readString(sourceRoot.resolve("skillbill/infrastructure/http/HttpTelemetryClient.kt")),
+      "java.net.http.HttpClient",
+    )
+    assertContains(
+      Files.readString(sourceRoot.resolve("skillbill/infrastructure/fs/FileTelemetryConfigStore.kt")),
+      "java.nio.file.Files",
+    )
+    assertContains(
+      Files.readString(sourceRoot.resolve("skillbill/contracts/telemetry/TelemetryProxyContracts.kt")),
+      "data class TelemetryProxyBatchEvent",
+    )
+  }
+
+  @Test
+  fun `telemetry sync orchestration avoids concrete db filesystem and http APIs`() {
+    assertNoBannedImports(
+      files =
+      listOf(
+        sourceRoot.resolve("skillbill/telemetry/TelemetrySyncRuntime.kt"),
+        sourceRoot.resolve("skillbill/telemetry/TelemetryConfigMutations.kt"),
+        sourceRoot.resolve("skillbill/telemetry/DefaultTelemetrySettingsProvider.kt"),
+        sourceRoot.resolve("skillbill/telemetry/TelemetryRemoteStatsRuntime.kt"),
+      ).map(::sourceFile),
+      bannedImports =
+      listOf(
+        "java.net.http",
+        "java.sql",
+        "java.nio.file.Files",
+        "skillbill.db",
+        "skillbill.infrastructure",
       ),
     )
   }

--- a/runtime-kotlin/src/test/kotlin/skillbill/db/TelemetryOutboxStoreTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/db/TelemetryOutboxStoreTest.kt
@@ -28,6 +28,9 @@ class TelemetryOutboxStoreTest {
       assertEquals(1, store.pendingCount())
       assertEquals(listOf(secondId), pendingRows.map { it.id })
       assertTrue(pendingRows.all { it.syncedAt == null })
+
+      assertEquals(2, store.clear())
+      assertEquals(0, store.pendingCount())
     }
   }
 }

--- a/runtime-kotlin/src/test/kotlin/skillbill/telemetry/TelemetryRuntimeTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/telemetry/TelemetryRuntimeTest.kt
@@ -3,6 +3,9 @@ package skillbill.telemetry
 import skillbill.contracts.JsonSupport
 import skillbill.db.DatabaseRuntime
 import skillbill.db.TelemetryOutboxStore
+import skillbill.infrastructure.http.HttpTelemetryClient
+import skillbill.ports.persistence.TelemetryOutboxRecord
+import skillbill.ports.telemetry.TelemetryClient
 import java.io.IOException
 import java.nio.file.Files
 import kotlin.test.Test
@@ -17,16 +20,17 @@ class TelemetryRuntimeTest {
     val settings = telemetrySettings(Files.createTempFile("telemetry", ".json"))
 
     val payload =
-      TelemetryRemoteStatsRuntime.fetchRemoteStats(
+      HttpTelemetryClient(
+        requester = requester,
+        environment = mapOf("SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN" to "stats-token-123"),
+      ).fetchRemoteStats(
+        settings = settings,
         request =
         RemoteStatsRequest(
           workflow = "bill-feature-verify",
           dateFrom = "2026-04-01",
           dateTo = "2026-04-22",
         ),
-        settings = settings,
-        requester = requester,
-        environment = mapOf("SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN" to "stats-token-123"),
       )
 
     assertEquals("bill-feature-verify", payload["workflow"])
@@ -42,7 +46,7 @@ class TelemetryRuntimeTest {
     val requester = HttpRequester { _, _, _, _ -> HttpResponse(statusCode = 404, body = "") }
     val settings = telemetrySettings(Files.createTempFile("telemetry-capabilities", ".json"), customProxyUrl = null)
 
-    val payload = TelemetryHttpRuntime.fetchProxyCapabilities(settings = settings, requester = requester)
+    val payload = HttpTelemetryClient(requester).fetchProxyCapabilities(settings)
 
     assertEquals("0", payload["contract_version"])
     assertEquals(false, payload["supports_stats"])
@@ -63,31 +67,30 @@ class TelemetryRuntimeTest {
       val outboxStore = TelemetryOutboxStore(connection)
       outboxStore.enqueue("skillbill_feature_implement_started", JsonSupport.mapToJsonString(mapOf("name" to "ok")))
       outboxStore.enqueue("skillbill_feature_implement_finished", JsonSupport.mapToJsonString(mapOf("name" to "fail")))
-    }
 
-    val successRequester = HttpRequester { _, _, _, _ -> HttpResponse(statusCode = 200, body = "") }
-    val successResult = TelemetrySyncRuntime.syncTelemetry(dbPath, settings, successRequester)
-    assertEquals("synced", successResult.status)
-    assertEquals(2, successResult.syncedEvents)
+      val successClient = RecordingTelemetryClient()
+      val successResult = TelemetrySyncRuntime.syncTelemetry(settings, outboxStore, successClient)
+      assertEquals("synced", successResult.status)
+      assertEquals(2, successResult.syncedEvents)
+      assertEquals(listOf(listOf(1L, 2L)), successClient.sentBatchIds)
+    }
 
     DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
       val outboxStore = TelemetryOutboxStore(connection)
       outboxStore.enqueue("skillbill_feature_verify_started", JsonSupport.mapToJsonString(mapOf("name" to "retry")))
-    }
-    val failingRequester = HttpRequester { _, _, _, _ -> throw IOException("blocked by network isolation sentinel") }
-    val failedResult = TelemetrySyncRuntime.syncTelemetry(dbPath, settings, failingRequester)
-    assertEquals("failed", failedResult.status)
-    assertEquals("blocked by network isolation sentinel", failedResult.message)
-    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
-      val latestError = TelemetryOutboxStore(connection).latestError()
-      assertEquals("blocked by network isolation sentinel", latestError)
+
+      val failingClient = RecordingTelemetryClient(failure = IOException("blocked by network isolation sentinel"))
+      val failedResult = TelemetrySyncRuntime.syncTelemetry(settings, outboxStore, failingClient)
+      assertEquals("failed", failedResult.status)
+      assertEquals("blocked by network isolation sentinel", failedResult.message)
+      assertEquals("blocked by network isolation sentinel", outboxStore.latestError())
     }
   }
 
   @Test
-  fun `autoSyncTelemetry returns disabled result when telemetry is off`() {
+  fun `syncTelemetry covers disabled noop and unconfigured paths`() {
     val dbPath = Files.createTempFile("telemetry-invalid", ".db")
-    val settings =
+    val disabledSettings =
       TelemetrySettings(
         configPath = Files.createTempFile("telemetry-invalid-config", ".json"),
         level = "off",
@@ -97,16 +100,71 @@ class TelemetryRuntimeTest {
         customProxyUrl = null,
         batchSize = 50,
       )
-    val result =
-      TelemetrySyncRuntime.autoSyncTelemetry(
-        dbPath = dbPath,
-        reportFailures = false,
-        settings = settings,
-      )
 
-    assertEquals("disabled", result?.status)
-    assertEquals(false, TelemetrySyncRuntime.telemetryStatusPayload(dbPath, settings)["telemetry_enabled"])
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val outboxStore = TelemetryOutboxStore(connection)
+      val result =
+        TelemetrySyncRuntime.autoSyncTelemetry(
+          settings = disabledSettings,
+          outboxRepository = outboxStore,
+          client = RecordingTelemetryClient(failure = IOException("must not call client")),
+          reportFailures = false,
+        )
+
+      assertEquals("disabled", result?.status)
+      assertEquals(
+        false,
+        TelemetrySyncRuntime.telemetryStatusPayload(dbPath, disabledSettings)["telemetry_enabled"],
+      )
+    }
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val outboxStore = TelemetryOutboxStore(connection)
+      val noopResult =
+        TelemetrySyncRuntime.syncTelemetry(
+          telemetrySettings(Files.createTempFile("telemetry-noop", ".json")),
+          outboxStore,
+          RecordingTelemetryClient(),
+        )
+
+      assertEquals("noop", noopResult.status)
+    }
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val outboxStore = TelemetryOutboxStore(connection)
+      outboxStore.enqueue("skillbill_feature_verify_started", JsonSupport.mapToJsonString(mapOf("name" to "pending")))
+      val unconfiguredResult =
+        TelemetrySyncRuntime.syncTelemetry(
+          telemetrySettings(
+            configPath = Files.createTempFile("telemetry-unconfigured", ".json"),
+            proxyUrl = "",
+            customProxyUrl = null,
+          ),
+          outboxStore,
+          RecordingTelemetryClient(failure = IOException("must not call client")),
+        )
+
+      assertEquals("unconfigured", unconfiguredResult.status)
+      assertEquals(1, unconfiguredResult.pendingEvents)
+    }
   }
+}
+
+private class RecordingTelemetryClient(
+  private val failure: IOException? = null,
+) : TelemetryClient {
+  val sentBatchIds = mutableListOf<List<Long>>()
+
+  override fun sendBatch(settings: TelemetrySettings, rows: List<TelemetryOutboxRecord>) {
+    failure?.let { throw it }
+    sentBatchIds += rows.map { it.id }
+  }
+
+  override fun fetchProxyCapabilities(settings: TelemetrySettings): Map<String, Any?> =
+    error("Unexpected fetchProxyCapabilities")
+
+  override fun fetchRemoteStats(settings: TelemetrySettings, request: RemoteStatsRequest): Map<String, Any?> =
+    error("Unexpected fetchRemoteStats")
 }
 
 private fun remoteStatsRequester(requests: MutableList<Triple<String, String, String?>>): HttpRequester =


### PR DESCRIPTION
# Summary

Implements SKILL-28 Phase 5 by moving telemetry behind explicit ports and concrete adapters while keeping CLI/MCP payload contracts stable. This PR is stacked on `feat/SKILL-28-domain-persistence-separation`.

- Adds `TelemetrySettingsProvider`, `TelemetryConfigStore`, `TelemetryClient`, and extends `TelemetryOutboxRepository` for outbox clearing.
- Moves config file IO into `infrastructure/fs`, HTTP relay details into `infrastructure/http`, and telemetry proxy payload DTO mapping into `contracts/telemetry`.
- Rewires application telemetry/status/sync/mutation paths through the new ports and adds architecture guardrails plus behavior coverage.

## Feature Flags

N/A

# How Has This Been Tested?

`./gradlew check --no-configuration-cache`

1. Run the Gradle check from `runtime-kotlin`.
2. Verify architecture, CLI/MCP contract, telemetry sync, and persistence tests pass.
3. Expected result: build succeeds with 63 tests passing.