### PR TITLE
SKILL-27: Port workflow runtime to Kotlin

### DIFF
--- a/.feature-specs/SKILL-27-workflow-runtime/spec.md
+++ b/.feature-specs/SKILL-27-workflow-runtime/spec.md
@@ -1,0 +1,177 @@
+---
+issue_key: SKILL-27
+feature_name: workflow-runtime
+feature_size: MEDIUM
+status: In Progress
+created: 2026-04-25
+phase: 5 - Workflow runtime
+rollout_needed: false
+---
+
+# SKILL-27 Phase 5 - Workflow Runtime
+
+## Sources
+
+- `docs/migrations/SKILL-27-kotlin-runtime-port.md`
+- `.feature-specs/SKILL-27-kotlin-runtime-port/spec.md`
+- `.feature-specs/SKILL-27-surface-integration/spec.md`
+- `.feature-specs/SKILL-28-runtime-architecture/spec.md`
+- `skill_bill/feature_implement.py`
+- `skill_bill/feature_verify.py`
+- `skill_bill/cli.py`
+- `skill_bill/mcp_server.py`
+- `runtime-kotlin/ARCHITECTURE.md`
+- `runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/WorkflowStateRepository.kt`
+- `runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/WorkflowStateStore.kt`
+
+## Acceptance Criteria
+
+1. Kotlin owns feature-implement workflow state/runtime behavior for open,
+   update, get, list, latest, resume, and continue semantics.
+2. Kotlin owns feature-verify workflow state/runtime behavior for the same
+   workflow-state and continuation semantics.
+3. Resume/continue payload builders preserve the Python contract fields, step
+   ids, artifact handling, blocked/done/reopened behavior, and step-specific
+   directives.
+4. Existing SQLite workflow persistence is reused through runtime ports; no new
+   local store or schema redesign.
+5. Add parity-focused Kotlin tests for workflow rows, list/latest resolution,
+   resume summaries, continuation payloads, and representative implement/verify
+   behavior.
+6. Keep production Python entrypoints, loader/scaffolder, install behavior,
+   launcher/cutover wiring, and Python deletion out of scope.
+
+## Non-goals
+
+- Cutting over `skill-bill` or `skill-bill-mcp` production entrypoints.
+- Porting scaffold, loader, install, launcher, or cutover behavior.
+- Changing workflow contracts or step ids.
+- Redesigning the SQLite schema or deleting Python runtime code.
+
+## Consolidated Scope
+
+Phase 5 ports the two durable workflow runtimes into `runtime-kotlin/` while
+leaving externally installed Python entrypoints active. The Python modules
+`skill_bill/feature_implement.py` and `skill_bill/feature_verify.py` remain the
+behavioral oracle for this phase.
+
+The Kotlin runtime should replace the current reserved workflow surfaces with
+real in-module runtime behavior for:
+
+- `bill-feature-implement`
+- `bill-feature-verify`
+
+The port must preserve the existing SQLite-backed workflow tables:
+
+- `feature_implement_workflows`
+- `feature_verify_workflows`
+
+Persistence should flow through the existing runtime ports and adapters,
+especially `WorkflowStateRepository` and `WorkflowStateStore`, extending them
+only as needed for list/latest/update behavior. Do not create a parallel store,
+new schema, or workflow database.
+
+The workflow payload contract must preserve these shared fields:
+
+- `workflow_id`
+- `session_id`
+- `workflow_name`
+- `contract_version`
+- `workflow_status`
+- `current_step_id`
+- `steps`
+- `artifacts`
+- `started_at`
+- `updated_at`
+- `finished_at`
+- `status`
+- `db_path`
+
+Resume payloads must preserve:
+
+- `resume_mode`
+- `resume_step_id`
+- `last_completed_step_id`
+- `available_artifacts`
+- `required_artifacts`
+- `missing_artifacts`
+- `can_resume`
+- `next_action`
+
+Continue payloads must preserve:
+
+- `skill_name`
+- `continuation_mode`
+- `workflow_status_before_continue`
+- `continue_status`
+- `continue_step_id`
+- `continue_step_label`
+- `continue_step_directive`
+- `reference_sections`
+- `step_artifact_keys`
+- `step_artifacts`
+- `session_summary`
+- `continuation_brief`
+- `continuation_entry_prompt`
+
+For `bill-feature-implement`, continue payloads also preserve:
+
+- `feature_name`
+- `feature_size`
+- `branch_name`
+
+The implementation workflow keeps these stable step ids:
+
+`assess`, `create_branch`, `preplan`, `plan`, `implement`, `review`, `audit`,
+`validate`, `write_history`, `commit_push`, `pr_description`, `finish`.
+
+The implementation workflow keeps these stable artifact names:
+
+`assessment`, `branch`, `preplan_digest`, `plan`, `implementation_summary`,
+`review_result`, `audit_report`, `validation_result`, `history_result`,
+`commit_push_result`, `pr_result`.
+
+The verify workflow keeps these stable step ids:
+
+`collect_inputs`, `extract_criteria`, `gather_diff`, `feature_flag_audit`,
+`code_review`, `completeness_audit`, `verdict`, `finish`.
+
+The verify workflow keeps these stable artifact names and continuation inputs:
+
+`input_context`, `criteria_summary`, `diff_summary`,
+`feature_flag_audit_result`, `review_result`, `completeness_audit_result`,
+`verdict_result`, `session_notes`, `review_diff_pointer`.
+
+Continue behavior must preserve Python semantics for `blocked`, `done`,
+`already_running`, and `reopened`. Reopening increments the selected step's
+`attempt_count`, marks that step `running`, sets `workflow_status` to
+`running`, and keeps prior artifacts authoritative. Blocked continuations must
+surface `missing_artifacts` and the existing error text rather than silently
+continuing.
+
+Kotlin tests should use the current Python tests as the parity map:
+
+- `tests/test_feature_implement_workflow_state.py`
+- `tests/test_feature_implement_workflow_e2e.py`
+- `tests/test_feature_implement_agent_resume.py`
+- `tests/test_feature_verify_workflow_state.py`
+- `tests/test_feature_verify_workflow_e2e.py`
+- `tests/test_feature_verify_agent_resume.py`
+- `tests/test_feature_verify_workflow_contract.py`
+- workflow-related coverage in `tests/test_cli.py`, `tests/test_mcp_server.py`,
+  and `tests/test_mcp_stdio.py`
+
+The architectural direction from SKILL-28 applies: CLI and MCP are adapters,
+application owns orchestration, persistence flows through ports, JSON payloads
+are boundary concerns, and public model declarations belong in explicit
+`model` packages.
+
+## Phase 5 Implementation Notes
+
+- Kotlin runtime owns workflow state/runtime semantics in `WorkflowService`,
+  `WorkflowEngine`, and workflow contract builders.
+- Persistence reuses the existing SQLite workflow tables through
+  `WorkflowStateRepository` and `WorkflowStateStore`; no schema redesign or new
+  local workflow store is part of this phase.
+- Python production entrypoints, loader/scaffolder behavior, install behavior,
+  launcher/cutover wiring, and Python runtime deletion remain out of scope.

--- a/runtime-kotlin/ARCHITECTURE.md
+++ b/runtime-kotlin/ARCHITECTURE.md
@@ -34,8 +34,8 @@ di
   SQL-backed review helpers.
 - `runtime-infra-http`: telemetry HTTP client/requester and HTTP wire mapping.
 - `runtime-infra-fs`: telemetry config file adapter.
-- `runtime-core`: Kotlin-Inject composition root, module metadata, and reserved
-  runtime surfaces.
+- `runtime-core`: Kotlin-Inject composition root, module metadata, active
+  workflow surface declarations, and remaining reserved runtime surfaces.
 - `runtime-cli`: Clikt command tree, terminal rendering, JSON output, help, and
   completion surfaces.
 - `runtime-mcp`: MCP adapter surface and MCP-specific payload shaping.
@@ -78,10 +78,15 @@ di
   serialization helpers. Mapping from application/domain/port models into
   contract DTOs belongs in application or adapter-owned packages.
 - `skillbill.error`: runtime exception taxonomy.
-- `skillbill.workflow.*`, `skillbill.install`, `skillbill.launcher`, and
-  `skillbill.scaffold`: reserved runtime surfaces. Each exposes a
-  `RuntimeSurfaceContract` with status, owner package, and the reason it stays
-  placeholder-only until that behavior is intentionally ported.
+- `skillbill.workflow.*`: active durable workflow state/runtime surfaces for
+  feature-implement and feature-verify. State behavior is owned by
+  `skillbill.application.WorkflowService`, modeled in `runtime-domain`, mapped
+  through `runtime-contracts`, and persisted through workflow repository ports
+  backed by the existing SQLite tables.
+- `skillbill.install`, `skillbill.launcher`, and `skillbill.scaffold`:
+  reserved runtime surfaces. Each exposes a `RuntimeSurfaceContract` with
+  status, owner package, and the reason it stays placeholder-only until that
+  behavior is intentionally ported.
 
 ## Boundary Rules
 
@@ -139,6 +144,9 @@ useful for the next refactors:
   not import JDBC or persistence adapters
 - SQL-backed review persistence, stats, workflow telemetry, and feedback
   helpers live under `skillbill.infrastructure.sqlite.review`
+- workflow state persistence reuses `feature_implement_workflows` and
+  `feature_verify_workflows` through `WorkflowStateRepository`; there is no
+  workflow-local store or schema redesign
 - telemetry sync orchestration depends on telemetry ports and the outbox
   repository, not on SQLite, filesystem IO, or Java HTTP APIs
 - telemetry HTTP request/response details live under `skillbill.infrastructure.http`
@@ -151,8 +159,9 @@ useful for the next refactors:
 - CLI and MCP JSON output should be produced through explicit contract DTOs and
   mappers, while CLI text rendering should consume typed CLI presenter models
   instead of raw maps
-- reserved runtime surfaces must expose a documented `RuntimeSurfaceContract`
-  instead of empty marker interfaces
+- runtime surfaces must expose a documented `RuntimeSurfaceContract`; active
+  workflow surfaces declare open/update/get/list/latest/resume/continue while
+  reserved surfaces stay placeholder-only
 - `RuntimeContext` lives in `skillbill.model` and must not import
   infrastructure defaults; concrete adapters are provided by CLI/MCP contexts
   or DI composition roots

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -64,6 +64,15 @@ Areas: skillbill.db, runtime architecture tests, database migration tests
 Feature flag: N/A
 Acceptance criteria: 5/5 implemented
 
+## [2026-04-25] workflow-runtime-phase-5
+Areas: skillbill.workflow, skillbill.application, skillbill.ports.persistence, skillbill.infrastructure.sqlite, skillbill.cli, skillbill.mcp, runtime contracts
+- Added Kotlin-owned durable workflow runtime behavior for `bill-feature-implement` and `bill-feature-verify`: open, update, get, list, latest, resume, and continue now route through `WorkflowService`.
+- Reused the existing `feature_implement_workflows` and `feature_verify_workflows` SQLite tables through `WorkflowStateRepository`; no workflow-local store, schema redesign, Python entrypoint cutover, loader/scaffolder/install changes, launcher changes, or Python deletion were included.
+- Preserved stable step ids, step state ordering, artifact patch semantics, resume summaries, session-summary hydration from telemetry session rows, blocked/done/already-running/reopened continuation decisions, and exact step-specific continuation directives in Kotlin domain/contract code.
+- CLI and MCP adapters now delegate workflow calls to application services and add adapter-facing `status`/`db_path`/blocked-error payload fields at the boundary.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-04-24] runtime-telemetry-ported-subsystem
 Areas: skillbill.application, skillbill.telemetry, skillbill.ports.telemetry, skillbill.infrastructure.http, skillbill.infrastructure.fs, skillbill.contracts.telemetry, architecture tests
 - Added telemetry settings/config/client ports and wired them through Kotlin-Inject; application telemetry/status/sync/mutation paths now use ports plus `TelemetryOutboxRepository`.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowRecordMapping.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowRecordMapping.kt
@@ -1,0 +1,55 @@
+package skillbill.application
+
+import skillbill.ports.persistence.model.FeatureImplementSessionSummary
+import skillbill.ports.persistence.model.FeatureVerifySessionSummary
+import skillbill.ports.persistence.model.WorkflowStateRecord
+import skillbill.workflow.model.WorkflowStateSnapshot
+
+internal fun WorkflowStateRecord.toSnapshot(): WorkflowStateSnapshot = WorkflowStateSnapshot(
+  workflowId = workflowId,
+  sessionId = sessionId,
+  workflowName = workflowName,
+  contractVersion = contractVersion,
+  workflowStatus = workflowStatus,
+  currentStepId = currentStepId,
+  stepsJson = stepsJson,
+  artifactsJson = artifactsJson,
+  startedAt = startedAt,
+  updatedAt = updatedAt,
+  finishedAt = finishedAt,
+)
+
+internal fun WorkflowStateSnapshot.toRecord(): WorkflowStateRecord = WorkflowStateRecord(
+  workflowId = workflowId,
+  sessionId = sessionId,
+  workflowName = workflowName,
+  contractVersion = contractVersion,
+  workflowStatus = workflowStatus,
+  currentStepId = currentStepId,
+  stepsJson = stepsJson,
+  artifactsJson = artifactsJson,
+  startedAt = startedAt,
+  updatedAt = updatedAt,
+  finishedAt = finishedAt,
+)
+
+internal fun FeatureImplementSessionSummary.toPayload(): Map<String, Any?> = linkedMapOf(
+  "session_id" to sessionId,
+  "issue_key_provided" to issueKeyProvided,
+  "issue_key_type" to issueKeyType,
+  "spec_input_types" to specInputTypes,
+  "spec_word_count" to specWordCount,
+  "feature_size" to featureSize,
+  "feature_name" to featureName,
+  "rollout_needed" to rolloutNeeded,
+  "acceptance_criteria_count" to acceptanceCriteriaCount,
+  "open_questions_count" to openQuestionsCount,
+  "spec_summary" to specSummary,
+)
+
+internal fun FeatureVerifySessionSummary.toPayload(): Map<String, Any?> = linkedMapOf(
+  "session_id" to sessionId,
+  "acceptance_criteria_count" to acceptanceCriteriaCount,
+  "rollout_relevant" to rolloutRelevant,
+  "spec_summary" to specSummary,
+)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
@@ -1,0 +1,236 @@
+package skillbill.application
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.WorkflowFamilyKind
+import skillbill.application.model.WorkflowUpdateRequest
+import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.ports.persistence.model.WorkflowStateRecord
+import skillbill.workflow.WorkflowEngine
+import skillbill.workflow.implement.FeatureImplementWorkflowDefinition
+import skillbill.workflow.model.WorkflowDefinition
+import skillbill.workflow.model.WorkflowStateSnapshot
+import skillbill.workflow.model.WorkflowUpdateInput
+import skillbill.workflow.verify.FeatureVerifyWorkflowDefinition
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.random.Random
+
+@Inject
+class WorkflowService(
+  private val database: DatabaseSessionFactory,
+) {
+  fun open(
+    kind: WorkflowFamilyKind,
+    sessionId: String = "",
+    currentStepId: String? = null,
+    dbOverride: String? = null,
+  ): Map<String, Any?> {
+    val family = kind.workflowFamily()
+    val stepId = currentStepId ?: family.definition.defaultInitialStepId
+    val workflowId = generateWorkflowId(family.definition.workflowIdPrefix)
+    WorkflowEngine.validateOpen(family.definition, stepId)?.let { error ->
+      return errorPayload(workflowId, error)
+    }
+    return database.transaction(dbOverride) { unitOfWork ->
+      val record = WorkflowEngine.openRecord(family.definition, workflowId, sessionId, stepId)
+      family.save(unitOfWork.workflowStates, record)
+      val saved = family.get(unitOfWork.workflowStates, workflowId) ?: record
+      ok(WorkflowEngine.fullPayload(family.definition, saved), unitOfWork)
+    }
+  }
+
+  fun update(kind: WorkflowFamilyKind, request: WorkflowUpdateRequest, dbOverride: String? = null): Map<String, Any?> {
+    val family = kind.workflowFamily()
+    val input = request.toWorkflowUpdateInput()
+    WorkflowEngine.validateUpdate(family.definition, input)?.let { error ->
+      return errorPayload(request.workflowId, error)
+    }
+    return database.transaction(dbOverride) { unitOfWork ->
+      val existing = family.get(unitOfWork.workflowStates, request.workflowId)
+        ?: return@transaction unknownWorkflowPayload(request.workflowId)
+      family.save(unitOfWork.workflowStates, WorkflowEngine.updateRecord(family.definition, existing, input))
+      val updated = family.get(unitOfWork.workflowStates, request.workflowId) ?: existing
+      ok(WorkflowEngine.fullPayload(family.definition, updated), unitOfWork)
+    }
+  }
+
+  fun get(kind: WorkflowFamilyKind, workflowId: String, dbOverride: String? = null): Map<String, Any?> =
+    database.read(dbOverride) { unitOfWork ->
+      val family = kind.workflowFamily()
+      val record = family.get(unitOfWork.workflowStates, workflowId)
+        ?: return@read unknownWorkflowPayload(workflowId, unitOfWork.dbPath.toString())
+      ok(WorkflowEngine.fullPayload(family.definition, record), unitOfWork)
+    }
+
+  fun list(kind: WorkflowFamilyKind, limit: Int = DEFAULT_LIST_LIMIT, dbOverride: String? = null): Map<String, Any?> =
+    database.read(dbOverride) { unitOfWork ->
+      val family = kind.workflowFamily()
+      val rows = family.list(unitOfWork.workflowStates, limit)
+      linkedMapOf(
+        "status" to "ok",
+        "db_path" to unitOfWork.dbPath.toString(),
+        "workflow_count" to rows.size,
+        "workflows" to rows.map { WorkflowEngine.summaryPayload(family.definition, it) },
+      )
+    }
+
+  fun latest(kind: WorkflowFamilyKind, dbOverride: String? = null): Map<String, Any?> =
+    database.read(dbOverride) { unitOfWork ->
+      val family = kind.workflowFamily()
+      val record = family.latest(unitOfWork.workflowStates)
+        ?: return@read linkedMapOf(
+          "status" to "error",
+          "error" to "No ${family.humanName} workflows found.",
+          "db_path" to unitOfWork.dbPath.toString(),
+        )
+      ok(WorkflowEngine.summaryPayload(family.definition, record), unitOfWork)
+    }
+
+  fun resume(kind: WorkflowFamilyKind, workflowId: String, dbOverride: String? = null): Map<String, Any?> =
+    database.read(dbOverride) { unitOfWork ->
+      val family = kind.workflowFamily()
+      val record = family.get(unitOfWork.workflowStates, workflowId)
+        ?: return@read unknownWorkflowPayload(workflowId, unitOfWork.dbPath.toString())
+      ok(WorkflowEngine.resumePayload(family.definition, record), unitOfWork)
+    }
+
+  fun continueWorkflow(kind: WorkflowFamilyKind, workflowId: String, dbOverride: String? = null): Map<String, Any?> =
+    database.transaction(dbOverride) { unitOfWork ->
+      val family = kind.workflowFamily()
+      var record = family.get(unitOfWork.workflowStates, workflowId)
+        ?: return@transaction unknownWorkflowPayload(workflowId, unitOfWork.dbPath.toString())
+      val sessionSummary = family.sessionSummary(unitOfWork.workflowStates, record.sessionId.orEmpty())
+      var decision = WorkflowEngine.continueDecision(family.definition, record, sessionSummary)
+      if (decision.shouldReopen) {
+        val continueStatus = decision.payload["continue_status"]
+        val reopened = WorkflowEngine.updateRecord(family.definition, record, decision.toReopenInput(record.sessionId))
+        family.save(unitOfWork.workflowStates, reopened)
+        record = family.get(unitOfWork.workflowStates, workflowId) ?: reopened
+        val refreshedPayload =
+          LinkedHashMap(
+            WorkflowEngine.continueDecision(family.definition, record, sessionSummary).payload,
+          )
+        refreshedPayload["continue_status"] = continueStatus
+        decision = decision.copy(payload = refreshedPayload)
+      }
+      continuePayload(decision.payload, unitOfWork)
+    }
+}
+
+private const val DEFAULT_LIST_LIMIT: Int = 20
+private const val WORKFLOW_ID_SUFFIX_LENGTH: Int = 4
+private const val SUFFIX_CHARS: String = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+private fun WorkflowUpdateRequest.toWorkflowUpdateInput(): WorkflowUpdateInput = WorkflowUpdateInput(
+  workflowStatus = workflowStatus,
+  currentStepId = currentStepId,
+  stepUpdates = stepUpdates,
+  artifactsPatch = artifactsPatch,
+  sessionId = sessionId,
+)
+
+private fun skillbill.workflow.model.WorkflowContinueDecision.toReopenInput(sessionId: String): WorkflowUpdateInput =
+  WorkflowUpdateInput(
+    workflowStatus = "running",
+    currentStepId = resumeStepId,
+    stepUpdates =
+    listOf(
+      mapOf(
+        "step_id" to resumeStepId,
+        "status" to "running",
+        "attempt_count" to nextAttemptCount,
+      ),
+    ),
+    artifactsPatch = null,
+    sessionId = sessionId,
+  )
+
+private fun ok(payload: Map<String, Any?>, unitOfWork: UnitOfWork): Map<String, Any?> = LinkedHashMap(payload).apply {
+  put("status", "ok")
+  put("db_path", unitOfWork.dbPath.toString())
+}
+
+private fun unknownWorkflowPayload(workflowId: String, dbPath: String? = null): Map<String, Any?> =
+  LinkedHashMap<String, Any?>().apply {
+    put("status", "error")
+    put("workflow_id", workflowId)
+    put("error", "Unknown workflow_id '$workflowId'.")
+    dbPath?.let { put("db_path", it) }
+  }
+
+private fun errorPayload(workflowId: String, error: String): Map<String, Any?> =
+  linkedMapOf("status" to "error", "workflow_id" to workflowId, "error" to error)
+
+private fun continuePayload(payload: Map<String, Any?>, unitOfWork: UnitOfWork): Map<String, Any?> =
+  LinkedHashMap(payload).apply {
+    put("db_path", unitOfWork.dbPath.toString())
+    if (this["continue_status"] == "blocked") {
+      val missingArtifacts = this["missing_artifacts"] as? List<*> ?: emptyList<Any?>()
+      put("status", "error")
+      put(
+        "error",
+        "Cannot continue workflow until the missing artifacts are restored: " +
+          missingArtifacts.joinToString { it.toString() },
+      )
+    } else {
+      put("status", "ok")
+    }
+  }
+
+private fun generateWorkflowId(prefix: String): String {
+  val now = OffsetDateTime.now(ZoneOffset.UTC)
+  val suffix = (1..WORKFLOW_ID_SUFFIX_LENGTH).map { SUFFIX_CHARS[Random.nextInt(SUFFIX_CHARS.length)] }
+    .joinToString("")
+  return "$prefix-${now.year}${now.monthValue.twoDigits()}${now.dayOfMonth.twoDigits()}-" +
+    "${now.hour.twoDigits()}${now.minute.twoDigits()}${now.second.twoDigits()}-$suffix"
+}
+
+private fun Int.twoDigits(): String = toString().padStart(2, '0')
+
+private fun WorkflowFamilyKind.workflowFamily(): WorkflowFamily = when (this) {
+  WorkflowFamilyKind.IMPLEMENT -> WorkflowFamily.IMPLEMENT
+  WorkflowFamilyKind.VERIFY -> WorkflowFamily.VERIFY
+}
+
+private enum class WorkflowFamily(
+  val definition: WorkflowDefinition,
+  val humanName: String,
+) {
+  IMPLEMENT(FeatureImplementWorkflowDefinition.definition, "feature-implement"),
+  VERIFY(FeatureVerifyWorkflowDefinition.definition, "feature-verify"),
+  ;
+
+  fun save(repository: WorkflowStateRepository, record: WorkflowStateSnapshot) {
+    when (this) {
+      IMPLEMENT -> repository.saveFeatureImplementWorkflow(record.toRecord())
+      VERIFY -> repository.saveFeatureVerifyWorkflow(record.toRecord())
+    }
+  }
+
+  fun get(repository: WorkflowStateRepository, workflowId: String): WorkflowStateSnapshot? = when (this) {
+    IMPLEMENT -> repository.getFeatureImplementWorkflow(workflowId)
+    VERIFY -> repository.getFeatureVerifyWorkflow(workflowId)
+  }?.toSnapshot()
+
+  fun list(repository: WorkflowStateRepository, limit: Int): List<WorkflowStateSnapshot> = when (this) {
+    IMPLEMENT -> repository.listFeatureImplementWorkflows(limit)
+    VERIFY -> repository.listFeatureVerifyWorkflows(limit)
+  }.map(WorkflowStateRecord::toSnapshot)
+
+  fun latest(repository: WorkflowStateRepository): WorkflowStateSnapshot? = when (this) {
+    IMPLEMENT -> repository.latestFeatureImplementWorkflow()
+    VERIFY -> repository.latestFeatureVerifyWorkflow()
+  }?.toSnapshot()
+
+  fun sessionSummary(repository: WorkflowStateRepository, sessionId: String): Map<String, Any?> {
+    if (sessionId.isBlank()) {
+      return emptyMap()
+    }
+    return when (this) {
+      IMPLEMENT -> repository.getFeatureImplementSessionSummary(sessionId)?.toPayload().orEmpty()
+      VERIFY -> repository.getFeatureVerifySessionSummary(sessionId)?.toPayload().orEmpty()
+    }
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/WorkflowUpdateRequest.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/WorkflowUpdateRequest.kt
@@ -1,0 +1,15 @@
+package skillbill.application.model
+
+data class WorkflowUpdateRequest(
+  val workflowId: String,
+  val workflowStatus: String,
+  val currentStepId: String = "",
+  val stepUpdates: List<Map<String, Any?>>? = null,
+  val artifactsPatch: Map<String, Any?>? = null,
+  val sessionId: String = "",
+)
+
+enum class WorkflowFamilyKind {
+  IMPLEMENT,
+  VERIFY,
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/SkillBillCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/SkillBillCommand.kt
@@ -8,11 +8,7 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 class SkillBillCommand(
   private val state: CliRunState,
-  reviewCommands: ReviewTopLevelCommands,
-  learningsCommand: LearningsCommand,
-  telemetryCommand: TelemetryCommand,
-  versionCommand: VersionCommand,
-  doctorCommand: DoctorCliCommand,
+  commands: TopLevelCliCommands,
 ) : DocumentedCliCommand(
   "skill-bill",
   "Import Skill Bill review output, triage findings, manage learnings, and inspect telemetry.",
@@ -25,16 +21,18 @@ class SkillBillCommand(
   init {
     completionOption()
     subcommands(
-      reviewCommands.importReviewCommand,
-      reviewCommands.recordFeedbackCommand,
-      reviewCommands.triageCommand,
-      reviewCommands.statsCommand,
-      reviewCommands.featureImplementStatsCommand,
-      reviewCommands.featureVerifyStatsCommand,
-      learningsCommand,
-      telemetryCommand,
-      versionCommand,
-      doctorCommand,
+      commands.review.importReviewCommand,
+      commands.review.recordFeedbackCommand,
+      commands.review.triageCommand,
+      commands.review.statsCommand,
+      commands.review.featureImplementStatsCommand,
+      commands.review.featureVerifyStatsCommand,
+      commands.learnings,
+      commands.telemetry,
+      commands.workflows.workflowCommand,
+      commands.workflows.verifyWorkflowCommand,
+      commands.version,
+      commands.doctor,
     )
   }
 
@@ -46,4 +44,21 @@ class SkillBillCommand(
   override fun run() {
     state.dbOverride = dbOverride
   }
+}
+
+@Inject
+class TopLevelCliCommands(
+  reviewCommands: ReviewTopLevelCommands,
+  learningsCommand: LearningsCommand,
+  telemetryCommand: TelemetryCommand,
+  workflowCommands: WorkflowTopLevelCommands,
+  versionCommand: VersionCommand,
+  doctorCommand: DoctorCliCommand,
+) {
+  val review = reviewCommands
+  val learnings = learningsCommand
+  val telemetry = telemetryCommand
+  val workflows = workflowCommands
+  val version = versionCommand
+  val doctor = doctorCommand
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliCommands.kt
@@ -1,0 +1,368 @@
+package skillbill.cli
+
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.optional
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.int
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.WorkflowService
+import skillbill.application.model.WorkflowFamilyKind
+import skillbill.application.model.WorkflowUpdateRequest
+import skillbill.contracts.JsonSupport
+
+@Inject
+class WorkflowTopLevelCommands(
+  implementCommands: ImplementWorkflowCommands,
+  verifyCommands: VerifyWorkflowCommands,
+) {
+  val workflowCommand: DocumentedNoOpCliCommand =
+    object : DocumentedNoOpCliCommand("workflow", "Inspect or resume durable bill-feature-implement workflow runs.") {}
+      .subcommands(
+        implementCommands.open,
+        implementCommands.update,
+        implementCommands.get,
+        implementCommands.list,
+        implementCommands.latest,
+        implementCommands.resume,
+        implementCommands.continueCommand,
+      )
+  val verifyWorkflowCommand: DocumentedNoOpCliCommand =
+    object : DocumentedNoOpCliCommand(
+      "verify-workflow",
+      "Inspect or resume durable bill-feature-verify workflow runs.",
+    ) {}
+      .subcommands(
+        verifyCommands.open,
+        verifyCommands.update,
+        verifyCommands.get,
+        verifyCommands.list,
+        verifyCommands.latest,
+        verifyCommands.resume,
+        verifyCommands.continueCommand,
+      )
+}
+
+@Inject
+class ImplementWorkflowCommands(
+  implementOpen: ImplementWorkflowOpenCommand,
+  implementUpdate: ImplementWorkflowUpdateCommand,
+  implementGet: ImplementWorkflowGetCommand,
+  implementInspection: ImplementWorkflowInspectionCommands,
+  implementResume: ImplementWorkflowResumeCommand,
+  implementContinue: ImplementWorkflowContinueCommand,
+) {
+  val open = implementOpen
+  val update = implementUpdate
+  val get = implementGet
+  val list = implementInspection.list
+  val latest = implementInspection.latest
+  val resume = implementResume
+  val continueCommand = implementContinue
+}
+
+@Inject
+class ImplementWorkflowInspectionCommands(
+  val list: ImplementWorkflowListCommand,
+  val latest: ImplementWorkflowLatestCommand,
+)
+
+@Inject
+class VerifyWorkflowCommands(
+  verifyOpen: VerifyWorkflowOpenCommand,
+  verifyUpdate: VerifyWorkflowUpdateCommand,
+  verifyGet: VerifyWorkflowGetCommand,
+  verifyInspection: VerifyWorkflowInspectionCommands,
+  verifyResume: VerifyWorkflowResumeCommand,
+  verifyContinue: VerifyWorkflowContinueCommand,
+) {
+  val open = verifyOpen
+  val update = verifyUpdate
+  val get = verifyGet
+  val list = verifyInspection.list
+  val latest = verifyInspection.latest
+  val resume = verifyResume
+  val continueCommand = verifyContinue
+}
+
+@Inject
+class VerifyWorkflowInspectionCommands(
+  val list: VerifyWorkflowListCommand,
+  val latest: VerifyWorkflowLatestCommand,
+)
+
+@Inject
+class ImplementWorkflowOpenCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowOpenCommand("open", service, state, WorkflowFamilyKind.IMPLEMENT)
+
+@Inject
+class VerifyWorkflowOpenCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowOpenCommand("open", service, state, WorkflowFamilyKind.VERIFY)
+
+open class WorkflowOpenCommand(
+  name: String,
+  private val service: WorkflowService,
+  private val state: CliRunState,
+  private val kind: WorkflowFamilyKind,
+) : DocumentedCliCommand(name, "Open durable workflow state.") {
+  private val sessionId by option("--session-id", help = "Optional workflow telemetry session id.").default("")
+  private val currentStepId by option("--current-step-id", help = "Initial workflow step id.")
+  private val format by formatOption()
+
+  override fun run() {
+    val payload =
+      service.open(kind, sessionId, currentStepId, state.dbOverride)
+    state.complete(payload, format, exitCode = payload.exitCode())
+  }
+}
+
+@Inject
+class ImplementWorkflowUpdateCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowUpdateCommand("update", service, state, WorkflowFamilyKind.IMPLEMENT)
+
+@Inject
+class VerifyWorkflowUpdateCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowUpdateCommand("update", service, state, WorkflowFamilyKind.VERIFY)
+
+open class WorkflowUpdateCommand(
+  name: String,
+  private val service: WorkflowService,
+  private val state: CliRunState,
+  private val kind: WorkflowFamilyKind,
+) : DocumentedCliCommand(name, "Update durable workflow state.") {
+  private val workflowId by argument(help = "Workflow id to update.")
+  private val workflowStatus by option("--workflow-status", help = "Next workflow status.").required()
+  private val currentStepId by option("--current-step-id", help = "Optional current step id.").default("")
+  private val stepUpdates by option("--step-updates", help = "JSON array of step updates.")
+  private val artifactsPatch by option("--artifacts-patch", help = "JSON object of artifacts to merge.")
+  private val sessionId by option("--session-id", help = "Optional replacement session id.").default("")
+  private val format by formatOption()
+
+  override fun run() {
+    val request =
+      WorkflowUpdateRequest(
+        workflowId = workflowId,
+        workflowStatus = workflowStatus,
+        currentStepId = currentStepId,
+        stepUpdates = stepUpdates?.let(::parseStepUpdates),
+        artifactsPatch = artifactsPatch?.let(::parseArtifactsPatch),
+        sessionId = sessionId,
+      )
+    val payload =
+      service.update(kind, request, state.dbOverride)
+    state.complete(payload, format, exitCode = payload.exitCode())
+  }
+}
+
+@Inject
+class ImplementWorkflowGetCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowGetCommand("get", service, state, WorkflowFamilyKind.IMPLEMENT)
+
+@Inject
+class VerifyWorkflowGetCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowGetCommand("get", service, state, WorkflowFamilyKind.VERIFY)
+
+open class WorkflowGetCommand(
+  name: String,
+  private val service: WorkflowService,
+  private val state: CliRunState,
+  private val kind: WorkflowFamilyKind,
+) : DocumentedCliCommand(name, "Fetch durable workflow state.") {
+  private val workflowId by argument(help = "Workflow id to inspect.").optional()
+  private val latest by option("--latest", help = "Resolve the most recently updated workflow.").flag(default = false)
+  private val format by formatOption()
+
+  override fun run() {
+    val resolution = resolveWorkflowId(workflowId, latest, service, state, kind)
+    val payload =
+      if (resolution.errorPayload != null) {
+        resolution.errorPayload
+      } else {
+        service.get(kind, requireNotNull(resolution.workflowId), state.dbOverride)
+      }
+    state.complete(payload, format, exitCode = payload.exitCode())
+  }
+}
+
+@Inject
+class ImplementWorkflowListCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowListCommand("list", service, state, WorkflowFamilyKind.IMPLEMENT)
+
+@Inject
+class VerifyWorkflowListCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowListCommand("list", service, state, WorkflowFamilyKind.VERIFY)
+
+open class WorkflowListCommand(
+  name: String,
+  private val service: WorkflowService,
+  private val state: CliRunState,
+  private val kind: WorkflowFamilyKind,
+) : DocumentedCliCommand(name, "List recent persisted workflow runs.") {
+  private val limit by option("--limit", help = "Maximum number of workflows to return.").int()
+    .default(DEFAULT_WORKFLOW_LIST_LIMIT)
+  private val format by formatOption()
+
+  override fun run() {
+    val payload =
+      service.list(kind, limit, state.dbOverride)
+    state.complete(payload, format, exitCode = payload.exitCode())
+  }
+}
+
+@Inject
+class ImplementWorkflowLatestCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowLatestCommand("latest", service, state, WorkflowFamilyKind.IMPLEMENT)
+
+@Inject
+class VerifyWorkflowLatestCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowLatestCommand("latest", service, state, WorkflowFamilyKind.VERIFY)
+
+open class WorkflowLatestCommand(
+  name: String,
+  private val service: WorkflowService,
+  private val state: CliRunState,
+  private val kind: WorkflowFamilyKind,
+) : DocumentedCliCommand(name, "Fetch the most recently updated workflow run.") {
+  private val format by formatOption()
+
+  override fun run() {
+    val payload =
+      service.latest(kind, state.dbOverride)
+    state.complete(payload, format, exitCode = payload.exitCode())
+  }
+}
+
+@Inject
+class ImplementWorkflowResumeCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowResumeCommand("resume", service, state, WorkflowFamilyKind.IMPLEMENT)
+
+@Inject
+class VerifyWorkflowResumeCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowResumeCommand("resume", service, state, WorkflowFamilyKind.VERIFY)
+
+open class WorkflowResumeCommand(
+  name: String,
+  private val service: WorkflowService,
+  private val state: CliRunState,
+  private val kind: WorkflowFamilyKind,
+) : DocumentedCliCommand(name, "Summarize how to resume or recover a workflow run.") {
+  private val workflowId by argument(help = "Workflow id to resume or recover.").optional()
+  private val latest by option("--latest", help = "Resolve the most recently updated workflow.").flag(default = false)
+  private val format by formatOption()
+
+  override fun run() {
+    val resolution = resolveWorkflowId(workflowId, latest, service, state, kind)
+    val payload =
+      if (resolution.errorPayload != null) {
+        resolution.errorPayload
+      } else {
+        service.resume(kind, requireNotNull(resolution.workflowId), state.dbOverride)
+      }
+    state.complete(payload, format, exitCode = payload.exitCode())
+  }
+}
+
+@Inject
+class ImplementWorkflowContinueCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowContinueCommand("continue", service, state, WorkflowFamilyKind.IMPLEMENT)
+
+@Inject
+class VerifyWorkflowContinueCommand(
+  service: WorkflowService,
+  state: CliRunState,
+) : WorkflowContinueCommand("continue", service, state, WorkflowFamilyKind.VERIFY)
+
+open class WorkflowContinueCommand(
+  name: String,
+  private val service: WorkflowService,
+  private val state: CliRunState,
+  private val kind: WorkflowFamilyKind,
+) : DocumentedCliCommand(name, "Activate a resumable workflow and emit a recovered continuation brief.") {
+  private val workflowId by argument(help = "Workflow id to continue.").optional()
+  private val latest by option("--latest", help = "Resolve the most recently updated workflow.").flag(default = false)
+  private val format by formatOption()
+
+  override fun run() {
+    val resolution = resolveWorkflowId(workflowId, latest, service, state, kind)
+    val payload =
+      if (resolution.errorPayload != null) {
+        resolution.errorPayload
+      } else {
+        service.continueWorkflow(kind, requireNotNull(resolution.workflowId), state.dbOverride)
+      }
+    state.complete(payload, format, exitCode = payload.exitCode())
+  }
+}
+
+private fun parseStepUpdates(rawValue: String): List<Map<String, Any?>> =
+  JsonSupport.parseArrayOrEmpty(rawValue).mapIndexed { index, value ->
+    val update = JsonSupport.anyToStringAnyMap(value)
+    require(update != null) { "step_updates[$index] must be an object." }
+    update
+  }
+
+private fun parseArtifactsPatch(rawValue: String): Map<String, Any?> = JsonSupport.parseObjectOrNull(rawValue)
+  ?.let(JsonSupport::jsonElementToValue)
+  ?.let(JsonSupport::anyToStringAnyMap)
+  ?: run {
+    require(false) { "artifacts_patch must be an object." }
+    emptyMap()
+  }
+
+private fun Map<String, Any?>.exitCode(): Int = if (this["status"] == "error") 1 else 0
+
+private fun resolveWorkflowId(
+  workflowId: String?,
+  latest: Boolean,
+  service: WorkflowService,
+  state: CliRunState,
+  kind: WorkflowFamilyKind,
+): WorkflowIdResolution {
+  workflowId?.let { return WorkflowIdResolution(workflowId = it) }
+  require(latest) { "Provide a workflow_id or pass --latest." }
+  val latestPayload =
+    when (kind) {
+      WorkflowFamilyKind.IMPLEMENT -> service.latest(WorkflowFamilyKind.IMPLEMENT, state.dbOverride)
+      WorkflowFamilyKind.VERIFY -> service.latest(WorkflowFamilyKind.VERIFY, state.dbOverride)
+    }
+  return WorkflowIdResolution(
+    workflowId = latestPayload["workflow_id"] as? String,
+    errorPayload = latestPayload.takeIf { it["status"] == "error" },
+  )
+}
+
+private const val DEFAULT_WORKFLOW_LIST_LIMIT: Int = 20
+
+private data class WorkflowIdResolution(
+  val workflowId: String?,
+  val errorPayload: Map<String, Any?>? = null,
+)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
@@ -328,6 +328,116 @@ class CliRuntimeTest {
   }
 
   @Test
+  fun `workflow cli commands list latest resume and block continuation`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-workflow")
+    val dbPath = tempDir.resolve("metrics.db")
+    val opened =
+      runJson(
+        "--db",
+        dbPath.toString(),
+        "workflow",
+        "open",
+        "--session-id",
+        "fis-20260425-000001-test",
+        "--format",
+        "json",
+      )
+    val workflowId = opened["workflow_id"] as String
+
+    val listed = runJson("--db", dbPath.toString(), "workflow", "list", "--format", "json")
+    val latest = runJson("--db", dbPath.toString(), "workflow", "latest", "--format", "json")
+    val resumed = runJson("--db", dbPath.toString(), "workflow", "resume", workflowId, "--format", "json")
+
+    assertEquals(1, listed["workflow_count"])
+    assertEquals(workflowId, latest["workflow_id"])
+    assertEquals("resume", resumed["resume_mode"])
+
+    val update =
+      runJson(
+        "--db",
+        dbPath.toString(),
+        "workflow",
+        "update",
+        workflowId,
+        "--workflow-status",
+        "blocked",
+        "--current-step-id",
+        "implement",
+        "--step-updates",
+        """[{"step_id":"implement","status":"blocked","attempt_count":1}]""",
+        "--artifacts-patch",
+        """{"preplan_digest":{"ok":true}}""",
+        "--format",
+        "json",
+      )
+    assertEquals("blocked", update["workflow_status"])
+
+    val continued =
+      CliRuntime.run(
+        listOf("--db", dbPath.toString(), "workflow", "continue", workflowId, "--format", "json"),
+      )
+    val continuePayload = decodeJsonObject(continued.stdout)
+    assertEquals(1, continued.exitCode)
+    assertEquals("blocked", continuePayload["continue_status"])
+    assertEquals(listOf("plan"), continuePayload["missing_artifacts"])
+  }
+
+  @Test
+  fun `verify workflow cli preserves prior step completion and continuation payloads`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-verify-workflow")
+    val dbPath = tempDir.resolve("metrics.db")
+    val opened =
+      runJson(
+        "--db",
+        dbPath.toString(),
+        "verify-workflow",
+        "open",
+        "--current-step-id",
+        "code_review",
+        "--format",
+        "json",
+      )
+    val workflowId = opened["workflow_id"] as String
+    val steps = opened.steps()
+    assertEquals("completed", steps.single { it["step_id"] == "gather_diff" }["status"])
+
+    runJson(
+      "--db",
+      dbPath.toString(),
+      "verify-workflow",
+      "update",
+      workflowId,
+      "--workflow-status",
+      "running",
+      "--current-step-id",
+      "verdict",
+      "--step-updates",
+      """[{"step_id":"verdict","status":"blocked","attempt_count":1}]""",
+      "--artifacts-patch",
+      """{"criteria_summary":{},"diff_summary":{},"review_result":{},"completeness_audit_result":{}}""",
+      "--format",
+      "json",
+    )
+
+    val continued = runJson("--db", dbPath.toString(), "verify-workflow", "continue", "--latest", "--format", "json")
+    assertEquals("reopened", continued["continue_status"])
+    assertEquals("verdict", continued["continue_step_id"])
+  }
+
+  @Test
+  fun `workflow latest no rows returns resolved db path`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-empty-workflow")
+    val context = CliRuntimeContext(userHome = tempDir)
+
+    val result = CliRuntime.run(listOf("workflow", "resume", "--latest", "--format", "json"), context)
+    val payload = decodeJsonObject(result.stdout)
+
+    assertEquals(1, result.exitCode)
+    assertEquals("No feature-implement workflows found.", payload["error"])
+    assertEquals(tempDir.resolve(".skill-bill/review-metrics.db").toString(), payload["db_path"])
+  }
+
+  @Test
   fun `clikt validation reports command usage errors`() {
     val missingRequiredOption = CliRuntime.run(listOf("record-feedback", "--run-id", "rvw-1"))
     assertEquals(1, missingRequiredOption.exitCode)
@@ -346,6 +456,8 @@ class CliRuntimeTest {
 
 private fun runJson(vararg arguments: String, context: CliRuntimeContext = CliRuntimeContext()): Map<String, Any?> =
   runJson(arguments.toList(), context)
+
+private fun Map<String, Any?>.steps(): List<Map<*, *>> = (this["steps"] as List<*>).map { step -> step as Map<*, *> }
 
 private fun runJson(arguments: List<String>, context: CliRuntimeContext = CliRuntimeContext()): Map<String, Any?> {
   val result = CliRuntime.run(arguments, context)

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/workflow/WorkflowContracts.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/workflow/WorkflowContracts.kt
@@ -1,0 +1,74 @@
+package skillbill.contracts.workflow
+
+object WorkflowContracts {
+  fun fullWorkflowPayload(fields: Map<String, Any?>): Map<String, Any?> = orderedPayload(
+    fields,
+    listOf(
+      "workflow_id",
+      "session_id",
+      "workflow_name",
+      "contract_version",
+      "workflow_status",
+      "current_step_id",
+      "steps",
+      "artifacts",
+      "started_at",
+      "updated_at",
+      "finished_at",
+    ),
+  )
+
+  fun summaryWorkflowPayload(fields: Map<String, Any?>): Map<String, Any?> = orderedPayload(
+    fields,
+    listOf(
+      "workflow_id",
+      "session_id",
+      "workflow_name",
+      "contract_version",
+      "workflow_status",
+      "current_step_id",
+      "started_at",
+      "updated_at",
+      "finished_at",
+    ),
+  )
+
+  fun resumePayload(basePayload: Map<String, Any?>, resumeFields: Map<String, Any?>): Map<String, Any?> =
+    LinkedHashMap(basePayload).apply {
+      put("resume_mode", resumeFields["resume_mode"])
+      put("resume_step_id", resumeFields["resume_step_id"])
+      put("last_completed_step_id", resumeFields["last_completed_step_id"])
+      put("available_artifacts", resumeFields["available_artifacts"])
+      put("required_artifacts", resumeFields["required_artifacts"])
+      put("missing_artifacts", resumeFields["missing_artifacts"])
+      put("can_resume", resumeFields["can_resume"])
+      put("next_action", resumeFields["next_action"])
+    }
+
+  fun continuePayload(resumePayload: Map<String, Any?>, continueFields: Map<String, Any?>): Map<String, Any?> =
+    LinkedHashMap(resumePayload).apply {
+      put("skill_name", continueFields["skill_name"])
+      put("continuation_mode", "resume_existing_workflow")
+      put("workflow_status_before_continue", continueFields["workflow_status_before_continue"])
+      put("continue_status", continueFields["continue_status"])
+      put("continue_step_id", continueFields["continue_step_id"])
+      put("continue_step_label", continueFields["continue_step_label"])
+      put("continue_step_directive", continueFields["continue_step_directive"])
+      put("reference_sections", continueFields["reference_sections"])
+      put("step_artifact_keys", continueFields["step_artifact_keys"])
+      put("step_artifacts", continueFields["step_artifacts"])
+      (continueFields["extra_fields"] as? Map<*, *>)?.forEach { (key, value) ->
+        if (key is String) {
+          put(key, value)
+        }
+      }
+      put("session_summary", continueFields["session_summary"])
+      put("continuation_brief", continueFields["continuation_brief"])
+      put("continuation_entry_prompt", continueFields["continuation_entry_prompt"])
+    }
+
+  private fun orderedPayload(fields: Map<String, Any?>, keys: List<String>): Map<String, Any?> =
+    linkedMapOf<String, Any?>().apply {
+      keys.forEach { key -> put(key, fields[key]) }
+    }
+}

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -6,6 +6,7 @@ import skillbill.application.LearningService
 import skillbill.application.ReviewService
 import skillbill.application.SystemService
 import skillbill.application.TelemetryService
+import skillbill.application.WorkflowService
 import skillbill.infrastructure.fs.FileTelemetryConfigStore
 import skillbill.infrastructure.http.HttpTelemetryClient
 import skillbill.infrastructure.sqlite.SQLiteDatabaseSessionFactory
@@ -36,4 +37,5 @@ abstract class RuntimeComponent(
   abstract val reviewService: ReviewService
   abstract val systemService: SystemService
   abstract val telemetryService: TelemetryService
+  abstract val workflowService: WorkflowService
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowRuntime.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowRuntime.kt
@@ -3,16 +3,15 @@ package skillbill.workflow.implement
 import skillbill.contracts.surface.RuntimeSurfaceContract
 import skillbill.contracts.surface.RuntimeSurfaceStatus
 
-/** Reserved until feature-implement orchestration moves out of the agent shell. */
+/** Kotlin-owned durable workflow runtime surface for feature implementation state. */
 object FeatureImplementWorkflowRuntime {
   val contract: RuntimeSurfaceContract = RuntimeSurfaceContract(
     name = "feature-implement-workflow",
     ownerPackage = "skillbill.workflow.implement",
     contractVersion = "0.1",
-    status = RuntimeSurfaceStatus.RESERVED,
-    summary = "Feature implementation workflow orchestration surface.",
-    placeholderReason =
-    "Durable workflow state is already persisted through repository ports, but the end-to-end feature-implement " +
-      "orchestration contract is still owned by the governed agent skill shell.",
+    status = RuntimeSurfaceStatus.ACTIVE,
+    summary = "Feature implementation workflow state, resume, and continuation surface.",
+    placeholderReason = "",
+    supportedOperations = listOf("open", "update", "get", "list", "latest", "resume", "continue"),
   )
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowRuntime.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowRuntime.kt
@@ -3,16 +3,15 @@ package skillbill.workflow.verify
 import skillbill.contracts.surface.RuntimeSurfaceContract
 import skillbill.contracts.surface.RuntimeSurfaceStatus
 
-/** Reserved until feature-verify orchestration moves out of the agent shell. */
+/** Kotlin-owned durable workflow runtime surface for feature verification state. */
 object FeatureVerifyWorkflowRuntime {
   val contract: RuntimeSurfaceContract = RuntimeSurfaceContract(
     name = "feature-verify-workflow",
     ownerPackage = "skillbill.workflow.verify",
     contractVersion = "0.1",
-    status = RuntimeSurfaceStatus.RESERVED,
-    summary = "Feature verification workflow orchestration surface.",
-    placeholderReason =
-    "Durable workflow state is already persisted through repository ports, but the end-to-end feature-verify " +
-      "orchestration contract is still owned by the governed agent skill shell.",
+    status = RuntimeSurfaceStatus.ACTIVE,
+    summary = "Feature verification workflow state, resume, and continuation surface.",
+    placeholderReason = "",
+    supportedOperations = listOf("open", "update", "get", "list", "latest", "resume", "continue"),
   )
 }

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -1,6 +1,8 @@
 package skillbill.application
 
 import skillbill.application.model.AddLearningInput
+import skillbill.application.model.WorkflowFamilyKind
+import skillbill.application.model.WorkflowUpdateRequest
 import skillbill.learnings.model.CreateLearningRequest
 import skillbill.learnings.model.LearningRecord
 import skillbill.learnings.model.LearningScope
@@ -14,6 +16,8 @@ import skillbill.ports.persistence.ReviewRepository
 import skillbill.ports.persistence.TelemetryOutboxRepository
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.ports.persistence.model.FeatureImplementSessionSummary
+import skillbill.ports.persistence.model.FeatureVerifySessionSummary
 import skillbill.ports.persistence.model.LearningResolution
 import skillbill.ports.persistence.model.TelemetryOutboxRecord
 import skillbill.ports.persistence.model.WorkflowStateRecord
@@ -166,12 +170,145 @@ class ApplicationPersistencePortTest {
     assertEquals(listOf(listOf(1L)), client.sentBatchIds)
     assertEquals(0, outboxRepository.pendingCount())
   }
+
+  @Test
+  fun `workflow service owns implement rows list resume and continuation through ports`() {
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+
+    val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
+    val workflowId = opened["workflow_id"] as String
+    val updated =
+      service.update(
+        WorkflowFamilyKind.IMPLEMENT,
+        WorkflowUpdateRequest(
+          workflowId = workflowId,
+          workflowStatus = "blocked",
+          currentStepId = "implement",
+          stepUpdates = listOf(mapOf("step_id" to "implement", "status" to "blocked", "attempt_count" to 1)),
+          artifactsPatch = mapOf("preplan_digest" to mapOf("ok" to true)),
+        ),
+        dbOverride = null,
+      )
+    val listed = service.list(WorkflowFamilyKind.IMPLEMENT, dbOverride = null)
+    val latest = service.latest(WorkflowFamilyKind.IMPLEMENT, dbOverride = null)
+    val resumed = service.resume(WorkflowFamilyKind.IMPLEMENT, workflowId, dbOverride = null)
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, workflowId, dbOverride = null)
+
+    assertEquals(listOf("transaction", "transaction", "read", "read", "read", "transaction"), database.calls)
+    assertEquals("blocked", updated["workflow_status"])
+    assertEquals(1, listed["workflow_count"])
+    assertEquals(workflowId, latest["workflow_id"])
+    assertEquals(listOf("plan"), resumed["missing_artifacts"])
+    assertEquals("error", continued["status"])
+    assertEquals("blocked", continued["continue_status"])
+  }
+
+  @Test
+  fun `workflow service hydrates implement session summary for continuation payloads`() {
+    val workflowRepository =
+      InMemoryWorkflowStateRepository(
+        implementSessionSummary =
+        FeatureImplementSessionSummary(
+          sessionId = "fis-001",
+          issueKeyProvided = true,
+          issueKeyType = "other",
+          specInputTypes = listOf("markdown_file"),
+          specWordCount = 42,
+          featureSize = "MEDIUM",
+          featureName = "workflow-runtime",
+          rolloutNeeded = false,
+          acceptanceCriteriaCount = 6,
+          openQuestionsCount = 0,
+          specSummary = "Port workflow runtime",
+        ),
+      )
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+
+    val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, opened["workflow_id"] as String, null)
+    val sessionSummary = continued["session_summary"] as Map<*, *>
+
+    assertEquals("fis-001", sessionSummary["session_id"])
+    assertEquals(listOf("markdown_file"), sessionSummary["spec_input_types"])
+    assertEquals("workflow-runtime", sessionSummary["feature_name"])
+    assertEquals("Port workflow runtime", sessionSummary["spec_summary"])
+  }
+
+  @Test
+  fun `workflow service owns verify prior steps done resume and reopened continuation`() {
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+
+    val opened = service.open(WorkflowFamilyKind.VERIFY, currentStepId = "code_review", dbOverride = null)
+    val workflowId = opened["workflow_id"] as String
+    val steps = opened.steps()
+    assertEquals("completed", steps.single { it["step_id"] == "gather_diff" }["status"])
+
+    service.update(
+      WorkflowFamilyKind.VERIFY,
+      WorkflowUpdateRequest(
+        workflowId = workflowId,
+        workflowStatus = "running",
+        currentStepId = "verdict",
+        stepUpdates = listOf(mapOf("step_id" to "verdict", "status" to "blocked", "attempt_count" to 1)),
+        artifactsPatch =
+        mapOf(
+          "criteria_summary" to emptyMap<String, Any?>(),
+          "diff_summary" to emptyMap(),
+          "review_result" to emptyMap(),
+          "completeness_audit_result" to emptyMap(),
+        ),
+      ),
+      dbOverride = null,
+    )
+
+    val resumed = service.resume(WorkflowFamilyKind.VERIFY, workflowId, dbOverride = null)
+    val continued = service.continueWorkflow(WorkflowFamilyKind.VERIFY, workflowId, dbOverride = null)
+    val afterContinue = service.get(WorkflowFamilyKind.VERIFY, workflowId, dbOverride = null)
+    val continuedSteps = afterContinue.steps()
+
+    assertEquals("resume", resumed["resume_mode"])
+    assertEquals("ok", continued["status"])
+    assertEquals("reopened", continued["continue_status"])
+    assertEquals("running", continuedSteps.single { it["step_id"] == "verdict" }["status"])
+    assertEquals(2, continuedSteps.single { it["step_id"] == "verdict" }["attempt_count"])
+  }
+
+  @Test
+  fun `workflow service hydrates verify session summary for continuation payloads`() {
+    val workflowRepository =
+      InMemoryWorkflowStateRepository(
+        verifySessionSummary =
+        FeatureVerifySessionSummary(
+          sessionId = "fvr-001",
+          acceptanceCriteriaCount = 3,
+          rolloutRelevant = true,
+          specSummary = "Verify workflow runtime",
+        ),
+      )
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+
+    val opened = service.open(WorkflowFamilyKind.VERIFY, sessionId = "fvr-001", dbOverride = null)
+    val continued = service.continueWorkflow(WorkflowFamilyKind.VERIFY, opened["workflow_id"] as String, null)
+    val sessionSummary = continued["session_summary"] as Map<*, *>
+
+    assertEquals("fvr-001", sessionSummary["session_id"])
+    assertEquals(3, sessionSummary["acceptance_criteria_count"])
+    assertEquals(true, sessionSummary["rollout_relevant"])
+    assertEquals("Verify workflow runtime", sessionSummary["spec_summary"])
+  }
 }
 
 private class FakeDatabaseSessionFactory(
   private val reviews: ReviewRepository = FakeReviewRepository(),
   private val learnings: LearningRepository = FakeLearningRepository(),
   private val telemetryOutbox: TelemetryOutboxRepository = NoopTelemetryOutboxRepository,
+  private val workflows: WorkflowStateRepository = NoopWorkflowStateRepository,
 ) : DatabaseSessionFactory {
   val calls = mutableListOf<String>()
   private val dbPath = Path.of("/fake/metrics.db")
@@ -195,7 +332,7 @@ private class FakeDatabaseSessionFactory(
     override val reviews: ReviewRepository = this@FakeDatabaseSessionFactory.reviews
     override val learnings: LearningRepository = this@FakeDatabaseSessionFactory.learnings
     override val telemetryOutbox: TelemetryOutboxRepository = this@FakeDatabaseSessionFactory.telemetryOutbox
-    override val workflowStates: WorkflowStateRepository = NoopWorkflowStateRepository
+    override val workflowStates: WorkflowStateRepository = this@FakeDatabaseSessionFactory.workflows
   }
 }
 
@@ -399,6 +536,56 @@ private object NoopWorkflowStateRepository : WorkflowStateRepository {
   override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? = null
 
   override fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord? = null
+
+  override fun listFeatureImplementWorkflows(limit: Int): List<WorkflowStateRecord> = emptyList()
+
+  override fun listFeatureVerifyWorkflows(limit: Int): List<WorkflowStateRecord> = emptyList()
+
+  override fun latestFeatureImplementWorkflow(): WorkflowStateRecord? = null
+
+  override fun latestFeatureVerifyWorkflow(): WorkflowStateRecord? = null
+
+  override fun getFeatureImplementSessionSummary(sessionId: String): FeatureImplementSessionSummary? = null
+
+  override fun getFeatureVerifySessionSummary(sessionId: String): FeatureVerifySessionSummary? = null
+}
+
+private fun Map<String, Any?>.steps(): List<Map<*, *>> = (this["steps"] as List<*>).map { step -> step as Map<*, *> }
+
+private class InMemoryWorkflowStateRepository(
+  private val implementSessionSummary: FeatureImplementSessionSummary? = null,
+  private val verifySessionSummary: FeatureVerifySessionSummary? = null,
+) : WorkflowStateRepository {
+  private val implementRows = linkedMapOf<String, WorkflowStateRecord>()
+  private val verifyRows = linkedMapOf<String, WorkflowStateRecord>()
+
+  override fun saveFeatureImplementWorkflow(row: WorkflowStateRecord) {
+    implementRows[row.workflowId] = row
+  }
+
+  override fun saveFeatureVerifyWorkflow(row: WorkflowStateRecord) {
+    verifyRows[row.workflowId] = row
+  }
+
+  override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? = implementRows[workflowId]
+
+  override fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord? = verifyRows[workflowId]
+
+  override fun listFeatureImplementWorkflows(limit: Int): List<WorkflowStateRecord> =
+    implementRows.values.toList().asReversed().take(limit)
+
+  override fun listFeatureVerifyWorkflows(limit: Int): List<WorkflowStateRecord> =
+    verifyRows.values.toList().asReversed().take(limit)
+
+  override fun latestFeatureImplementWorkflow(): WorkflowStateRecord? = listFeatureImplementWorkflows(1).firstOrNull()
+
+  override fun latestFeatureVerifyWorkflow(): WorkflowStateRecord? = listFeatureVerifyWorkflows(1).firstOrNull()
+
+  override fun getFeatureImplementSessionSummary(sessionId: String): FeatureImplementSessionSummary? =
+    implementSessionSummary?.takeIf { it.sessionId == sessionId }
+
+  override fun getFeatureVerifySessionSummary(sessionId: String): FeatureVerifySessionSummary? =
+    verifySessionSummary?.takeIf { it.sessionId == sessionId }
 }
 
 private fun learningRecord(id: Int, title: String = "Learning $id"): LearningRecord = LearningRecord(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/WorkflowEngine.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/WorkflowEngine.kt
@@ -1,0 +1,409 @@
+@file:Suppress("LongMethod", "LongParameterList", "ReturnCount", "TooManyFunctions")
+
+package skillbill.workflow
+
+import skillbill.contracts.JsonSupport
+import skillbill.contracts.workflow.WorkflowContracts
+import skillbill.workflow.model.WorkflowContinueDecision
+import skillbill.workflow.model.WorkflowDefinition
+import skillbill.workflow.model.WorkflowStateSnapshot
+import skillbill.workflow.model.WorkflowUpdateInput
+
+object WorkflowEngine {
+  private val resumableStepStatuses = setOf("running", "blocked", "pending")
+
+  fun validateOpen(definition: WorkflowDefinition, currentStepId: String): String? =
+    validateEnum(currentStepId, definition.stepIds, "current_step_id")
+
+  fun validateUpdate(definition: WorkflowDefinition, input: WorkflowUpdateInput): String? {
+    validateEnum(input.workflowStatus, definition.workflowStatuses, "workflow_status")?.let { return it }
+    if (input.currentStepId.isNotBlank()) {
+      validateEnum(input.currentStepId, definition.stepIds, "current_step_id")?.let { return it }
+    }
+    input.stepUpdates?.let { updates ->
+      val seenStepIds = mutableSetOf<String>()
+      updates.forEachIndexed { index, update ->
+        val stepId = update["step_id"] as? String
+        if (stepId.isNullOrBlank()) {
+          return "step_updates[$index].step_id must be a non-empty string."
+        }
+        validateEnum(stepId, definition.stepIds, "step_updates.step_id")?.let { return it }
+        if (!seenStepIds.add(stepId)) {
+          return "Duplicate step_id '$stepId' in step_updates."
+        }
+        val status = update["status"] as? String
+        if (status.isNullOrBlank()) {
+          return "step_updates[$index].status must be a non-empty string."
+        }
+        validateEnum(status, definition.stepStatuses, "step_updates.status")?.let { return it }
+        val attemptCount = update["attempt_count"] as? Number
+        if (attemptCount == null || attemptCount.toInt() < 0) {
+          return "step_updates[$index].attempt_count must be an integer >= 0."
+        }
+      }
+    }
+    return null
+  }
+
+  fun openRecord(
+    definition: WorkflowDefinition,
+    workflowId: String,
+    sessionId: String,
+    currentStepId: String,
+  ): WorkflowStateSnapshot = WorkflowStateSnapshot(
+    workflowId = workflowId,
+    sessionId = sessionId.trim(),
+    workflowName = definition.workflowName,
+    contractVersion = definition.contractVersion,
+    workflowStatus = "running",
+    currentStepId = currentStepId,
+    stepsJson = jsonString(defaultSteps(definition, currentStepId)),
+    artifactsJson = jsonString(emptyMap<String, Any?>()),
+    startedAt = null,
+    updatedAt = null,
+    finishedAt = null,
+  )
+
+  fun updateRecord(
+    definition: WorkflowDefinition,
+    existing: WorkflowStateSnapshot,
+    input: WorkflowUpdateInput,
+  ): WorkflowStateSnapshot {
+    val existingArtifacts = decodeObject(existing.artifactsJson)
+    val mergedArtifacts = LinkedHashMap(existingArtifacts)
+    input.artifactsPatch?.let { patch -> mergedArtifacts.putAll(patch) }
+    val terminal = input.workflowStatus in definition.terminalStatuses
+    return existing.copy(
+      sessionId = input.sessionId.trim().ifBlank { existing.sessionId.orEmpty() },
+      workflowStatus = input.workflowStatus,
+      currentStepId = input.currentStepId.trim().ifBlank { existing.currentStepId.orEmpty() },
+      stepsJson = jsonString(mergeStepUpdates(definition, decodeSteps(existing.stepsJson), input.stepUpdates)),
+      artifactsJson = jsonString(mergedArtifacts),
+      finishedAt = if (terminal) existing.finishedAt ?: "" else null,
+    )
+  }
+
+  fun fullPayload(definition: WorkflowDefinition, record: WorkflowStateSnapshot): Map<String, Any?> =
+    WorkflowContracts.fullWorkflowPayload(
+      mapOf(
+        "workflow_id" to record.workflowId,
+        "session_id" to record.sessionId.orEmpty(),
+        "workflow_name" to record.workflowName.ifBlank { definition.workflowName },
+        "contract_version" to record.contractVersion.ifBlank { definition.contractVersion },
+        "workflow_status" to record.workflowStatus.ifBlank { "pending" },
+        "current_step_id" to record.currentStepId.orEmpty(),
+        "steps" to decodeSteps(record.stepsJson),
+        "artifacts" to decodeObject(record.artifactsJson),
+        "started_at" to record.startedAt.orEmpty(),
+        "updated_at" to record.updatedAt.orEmpty(),
+        "finished_at" to record.finishedAt.orEmpty(),
+      ),
+    )
+
+  fun summaryPayload(definition: WorkflowDefinition, record: WorkflowStateSnapshot): Map<String, Any?> =
+    WorkflowContracts.summaryWorkflowPayload(
+      mapOf(
+        "workflow_id" to record.workflowId,
+        "session_id" to record.sessionId.orEmpty(),
+        "workflow_name" to record.workflowName.ifBlank { definition.workflowName },
+        "contract_version" to record.contractVersion.ifBlank { definition.contractVersion },
+        "workflow_status" to record.workflowStatus.ifBlank { "pending" },
+        "current_step_id" to record.currentStepId.orEmpty(),
+        "started_at" to record.startedAt.orEmpty(),
+        "updated_at" to record.updatedAt.orEmpty(),
+        "finished_at" to record.finishedAt.orEmpty(),
+      ),
+    )
+
+  fun resumePayload(definition: WorkflowDefinition, record: WorkflowStateSnapshot): Map<String, Any?> {
+    val payload = fullPayload(definition, record)
+    val workflowStatus = payload["workflow_status"] as String
+    val currentStepId = payload["current_step_id"] as String
+    val steps = payload["steps"].asStepList()
+    val artifacts = payload["artifacts"].asStringAnyMap()
+    val stepsById = steps.associateBy { it["step_id"].toString() }
+    val lastCompletedStepId =
+      definition.stepIds.lastOrNull { stepId -> stepsById[stepId]?.get("status") == "completed" }.orEmpty()
+
+    var resumeStepId = currentStepId
+    val resumeMode =
+      when {
+        workflowStatus == "completed" -> "done"
+        workflowStatus in definition.terminalStatuses -> "recover"
+        else -> "resume"
+      }
+    if (resumeMode == "resume" && stepsById[currentStepId]?.get("status") == "completed") {
+      resumeStepId =
+        definition.stepIds.firstOrNull { stepId -> stepsById[stepId]?.get("status") in resumableStepStatuses }
+          ?: currentStepId
+    }
+    val availableArtifacts = artifacts.keys.sorted()
+    val requiredArtifacts = definition.requiredArtifactsByStep[resumeStepId].orEmpty()
+    val missingArtifacts = requiredArtifacts.filterNot(artifacts::containsKey)
+    val canResume = resumeMode != "done" && missingArtifacts.isEmpty()
+    val nextAction =
+      if (resumeMode == "done") {
+        "Workflow already completed. Inspect ${definition.completedTerminalSummaryArtifact} or telemetry for a summary."
+      } else {
+        definition.resumeActions[resumeStepId]
+          ?: "Inspect workflow state, refresh missing artifacts, and continue from the current step."
+      }
+    return WorkflowContracts.resumePayload(
+      payload,
+      mapOf(
+        "resume_mode" to resumeMode,
+        "resume_step_id" to resumeStepId,
+        "last_completed_step_id" to lastCompletedStepId,
+        "available_artifacts" to availableArtifacts,
+        "required_artifacts" to requiredArtifacts,
+        "missing_artifacts" to missingArtifacts,
+        "can_resume" to canResume,
+        "next_action" to nextAction,
+      ),
+    )
+  }
+
+  fun continueDecision(
+    definition: WorkflowDefinition,
+    record: WorkflowStateSnapshot,
+    sessionSummary: Map<String, Any?> = emptyMap(),
+  ): WorkflowContinueDecision {
+    val resumePayload = resumePayload(definition, record)
+    val workflowStatusBefore = resumePayload["workflow_status"] as String
+    val resumeMode = resumePayload["resume_mode"] as String
+    val resumeStepId = resumePayload["resume_step_id"] as String
+    val currentStepId = resumePayload["current_step_id"] as String
+    val artifacts = resumePayload["artifacts"].asStringAnyMap()
+    val steps = resumePayload["steps"].asStepList()
+    val canResume = resumePayload["can_resume"] as Boolean
+    val stepArtifacts = continueArtifactKeys(definition, resumeStepId, artifacts)
+    val currentStep = steps.firstOrNull { it["step_id"] == resumeStepId }.orEmpty()
+    val attemptCount = (currentStep["attempt_count"] as? Number)?.toInt() ?: 0
+    val alreadyRunning =
+      workflowStatusBefore == "running" &&
+        currentStepId == resumeStepId &&
+        currentStep["status"] == "running"
+    val continueStatus =
+      when {
+        resumeMode == "done" -> "done"
+        canResume && alreadyRunning -> "already_running"
+        canResume -> "reopened"
+        else -> "blocked"
+      }
+    val extraFields =
+      if (definition.skillName == "bill-feature-implement") {
+        implementExtraFields(artifacts)
+      } else {
+        emptyMap()
+      }
+    val payload =
+      WorkflowContracts.continuePayload(
+        resumePayload,
+        mapOf(
+          "skill_name" to definition.skillName,
+          "workflow_status_before_continue" to workflowStatusBefore,
+          "continue_status" to continueStatus,
+          "continue_step_id" to resumeStepId,
+          "continue_step_label" to (definition.stepLabels[resumeStepId] ?: resumeStepId),
+          "continue_step_directive" to (
+            definition.continuationDirectives[resumeStepId]
+              ?: "Resume the workflow from the current step using the recovered artifacts as authoritative context."
+            ),
+          "reference_sections" to definition.continuationReferenceSections[resumeStepId].orEmpty(),
+          "step_artifact_keys" to stepArtifacts,
+          "step_artifacts" to stepArtifacts.associateWith { artifacts.getValue(it) },
+          "session_summary" to sessionSummary,
+          "continuation_brief" to
+            continuationBrief(
+              definition = definition,
+              workflowId = record.workflowId,
+              resumeStepId = resumeStepId,
+              continueStatus = continueStatus,
+              nextAction = resumePayload["next_action"].toString(),
+              artifactKeys = stepArtifacts,
+            ),
+          "continuation_entry_prompt" to
+            continuationEntryPrompt(
+              definition = definition,
+              workflowId = record.workflowId,
+              sessionId = record.sessionId.orEmpty(),
+              resumeStepId = resumeStepId,
+              continueStatus = continueStatus,
+              artifactKeys = stepArtifacts,
+              nextAction = resumePayload["next_action"].toString(),
+              sessionSummary = sessionSummary,
+              extraFields = extraFields,
+            ),
+          "extra_fields" to extraFields,
+        ),
+      )
+    return WorkflowContinueDecision(
+      payload = payload,
+      shouldReopen = continueStatus == "reopened",
+      resumeStepId = resumeStepId,
+      nextAttemptCount = maxOf(attemptCount + 1, 1),
+    )
+  }
+
+  private fun defaultSteps(definition: WorkflowDefinition, initialStepId: String): List<Map<String, Any?>> {
+    var seenInitial = false
+    return definition.stepIds.map { stepId ->
+      when {
+        stepId == initialStepId -> {
+          seenInitial = true
+          step(stepId, "running", 1)
+        }
+        definition.openPriorStepsCompleted && !seenInitial -> step(stepId, "completed", 1)
+        else -> step(stepId, "pending", 0)
+      }
+    }
+  }
+
+  private fun mergeStepUpdates(
+    definition: WorkflowDefinition,
+    existingSteps: List<Map<String, Any?>>,
+    stepUpdates: List<Map<String, Any?>>?,
+  ): List<Map<String, Any?>> {
+    if (stepUpdates == null) {
+      return existingSteps
+    }
+    val byStepId = existingSteps.associateByTo(LinkedHashMap()) { it["step_id"].toString() }
+    stepUpdates.forEach { update ->
+      val stepId = update["step_id"].toString()
+      byStepId[stepId] = step(stepId, update["status"].toString(), (update["attempt_count"] as Number).toInt())
+    }
+    return definition.stepIds.mapNotNull(byStepId::get)
+  }
+
+  private fun continueArtifactKeys(
+    definition: WorkflowDefinition,
+    resumeStepId: String,
+    artifacts: Map<String, Any?>,
+  ): List<String> {
+    val keys = mutableListOf<String>()
+    definition.continuationArtifactOrder.forEach { key ->
+      if (key in artifacts) {
+        keys += key
+      }
+    }
+    definition.requiredArtifactsByStep[resumeStepId].orEmpty().forEach { key ->
+      if (key in artifacts && key !in keys) {
+        keys += key
+      }
+    }
+    return keys
+  }
+
+  private fun continuationBrief(
+    definition: WorkflowDefinition,
+    workflowId: String,
+    resumeStepId: String,
+    continueStatus: String,
+    nextAction: String,
+    artifactKeys: List<String>,
+  ): String {
+    val stepLabel = definition.stepLabels[resumeStepId] ?: resumeStepId
+    val artifacts = artifactKeys.joinToString().ifBlank { "none" }
+    val instructionPath =
+      if (definition.skillName == "bill-feature-implement") {
+        "`skills/bill-feature-implement/SKILL.md` and `skills/bill-feature-implement/reference.md`"
+      } else {
+        "`skills/bill-feature-verify/SKILL.md`"
+      }
+    return "Resume `${definition.skillName}` workflow `$workflowId` from `$stepLabel` (`$resumeStepId`). " +
+      "Follow the normal step instructions in $instructionPath. " +
+      "Use the recovered `step_artifacts` in this payload ($artifacts) instead of reconstructing prior context from " +
+      "chat history. Workflow activation status: `$continueStatus`. Next action: $nextAction"
+  }
+
+  private fun continuationEntryPrompt(
+    definition: WorkflowDefinition,
+    workflowId: String,
+    sessionId: String,
+    resumeStepId: String,
+    continueStatus: String,
+    artifactKeys: List<String>,
+    nextAction: String,
+    sessionSummary: Map<String, Any?>,
+    extraFields: Map<String, Any?>,
+  ): String {
+    val references = definition.continuationReferenceSections[resumeStepId].orEmpty().joinToString("; ")
+    val directive =
+      definition.continuationDirectives[resumeStepId]
+        ?: "Resume the workflow from the recovered current step using the persisted artifacts as authoritative context."
+    val artifacts = artifactKeys.joinToString().ifBlank { "none" }
+    val commonLines =
+      mutableListOf(
+        "Use `${definition.skillName}` in continuation mode.",
+        "Workflow id: $workflowId",
+        "Session id: ${sessionId.ifBlank { "(none)" }}",
+        "Continue status: $continueStatus",
+        "Resume step: $resumeStepId (${definition.stepLabels[resumeStepId] ?: resumeStepId})",
+      )
+    if (definition.skillName == "bill-feature-implement") {
+      commonLines += "Feature: ${(extraFields["feature_name"] as String).ifBlank { "(unknown)" }}"
+      commonLines += "Feature size: ${(extraFields["feature_size"] as String).ifBlank { "(unknown)" }}"
+      commonLines += "Branch: ${(extraFields["branch_name"] as String).ifBlank { "(unknown)" }}"
+    }
+    commonLines += "Recovered artifacts: $artifacts"
+    if (definition.skillName == "bill-feature-verify") {
+      commonLines += "Acceptance criteria count: ${sessionSummary["acceptance_criteria_count"] ?: 0}"
+      commonLines += "Rollout relevant: ${sessionSummary["rollout_relevant"] ?: false}"
+    }
+    val specSummary = sessionSummary["spec_summary"]?.toString()?.ifBlank { "(none saved)" } ?: "(none saved)"
+    commonLines += "Spec summary: $specSummary"
+    commonLines += "Reference sections: ${references.ifBlank { "normal step instructions only" }}"
+    commonLines +=
+      "Rules: do not rerun completed steps unless the workflow sends work backwards; treat artifacts as authoritative."
+    commonLines += "Keep the same workflow_id and session_id, then continue `${definition.skillName}`."
+    commonLines += "Step directive: $directive"
+    commonLines += "Immediate next action: $nextAction"
+    return commonLines.joinToString("\n")
+  }
+
+  private fun implementExtraFields(artifacts: Map<String, Any?>): Map<String, Any?> {
+    val assessment = artifacts["assessment"] as? Map<*, *> ?: emptyMap<Any?, Any?>()
+    val branch = artifacts["branch"]
+    val branchName =
+      when (branch) {
+        is Map<*, *> -> branch["branch_name"]?.toString().orEmpty().trim()
+        is String -> branch.trim()
+        else -> ""
+      }
+    return linkedMapOf(
+      "feature_name" to assessment["feature_name"].toStringOrEmpty(),
+      "feature_size" to assessment["feature_size"].toStringOrEmpty(),
+      "branch_name" to branchName,
+    )
+  }
+
+  private fun step(stepId: String, status: String, attemptCount: Int): Map<String, Any?> =
+    linkedMapOf("step_id" to stepId, "status" to status, "attempt_count" to attemptCount)
+
+  private fun decodeSteps(rawValue: String): List<Map<String, Any?>> = JsonSupport.parseArrayOrEmpty(rawValue)
+    .mapNotNull(JsonSupport::anyToStringAnyMap)
+
+  private fun decodeObject(rawValue: String): Map<String, Any?> = JsonSupport.parseObjectOrNull(rawValue)
+    ?.let(JsonSupport::jsonElementToValue)
+    ?.let(JsonSupport::anyToStringAnyMap)
+    ?: emptyMap()
+
+  private fun jsonString(value: Any?): String = JsonSupport.json.encodeToString(
+    kotlinx.serialization.json.JsonElement.serializer(),
+    JsonSupport.valueToJsonElement(value),
+  )
+
+  private fun validateEnum(value: String, allowed: Collection<String>, fieldName: String): String? =
+    if (value !in allowed) {
+      "Invalid $fieldName '$value'. Allowed: ${allowed.joinToString()}"
+    } else {
+      null
+    }
+
+  private fun Any?.toStringOrEmpty(): String = this?.toString().orEmpty()
+
+  private fun Any?.asStepList(): List<Map<String, Any?>> =
+    (this as? List<*>).orEmpty().mapNotNull(JsonSupport::anyToStringAnyMap)
+
+  private fun Any?.asStringAnyMap(): Map<String, Any?> = JsonSupport.anyToStringAnyMap(this).orEmpty()
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowDefinition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowDefinition.kt
@@ -1,0 +1,183 @@
+package skillbill.workflow.implement
+
+import skillbill.workflow.model.WorkflowDefinition
+
+object FeatureImplementWorkflowDefinition {
+  val definition: WorkflowDefinition = WorkflowDefinition(
+    skillName = "bill-feature-implement",
+    workflowName = "bill-feature-implement",
+    workflowIdPrefix = "wfl",
+    defaultSessionPrefix = "fis",
+    contractVersion = "0.1",
+    workflowStatuses = setOf("pending", "running", "completed", "failed", "abandoned", "blocked"),
+    stepStatuses = setOf("pending", "running", "completed", "failed", "blocked", "skipped"),
+    terminalStatuses = setOf("completed", "failed", "abandoned"),
+    defaultInitialStepId = "assess",
+    stepIds =
+    listOf(
+      "assess",
+      "create_branch",
+      "preplan",
+      "plan",
+      "implement",
+      "review",
+      "audit",
+      "validate",
+      "write_history",
+      "commit_push",
+      "pr_description",
+      "finish",
+    ),
+    stepLabels =
+    mapOf(
+      "assess" to "Step 1: Collect Design Doc + Assess Size",
+      "create_branch" to "Step 1b: Create Feature Branch",
+      "preplan" to "Step 2: Pre-Planning",
+      "plan" to "Step 3: Create Implementation Plan",
+      "implement" to "Step 4: Execute Plan",
+      "review" to "Step 5: Code Review",
+      "audit" to "Step 6: Completeness Audit",
+      "validate" to "Step 6b: Quality Check",
+      "write_history" to "Step 7: Boundary History",
+      "commit_push" to "Step 8: Commit and Push",
+      "pr_description" to "Step 9: PR Description",
+      "finish" to "Finish",
+    ),
+    requiredArtifactsByStep =
+    mapOf(
+      "assess" to emptyList(),
+      "create_branch" to listOf("assessment"),
+      "preplan" to listOf("assessment", "branch"),
+      "plan" to listOf("assessment", "preplan_digest"),
+      "implement" to listOf("plan", "preplan_digest"),
+      "review" to listOf("implementation_summary"),
+      "audit" to listOf("implementation_summary", "review_result"),
+      "validate" to listOf("audit_report"),
+      "write_history" to listOf("implementation_summary", "validation_result"),
+      "commit_push" to listOf("implementation_summary", "validation_result", "history_result"),
+      "pr_description" to listOf("implementation_summary", "branch"),
+      "finish" to listOf("pr_result"),
+    ),
+    resumeActions =
+    mapOf(
+      "assess" to "Reconstruct or confirm the Step 1 assessment, then reopen the workflow from create_branch.",
+      "create_branch" to "Create or verify the feature branch, persist the branch artifact, then continue to preplan.",
+      "preplan" to
+        "Re-run the pre-planning phase using the assessment and branch artifacts, then persist preplan_digest.",
+      "plan" to "Re-run the planning phase using assessment and preplan_digest, then persist the plan artifact.",
+      "implement" to
+        "Resume implementation from the persisted plan and preplan_digest, then refresh implementation_summary.",
+      "review" to
+        "Resume code review from the latest implementation_summary and persist review_result after each pass.",
+      "audit" to
+        "Resume the completeness audit from implementation_summary and review_result, then persist audit_report.",
+      "validate" to "Resume final validation from the latest audit_report, then persist validation_result.",
+      "write_history" to
+        "Resume boundary history from implementation_summary and validation_result, then persist history_result.",
+      "commit_push" to
+        "Resume commit/push after verifying implementation_summary, validation_result, and history_result are current.",
+      "pr_description" to "Resume PR creation using the branch and implementation_summary, then persist pr_result.",
+      "finish" to "Close the workflow by marking finish completed and setting the final workflow_status.",
+    ),
+    continuationReferenceSections =
+    mapOf(
+      "assess" to listOf(
+        "SKILL.md :: Workflow State",
+        "SKILL.md :: Step 1: Collect Design Doc + Assess Size (orchestrator)",
+      ),
+      "create_branch" to listOf(
+        "SKILL.md :: Workflow State",
+        "SKILL.md :: Step 1b: Create Feature Branch (orchestrator)",
+      ),
+      "preplan" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 2: Pre-Planning (subagent)",
+        "reference.md :: Pre-planning subagent briefing",
+      ),
+      "plan" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 3: Create Implementation Plan (subagent)",
+        "reference.md :: Planning subagent briefing",
+      ),
+      "implement" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 4: Execute Plan (subagent)",
+        "reference.md :: Implementation subagent briefing",
+      ),
+      "review" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 5: Code Review (orchestrator)",
+        "reference.md :: Fix-loop briefing (used by Step 5 review loop)",
+      ),
+      "audit" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 6: Completeness Audit (subagent)",
+        "reference.md :: Completeness audit subagent briefing",
+      ),
+      "validate" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 6b: Final Validation Gate (subagent)",
+        "reference.md :: Quality-check subagent briefing",
+      ),
+      "write_history" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 7: Write Boundary History (orchestrator)",
+      ),
+      "commit_push" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 8: Commit and Push (orchestrator)",
+      ),
+      "pr_description" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 9: Generate PR Description (subagent)",
+        "reference.md :: PR-description subagent briefing",
+      ),
+      "finish" to listOf(
+        "SKILL.md :: Telemetry: Record Finished",
+        "reference.md :: Workflow State Contract",
+      ),
+    ),
+    continuationDirectives =
+    mapOf(
+      "assess" to
+        "Reconstruct the Step 1 assessment from the saved assessment artifact, confirm it with the user if needed, " +
+        "then reopen the normal flow from create_branch.",
+      "create_branch" to
+        "Do not rerun Step 1 discovery. Reuse the saved assessment artifact, create or verify the feature branch, " +
+        "persist the branch artifact, then continue into preplan.",
+      "preplan" to
+        "Skip Steps 1 and 1b. Reuse the saved assessment and branch artifacts as the contract and branch context, " +
+        "then spawn the pre-planning subagent with those recovered inputs.",
+      "plan" to
+        "Skip the discovery steps. Reuse the saved assessment and preplan_digest artifacts, then spawn the planning " +
+        "subagent from that recovered context.",
+      "implement" to
+        "Do not re-plan unless the recovered plan proves invalid. Reuse the saved plan and preplan_digest artifacts, " +
+        "then resume the implementation subagent from Step 4.",
+      "review" to
+        "Do not re-run implementation first unless the review loop sends work back. Start from the latest " +
+        "implementation_summary artifact and run Step 5 inline in the orchestrator.",
+      "audit" to
+        "Resume at the completeness audit using the latest implementation_summary and review_result artifacts. Only " +
+        "loop back to planning if the audit actually finds gaps.",
+      "validate" to
+        "Resume the final validation gate from the latest audit_report artifact, then continue the normal " +
+        "finalization sequence without pausing unless validation fails.",
+      "write_history" to
+        "Skip directly to boundary history writing using the persisted implementation_summary and validation_result " +
+        "artifacts, then continue with commit and PR creation.",
+      "commit_push" to
+        "Do not revisit earlier steps. Verify the persisted implementation_summary, validation_result, and " +
+        "history_result artifacts are still current, then run commit/push.",
+      "pr_description" to
+        "Resume directly at PR creation using the saved branch and implementation_summary artifacts, then finish the " +
+        "workflow and telemetry sequence.",
+      "finish" to
+        "Do not re-execute work. Close the workflow cleanly by inspecting pr_result and final telemetry state, then " +
+        "emit only the terminal summary if anything is still missing.",
+    ),
+    continuationArtifactOrder = listOf("assessment", "branch"),
+    openPriorStepsCompleted = false,
+    completedTerminalSummaryArtifact = "pr_result",
+  )
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/WorkflowModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/WorkflowModels.kt
@@ -1,0 +1,57 @@
+package skillbill.workflow.model
+
+data class WorkflowStepState(
+  val stepId: String,
+  val status: String,
+  val attemptCount: Int,
+)
+
+data class WorkflowUpdateInput(
+  val workflowStatus: String,
+  val currentStepId: String,
+  val stepUpdates: List<Map<String, Any?>>?,
+  val artifactsPatch: Map<String, Any?>?,
+  val sessionId: String,
+)
+
+data class WorkflowStateSnapshot(
+  val workflowId: String,
+  val sessionId: String,
+  val workflowName: String,
+  val contractVersion: String,
+  val workflowStatus: String,
+  val currentStepId: String,
+  val stepsJson: String,
+  val artifactsJson: String,
+  val startedAt: String?,
+  val updatedAt: String?,
+  val finishedAt: String?,
+)
+
+data class WorkflowContinueDecision(
+  val payload: Map<String, Any?>,
+  val shouldReopen: Boolean,
+  val resumeStepId: String,
+  val nextAttemptCount: Int,
+)
+
+data class WorkflowDefinition(
+  val skillName: String,
+  val workflowName: String,
+  val workflowIdPrefix: String,
+  val defaultSessionPrefix: String,
+  val contractVersion: String,
+  val workflowStatuses: Set<String>,
+  val stepStatuses: Set<String>,
+  val terminalStatuses: Set<String>,
+  val defaultInitialStepId: String,
+  val stepIds: List<String>,
+  val stepLabels: Map<String, String>,
+  val requiredArtifactsByStep: Map<String, List<String>>,
+  val resumeActions: Map<String, String>,
+  val continuationReferenceSections: Map<String, List<String>>,
+  val continuationDirectives: Map<String, String>,
+  val continuationArtifactOrder: List<String>,
+  val openPriorStepsCompleted: Boolean,
+  val completedTerminalSummaryArtifact: String,
+)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowDefinition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowDefinition.kt
@@ -1,0 +1,135 @@
+package skillbill.workflow.verify
+
+import skillbill.workflow.model.WorkflowDefinition
+
+object FeatureVerifyWorkflowDefinition {
+  val definition: WorkflowDefinition = WorkflowDefinition(
+    skillName = "bill-feature-verify",
+    workflowName = "bill-feature-verify",
+    workflowIdPrefix = "wfv",
+    defaultSessionPrefix = "fvr",
+    contractVersion = "0.1",
+    workflowStatuses = setOf("pending", "running", "completed", "failed", "abandoned"),
+    stepStatuses = setOf("pending", "running", "completed", "failed", "blocked", "skipped"),
+    terminalStatuses = setOf("completed", "failed", "abandoned"),
+    defaultInitialStepId = "gather_diff",
+    stepIds =
+    listOf(
+      "collect_inputs",
+      "extract_criteria",
+      "gather_diff",
+      "feature_flag_audit",
+      "code_review",
+      "completeness_audit",
+      "verdict",
+      "finish",
+    ),
+    stepLabels =
+    mapOf(
+      "collect_inputs" to "Step 1: Collect Inputs",
+      "extract_criteria" to "Step 2: Extract Acceptance Criteria",
+      "gather_diff" to "Step 3: Gather PR Diff",
+      "feature_flag_audit" to "Step 4: Feature Flag Audit",
+      "code_review" to "Step 5: Code Review",
+      "completeness_audit" to "Step 6: Completeness Audit",
+      "verdict" to "Step 7: Consolidated Verdict",
+      "finish" to "Finish",
+    ),
+    requiredArtifactsByStep =
+    mapOf(
+      "collect_inputs" to emptyList(),
+      "extract_criteria" to listOf("input_context"),
+      "gather_diff" to listOf("input_context", "criteria_summary"),
+      "feature_flag_audit" to listOf("criteria_summary", "diff_summary"),
+      "code_review" to listOf("criteria_summary", "diff_summary"),
+      "completeness_audit" to listOf("criteria_summary", "diff_summary", "review_result"),
+      "verdict" to listOf("criteria_summary", "review_result", "completeness_audit_result"),
+      "finish" to listOf("verdict_result"),
+    ),
+    resumeActions =
+    mapOf(
+      "collect_inputs" to "Reconfirm the task spec and PR inputs, then reopen the workflow from extract_criteria.",
+      "extract_criteria" to
+        "Re-extract and confirm the criteria, then persist criteria_summary before moving to gather_diff.",
+      "gather_diff" to
+        "Reuse input_context and criteria_summary, then gather the diff target and persist diff_summary.",
+      "feature_flag_audit" to
+        "Reuse criteria_summary and diff_summary, run the audit if still required, and persist the result.",
+      "code_review" to
+        "Reuse criteria_summary and diff_summary, then invoke bill-code-review and persist review_result.",
+      "completeness_audit" to
+        "Reuse criteria_summary, diff_summary, and review_result, then persist completeness_audit_result.",
+      "verdict" to
+        "Reuse saved review and audit artifacts, then write the final verdict without rerunning earlier phases.",
+      "finish" to "Close the workflow by marking the verdict complete and emitting the terminal summary.",
+    ),
+    continuationReferenceSections =
+    mapOf(
+      "collect_inputs" to listOf("SKILL.md :: Workflow State", "SKILL.md :: Step 1: Collect Inputs"),
+      "extract_criteria" to listOf("SKILL.md :: Workflow State", "SKILL.md :: Step 2: Extract Acceptance Criteria"),
+      "gather_diff" to listOf("SKILL.md :: Continuation Mode", "SKILL.md :: Step 3: Gather PR Diff"),
+      "feature_flag_audit" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 4: Feature Flag Audit (conditional)",
+        "audit-rubrics.md :: Feature Flag Audit",
+      ),
+      "code_review" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 5: Code Review",
+        "SKILL.md :: Nested child tools",
+      ),
+      "completeness_audit" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 6: Completeness Audit",
+        "audit-rubrics.md :: Completeness Audit",
+      ),
+      "verdict" to listOf(
+        "SKILL.md :: Continuation Mode",
+        "SKILL.md :: Step 7: Consolidated Verdict",
+        "audit-rubrics.md :: Consolidated Verdict",
+      ),
+      "finish" to listOf("SKILL.md :: Telemetry", "SKILL.md :: Workflow State"),
+    ),
+    continuationDirectives =
+    mapOf(
+      "collect_inputs" to
+        "Reconfirm the spec and PR inputs before continuing, then reopen the workflow from Step 2 with the " +
+        "recovered context.",
+      "extract_criteria" to
+        "Re-extract the criteria from the saved spec context, confirm them with the user, and persist " +
+        "criteria_summary before advancing.",
+      "gather_diff" to
+        "Skip Steps 1 and 2. Reuse the saved input_context and criteria_summary artifacts, then gather the diff " +
+        "target and persist diff_summary.",
+      "feature_flag_audit" to
+        "Reuse the saved criteria_summary and diff_summary artifacts. Run the audit only when the spec or diff " +
+        "still requires it, then persist feature_flag_audit_result.",
+      "code_review" to
+        "Reuse the saved criteria_summary and diff_summary artifacts, pass orchestrated=true to bill-code-review, " +
+        "and store the returned telemetry payload with the review result.",
+      "completeness_audit" to
+        "Reuse criteria_summary, diff_summary, and review_result. If the verify target changed materially, refresh " +
+        "the diff before re-running the audit.",
+      "verdict" to
+        "Reuse the saved review and audit artifacts to produce the final verdict without rerunning earlier steps " +
+        "unless recovery made them stale.",
+      "finish" to
+        "Do not re-run analysis. Close the workflow using the saved verdict_result and return the terminal summary " +
+        "only.",
+    ),
+    continuationArtifactOrder =
+    listOf(
+      "input_context",
+      "criteria_summary",
+      "diff_summary",
+      "feature_flag_audit_result",
+      "review_result",
+      "completeness_audit_result",
+      "verdict_result",
+      "session_notes",
+      "review_diff_pointer",
+    ),
+    openPriorStepsCompleted = true,
+    completedTerminalSummaryArtifact = "verdict_result",
+  )
+}

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/FeatureImplementWorkflowRuntimeTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/FeatureImplementWorkflowRuntimeTest.kt
@@ -1,0 +1,140 @@
+package skillbill.workflow
+
+import skillbill.workflow.implement.FeatureImplementWorkflowDefinition
+import skillbill.workflow.model.WorkflowUpdateInput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FeatureImplementWorkflowRuntimeTest {
+  private val definition = FeatureImplementWorkflowDefinition.definition
+
+  @Test
+  fun `implement open starts only the requested step`() {
+    val record = WorkflowEngine.openRecord(definition, "wfl-001", "fis-001", "plan")
+    val payload = WorkflowEngine.fullPayload(definition, record)
+    val steps = payload.steps()
+
+    assertEquals("bill-feature-implement", payload["workflow_name"])
+    assertEquals("plan", payload["current_step_id"])
+    assertEquals("running", steps.single { it["step_id"] == "plan" }["status"])
+    assertTrue(steps.filterNot { it["step_id"] == "plan" }.all { it["status"] == "pending" })
+  }
+
+  @Test
+  fun `implement update merges steps in stable order and preserves artifact patches`() {
+    val opened = WorkflowEngine.openRecord(definition, "wfl-001", "fis-001", "assess")
+    val updated =
+      WorkflowEngine.updateRecord(
+        definition,
+        opened,
+        WorkflowUpdateInput(
+          workflowStatus = "running",
+          currentStepId = "implement",
+          stepUpdates =
+          listOf(
+            mapOf("step_id" to "implement", "status" to "running", "attempt_count" to 1),
+            mapOf("step_id" to "assess", "status" to "completed", "attempt_count" to 1),
+          ),
+          artifactsPatch = mapOf("assessment" to mapOf("feature_name" to "workflow-runtime")),
+          sessionId = "",
+        ),
+      )
+
+    val payload = WorkflowEngine.fullPayload(definition, updated)
+    val steps = payload.steps()
+    val artifacts = payload["artifacts"] as Map<*, *>
+    assertEquals(definition.stepIds, steps.map { it["step_id"] })
+    assertEquals("completed", steps.first()["status"])
+    assertEquals(mapOf("feature_name" to "workflow-runtime"), artifacts["assessment"])
+  }
+
+  @Test
+  fun `implement continue blocks missing artifacts and reopens blocked step`() {
+    val opened = WorkflowEngine.openRecord(definition, "wfl-001", "fis-001", "assess")
+    val blocked =
+      WorkflowEngine.updateRecord(
+        definition,
+        opened,
+        WorkflowUpdateInput(
+          workflowStatus = "blocked",
+          currentStepId = "implement",
+          stepUpdates = listOf(mapOf("step_id" to "implement", "status" to "blocked", "attempt_count" to 1)),
+          artifactsPatch = mapOf("preplan_digest" to mapOf("ok" to true)),
+          sessionId = "",
+        ),
+      )
+
+    val blockedDecision = WorkflowEngine.continueDecision(definition, blocked)
+    assertEquals("blocked", blockedDecision.payload["continue_status"])
+    assertEquals(listOf("plan"), blockedDecision.payload["missing_artifacts"])
+    assertFalse(blockedDecision.shouldReopen)
+
+    val resumable =
+      WorkflowEngine.updateRecord(
+        definition,
+        blocked,
+        WorkflowUpdateInput(
+          workflowStatus = "blocked",
+          currentStepId = "implement",
+          stepUpdates = null,
+          artifactsPatch = mapOf("plan" to mapOf("task_count" to 13)),
+          sessionId = "",
+        ),
+      )
+    val reopened = WorkflowEngine.continueDecision(definition, resumable)
+    assertEquals("reopened", reopened.payload["continue_status"])
+    assertTrue(reopened.shouldReopen)
+    assertEquals(2, reopened.nextAttemptCount)
+  }
+
+  @Test
+  fun `implement validation preserves Python workflow status contract`() {
+    val pending =
+      WorkflowUpdateInput(
+        workflowStatus = "pending",
+        currentStepId = "assess",
+        stepUpdates = listOf(mapOf("step_id" to "assess", "status" to "failed", "attempt_count" to 1)),
+        artifactsPatch = null,
+        sessionId = "",
+      )
+    val abandoned = pending.copy(workflowStatus = "abandoned")
+
+    assertEquals(null, WorkflowEngine.validateUpdate(definition, pending))
+    assertEquals(null, WorkflowEngine.validateUpdate(definition, abandoned))
+    assertEquals("recover", WorkflowEngine.resumePayload(definition, completedAs("abandoned"))["resume_mode"])
+    assertEquals(
+      "Invalid workflow_status 'canceled'. Allowed: pending, running, completed, failed, abandoned, blocked",
+      WorkflowEngine.validateUpdate(definition, pending.copy(workflowStatus = "canceled")),
+    )
+  }
+
+  @Test
+  fun `implement continuation directives preserve Python oracle text`() {
+    assertEquals(
+      "Do not rerun Step 1 discovery. Reuse the saved assessment artifact, create or verify the feature branch, " +
+        "persist the branch artifact, then continue into preplan.",
+      definition.continuationDirectives["create_branch"],
+    )
+    assertEquals(
+      "Do not re-execute work. Close the workflow cleanly by inspecting pr_result and final telemetry state, then " +
+        "emit only the terminal summary if anything is still missing.",
+      definition.continuationDirectives["finish"],
+    )
+  }
+
+  private fun completedAs(status: String) = WorkflowEngine.updateRecord(
+    definition,
+    WorkflowEngine.openRecord(definition, "wfl-terminal", "fis-001", "assess"),
+    WorkflowUpdateInput(
+      workflowStatus = status,
+      currentStepId = "finish",
+      stepUpdates = listOf(mapOf("step_id" to "finish", "status" to "completed", "attempt_count" to 1)),
+      artifactsPatch = mapOf("pr_result" to emptyMap<String, Any?>()),
+      sessionId = "",
+    ),
+  )
+}
+
+private fun Map<String, Any?>.steps(): List<Map<*, *>> = (this["steps"] as List<*>).map { step -> step as Map<*, *> }

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/FeatureVerifyWorkflowRuntimeTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/FeatureVerifyWorkflowRuntimeTest.kt
@@ -1,0 +1,123 @@
+package skillbill.workflow
+
+import skillbill.workflow.model.WorkflowUpdateInput
+import skillbill.workflow.verify.FeatureVerifyWorkflowDefinition
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FeatureVerifyWorkflowRuntimeTest {
+  private val definition = FeatureVerifyWorkflowDefinition.definition
+
+  @Test
+  fun `verify open completes steps before the initial step`() {
+    val record = WorkflowEngine.openRecord(definition, "wfv-001", "fvr-001", "code_review")
+    val steps = WorkflowEngine.fullPayload(definition, record).steps()
+
+    assertEquals("completed", steps.single { it["step_id"] == "collect_inputs" }["status"])
+    assertEquals("completed", steps.single { it["step_id"] == "gather_diff" }["status"])
+    assertEquals("running", steps.single { it["step_id"] == "code_review" }["status"])
+    assertEquals("pending", steps.single { it["step_id"] == "verdict" }["status"])
+  }
+
+  @Test
+  fun `verify resume reports done and recover modes`() {
+    val running = WorkflowEngine.openRecord(definition, "wfv-001", "fvr-001", "gather_diff")
+    val completed =
+      WorkflowEngine.updateRecord(
+        definition,
+        running,
+        WorkflowUpdateInput(
+          workflowStatus = "completed",
+          currentStepId = "finish",
+          stepUpdates = listOf(mapOf("step_id" to "finish", "status" to "completed", "attempt_count" to 1)),
+          artifactsPatch = mapOf("verdict_result" to mapOf("verdict" to "pass")),
+          sessionId = "",
+        ),
+      )
+    val failed = completed.copy(workflowStatus = "failed")
+
+    assertEquals("done", WorkflowEngine.resumePayload(definition, completed)["resume_mode"])
+    assertEquals("recover", WorkflowEngine.resumePayload(definition, failed)["resume_mode"])
+  }
+
+  @Test
+  fun `verify continuation preserves artifact order and directives`() {
+    val record =
+      WorkflowEngine.updateRecord(
+        definition,
+        WorkflowEngine.openRecord(definition, "wfv-001", "fvr-001", "code_review"),
+        WorkflowUpdateInput(
+          workflowStatus = "blocked",
+          currentStepId = "verdict",
+          stepUpdates = listOf(mapOf("step_id" to "verdict", "status" to "blocked", "attempt_count" to 1)),
+          artifactsPatch =
+          linkedMapOf(
+            "review_result" to mapOf("findings" to emptyList<String>()),
+            "criteria_summary" to mapOf("criteria" to 3),
+            "diff_summary" to mapOf("files" to 4),
+            "completeness_audit_result" to mapOf("result" to "pass"),
+          ),
+          sessionId = "",
+        ),
+      )
+
+    val decision = WorkflowEngine.continueDecision(definition, record)
+
+    assertEquals("reopened", decision.payload["continue_status"])
+    assertEquals(
+      listOf("criteria_summary", "diff_summary", "review_result", "completeness_audit_result"),
+      decision.payload["step_artifact_keys"],
+    )
+    assertTrue(decision.payload["continue_step_directive"].toString().contains("final verdict"))
+  }
+
+  @Test
+  fun `verify validation preserves Python workflow status contract`() {
+    val pending =
+      WorkflowUpdateInput(
+        workflowStatus = "pending",
+        currentStepId = "code_review",
+        stepUpdates = listOf(mapOf("step_id" to "code_review", "status" to "failed", "attempt_count" to 1)),
+        artifactsPatch = null,
+        sessionId = "",
+      )
+    val abandoned = pending.copy(workflowStatus = "abandoned")
+
+    assertEquals(null, WorkflowEngine.validateUpdate(definition, pending))
+    assertEquals(null, WorkflowEngine.validateUpdate(definition, abandoned))
+    assertEquals("recover", WorkflowEngine.resumePayload(definition, completedAs("abandoned"))["resume_mode"])
+    assertEquals(
+      "Invalid workflow_status 'blocked'. Allowed: pending, running, completed, failed, abandoned",
+      WorkflowEngine.validateUpdate(definition, pending.copy(workflowStatus = "blocked")),
+    )
+  }
+
+  @Test
+  fun `verify continuation directives preserve Python oracle text`() {
+    assertEquals(
+      "Reuse the saved criteria_summary and diff_summary artifacts, pass orchestrated=true to bill-code-review, " +
+        "and store the returned telemetry payload with the review result.",
+      definition.continuationDirectives["code_review"],
+    )
+    assertEquals(
+      "Reuse the saved review and audit artifacts to produce the final verdict without rerunning earlier steps " +
+        "unless recovery made them stale.",
+      definition.continuationDirectives["verdict"],
+    )
+  }
+
+  private fun completedAs(status: String) = WorkflowEngine.updateRecord(
+    definition,
+    WorkflowEngine.openRecord(definition, "wfv-terminal", "fvr-001", "gather_diff"),
+    WorkflowUpdateInput(
+      workflowStatus = status,
+      currentStepId = "finish",
+      stepUpdates = listOf(mapOf("step_id" to "finish", "status" to "completed", "attempt_count" to 1)),
+      artifactsPatch = mapOf("verdict_result" to emptyMap<String, Any?>()),
+      sessionId = "",
+    ),
+  )
+}
+
+private fun Map<String, Any?>.steps(): List<Map<*, *>> = (this["steps"] as List<*>).map { step -> step as Map<*, *> }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/WorkflowStateStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/WorkflowStateStore.kt
@@ -1,28 +1,33 @@
 package skillbill.db
 
+import skillbill.contracts.JsonSupport
 import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.ports.persistence.model.FeatureImplementSessionSummary
+import skillbill.ports.persistence.model.FeatureVerifySessionSummary
 import skillbill.ports.persistence.model.WorkflowStateRecord
 import java.sql.Connection
 
 typealias WorkflowStateRow = WorkflowStateRecord
 
+private const val WORKFLOW_ID_PARAMETER_INDEX: Int = 1
+private const val SESSION_ID_PARAMETER_INDEX: Int = 2
+private const val WORKFLOW_NAME_PARAMETER_INDEX: Int = 3
+private const val CONTRACT_VERSION_PARAMETER_INDEX: Int = 4
+private const val WORKFLOW_STATUS_PARAMETER_INDEX: Int = 5
+private const val CURRENT_STEP_ID_PARAMETER_INDEX: Int = 6
+private const val STEPS_JSON_PARAMETER_INDEX: Int = 7
+private const val ARTIFACTS_JSON_PARAMETER_INDEX: Int = 8
+private const val INSERT_TERMINAL_PARAMETER_INDEX: Int = 9
+private const val INSERT_FINISHED_AT_PARAMETER_INDEX: Int = 10
+private const val UPDATE_TERMINAL_PARAMETER_INDEX: Int = 11
+
+private val terminalWorkflowStatuses: Set<String> = setOf("completed", "failed", "abandoned")
+
 class WorkflowStateStore(
   private val connection: Connection,
 ) : WorkflowStateRepository {
-  private companion object {
-    const val WORKFLOW_ID_PARAMETER_INDEX: Int = 1
-    const val SESSION_ID_PARAMETER_INDEX: Int = 2
-    const val WORKFLOW_NAME_PARAMETER_INDEX: Int = 3
-    const val CONTRACT_VERSION_PARAMETER_INDEX: Int = 4
-    const val WORKFLOW_STATUS_PARAMETER_INDEX: Int = 5
-    const val CURRENT_STEP_ID_PARAMETER_INDEX: Int = 6
-    const val STEPS_JSON_PARAMETER_INDEX: Int = 7
-    const val ARTIFACTS_JSON_PARAMETER_INDEX: Int = 8
-    const val FINISHED_AT_PARAMETER_INDEX: Int = 9
-  }
-
   override fun saveFeatureImplementWorkflow(row: WorkflowStateRecord) {
-    upsert(
+    connection.upsertWorkflowRow(
       tableName = "feature_implement_workflows",
       row = row,
       defaultContractVersion = DbConstants.FEATURE_IMPLEMENT_WORKFLOW_CONTRACT_VERSION,
@@ -30,65 +35,143 @@ class WorkflowStateStore(
   }
 
   override fun saveFeatureVerifyWorkflow(row: WorkflowStateRecord) {
-    upsert(
+    connection.upsertWorkflowRow(
       tableName = "feature_verify_workflows",
       row = row,
       defaultContractVersion = DbConstants.FEATURE_VERIFY_WORKFLOW_CONTRACT_VERSION,
     )
   }
 
-  override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? = get(
-    "feature_implement_workflows",
-    workflowId,
-  )
+  override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? =
+    connection.getWorkflowRow("feature_implement_workflows", workflowId)
 
   override fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord? =
-    get("feature_verify_workflows", workflowId)
+    connection.getWorkflowRow("feature_verify_workflows", workflowId)
 
-  private fun upsert(tableName: String, row: WorkflowStateRecord, defaultContractVersion: String) {
+  override fun listFeatureImplementWorkflows(limit: Int): List<WorkflowStateRecord> =
+    connection.listWorkflowRows("feature_implement_workflows", limit)
+
+  override fun listFeatureVerifyWorkflows(limit: Int): List<WorkflowStateRecord> =
+    connection.listWorkflowRows("feature_verify_workflows", limit)
+
+  override fun latestFeatureImplementWorkflow(): WorkflowStateRecord? = listFeatureImplementWorkflows(1).firstOrNull()
+
+  override fun latestFeatureVerifyWorkflow(): WorkflowStateRecord? = listFeatureVerifyWorkflows(1).firstOrNull()
+
+  override fun getFeatureImplementSessionSummary(sessionId: String): FeatureImplementSessionSummary? =
     connection.prepareStatement(
       """
-      INSERT INTO $tableName (
-        workflow_id,
+      SELECT
         session_id,
-        workflow_name,
-        contract_version,
-        workflow_status,
-        current_step_id,
-        steps_json,
-        artifacts_json,
-        finished_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(workflow_id) DO UPDATE SET
-        session_id = excluded.session_id,
-        workflow_name = excluded.workflow_name,
-        contract_version = excluded.contract_version,
-        workflow_status = excluded.workflow_status,
-        current_step_id = excluded.current_step_id,
-        steps_json = excluded.steps_json,
-        artifacts_json = excluded.artifacts_json,
-        updated_at = CURRENT_TIMESTAMP,
-        finished_at = excluded.finished_at
+        issue_key_provided,
+        issue_key_type,
+        spec_input_types,
+        spec_word_count,
+        feature_size,
+        feature_name,
+        rollout_needed,
+        acceptance_criteria_count,
+        open_questions_count,
+        spec_summary
+      FROM feature_implement_sessions
+      WHERE session_id = ?
       """.trimIndent(),
     ).use { statement ->
-      statement.setString(WORKFLOW_ID_PARAMETER_INDEX, row.workflowId)
-      statement.setString(SESSION_ID_PARAMETER_INDEX, row.sessionId)
-      statement.setString(WORKFLOW_NAME_PARAMETER_INDEX, row.workflowName)
-      statement.setString(
-        CONTRACT_VERSION_PARAMETER_INDEX,
-        row.contractVersion.ifBlank { defaultContractVersion },
-      )
-      statement.setString(WORKFLOW_STATUS_PARAMETER_INDEX, row.workflowStatus)
-      statement.setString(CURRENT_STEP_ID_PARAMETER_INDEX, row.currentStepId)
-      statement.setString(STEPS_JSON_PARAMETER_INDEX, row.stepsJson)
-      statement.setString(ARTIFACTS_JSON_PARAMETER_INDEX, row.artifactsJson)
-      statement.setString(FINISHED_AT_PARAMETER_INDEX, row.finishedAt)
-      statement.executeUpdate()
+      statement.setString(WORKFLOW_ID_PARAMETER_INDEX, sessionId)
+      statement.executeQuery().use { resultSet ->
+        if (!resultSet.next()) {
+          return null
+        }
+        FeatureImplementSessionSummary(
+          sessionId = resultSet.getString("session_id"),
+          issueKeyProvided = resultSet.getInt("issue_key_provided") == 1,
+          issueKeyType = resultSet.getString("issue_key_type"),
+          specInputTypes = decodeStringList(resultSet.getString("spec_input_types")),
+          specWordCount = resultSet.getInt("spec_word_count"),
+          featureSize = resultSet.getString("feature_size"),
+          featureName = resultSet.getString("feature_name"),
+          rolloutNeeded = resultSet.getInt("rollout_needed") == 1,
+          acceptanceCriteriaCount = resultSet.getInt("acceptance_criteria_count"),
+          openQuestionsCount = resultSet.getInt("open_questions_count"),
+          specSummary = resultSet.getString("spec_summary"),
+        )
+      }
     }
-  }
 
-  private fun get(tableName: String, workflowId: String): WorkflowStateRecord? = connection.prepareStatement(
+  override fun getFeatureVerifySessionSummary(sessionId: String): FeatureVerifySessionSummary? =
+    connection.prepareStatement(
+      """
+      SELECT
+        session_id,
+        acceptance_criteria_count,
+        rollout_relevant,
+        spec_summary
+      FROM feature_verify_sessions
+      WHERE session_id = ?
+      """.trimIndent(),
+    ).use { statement ->
+      statement.setString(WORKFLOW_ID_PARAMETER_INDEX, sessionId)
+      statement.executeQuery().use { resultSet ->
+        if (!resultSet.next()) {
+          return null
+        }
+        FeatureVerifySessionSummary(
+          sessionId = resultSet.getString("session_id"),
+          acceptanceCriteriaCount = resultSet.getInt("acceptance_criteria_count"),
+          rolloutRelevant = resultSet.getInt("rollout_relevant") == 1,
+          specSummary = resultSet.getString("spec_summary"),
+        )
+      }
+    }
+}
+
+private fun Connection.upsertWorkflowRow(tableName: String, row: WorkflowStateRecord, defaultContractVersion: String) {
+  prepareStatement(
     """
+    INSERT INTO $tableName (
+      workflow_id,
+      session_id,
+      workflow_name,
+      contract_version,
+      workflow_status,
+      current_step_id,
+      steps_json,
+      artifacts_json,
+      finished_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, CASE WHEN ? THEN COALESCE(NULLIF(?, ''), CURRENT_TIMESTAMP) ELSE NULL END)
+    ON CONFLICT(workflow_id) DO UPDATE SET
+      session_id = excluded.session_id,
+      workflow_name = excluded.workflow_name,
+      contract_version = excluded.contract_version,
+      workflow_status = excluded.workflow_status,
+      current_step_id = excluded.current_step_id,
+      steps_json = excluded.steps_json,
+      artifacts_json = excluded.artifacts_json,
+      updated_at = CURRENT_TIMESTAMP,
+      finished_at = CASE
+        WHEN ? THEN COALESCE(NULLIF(excluded.finished_at, ''), CURRENT_TIMESTAMP)
+        ELSE NULL
+      END
+    """.trimIndent(),
+  ).use { statement ->
+    val terminal = row.workflowStatus in terminalWorkflowStatuses
+    statement.setString(WORKFLOW_ID_PARAMETER_INDEX, row.workflowId)
+    statement.setString(SESSION_ID_PARAMETER_INDEX, row.sessionId)
+    statement.setString(WORKFLOW_NAME_PARAMETER_INDEX, row.workflowName)
+    statement.setString(CONTRACT_VERSION_PARAMETER_INDEX, row.contractVersion.ifBlank { defaultContractVersion })
+    statement.setString(WORKFLOW_STATUS_PARAMETER_INDEX, row.workflowStatus)
+    statement.setString(CURRENT_STEP_ID_PARAMETER_INDEX, row.currentStepId)
+    statement.setString(STEPS_JSON_PARAMETER_INDEX, row.stepsJson)
+    statement.setString(ARTIFACTS_JSON_PARAMETER_INDEX, row.artifactsJson)
+    statement.setBoolean(INSERT_TERMINAL_PARAMETER_INDEX, terminal)
+    statement.setString(INSERT_FINISHED_AT_PARAMETER_INDEX, row.finishedAt)
+    statement.setBoolean(UPDATE_TERMINAL_PARAMETER_INDEX, terminal)
+    statement.executeUpdate()
+  }
+}
+
+private fun Connection.getWorkflowRow(tableName: String, workflowId: String): WorkflowStateRecord? = prepareStatement(
+  """
       SELECT
         workflow_id,
         session_id,
@@ -103,26 +186,62 @@ class WorkflowStateStore(
         finished_at
       FROM $tableName
       WHERE workflow_id = ?
+  """.trimIndent(),
+).use { statement ->
+  statement.setString(1, workflowId)
+  statement.executeQuery().use { resultSet ->
+    if (!resultSet.next()) {
+      return null
+    }
+    resultSet.toWorkflowStateRecord()
+  }
+}
+
+private fun Connection.listWorkflowRows(tableName: String, limit: Int): List<WorkflowStateRecord> {
+  val normalizedLimit = limit.coerceAtLeast(0)
+  return prepareStatement(
+    """
+    SELECT
+      workflow_id,
+      session_id,
+      workflow_name,
+      contract_version,
+      workflow_status,
+      current_step_id,
+      steps_json,
+      artifacts_json,
+      started_at,
+      updated_at,
+      finished_at
+    FROM $tableName
+    ORDER BY updated_at DESC, rowid DESC
+    LIMIT ?
     """.trimIndent(),
   ).use { statement ->
-    statement.setString(WORKFLOW_ID_PARAMETER_INDEX, workflowId)
+    statement.setInt(1, normalizedLimit)
     statement.executeQuery().use { resultSet ->
-      if (!resultSet.next()) {
-        return null
+      buildList {
+        while (resultSet.next()) {
+          add(resultSet.toWorkflowStateRecord())
+        }
       }
-      WorkflowStateRecord(
-        workflowId = resultSet.getString("workflow_id"),
-        sessionId = resultSet.getString("session_id"),
-        workflowName = resultSet.getString("workflow_name"),
-        contractVersion = resultSet.getString("contract_version"),
-        workflowStatus = resultSet.getString("workflow_status"),
-        currentStepId = resultSet.getString("current_step_id"),
-        stepsJson = resultSet.getString("steps_json"),
-        artifactsJson = resultSet.getString("artifacts_json"),
-        startedAt = resultSet.getString("started_at"),
-        updatedAt = resultSet.getString("updated_at"),
-        finishedAt = resultSet.getString("finished_at"),
-      )
     }
   }
 }
+
+private fun java.sql.ResultSet.toWorkflowStateRecord(): WorkflowStateRecord = WorkflowStateRecord(
+  workflowId = getString("workflow_id"),
+  sessionId = getString("session_id"),
+  workflowName = getString("workflow_name"),
+  contractVersion = getString("contract_version"),
+  workflowStatus = getString("workflow_status"),
+  currentStepId = getString("current_step_id"),
+  stepsJson = getString("steps_json"),
+  artifactsJson = getString("artifacts_json"),
+  startedAt = getString("started_at"),
+  updatedAt = getString("updated_at"),
+  finishedAt = getString("finished_at"),
+)
+
+private fun decodeStringList(rawValue: String?): List<String> =
+  JsonSupport.parseArrayOrEmpty(rawValue.orEmpty()).mapNotNull { element -> element as? String }

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/WorkflowStateStoreTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/WorkflowStateStoreTest.kt
@@ -1,6 +1,7 @@
 package skillbill.db
 
 import java.nio.file.Files
+import java.sql.Connection
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -76,4 +77,161 @@ class WorkflowStateStoreTest {
       assertEquals("""{"review_result":{"verdict":"approve"}}""", saved.artifactsJson)
     }
   }
+
+  @Test
+  fun `terminal workflow update records finished timestamp when caller leaves it empty`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-workflow-terminal").resolve("metrics.db")
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val store = WorkflowStateStore(connection)
+      val initialRow =
+        workflowRow(
+          workflowId = "wfl-terminal",
+          sessionId = "fis-terminal",
+          workflowName = "bill-feature-implement",
+          currentStepId = "assess",
+        )
+
+      store.saveFeatureImplementWorkflow(initialRow)
+      store.saveFeatureImplementWorkflow(
+        initialRow.copy(
+          workflowStatus = "abandoned",
+          currentStepId = "finish",
+          finishedAt = "",
+        ),
+      )
+
+      val saved = assertNotNull(store.getFeatureImplementWorkflow("wfl-terminal"))
+      assertEquals("abandoned", saved.workflowStatus)
+      assertNotNull(saved.finishedAt)
+    }
+  }
+
+  @Test
+  fun `workflow lists and latest use updated timestamp then rowid ordering for both families`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-workflow-list").resolve("metrics.db")
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val store = WorkflowStateStore(connection)
+
+      listOf("wfl-001", "wfl-002", "wfl-003").forEachIndexed { index, workflowId ->
+        store.saveFeatureImplementWorkflow(
+          workflowRow(
+            workflowId = workflowId,
+            sessionId = "fis-00$index",
+            workflowName = "bill-feature-implement",
+            currentStepId = "assess",
+          ),
+        )
+      }
+      listOf("wfv-001", "wfv-002").forEachIndexed { index, workflowId ->
+        store.saveFeatureVerifyWorkflow(
+          workflowRow(
+            workflowId = workflowId,
+            sessionId = "fvr-00$index",
+            workflowName = "bill-feature-verify",
+            currentStepId = "gather_diff",
+          ),
+        )
+      }
+
+      assertEquals(listOf("wfl-003", "wfl-002"), store.listFeatureImplementWorkflows(2).map { it.workflowId })
+      assertEquals("wfl-003", store.latestFeatureImplementWorkflow()?.workflowId)
+      assertEquals(listOf("wfv-002", "wfv-001"), store.listFeatureVerifyWorkflows(10).map { it.workflowId })
+      assertEquals("wfv-002", store.latestFeatureVerifyWorkflow()?.workflowId)
+    }
+  }
+
+  @Test
+  fun `workflow session summaries preserve Python started payload shape`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-workflow-sessions").resolve("metrics.db")
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      insertFeatureImplementSession(connection)
+      insertFeatureVerifySession(connection)
+
+      val store = WorkflowStateStore(connection)
+      val implementSummary = assertNotNull(store.getFeatureImplementSessionSummary("fis-session"))
+      val verifySummary = assertNotNull(store.getFeatureVerifySessionSummary("fvr-session"))
+
+      assertEquals(true, implementSummary.issueKeyProvided)
+      assertEquals(listOf("markdown_file"), implementSummary.specInputTypes)
+      assertEquals("workflow-runtime", implementSummary.featureName)
+      assertEquals("Port workflow runtime", implementSummary.specSummary)
+      assertEquals(4, verifySummary.acceptanceCriteriaCount)
+      assertEquals(true, verifySummary.rolloutRelevant)
+      assertEquals("Verify workflow runtime", verifySummary.specSummary)
+    }
+  }
 }
+
+private fun insertFeatureImplementSession(connection: Connection) {
+  connection.prepareStatement(
+    """
+    INSERT INTO feature_implement_sessions (
+      session_id,
+      issue_key_provided,
+      issue_key_type,
+      spec_input_types,
+      spec_word_count,
+      feature_size,
+      feature_name,
+      rollout_needed,
+      acceptance_criteria_count,
+      open_questions_count,
+      spec_summary
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """.trimIndent(),
+  ).use { statement ->
+    statement.setString(1, "fis-session")
+    statement.setInt(2, 1)
+    statement.setString(3, "other")
+    statement.setString(4, """["markdown_file"]""")
+    statement.setInt(5, 123)
+    statement.setString(6, "MEDIUM")
+    statement.setString(7, "workflow-runtime")
+    statement.setInt(8, 0)
+    statement.setInt(9, 6)
+    statement.setInt(10, 0)
+    statement.setString(11, "Port workflow runtime")
+    statement.executeUpdate()
+  }
+}
+
+private fun insertFeatureVerifySession(connection: Connection) {
+  connection.prepareStatement(
+    """
+    INSERT INTO feature_verify_sessions (
+      session_id,
+      acceptance_criteria_count,
+      rollout_relevant,
+      spec_summary
+    ) VALUES (?, ?, ?, ?)
+    """.trimIndent(),
+  ).use { statement ->
+    statement.setString(1, "fvr-session")
+    statement.setInt(2, 4)
+    statement.setInt(3, 1)
+    statement.setString(4, "Verify workflow runtime")
+    statement.executeUpdate()
+  }
+}
+
+private fun workflowRow(
+  workflowId: String,
+  sessionId: String,
+  workflowName: String,
+  currentStepId: String,
+): WorkflowStateRow = WorkflowStateRow(
+  workflowId = workflowId,
+  sessionId = sessionId,
+  workflowName = workflowName,
+  contractVersion = "0.1",
+  workflowStatus = "running",
+  currentStepId = currentStepId,
+  stepsJson = "[]",
+  artifactsJson = "{}",
+  startedAt = null,
+  updatedAt = null,
+  finishedAt = null,
+)

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpComponent.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpComponent.kt
@@ -6,6 +6,7 @@ import skillbill.application.LearningService
 import skillbill.application.ReviewService
 import skillbill.application.SystemService
 import skillbill.application.TelemetryService
+import skillbill.application.WorkflowService
 import skillbill.di.RuntimeComponent
 
 @Component
@@ -21,4 +22,5 @@ class McpRuntimeServices(
   val reviewService: ReviewService,
   val systemService: SystemService,
   val telemetryService: TelemetryService,
+  val workflowService: WorkflowService,
 )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpRuntime.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpRuntime.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp
 
+import skillbill.application.model.WorkflowFamilyKind
+import skillbill.application.model.WorkflowUpdateRequest
 import skillbill.contracts.mcp.McpLearningsSkippedContract
 import skillbill.contracts.mcp.McpOrchestratedPayloadContract
 import skillbill.contracts.mcp.McpReviewImportSkippedContract
@@ -125,6 +127,57 @@ object McpRuntime {
 
   fun doctor(context: McpRuntimeContext = McpRuntimeContext()): Map<String, Any?> =
     services(context).systemService.doctor(dbOverride = null)
+}
+
+object McpWorkflowRuntime {
+  fun open(
+    kind: WorkflowFamilyKind,
+    sessionId: String = "",
+    currentStepId: String? = null,
+    context: McpRuntimeContext = McpRuntimeContext(),
+  ): Map<String, Any?> = services(context).workflowService.open(
+    kind,
+    sessionId = sessionId,
+    currentStepId = currentStepId,
+    dbOverride = null,
+  )
+
+  fun update(
+    kind: WorkflowFamilyKind,
+    request: WorkflowUpdateRequest,
+    context: McpRuntimeContext = McpRuntimeContext(),
+  ): Map<String, Any?> = services(context).workflowService.update(
+    kind,
+    request,
+    dbOverride = null,
+  )
+
+  fun get(
+    kind: WorkflowFamilyKind,
+    workflowId: String,
+    context: McpRuntimeContext = McpRuntimeContext(),
+  ): Map<String, Any?> = services(context).workflowService.get(kind, workflowId, dbOverride = null)
+
+  fun list(
+    kind: WorkflowFamilyKind,
+    limit: Int = 20,
+    context: McpRuntimeContext = McpRuntimeContext(),
+  ): Map<String, Any?> = services(context).workflowService.list(kind, limit, dbOverride = null)
+
+  fun latest(kind: WorkflowFamilyKind, context: McpRuntimeContext = McpRuntimeContext()): Map<String, Any?> =
+    services(context).workflowService.latest(kind, dbOverride = null)
+
+  fun resume(
+    kind: WorkflowFamilyKind,
+    workflowId: String,
+    context: McpRuntimeContext = McpRuntimeContext(),
+  ): Map<String, Any?> = services(context).workflowService.resume(kind, workflowId, dbOverride = null)
+
+  fun continueWorkflow(
+    kind: WorkflowFamilyKind,
+    workflowId: String,
+    context: McpRuntimeContext = McpRuntimeContext(),
+  ): Map<String, Any?> = services(context).workflowService.continueWorkflow(kind, workflowId, dbOverride = null)
 }
 
 private fun services(context: McpRuntimeContext, stdinText: String? = null): McpRuntimeServices {

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/RuntimeModuleSmokeTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/RuntimeModuleSmokeTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
 
 class RuntimeModuleSmokeTest {
   @Test
-  fun `runtime module declares package boundaries and reserved surface contracts`() {
+  fun `runtime module declares package boundaries and workflow surface contracts`() {
     assertEquals("runtime-kotlin", RuntimeModule.NAME)
     assertEquals(17, RuntimeModule.TOOLCHAIN_JDK)
     assertEquals(
@@ -39,7 +39,7 @@ class RuntimeModuleSmokeTest {
     )
     assertDeclaredPackages()
     assertRuntimeSurfacePackages()
-    assertReservedRuntimeContracts()
+    assertRuntimeContracts()
   }
 
   private fun assertDeclaredPackages() {
@@ -63,14 +63,12 @@ class RuntimeModuleSmokeTest {
     assertTrue(runtimeSurfaces.all { it.qualifiedName?.startsWith("skillbill.") == true })
   }
 
-  private fun assertReservedRuntimeContracts() {
+  private fun assertRuntimeContracts() {
     assertEquals(
       setOf(
         "install",
         "launcher",
         "scaffold",
-        "feature-implement-workflow",
-        "feature-verify-workflow",
       ),
       reservedContracts.map(RuntimeSurfaceContract::name).toSet(),
     )
@@ -79,6 +77,14 @@ class RuntimeModuleSmokeTest {
       assertEquals(RuntimeSurfaceStatus.RESERVED, contract.status)
       assertTrue(contract.placeholderReason.length > 60, "Placeholder reason is too weak for ${contract.name}")
       assertTrue(contract.supportedOperations.isEmpty(), "Reserved surfaces must not claim operations")
+    }
+    workflowContracts.forEach { contract ->
+      assertEquals("0.1", contract.contractVersion)
+      assertEquals(RuntimeSurfaceStatus.ACTIVE, contract.status)
+      assertEquals(
+        listOf("open", "update", "get", "list", "latest", "resume", "continue"),
+        contract.supportedOperations,
+      )
     }
   }
 
@@ -119,12 +125,12 @@ class RuntimeModuleSmokeTest {
         InstallRuntime.contract,
         LauncherRuntime.contract,
         ScaffoldRuntime.contract,
-        FeatureImplementWorkflowRuntime.contract,
-        FeatureVerifyWorkflowRuntime.contract,
       )
+    val workflowContracts = listOf(FeatureImplementWorkflowRuntime.contract, FeatureVerifyWorkflowRuntime.contract)
     val runtimeSurfacePackages: Set<String> =
       runtimeSurfaces
         .mapNotNull { it.qualifiedName?.substringBeforeLast(".") }
-        .toSet() + reservedContracts.map(RuntimeSurfaceContract::ownerPackage)
+        .toSet() + reservedContracts.map(RuntimeSurfaceContract::ownerPackage) +
+        workflowContracts.map(RuntimeSurfaceContract::ownerPackage)
   }
 }

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
@@ -1,6 +1,8 @@
 package skillbill.mcp
 
 import skillbill.SAMPLE_REVIEW
+import skillbill.application.model.WorkflowFamilyKind
+import skillbill.application.model.WorkflowUpdateRequest
 import skillbill.cli.CliRuntime
 import skillbill.cli.CliRuntimeContext
 import skillbill.contracts.JsonSupport
@@ -262,6 +264,85 @@ class McpRuntimeTest {
         ),
       )
     assertEquals(expectedRequests, capturedRequests)
+  }
+
+  @Test
+  fun `mcp workflow methods cover implement verbs and blocked continuation`() {
+    val tempDir = Files.createTempDirectory("skillbill-mcp-workflow")
+    val env = disabledTelemetryEnvironment(tempDir)
+    val context = McpRuntimeContext(environment = env, userHome = tempDir)
+    val opened = McpWorkflowRuntime.open(
+      WorkflowFamilyKind.IMPLEMENT,
+      sessionId = "fis-20260425-mcp",
+      context = context,
+    )
+    val workflowId = opened["workflow_id"] as String
+
+    val updated =
+      McpWorkflowRuntime.update(
+        WorkflowFamilyKind.IMPLEMENT,
+        WorkflowUpdateRequest(
+          workflowId = workflowId,
+          workflowStatus = "blocked",
+          currentStepId = "implement",
+          stepUpdates = listOf(mapOf("step_id" to "implement", "status" to "blocked", "attempt_count" to 1)),
+          artifactsPatch = mapOf("preplan_digest" to mapOf("ok" to true)),
+        ),
+        context,
+      )
+    val listed = McpWorkflowRuntime.list(WorkflowFamilyKind.IMPLEMENT, context = context)
+    val latest = McpWorkflowRuntime.latest(WorkflowFamilyKind.IMPLEMENT, context)
+    val got = McpWorkflowRuntime.get(WorkflowFamilyKind.IMPLEMENT, workflowId, context)
+    val resumed = McpWorkflowRuntime.resume(WorkflowFamilyKind.IMPLEMENT, workflowId, context)
+    val continued = McpWorkflowRuntime.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, workflowId, context)
+
+    assertEquals("blocked", updated["workflow_status"])
+    assertEquals(1, listed["workflow_count"])
+    assertEquals(workflowId, latest["workflow_id"])
+    assertEquals(workflowId, got["workflow_id"])
+    assertEquals(listOf("plan"), resumed["missing_artifacts"])
+    assertEquals("error", continued["status"])
+    assertEquals("blocked", continued["continue_status"])
+  }
+
+  @Test
+  fun `mcp workflow methods cover verify verbs and reopened continuation`() {
+    val tempDir = Files.createTempDirectory("skillbill-mcp-verify-workflow")
+    val env = disabledTelemetryEnvironment(tempDir)
+    val context = McpRuntimeContext(environment = env, userHome = tempDir)
+    val opened = McpWorkflowRuntime.open(WorkflowFamilyKind.VERIFY, currentStepId = "code_review", context = context)
+    val workflowId = opened["workflow_id"] as String
+
+    McpWorkflowRuntime.update(
+      WorkflowFamilyKind.VERIFY,
+      WorkflowUpdateRequest(
+        workflowId = workflowId,
+        workflowStatus = "running",
+        currentStepId = "verdict",
+        stepUpdates = listOf(mapOf("step_id" to "verdict", "status" to "blocked", "attempt_count" to 1)),
+        artifactsPatch =
+        mapOf(
+          "criteria_summary" to emptyMap<String, Any?>(),
+          "diff_summary" to emptyMap(),
+          "review_result" to emptyMap(),
+          "completeness_audit_result" to emptyMap(),
+        ),
+      ),
+      context = context,
+    )
+
+    val listed = McpWorkflowRuntime.list(WorkflowFamilyKind.VERIFY, context = context)
+    val latest = McpWorkflowRuntime.latest(WorkflowFamilyKind.VERIFY, context)
+    val got = McpWorkflowRuntime.get(WorkflowFamilyKind.VERIFY, workflowId, context)
+    val resumed = McpWorkflowRuntime.resume(WorkflowFamilyKind.VERIFY, workflowId, context)
+    val continued = McpWorkflowRuntime.continueWorkflow(WorkflowFamilyKind.VERIFY, workflowId, context)
+
+    assertEquals(1, listed["workflow_count"])
+    assertEquals(workflowId, latest["workflow_id"])
+    assertEquals("verdict", got["current_step_id"])
+    assertEquals("resume", resumed["resume_mode"])
+    assertEquals("ok", continued["status"])
+    assertEquals("reopened", continued["continue_status"])
   }
 }
 

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/WorkflowStateRepository.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/WorkflowStateRepository.kt
@@ -1,5 +1,7 @@
 package skillbill.ports.persistence
 
+import skillbill.ports.persistence.model.FeatureImplementSessionSummary
+import skillbill.ports.persistence.model.FeatureVerifySessionSummary
 import skillbill.ports.persistence.model.WorkflowStateRecord
 
 interface WorkflowStateRepository {
@@ -10,4 +12,16 @@ interface WorkflowStateRepository {
   fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord?
 
   fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord?
+
+  fun listFeatureImplementWorkflows(limit: Int = 20): List<WorkflowStateRecord>
+
+  fun listFeatureVerifyWorkflows(limit: Int = 20): List<WorkflowStateRecord>
+
+  fun latestFeatureImplementWorkflow(): WorkflowStateRecord?
+
+  fun latestFeatureVerifyWorkflow(): WorkflowStateRecord?
+
+  fun getFeatureImplementSessionSummary(sessionId: String): FeatureImplementSessionSummary?
+
+  fun getFeatureVerifySessionSummary(sessionId: String): FeatureVerifySessionSummary?
 }

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/model/WorkflowStateRecord.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/model/WorkflowStateRecord.kt
@@ -13,3 +13,24 @@ data class WorkflowStateRecord(
   val updatedAt: String?,
   val finishedAt: String?,
 )
+
+data class FeatureImplementSessionSummary(
+  val sessionId: String,
+  val issueKeyProvided: Boolean,
+  val issueKeyType: String,
+  val specInputTypes: List<String>,
+  val specWordCount: Int,
+  val featureSize: String,
+  val featureName: String,
+  val rolloutNeeded: Boolean,
+  val acceptanceCriteriaCount: Int,
+  val openQuestionsCount: Int,
+  val specSummary: String,
+)
+
+data class FeatureVerifySessionSummary(
+  val sessionId: String,
+  val acceptanceCriteriaCount: Int,
+  val rolloutRelevant: Boolean,
+  val specSummary: String,
+)


### PR DESCRIPTION
## Summary
- add Kotlin workflow domain, contract, application, CLI, and MCP runtime support for feature-implement and feature-verify workflow state
- reuse existing SQLite workflow/session tables through persistence ports, including list/latest and session-summary hydration for continuation payloads
- replace reserved workflow runtime surfaces with active metadata and document the Phase 5 boundary history

## Validation
- `(cd runtime-kotlin && ./gradlew spotlessApply check)`
- completeness audit: pass, all 6 acceptance criteria covered
- code review: pass after fixes for ID prefixes, status enums, terminal timestamps, and latest db_path parity

## Scope Notes
- production Python entrypoints, loader/scaffolder, install behavior, launcher/cutover wiring, and Python deletion are intentionally out of scope