### PR TITLE
SKILL-28: Document reserved runtime surfaces

### DIFF
--- a/runtime-kotlin/ARCHITECTURE.md
+++ b/runtime-kotlin/ARCHITECTURE.md
@@ -50,8 +50,9 @@ di
   telemetry proxy DTO/payload mappers.
 - `skillbill.error`: runtime exception taxonomy.
 - `skillbill.workflow.*`, `skillbill.install`, `skillbill.launcher`, and
-  `skillbill.scaffold`: placeholder or early runtime surfaces for later
-  SKILL-27/SKILL-28 phases.
+  `skillbill.scaffold`: reserved runtime surfaces. Each exposes a
+  `RuntimeSurfaceContract` with status, owner package, and the reason it stays
+  placeholder-only until that behavior is intentionally ported.
 
 ## Boundary Rules
 
@@ -111,6 +112,8 @@ useful for the next refactors:
 - CLI and MCP JSON output should be produced through explicit contract DTOs and
   mappers, while CLI text rendering should consume typed CLI presenter models
   instead of raw maps
+- reserved runtime surfaces must expose a documented `RuntimeSurfaceContract`
+  instead of empty marker interfaces
 - future `skillbill.domain.*` packages are protected from infrastructure
   imports as soon as they appear
 

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-25] runtime-placeholder-surface-contracts
+Areas: skillbill.install, skillbill.launcher, skillbill.scaffold, skillbill.workflow.*, skillbill.contracts.surface, runtime smoke tests
+- Replaced empty marker interfaces with reserved runtime surface objects exposing `RuntimeSurfaceContract` metadata.
+- Documented why install, launcher, scaffold, feature-implement workflow, and feature-verify workflow remain placeholder-only.
+- Reusable pattern: reserved runtime surfaces must declare owner package, contract version, reserved status, and a concrete placeholder reason before implementation.
+- Runtime smoke coverage now asserts reserved contracts and package boundaries instead of only checking class/package presence.
+Feature flag: N/A
+Acceptance criteria: 2/2 implemented
+
 ## [2026-04-25] runtime-contract-dtos-presenters
 Areas: skillbill.contracts, skillbill.cli, skillbill.mcp, skillbill.application, architecture tests, golden fixtures
 - Added explicit JSON contract DTOs for learning, review, MCP adapter-only payloads, and shared system version/doctor payloads.

--- a/runtime-kotlin/src/main/kotlin/skillbill/contracts/surface/RuntimeSurfaceContract.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/contracts/surface/RuntimeSurfaceContract.kt
@@ -1,0 +1,16 @@
+package skillbill.contracts.surface
+
+data class RuntimeSurfaceContract(
+  val name: String,
+  val ownerPackage: String,
+  val contractVersion: String,
+  val status: RuntimeSurfaceStatus,
+  val summary: String,
+  val placeholderReason: String,
+  val supportedOperations: List<String> = emptyList(),
+)
+
+enum class RuntimeSurfaceStatus {
+  ACTIVE,
+  RESERVED,
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/install/InstallRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/install/InstallRuntime.kt
@@ -1,4 +1,18 @@
 package skillbill.install
 
-/** Marker surface for the future install/upgrade port. */
-interface InstallRuntime
+import skillbill.contracts.surface.RuntimeSurfaceContract
+import skillbill.contracts.surface.RuntimeSurfaceStatus
+
+/** Reserved until install and upgrade behavior moves into the Kotlin runtime. */
+object InstallRuntime {
+  val contract: RuntimeSurfaceContract = RuntimeSurfaceContract(
+    name = "install",
+    ownerPackage = "skillbill.install",
+    contractVersion = "0.1",
+    status = RuntimeSurfaceStatus.RESERVED,
+    summary = "Install and upgrade runtime surface.",
+    placeholderReason =
+    "The governed Python installer and existing skill-bill CLI remain the source of truth for install/upgrade " +
+      "behavior until the Kotlin runtime owns distribution and agent-config writes.",
+  )
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/launcher/LauncherRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/launcher/LauncherRuntime.kt
@@ -1,4 +1,18 @@
 package skillbill.launcher
 
-/** Marker surface for the future dual-runtime launcher port. */
-interface LauncherRuntime
+import skillbill.contracts.surface.RuntimeSurfaceContract
+import skillbill.contracts.surface.RuntimeSurfaceStatus
+
+/** Reserved until the project needs a Kotlin-owned dual-runtime launcher. */
+object LauncherRuntime {
+  val contract: RuntimeSurfaceContract = RuntimeSurfaceContract(
+    name = "launcher",
+    ownerPackage = "skillbill.launcher",
+    contractVersion = "0.1",
+    status = RuntimeSurfaceStatus.RESERVED,
+    summary = "Runtime launcher and runtime-selection surface.",
+    placeholderReason =
+    "CLI and MCP entry points currently compose the Kotlin runtime directly; launcher behavior should stay " +
+      "placeholder-only until release packaging needs a Kotlin-owned Python/Kotlin runtime switch.",
+  )
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/scaffold/ScaffoldRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/scaffold/ScaffoldRuntime.kt
@@ -1,4 +1,18 @@
 package skillbill.scaffold
 
-/** Marker surface for the future scaffold and governed-loader port. */
-interface ScaffoldRuntime
+import skillbill.contracts.surface.RuntimeSurfaceContract
+import skillbill.contracts.surface.RuntimeSurfaceStatus
+
+/** Reserved until governed skill scaffolding is intentionally ported. */
+object ScaffoldRuntime {
+  val contract: RuntimeSurfaceContract = RuntimeSurfaceContract(
+    name = "scaffold",
+    ownerPackage = "skillbill.scaffold",
+    contractVersion = "0.1",
+    status = RuntimeSurfaceStatus.RESERVED,
+    summary = "Governed skill scaffolding and loader runtime surface.",
+    placeholderReason =
+    "The Python scaffolder remains canonical for governed skill authoring; Kotlin should expose this surface only " +
+      "after scaffold payload validation and atomic file writes are ported together.",
+  )
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowRuntime.kt
@@ -1,4 +1,18 @@
 package skillbill.workflow.implement
 
-/** Marker surface for the future feature-implement workflow port. */
-interface FeatureImplementWorkflowRuntime
+import skillbill.contracts.surface.RuntimeSurfaceContract
+import skillbill.contracts.surface.RuntimeSurfaceStatus
+
+/** Reserved until feature-implement orchestration moves out of the agent shell. */
+object FeatureImplementWorkflowRuntime {
+  val contract: RuntimeSurfaceContract = RuntimeSurfaceContract(
+    name = "feature-implement-workflow",
+    ownerPackage = "skillbill.workflow.implement",
+    contractVersion = "0.1",
+    status = RuntimeSurfaceStatus.RESERVED,
+    summary = "Feature implementation workflow orchestration surface.",
+    placeholderReason =
+    "Durable workflow state is already persisted through repository ports, but the end-to-end feature-implement " +
+      "orchestration contract is still owned by the governed agent skill shell.",
+  )
+}

--- a/runtime-kotlin/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowRuntime.kt
+++ b/runtime-kotlin/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowRuntime.kt
@@ -1,4 +1,18 @@
 package skillbill.workflow.verify
 
-/** Marker surface for the future feature-verify workflow port. */
-interface FeatureVerifyWorkflowRuntime
+import skillbill.contracts.surface.RuntimeSurfaceContract
+import skillbill.contracts.surface.RuntimeSurfaceStatus
+
+/** Reserved until feature-verify orchestration moves out of the agent shell. */
+object FeatureVerifyWorkflowRuntime {
+  val contract: RuntimeSurfaceContract = RuntimeSurfaceContract(
+    name = "feature-verify-workflow",
+    ownerPackage = "skillbill.workflow.verify",
+    contractVersion = "0.1",
+    status = RuntimeSurfaceStatus.RESERVED,
+    summary = "Feature verification workflow orchestration surface.",
+    placeholderReason =
+    "Durable workflow state is already persisted through repository ports, but the end-to-end feature-verify " +
+      "orchestration contract is still owned by the governed agent skill shell.",
+  )
+}

--- a/runtime-kotlin/src/test/kotlin/skillbill/RuntimeModuleSmokeTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/RuntimeModuleSmokeTest.kt
@@ -1,6 +1,8 @@
 package skillbill
 
 import skillbill.cli.CliRuntime
+import skillbill.contracts.surface.RuntimeSurfaceContract
+import skillbill.contracts.surface.RuntimeSurfaceStatus
 import skillbill.db.DatabaseRuntime
 import skillbill.install.InstallRuntime
 import skillbill.launcher.LauncherRuntime
@@ -17,8 +19,55 @@ import kotlin.test.assertTrue
 
 class RuntimeModuleSmokeTest {
   @Test
-  fun `package scaffold remains available for later subsystem ports`() {
-    val expectedSubsystemPackages =
+  fun `runtime module declares package boundaries and reserved surface contracts`() {
+    assertEquals("runtime-kotlin", RuntimeModule.NAME)
+    assertEquals(17, RuntimeModule.TOOLCHAIN_JDK)
+    assertDeclaredPackages()
+    assertRuntimeSurfacePackages()
+    assertReservedRuntimeContracts()
+  }
+
+  private fun assertDeclaredPackages() {
+    assertEquals(expectedSubsystemPackages, RuntimeModule.declaredSubsystemPackages.toSet())
+  }
+
+  private fun assertRuntimeSurfacePackages() {
+    assertEquals(
+      expectedSubsystemPackages -
+        setOf(
+          "skillbill.application",
+          "skillbill.contracts",
+          "skillbill.di",
+          "skillbill.error",
+          "skillbill.infrastructure",
+          "skillbill.ports",
+        ),
+      runtimeSurfacePackages,
+    )
+    assertTrue(runtimeSurfaces.all { it.qualifiedName?.startsWith("skillbill.") == true })
+  }
+
+  private fun assertReservedRuntimeContracts() {
+    assertEquals(
+      setOf(
+        "install",
+        "launcher",
+        "scaffold",
+        "feature-implement-workflow",
+        "feature-verify-workflow",
+      ),
+      reservedContracts.map(RuntimeSurfaceContract::name).toSet(),
+    )
+    reservedContracts.forEach { contract ->
+      assertEquals("0.1", contract.contractVersion)
+      assertEquals(RuntimeSurfaceStatus.RESERVED, contract.status)
+      assertTrue(contract.placeholderReason.length > 60, "Placeholder reason is too weak for ${contract.name}")
+      assertTrue(contract.supportedOperations.isEmpty(), "Reserved surfaces must not claim operations")
+    }
+  }
+
+  private companion object {
+    val expectedSubsystemPackages: Set<String> =
       setOf(
         "skillbill.application",
         "skillbill.cli",
@@ -47,31 +96,18 @@ class RuntimeModuleSmokeTest {
         TelemetryRuntime::class,
         ReviewRuntime::class,
         LearningsRuntime::class,
-        FeatureImplementWorkflowRuntime::class,
-        FeatureVerifyWorkflowRuntime::class,
-        ScaffoldRuntime::class,
-        InstallRuntime::class,
       )
-    val runtimeSurfacePackages =
+    val reservedContracts =
+      listOf(
+        InstallRuntime.contract,
+        LauncherRuntime.contract,
+        ScaffoldRuntime.contract,
+        FeatureImplementWorkflowRuntime.contract,
+        FeatureVerifyWorkflowRuntime.contract,
+      )
+    val runtimeSurfacePackages: Set<String> =
       runtimeSurfaces
         .mapNotNull { it.qualifiedName?.substringBeforeLast(".") }
-        .toSet()
-
-    assertEquals("runtime-kotlin", RuntimeModule.NAME)
-    assertEquals(17, RuntimeModule.TOOLCHAIN_JDK)
-    assertEquals(expectedSubsystemPackages, RuntimeModule.declaredSubsystemPackages.toSet())
-    assertEquals(
-      expectedSubsystemPackages -
-        setOf(
-          "skillbill.application",
-          "skillbill.contracts",
-          "skillbill.di",
-          "skillbill.error",
-          "skillbill.infrastructure",
-          "skillbill.ports",
-        ),
-      runtimeSurfacePackages,
-    )
-    assertTrue(runtimeSurfaces.all { it.qualifiedName?.startsWith("skillbill.") == true })
+        .toSet() + reservedContracts.map(RuntimeSurfaceContract::ownerPackage)
   }
 }

--- a/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
+++ b/runtime-kotlin/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
@@ -33,6 +33,7 @@ class RuntimeArchitectureTest {
     assertContains(architecture, "versioned database migrations")
     assertContains(architecture, "contract DTOs")
     assertContains(architecture, "typed CLI presenter models")
+    assertContains(architecture, "RuntimeSurfaceContract")
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Replace empty install, launcher, scaffold, feature-implement workflow, and feature-verify workflow marker interfaces with reserved runtime surface objects.
- Add `RuntimeSurfaceContract` metadata for name, owner package, contract version, reserved status, placeholder reason, and supported operations.
- Update the runtime architecture doc and boundary history for the reserved-surface contract pattern.
- Strengthen runtime smoke coverage so it asserts package boundaries plus meaningful reserved contracts instead of only class/package presence.

## Validation
- `./gradlew check --no-configuration-cache`
- `git diff --check`

## SKILL-28 Phase
Phase 8 - Implement or retire placeholder surfaces.
