### PR TITLE
SKILL-28: Add versioned runtime database migrations

### DIFF
--- a/runtime-kotlin/ARCHITECTURE.md
+++ b/runtime-kotlin/ARCHITECTURE.md
@@ -106,6 +106,8 @@ useful for the next refactors:
   and telemetry config file IO lives under `skillbill.infrastructure.fs`
 - telemetry proxy batch and stats wire payloads are explicit contract helpers,
   separate from sync orchestration
+- SQLite schema changes are represented as append-only versioned database migrations
+  and recorded in `schema_migrations`
 - future `skillbill.domain.*` packages are protected from infrastructure
   imports as soon as they appear
 
@@ -115,7 +117,6 @@ useful for the next refactors:
    results with typed results.
 2. Move remaining pure domain models/rules away from JDBC-shaped runtime
    objects.
-3. Add versioned database migrations.
-4. Add contract DTOs and golden output fixtures for the remaining JSON
+3. Add contract DTOs and golden output fixtures for the remaining JSON
    surfaces.
-5. Split Gradle modules only after package boundaries are proven.
+4. Split Gradle modules only after package boundaries are proven.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-25] runtime-versioned-db-migrations
+Areas: skillbill.db, runtime architecture tests, database migration tests
+- Added `schema_migrations` as the SQLite migration ledger and made `DatabaseMigrations` run ordered named migration objects only when their version is not recorded.
+- Preserved legacy additive/backfill behavior by wrapping the existing review/workflow column and feedback-event normalization helpers as versioned migrations.
+- Reusable pattern: future DB changes should append a new `DatabaseMigration` entry, keep names immutable, and cover legacy compatibility plus repeated-open behavior.
+- Known limitation: base schema still creates the current full schema first; versioned migrations record compatibility state inside the current single-module bootstrap.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented
+
 ## [2026-04-24] runtime-telemetry-ported-subsystem
 Areas: skillbill.application, skillbill.telemetry, skillbill.ports.telemetry, skillbill.infrastructure.http, skillbill.infrastructure.fs, skillbill.contracts.telemetry, architecture tests
 - Added telemetry settings/config/client ports and wired them through Kotlin-Inject; application telemetry/status/sync/mutation paths now use ports plus `TelemetryOutboxRepository`.

--- a/runtime-kotlin/src/main/kotlin/skillbill/db/DatabaseMigrations.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/db/DatabaseMigrations.kt
@@ -4,9 +4,78 @@ import java.sql.Connection
 import java.sql.SQLException
 
 internal object DatabaseMigrations {
+  val migrations: List<DatabaseMigration> =
+    listOf(
+      DatabaseMigration(
+        version = 1,
+        name = "add-review-workflow-session-columns",
+        operation = DatabaseColumnMigrations::apply,
+      ),
+      DatabaseMigration(
+        version = 2,
+        name = "normalize-feedback-event-outcomes",
+        operation = FeedbackEventMigration::apply,
+      ),
+    ).also(::requireDeterministicMigrations)
+
   fun apply(connection: Connection) {
-    DatabaseColumnMigrations.apply(connection)
-    FeedbackEventMigration.apply(connection)
+    val appliedVersions = appliedMigrationVersions(connection)
+    migrations
+      .filterNot { migration -> migration.version in appliedVersions }
+      .forEach { migration ->
+        connection.inTransaction {
+          migration.apply(this)
+          recordMigration(migration)
+        }
+      }
+  }
+
+  private fun appliedMigrationVersions(connection: Connection): Set<Int> = connection.prepareStatement(
+    """
+      SELECT version
+      FROM schema_migrations
+      ORDER BY version
+    """.trimIndent(),
+  ).use { statement ->
+    statement.executeQuery().use { resultSet ->
+      buildSet {
+        while (resultSet.next()) {
+          add(resultSet.getInt("version"))
+        }
+      }
+    }
+  }
+
+  private fun Connection.recordMigration(migration: DatabaseMigration) {
+    prepareStatement(
+      """
+      INSERT INTO schema_migrations (version, name)
+      VALUES (?, ?)
+      """.trimIndent(),
+    ).use { statement ->
+      statement.setInt(1, migration.version)
+      statement.setString(2, migration.name)
+      statement.executeUpdate()
+    }
+  }
+
+  private fun requireDeterministicMigrations(migrations: List<DatabaseMigration>) {
+    val versions = migrations.map { migration -> migration.version }
+    val names = migrations.map { migration -> migration.name }
+
+    require(versions == versions.sorted()) { "Database migrations must be ordered by version." }
+    require(versions.toSet().size == versions.size) { "Database migration versions must be unique." }
+    require(names.toSet().size == names.size) { "Database migration names must be unique." }
+  }
+}
+
+internal class DatabaseMigration(
+  val version: Int,
+  val name: String,
+  private val operation: (Connection) -> Unit,
+) {
+  fun apply(connection: Connection) {
+    operation(connection)
   }
 }
 

--- a/runtime-kotlin/src/main/kotlin/skillbill/db/DatabaseSchema.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/db/DatabaseSchema.kt
@@ -5,6 +5,7 @@ import java.sql.Connection
 internal object DatabaseSchema {
   val tableNames: Set<String> =
     setOf(
+      "schema_migrations",
       "review_runs",
       "findings",
       "feedback_events",
@@ -35,6 +36,13 @@ internal object DatabaseSchema {
 
   private val statements: List<String> =
     listOf(
+      """
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version INTEGER PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+      """.trimIndent(),
       """
       CREATE TABLE IF NOT EXISTS review_runs (
         review_run_id TEXT PRIMARY KEY,

--- a/runtime-kotlin/src/main/kotlin/skillbill/db/FeedbackEventMigration.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/db/FeedbackEventMigration.kt
@@ -18,13 +18,11 @@ internal object FeedbackEventMigration {
       return
     }
     val rows = legacyFeedbackEventRows(connection)
-    connection.inTransaction {
-      renameFeedbackEventsTable()
-      createCurrentFeedbackEventsTable()
-      insertFeedbackEventRows(rows)
-      createStatement().use { statement ->
-        statement.execute("DROP TABLE feedback_events_legacy")
-      }
+    connection.renameFeedbackEventsTable()
+    connection.createCurrentFeedbackEventsTable()
+    connection.insertFeedbackEventRows(rows)
+    connection.createStatement().use { statement ->
+      statement.execute("DROP TABLE feedback_events_legacy")
     }
   }
 

--- a/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
@@ -29,6 +29,8 @@ class RuntimeArchitectureTest {
     assertContains(architecture, "TelemetryConfigStore")
     assertContains(architecture, "TelemetryClient")
     assertContains(architecture, "telemetry proxy DTO/payload mappers")
+    assertContains(architecture, "schema_migrations")
+    assertContains(architecture, "versioned database migrations")
   }
 
   @Test

--- a/runtime-kotlin/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
@@ -5,9 +5,51 @@ import java.nio.file.Path
 import java.sql.DriverManager
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class DatabaseMigrationsTest {
+  @Test
+  fun `migration definitions are append-only and deterministic`() {
+    val migrationDefinitions = DatabaseMigrations.migrations.map { migration -> migration.version to migration.name }
+
+    assertEquals(
+      listOf(
+        1 to "add-review-workflow-session-columns",
+        2 to "normalize-feedback-event-outcomes",
+      ),
+      migrationDefinitions,
+    )
+    assertEquals(migrationDefinitions.sortedBy { (version, _) -> version }, migrationDefinitions)
+    assertEquals(migrationDefinitions.map { (version, _) -> version }.toSet().size, migrationDefinitions.size)
+    assertEquals(migrationDefinitions.map { (_, name) -> name }.toSet().size, migrationDefinitions.size)
+  }
+
+  @Test
+  fun `ensureDatabase records all migrations for new databases`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-migrations").resolve("new.db")
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val rows = migrationRows(connection)
+
+      assertEquals(
+        DatabaseMigrations.migrations.map { migration -> migration.version to migration.name },
+        rows.map { row -> row.version to row.name },
+      )
+      rows.forEach { row -> assertTrue(row.appliedAt.isNotBlank()) }
+    }
+  }
+
+  @Test
+  fun `ensureDatabase does not duplicate recorded migrations on repeated opens`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-migrations").resolve("repeat.db")
+
+    DatabaseRuntime.ensureDatabase(dbPath).close()
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      assertEquals(DatabaseMigrations.migrations.size, migrationRows(connection).size)
+    }
+  }
+
   @Test
   fun `ensureDatabase adds missing review session column and backfills it`() {
     val dbPath = Files.createTempDirectory("runtime-kotlin-db-migrations").resolve("legacy-review-runs.db")
@@ -19,6 +61,7 @@ class DatabaseMigrationsTest {
 
       assertTrue("review_session_id" in columns)
       assertEquals("rvw-legacy-001", reviewSessionId)
+      assertEquals(DatabaseMigrations.migrations.size, migrationRows(connection).size)
     }
   }
 
@@ -34,6 +77,42 @@ class DatabaseMigrationsTest {
 
       assertTrue("'fix_rejected'" in schemaSql)
       assertEquals("fix_rejected", migratedEventType)
+      assertEquals(DatabaseMigrations.migrations.size, migrationRows(connection).size)
+    }
+  }
+
+  @Test
+  fun `ensureDatabase resumes from recorded migration version`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-migrations").resolve("partial.db")
+    createLegacyFeedbackEventsDatabase(dbPath)
+
+    DriverManager.getConnection("jdbc:sqlite:$dbPath").use { connection ->
+      connection.createStatement().use { statement ->
+        statement.execute(
+          """
+          CREATE TABLE schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+          )
+          """.trimIndent(),
+        )
+      }
+      connection.prepareStatement(
+        """
+        INSERT INTO schema_migrations (version, name)
+        VALUES (?, ?)
+        """.trimIndent(),
+      ).use { statement ->
+        statement.setInt(1, 1)
+        statement.setString(2, "add-review-workflow-session-columns")
+        statement.executeUpdate()
+      }
+    }
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      assertEquals("fix_rejected", feedbackEventType(connection, "rvw-legacy-002", "F-001"))
+      assertNotNull(migrationRows(connection).singleOrNull { row -> row.version == 2 })
     }
   }
 
@@ -149,6 +228,28 @@ class DatabaseMigrationsTest {
       }
     }
 
+  private fun migrationRows(connection: java.sql.Connection): List<MigrationRow> = connection.prepareStatement(
+    """
+      SELECT version, name, applied_at
+      FROM schema_migrations
+      ORDER BY version
+    """.trimIndent(),
+  ).use { statement ->
+    statement.executeQuery().use { resultSet ->
+      buildList {
+        while (resultSet.next()) {
+          add(
+            MigrationRow(
+              version = resultSet.getInt("version"),
+              name = resultSet.getString("name"),
+              appliedAt = resultSet.getString("applied_at"),
+            ),
+          )
+        }
+      }
+    }
+  }
+
   private fun tableColumns(connection: java.sql.Connection, tableName: String): Set<String> =
     connection.createStatement().use { statement ->
       statement.executeQuery("PRAGMA table_info($tableName)").use { resultSet ->
@@ -159,6 +260,12 @@ class DatabaseMigrationsTest {
         }
       }
     }
+
+  private data class MigrationRow(
+    val version: Int,
+    val name: String,
+    val appliedAt: String,
+  )
 
   private companion object {
     const val CREATE_LEGACY_REVIEW_RUNS_SQL: String =


### PR DESCRIPTION
## Summary
- Add a `schema_migrations` ledger table to the runtime SQLite bootstrap.
- Convert the existing idempotent DB upgrade helpers into ordered named migration objects.
- Record applied migrations atomically with each migration and skip versions already present in the ledger.
- Preserve legacy review-run backfills and feedback-event normalization behavior.
- Update architecture docs/history and add migration guardrail coverage.

## Validation
- `./gradlew check --no-configuration-cache`
- `git diff --check`

## SKILL-28 Phase
Phase 6 - Version DB migrations explicitly.
