### PR TITLE
SKILL-32 Decompose oversized feature implementation work

### DIFF
--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-30] feature-implement-large-work-decomposition
+Areas: skills/bill-feature-implement/, runtime-kotlin/runtime-domain/, tests/
+- Added a planning-stage decomposition mode for oversized `bill-feature-implement` runs: Step 3 now returns either `mode: "implement"` or terminal `mode: "decompose"` with ordered subtask specs and acceptance criteria. reusable
+- Decomposition writes resumable `.feature-specs/.../spec_subtask_<n>_<slug>.md` handoff specs, presents dependency order, and closes before implementation as intentional planning-stage scope governance.
+- Updated the Kotlin workflow definition so the primary runtime resume/continue text treats the plan artifact as either an implementation plan or a terminal decomposition package. reusable
+- Known limit: full runtime-kotlin `check` still fails on an unrelated `runtime-application` detekt ReturnCount issue in `TelemetryService.autoSync`; affected `runtime-domain` checks pass.
+Feature flag: N/A
+Acceptance criteria: 4/4 implemented
+
 ## [2026-04-26] canonical-skill-md-shape
 Areas: skills/, platform-packs/, scripts/validate_agent_configs.py, skill_bill/, tests/, orchestration/shell-content-contract/
 - Locked SKILL.md to a single canonical shape across every skill: frontmatter + `## Descriptor` + `## Execution` + `## Ceremony` only, with a body banlist (fenced code, tables, `## Step N:` headings, embedded templates, install gates, telemetry instructions, routing rules, run-context placeholders). All substantive prose moves to content.md. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -2,9 +2,11 @@
 Areas: runtime-mcp tool registry, MCP stdio tools/list contract, lifecycle telemetry tools
 - Added explicit MCP input schemas for `feature_implement_started` and `feature_implement_finished`; the previous open schema made Codex expose these mandatory lifecycle tools as no-argument tools even though handlers required fields. reusable
 - Locked the regression with an MCP stdio tools/list test that asserts required lifecycle fields such as `feature_size`, `issue_key`, `session_id`, and `completion_status` are advertised.
+- Tightened feature-implement lifecycle validation so missing/defaulted started fields (`spec_input_types=[]`, zero criteria, zero text spec word count, `issue_key_type=none` with an issue key) and impossible completed metrics (`review_iterations=0`, skipped audit/validation) fail instead of emitting low-value events. reusable
 - Operational symptom: a completed SKILL-32 feature-implement run committed successfully but initially missed `skillbill_feature_implement_started` and `skillbill_feature_implement_finished`; the missing pair was backfilled through the Kotlin MCP stdio server as session `fis-20260430-074408-b27m`.
+- Known limit: the backfilled session has `duration_seconds=0` because started/finished were emitted together after the fact; future valid runs must call started at assessment time and finished at finalization time.
 Feature flag: N/A
-Acceptance criteria: MCP lifecycle schemas exposed, focused runtime-mcp check passes, telemetry pair backfilled
+Acceptance criteria: MCP lifecycle schemas exposed, incomplete telemetry rejected, focused runtime-mcp check passes, telemetry pair backfilled
 
 ## [2026-04-25] runtime-mcp-lifecycle-native
 Areas: runtime-application lifecycle telemetry service, runtime-infra-sqlite lifecycle telemetry store, runtime-mcp dispatcher, docs/migrations/SKILL-27-cutover-checklist.md

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,11 @@
+## [2026-04-30] runtime-mcp-test-telemetry-loopback
+Areas: runtime-mcp tests, lifecycle telemetry fixtures, MCP stdio tests
+- PostHog inspection found `test-install-id` lifecycle/review events from Kotlin MCP tests because enabled test configs left `proxy_url` blank, which correctly resolves to the hosted relay in production settings.
+- Added a loopback telemetry proxy override to enabled MCP test environments, including the user-home config coverage path and stdio tool-call fixture, so auto-sync cannot emit test events to production telemetry. reusable
+- Reusable pattern: tests that enable telemetry should either inject a fake requester or set an explicit test-only proxy; do not rely on blank proxy config when the runtime treats blank as hosted relay.
+Feature flag: N/A
+Acceptance criteria: test telemetry cannot target hosted relay, runtime-mcp check passes
+
 ## [2026-04-30] runtime-mcp-feature-implement-lifecycle-schemas
 Areas: runtime-mcp tool registry, MCP stdio tools/list contract, lifecycle telemetry tools
 - Added explicit MCP input schemas for `feature_implement_started` and `feature_implement_finished`; the previous open schema made Codex expose these mandatory lifecycle tools as no-argument tools even though handlers required fields. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,11 @@
+## [2026-04-30] runtime-mcp-feature-implement-lifecycle-schemas
+Areas: runtime-mcp tool registry, MCP stdio tools/list contract, lifecycle telemetry tools
+- Added explicit MCP input schemas for `feature_implement_started` and `feature_implement_finished`; the previous open schema made Codex expose these mandatory lifecycle tools as no-argument tools even though handlers required fields. reusable
+- Locked the regression with an MCP stdio tools/list test that asserts required lifecycle fields such as `feature_size`, `issue_key`, `session_id`, and `completion_status` are advertised.
+- Operational symptom: a completed SKILL-32 feature-implement run committed successfully but initially missed `skillbill_feature_implement_started` and `skillbill_feature_implement_finished`; the missing pair was backfilled through the Kotlin MCP stdio server as session `fis-20260430-074408-b27m`.
+Feature flag: N/A
+Acceptance criteria: MCP lifecycle schemas exposed, focused runtime-mcp check passes, telemetry pair backfilled
+
 ## [2026-04-25] runtime-mcp-lifecycle-native
 Areas: runtime-application lifecycle telemetry service, runtime-infra-sqlite lifecycle telemetry store, runtime-mcp dispatcher, docs/migrations/SKILL-27-cutover-checklist.md
 - Ported the remaining MCP telemetry lifecycle tools to Kotlin-native services and SQLite persistence while preserving standalone session/outbox behavior and orchestrated child telemetry payloads.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/LifecycleTelemetryValidation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/LifecycleTelemetryValidation.kt
@@ -22,6 +22,13 @@ private val featureVerifyCompletionStatuses = listOf("completed", "abandoned_at_
 fun validateFeatureImplementStarted(request: FeatureImplementStartedRequest): String? = listOfNotNull(
   validateEnum(request.featureSize, featureSizes, "feature_size"),
   validateEnum(request.issueKeyType, issueKeyTypes, "issue_key_type"),
+  validateNonBlank(request.featureName, "feature_name"),
+  validateNonBlank(request.issueKey, "issue_key"),
+  validateIssueKeyType(request),
+  validatePositive(request.acceptanceCriteriaCount, "acceptance_criteria_count"),
+  validateSpecInputTypes(request),
+  validateSpecWordCount(request),
+  validateNonBlank(request.specSummary, "spec_summary"),
   request.specInputTypes.firstNotNullOfOrNull { validateEnum(it, specInputTypes, "spec_input_types") },
 ).firstOrNull()
 
@@ -31,6 +38,7 @@ fun validateFeatureImplementFinished(request: FeatureImplementFinishedRequest): 
   validateEnum(request.auditResult, auditResults, "audit_result"),
   validateEnum(request.validationResult, validationResults, "validation_result"),
   validateEnum(request.boundaryHistoryValue, historySignalValues, "boundary_history_value"),
+  validateCompletedFeatureImplementFinished(request),
 ).firstOrNull()
 
 fun validateQualityCheckStarted(request: QualityCheckStartedRequest): String? =
@@ -48,3 +56,53 @@ fun validateFeatureVerifyFinished(request: FeatureVerifyFinishedRequest): String
 
 private fun validateEnum(value: String, allowed: List<String>, fieldName: String): String? =
   if (value in allowed) null else "Invalid $fieldName '$value'. Allowed: ${allowed.joinToString(", ")}"
+
+private fun validateNonBlank(value: String, fieldName: String): String? =
+  if (value.isBlank()) "$fieldName must be non-empty." else null
+
+private fun validatePositive(value: Int, fieldName: String): String? =
+  if (value > 0) null else "$fieldName must be greater than 0."
+
+private fun validateIssueKeyType(request: FeatureImplementStartedRequest): String? =
+  if (request.issueKey.isNotBlank() && request.issueKeyType == "none") {
+    "issue_key_type must not be 'none' when issue_key is provided."
+  } else {
+    null
+  }
+
+private fun validateSpecInputTypes(request: FeatureImplementStartedRequest): String? =
+  if (request.specInputTypes.isEmpty()) "spec_input_types must contain at least one input type." else null
+
+private fun validateSpecWordCount(request: FeatureImplementStartedRequest): String? {
+  val hasTextInput = request.specInputTypes.any { it != "image" }
+  return if (hasTextInput && request.specWordCount <= 0) {
+    "spec_word_count must be greater than 0 for text-based specs."
+  } else {
+    null
+  }
+}
+
+private fun validateCompletedFeatureImplementFinished(request: FeatureImplementFinishedRequest): String? {
+  if (request.completionStatus != "completed") {
+    return null
+  }
+  return listOfNotNull(
+    validatePositive(request.planTaskCount, "plan_task_count"),
+    validatePositive(request.planPhaseCount, "plan_phase_count"),
+    validatePositive(request.tasksCompleted, "tasks_completed"),
+    validatePositive(request.reviewIterations, "review_iterations"),
+    validatePositive(request.auditIterations, "audit_iterations"),
+    validateCompletedAuditResult(request.auditResult),
+    validateCompletedValidationResult(request.validationResult),
+  ).firstOrNull()
+}
+
+private fun validateCompletedAuditResult(auditResult: String): String? =
+  if (auditResult == "skipped") "audit_result must not be skipped when completion_status is completed." else null
+
+private fun validateCompletedValidationResult(validationResult: String): String? =
+  if (validationResult == "skipped") {
+    "validation_result must not be skipped when completion_status is completed."
+  } else {
+    null
+  }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowDefinition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/implement/FeatureImplementWorkflowDefinition.kt
@@ -33,7 +33,7 @@ object FeatureImplementWorkflowDefinition {
       "assess" to "Step 1: Collect Design Doc + Assess Size",
       "create_branch" to "Step 1b: Create Feature Branch",
       "preplan" to "Step 2: Pre-Planning",
-      "plan" to "Step 3: Create Implementation Plan",
+      "plan" to "Step 3: Create Implementation Plan or Decompose",
       "implement" to "Step 4: Execute Plan",
       "review" to "Step 5: Code Review",
       "audit" to "Step 6: Completeness Audit",
@@ -64,7 +64,9 @@ object FeatureImplementWorkflowDefinition {
       "create_branch" to "Create or verify the feature branch, persist the branch artifact, then continue to preplan.",
       "preplan" to
         "Re-run the pre-planning phase using the assessment and branch artifacts, then persist preplan_digest.",
-      "plan" to "Re-run the planning phase using assessment and preplan_digest, then persist the plan artifact.",
+      "plan" to
+        "Re-run the planning phase using assessment and preplan_digest. Persist either the implementation plan " +
+        "or the terminal decomposition package.",
       "implement" to
         "Resume implementation from the persisted plan and preplan_digest, then refresh implementation_summary.",
       "review" to
@@ -150,7 +152,8 @@ object FeatureImplementWorkflowDefinition {
         "then spawn the pre-planning subagent with those recovered inputs.",
       "plan" to
         "Skip the discovery steps. Reuse the saved assessment and preplan_digest artifacts, then spawn the planning " +
-        "subagent from that recovered context.",
+        "subagent from that recovered context. If it returns mode: \"decompose\", persist the subtask specs and " +
+        "close the workflow at planning instead of proceeding to implementation.",
       "implement" to
         "Do not re-plan unless the recovered plan proves invalid. Reuse the saved plan and preplan_digest artifacts, " +
         "then resume the implementation subagent from Step 4.",

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/FeatureImplementWorkflowRuntimeTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/FeatureImplementWorkflowRuntimeTest.kt
@@ -124,6 +124,22 @@ class FeatureImplementWorkflowRuntimeTest {
     )
   }
 
+  @Test
+  fun `implement planning step supports terminal decomposition branch`() {
+    assertEquals("Step 3: Create Implementation Plan or Decompose", definition.stepLabels["plan"])
+    assertEquals(
+      "Re-run the planning phase using assessment and preplan_digest. Persist either the implementation plan " +
+        "or the terminal decomposition package.",
+      definition.resumeActions["plan"],
+    )
+    assertEquals(
+      "Skip the discovery steps. Reuse the saved assessment and preplan_digest artifacts, then spawn the planning " +
+        "subagent from that recovered context. If it returns mode: \"decompose\", persist the subtask specs and " +
+        "close the workflow at planning instead of proceeding to implementation.",
+      definition.continuationDirectives["plan"],
+    )
+  }
+
   private fun completedAs(status: String) = WorkflowEngine.updateRecord(
     definition,
     WorkflowEngine.openRecord(definition, "wfl-terminal", "fis-001", "assess"),

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolRegistry.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolRegistry.kt
@@ -3,15 +3,20 @@ package skillbill.mcp
 data class McpToolSpec(
   val name: String,
   val description: String,
+  val inputSchema: Map<String, Any?> = openObjectSchema(),
 ) {
   fun toPayload(): Map<String, Any?> = linkedMapOf(
     "name" to name,
     "description" to description,
-    "inputSchema" to mapOf(
+    "inputSchema" to inputSchema,
+  )
+
+  companion object {
+    fun openObjectSchema(): Map<String, Any?> = mapOf(
       "type" to "object",
       "additionalProperties" to true,
-    ),
-  )
+    )
+  }
 }
 
 object McpToolRegistry {
@@ -85,8 +90,109 @@ object McpToolRegistry {
       "triage_findings" to "Record triage decisions for imported review findings.",
     )
 
+  private val inputSchemas: Map<String, Map<String, Any?>> =
+    mapOf(
+      "feature_implement_started" to objectSchema(
+        required = listOf(
+          "feature_size",
+          "acceptance_criteria_count",
+          "open_questions_count",
+          "spec_input_types",
+          "spec_word_count",
+          "rollout_needed",
+          "feature_name",
+          "issue_key",
+          "spec_summary",
+        ),
+        properties = mapOf(
+          "feature_size" to stringSchema(enum = listOf("SMALL", "MEDIUM", "LARGE")),
+          "acceptance_criteria_count" to integerSchema(),
+          "open_questions_count" to integerSchema(),
+          "spec_input_types" to arraySchema(stringSchema()),
+          "spec_word_count" to integerSchema(),
+          "rollout_needed" to booleanSchema(),
+          "feature_name" to stringSchema(),
+          "issue_key" to stringSchema(),
+          "issue_key_type" to stringSchema(enum = listOf("jira", "linear", "github", "other", "none")),
+          "spec_summary" to stringSchema(),
+        ),
+      ),
+      "feature_implement_finished" to objectSchema(
+        required = listOf(
+          "session_id",
+          "completion_status",
+          "plan_correction_count",
+          "plan_task_count",
+          "plan_phase_count",
+          "feature_flag_used",
+          "files_created",
+          "files_modified",
+          "tasks_completed",
+          "review_iterations",
+          "audit_result",
+          "audit_iterations",
+          "validation_result",
+          "boundary_history_written",
+          "pr_created",
+          "plan_deviation_notes",
+        ),
+        properties = mapOf(
+          "session_id" to stringSchema(),
+          "completion_status" to stringSchema(
+            enum = listOf(
+              "completed",
+              "abandoned_at_planning",
+              "abandoned_at_implementation",
+              "abandoned_at_review",
+              "error",
+            ),
+          ),
+          "plan_correction_count" to integerSchema(),
+          "plan_task_count" to integerSchema(),
+          "plan_phase_count" to integerSchema(),
+          "feature_flag_used" to booleanSchema(),
+          "files_created" to integerSchema(),
+          "files_modified" to integerSchema(),
+          "tasks_completed" to integerSchema(),
+          "review_iterations" to integerSchema(),
+          "audit_result" to stringSchema(enum = listOf("all_pass", "had_gaps", "skipped")),
+          "audit_iterations" to integerSchema(),
+          "validation_result" to stringSchema(enum = listOf("pass", "fail", "skipped")),
+          "boundary_history_written" to booleanSchema(),
+          "pr_created" to booleanSchema(),
+          "feature_flag_pattern" to stringSchema(enum = listOf("simple_conditional", "di_switch", "legacy", "none")),
+          "boundary_history_value" to stringSchema(enum = listOf("none", "irrelevant", "low", "medium", "high")),
+          "plan_deviation_notes" to stringSchema(),
+          "child_steps" to arraySchema(mapOf("type" to "object", "additionalProperties" to true)),
+        ),
+      ),
+    )
+
   val tools: List<McpToolSpec> =
     toolNames.map { name ->
-      McpToolSpec(name, descriptions.getValue(name))
+      McpToolSpec(name, descriptions.getValue(name), inputSchemas[name] ?: McpToolSpec.openObjectSchema())
     }
+
+  private fun objectSchema(required: List<String>, properties: Map<String, Map<String, Any?>>): Map<String, Any?> =
+    mapOf(
+      "type" to "object",
+      "additionalProperties" to false,
+      "properties" to properties,
+      "required" to required,
+    )
+
+  private fun stringSchema(enum: List<String> = emptyList()): Map<String, Any?> = if (enum.isEmpty()) {
+    mapOf("type" to "string")
+  } else {
+    mapOf("type" to "string", "enum" to enum)
+  }
+
+  private fun integerSchema(): Map<String, Any?> = mapOf("type" to "integer")
+
+  private fun booleanSchema(): Map<String, Any?> = mapOf("type" to "boolean")
+
+  private fun arraySchema(items: Map<String, Any?>): Map<String, Any?> = mapOf(
+    "type" to "array",
+    "items" to items,
+  )
 }

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
@@ -182,6 +182,55 @@ class McpRuntimeTest {
   }
 
   @Test
+  fun `feature implement lifecycle rejects defaulted incomplete telemetry fields`() {
+    val tempDir = Files.createTempDirectory("skillbill-mcp-feature-implement-invalid")
+    val env = enabledTelemetryEnvironment(tempDir)
+    val context = McpRuntimeContext(environment = env, userHome = tempDir)
+
+    val started =
+      McpToolDispatcher.call(
+        "feature_implement_started",
+        mapOf(
+          "feature_size" to "SMALL",
+          "feature_name" to "read-path-config-variant-resolution",
+          "issue_key" to "SKILL-32",
+        ),
+        context,
+      )
+    val finished =
+      McpRuntime.featureImplementFinished(
+        FeatureImplementFinishedRequest(
+          sessionId = "fis-invalid",
+          completionStatus = "completed",
+          planCorrectionCount = 0,
+          planTaskCount = 1,
+          planPhaseCount = 1,
+          featureFlagUsed = false,
+          filesCreated = 0,
+          filesModified = 1,
+          tasksCompleted = 1,
+          reviewIterations = 0,
+          auditResult = "all_pass",
+          auditIterations = 1,
+          validationResult = "pass",
+          boundaryHistoryWritten = true,
+          prCreated = false,
+          featureFlagPattern = "none",
+          boundaryHistoryValue = "medium",
+          planDeviationNotes = "",
+          childSteps = emptyList(),
+        ),
+        context,
+      )
+
+    assertEquals("error", started["status"])
+    assertEquals("issue_key_type must not be 'none' when issue_key is provided.", started["error"])
+    assertEquals("error", finished["status"])
+    assertEquals("review_iterations must be greater than 0.", finished["error"])
+    assertFalse(Files.exists(tempDir.resolve("metrics.db")))
+  }
+
+  @Test
   fun `orchestrated lifecycle telemetry returns child payloads without outbox events`() {
     val tempDir = Files.createTempDirectory("skillbill-mcp-lifecycle-orchestrated")
     val env = enabledTelemetryEnvironment(tempDir)

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
@@ -411,6 +411,7 @@ class McpRuntimeTest {
       """.trimIndent() + "\n",
     )
     val env = mapOf("SKILL_BILL_REVIEW_DB" to tempDir.resolve("metrics.db").toString())
+      .withTestTelemetryProxy()
 
     val result =
       McpRuntime.importReview(
@@ -569,7 +570,7 @@ private fun enabledTelemetryEnvironment(tempDir: Path): Map<String, String> {
   return mapOf(
     "SKILL_BILL_REVIEW_DB" to tempDir.resolve("metrics.db").toString(),
     CONFIG_ENVIRONMENT_KEY to configPath.toString(),
-  )
+  ).withTestTelemetryProxy()
 }
 
 private fun disabledTelemetryEnvironment(tempDir: Path): Map<String, String> {
@@ -592,6 +593,11 @@ private fun disabledTelemetryEnvironment(tempDir: Path): Map<String, String> {
     CONFIG_ENVIRONMENT_KEY to configPath.toString(),
   )
 }
+
+private fun Map<String, String>.withTestTelemetryProxy(): Map<String, String> =
+  this + (TELEMETRY_PROXY_URL_ENVIRONMENT_KEY to TEST_TELEMETRY_PROXY_URL)
+
+private const val TEST_TELEMETRY_PROXY_URL = "http://127.0.0.1:9/skill-bill-test-telemetry"
 
 private fun writeMcpTelemetryConfig(tempDir: Path, level: String): Path {
   val configPath = tempDir.resolve("config.json")

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
@@ -80,6 +80,29 @@ class McpStdioServerTest {
   }
 
   @Test
+  fun `feature implement lifecycle tools expose required input schemas`() {
+    val response =
+      decodeResponse(
+        McpStdioServer.handleLine(
+          """{"jsonrpc":"2.0","id":"tools","method":"tools/list","params":{}}""",
+        ),
+      )
+    val tools = response.map("result")["tools"] as List<*>
+
+    val startedSchema = tools.schemaFor("feature_implement_started")
+    val finishedSchema = tools.schemaFor("feature_implement_finished")
+
+    assertEquals(false, startedSchema["additionalProperties"])
+    assertEquals(false, finishedSchema["additionalProperties"])
+    assertTrue((startedSchema["required"] as List<*>).contains("feature_size"))
+    assertTrue((startedSchema["required"] as List<*>).contains("issue_key"))
+    assertTrue(startedSchema.properties().containsKey("acceptance_criteria_count"))
+    assertTrue((finishedSchema["required"] as List<*>).contains("session_id"))
+    assertTrue((finishedSchema["required"] as List<*>).contains("completion_status"))
+    assertTrue(finishedSchema.properties().containsKey("boundary_history_written"))
+  }
+
+  @Test
   fun `tools call wraps native payloads as text content`() {
     val response =
       decodeResponse(
@@ -147,6 +170,16 @@ class McpStdioServerTest {
     assertEquals("fix_rejected", requireNotNull(JsonSupport.anyToStringAnyMap(recorded[1]))["outcome_type"])
   }
 }
+
+private fun List<*>.schemaFor(toolName: String): Map<String, Any?> {
+  val tool = first { item -> JsonSupport.anyToStringAnyMap(item)?.get("name") == toolName }
+  return requireNotNull(JsonSupport.anyToStringAnyMap(tool)?.get("inputSchema")).let { schema ->
+    requireNotNull(JsonSupport.anyToStringAnyMap(schema))
+  }
+}
+
+private fun Map<String, Any?>.properties(): Map<String, Any?> =
+  requireNotNull(JsonSupport.anyToStringAnyMap(this["properties"]))
 
 private fun enabledStdioTelemetryEnvironment(tempDir: Path): Map<String, String> {
   val configPath = tempDir.resolve("config.json")

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
@@ -3,6 +3,7 @@ package skillbill.mcp
 import skillbill.SAMPLE_REVIEW
 import skillbill.contracts.JsonSupport
 import skillbill.telemetry.CONFIG_ENVIRONMENT_KEY
+import skillbill.telemetry.TELEMETRY_PROXY_URL_ENVIRONMENT_KEY
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -199,8 +200,11 @@ private fun enabledStdioTelemetryEnvironment(tempDir: Path): Map<String, String>
   return mapOf(
     "SKILL_BILL_REVIEW_DB" to tempDir.resolve("metrics.db").toString(),
     CONFIG_ENVIRONMENT_KEY to configPath.toString(),
+    TELEMETRY_PROXY_URL_ENVIRONMENT_KEY to TEST_TELEMETRY_PROXY_URL,
   )
 }
+
+private const val TEST_TELEMETRY_PROXY_URL = "http://127.0.0.1:9/skill-bill-test-telemetry"
 
 private fun toolCallRequest(id: Int, name: String, arguments: Map<String, Any?>): String = JsonSupport.mapToJsonString(
   mapOf(

--- a/skills/bill-feature-implement/SKILL.md
+++ b/skills/bill-feature-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bill-feature-implement
-description: Use when doing end-to-end feature implementation from design doc to verified code. Automatically scales ceremony based on feature size - lightweight for small changes, full orchestration for large features. Runs each heavy phase (pre-planning, planning, implementation, completeness audit, quality check, PR description) inside its own subagent with a rich self-contained briefing, to keep the orchestrator context small. Code review stays in the orchestrator because it already spawns specialist subagents internally. Use when user mentions implement feature, build feature, implement spec, or feature from design doc.
+description: Use when doing end-to-end feature implementation from design doc to verified code. Automatically scales ceremony based on feature size - lightweight for small changes, full orchestration for medium features, and explicit decomposition into resumable subtask specs when work is too large for one reliable execution. Runs each heavy phase (pre-planning, planning, implementation, completeness audit, quality check, PR description) inside its own subagent with a rich self-contained briefing, to keep the orchestrator context small. Code review stays in the orchestrator because it already spawns specialist subagents internally. Use when user mentions implement feature, build feature, implement spec, or feature from design doc.
 ---
 
 ## Descriptor

--- a/skills/bill-feature-implement/content.md
+++ b/skills/bill-feature-implement/content.md
@@ -27,7 +27,7 @@ Workflow-state rules:
 
 Stable step ids: `assess`, `create_branch`, `preplan`, `plan`, `implement`, `review`, `audit`, `validate`, `write_history`, `commit_push`, `pr_description`, `finish`. Stable artifact names: `assessment`, `branch`, `preplan_digest`, `plan`, `implementation_summary`, `review_result`, `audit_report`, `validation_result`, `history_result`, `commit_push_result`, `pr_result`.
 
-Phase-to-artifact mapping: Step 1 -> `assessment`; Step 1b -> `branch`; Step 2 -> `preplan_digest`; Step 3 -> `plan`; Step 4 -> `implementation_summary`; Step 5 -> `review_result`; Step 6 -> `audit_report`; Step 6b -> `validation_result`; Step 7 -> `history_result`; Step 8 -> `commit_push_result` (reserved shell-owned artifact name; runtime behavior unchanged unless the workflow runtime already persists it); Step 9 -> `pr_result`.
+Phase-to-artifact mapping: Step 1 -> `assessment`; Step 1b -> `branch`; Step 2 -> `preplan_digest`; Step 3 -> `plan` (implementation plan or decomposition package); Step 4 -> `implementation_summary`; Step 5 -> `review_result`; Step 6 -> `audit_report`; Step 6b -> `validation_result`; Step 7 -> `history_result`; Step 8 -> `commit_push_result` (reserved shell-owned artifact name; runtime behavior unchanged unless the workflow runtime already persists it); Step 9 -> `pr_result`.
 
 ## Continuation Mode
 
@@ -113,11 +113,20 @@ Primary artifact: `plan`
 
 Spawn a subagent with the planning briefing defined in [reference.md](reference.md) under `Planning subagent briefing`. The briefing includes acceptance criteria, non-goals, feature size, pre-planning digest (from Step 2), rollout info, feature-flag pattern (if any), and validation strategy.
 
-The subagent returns the planning return contract: an ordered task list, each task with description, files to create or modify, which acceptance criteria it satisfies, and test coverage (or `None` when deferred to the final test task). For MEDIUM/LARGE with more than 15 tasks, the plan must be split into phases with checkpoints.
+The subagent returns one of two planning return contracts:
 
-If the plan includes testable logic, the final task must be a dedicated test task. The subagent is responsible for enforcing this rule in the plan it returns.
+- `mode: "implement"` — an ordered task list, each task with description, files to create or modify, which acceptance criteria it satisfies, and test coverage (or `None` when deferred to the final test task). MEDIUM plans may use phases with checkpoints when helpful.
+- `mode: "decompose"` — a terminal decomposition package for work that is too large for one reliable feature-implement run.
 
-The orchestrator presents the plan, then proceeds to implementation — the plan is not a second approval gate. Persist `plan` before advancing to `implement`.
+Decomposition is mandatory when a plan would exceed 15 atomic implementation tasks, touch more than 6 boundaries, contain multiple independently resumable milestones, or require sequencing where later work depends on foundation that should be verified separately. In decomposition mode, the planning subagent writes subtask specs under `.feature-specs/{ISSUE_KEY}-{feature-name}/` using names like `spec_subtask_1_foundation.md`, `spec_subtask_2_runtime-wiring.md`, and `spec_subtask_3_validation.md`. Each subtask spec must contain its own acceptance criteria, non-goals, dependency notes, validation strategy, and a clear instruction to run `bill-feature-implement` on that subtask spec in a later session.
+
+If an implementation plan includes testable logic, the final task must be a dedicated test task. The subagent is responsible for enforcing this rule when it returns `mode: "implement"`.
+
+The orchestrator presents the plan, then proceeds to implementation — the plan is not a second approval gate.
+
+If the planning subagent returns `mode: "decompose"`, the orchestrator must not proceed to implementation. Persist `plan`, present the decomposition summary with wording equivalent to: "I split this into N subtasks. Here are the acceptance criteria for each subtask. We should work on the first subtask first because of the dependency reason." Then close the workflow as an intentional planning-stage stop: mark `plan` completed, mark later steps skipped, set workflow status to `abandoned`, keep `current_step_id: "plan"`, call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`, and record `plan_deviation_notes` as `decomposed into N subtasks`. This is a successful scope-governance outcome, not an implementation failure.
+
+Persist `plan` before advancing to `implement` or before closing on decomposition.
 
 ## Step 4: Execute Plan (subagent)
 

--- a/skills/bill-feature-implement/reference.md
+++ b/skills/bill-feature-implement/reference.md
@@ -83,7 +83,7 @@ has in hand:
 - Step 1 → `assessment`
 - Step 1b → `branch`
 - Step 2 → `preplan_digest`
-- Step 3 → `plan`
+- Step 3 → `plan` (implementation plan or decomposition package)
 - Step 4 → `implementation_summary`
 - Step 5 → `review_result`
 - Step 6 → `audit_report`
@@ -240,11 +240,12 @@ RESULT:
 ```
 You are the planning subagent for feature implementation. Do not re-read the raw spec; operate on the briefing below.
 
-Goal: produce an ordered, atomic task plan the implementation subagent will execute.
+Goal: produce either an ordered implementation plan the implementation subagent can execute, or a decomposition package that splits oversized work into resumable subtask specs.
 
 Feature: {feature_name}
 Issue key: {issue_key}
 Feature size: {feature_size}
+Spec path (MEDIUM/LARGE): {spec_path}
 
 Acceptance criteria (contract):
 {numbered_list}
@@ -260,16 +261,26 @@ Planning rules:
 - Order tasks by dependency (data layer → domain → presentation).
 - Each task must reference the acceptance criteria it satisfies.
 - If the plan includes testable logic, the FINAL task must be a dedicated test task. Implementation tasks may have `tests: "None"` only because the final test task will cover them. Skip the final test task only when there is genuinely nothing testable (pure config, docs, agent-config/skill prose, UI changes with no test infra).
-- For MEDIUM/LARGE: if the plan exceeds 15 tasks, split into phases with a checkpoint between each.
+- For MEDIUM: if the plan benefits from phases, split it into phases with checkpoints.
+- For LARGE or any plan that would exceed 15 atomic implementation tasks, touch more than 6 boundaries, contain multiple independently resumable milestones, or require sequencing where later work depends on foundation that should be verified separately: switch to decomposition mode.
 - If rollout uses a feature flag, every task states how it respects the flag strategy (pattern: {feature_flag_pattern}).
 - Reference design artifacts (mockups, screenshots, wireframes, API examples) by filename where relevant.
 - Do NOT implement anything.
 - Do NOT expose a separate "codebase patterns" section; fold those findings into task descriptions.
 
+Decomposition rules:
+- Once decomposition mode is selected, do not implement anything and do not return an implementation task list.
+- Read the saved spec path only as needed to create accurate subtask specs.
+- Write subtask specs under `.feature-specs/{issue_key}-{feature_name}/` using names like `spec_subtask_1_foundation.md`, `spec_subtask_2_runtime-wiring.md`, and `spec_subtask_3_validation.md`.
+- Keep `spec.md` as the parent overview. Each subtask spec links back to `spec.md`, contains only the scope for that subtask, and includes acceptance criteria, non-goals, dependencies, validation strategy, and the recommended next `bill-feature-implement` prompt.
+- Prefer 2-4 subtasks. Each subtask should be small enough for one independent feature-implement run.
+- Order subtasks by dependency and identify the first subtask to run.
+
 Return exactly one RESULT: block as your final message, containing valid JSON with this shape:
 
 RESULT:
 {
+  "mode": "implement",
   "rollout_summary": "<feature flag + pattern, or N/A>",
   "validation_strategy": "<inherit from pre-planning digest>",
   "phases": [
@@ -289,6 +300,31 @@ RESULT:
   "task_count": <int>,
   "phase_count": <int>,
   "has_dedicated_test_task": <bool>
+}
+
+For decomposition mode, return this shape instead:
+
+RESULT:
+{
+  "mode": "decompose",
+  "decomposition_reason": "<why this is too large for one reliable feature-implement execution>",
+  "parent_spec_path": "<path to spec.md>",
+  "recommended_first_subtask_id": 1,
+  "subtasks": [
+    {
+      "id": 1,
+      "name": "<short dependency-ordered name>",
+      "spec_path": ".feature-specs/{issue_key}-{feature_name}/spec_subtask_1_<slug>.md",
+      "depends_on": [],
+      "dependency_reason": "<why this comes first, or empty for the first subtask>",
+      "scope": "<what this subtask owns>",
+      "acceptance_criteria": ["<criterion 1>", "<criterion 2>"],
+      "non_goals": ["<explicitly deferred work>"],
+      "validation_strategy": "<bill-quality-check or repo-native command>",
+      "handoff_prompt": "Run bill-feature-implement on <spec_path>."
+    }
+  ],
+  "presentation_summary": "I split this into N subtasks. We should work on subtask <id> first because <dependency reason>."
 }
 ```
 
@@ -480,18 +516,22 @@ RESULT:
 
 | | SMALL (≤5 tasks, ≤3 boundaries) | MEDIUM (6-15 tasks, ≤6 boundaries) | LARGE (>15 tasks or >6 boundaries) |
 |---|---|---|---|
-| Save spec to disk | No | Yes | Yes |
-| Post-implementation compact (inside impl subagent) | No | Yes | Yes |
-| Completeness audit | Quick confirmation | Full per-criterion report | Full per-criterion report |
-| Boundary history write | If impactful | Yes | Yes |
-| Codebase discovery (inside pre-planning subagent) | No | Yes | Yes |
+| Save spec to disk | No | Yes | Yes, plus subtask specs when decomposed |
+| Planning output | Implementation plan | Implementation plan | Decomposition package |
+| Post-implementation compact (inside impl subagent) | No | Yes | Only in later subtask runs |
+| Completeness audit | Quick confirmation | Full per-criterion report | Only in later subtask runs |
+| Boundary history write | If impactful | Yes | Only in later subtask runs |
+| Codebase discovery (inside pre-planning subagent) | No | Yes | Yes, enough to split safely |
 
-All sizes: feature flag if required, code review (inline in orchestrator), quality check (subagent), boundary history (inline), commit/push (inline), PR description (subagent).
+SMALL and MEDIUM implementation runs: feature flag if required, code review (inline in orchestrator), quality check (subagent), boundary history (inline), commit/push (inline), PR description (subagent).
+
+LARGE decomposition runs stop after Step 3, persist the decomposition package as `plan`, write subtask specs, and close with `completion_status: "abandoned_at_planning"` plus `plan_deviation_notes: "decomposed into N subtasks"`. This is an intentional planning-stage terminal state. The next implementation run starts from the first generated subtask spec.
 
 ## Error Recovery
 
 - **Pre-planning subagent fails** — report the error and ask the user whether to retry, adjust scope, or abandon. If abandoned, call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`.
 - **Planning subagent returns an invalid plan** (missing fields, no dedicated test task when testable logic exists, etc.) — respawn it once with a corrective briefing that lists the violations. If it still fails, abandon at planning.
+- **Planning subagent returns `mode: "decompose"`** — treat this as a valid terminal planning result. Persist the `plan` artifact, present the subtask order and acceptance criteria, mark later workflow steps skipped, close workflow state as `abandoned` at `plan`, and call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`.
 - **Implementation subagent stops early with `stopped_early: true`** — the orchestrator decides: if `plan_deviation_notes` imply a re-plan, respawn the planning subagent with the deviation notes and then a fresh implementation subagent; otherwise, hand to the user.
 - **Code-review fix loop exceeds 3 iterations** — stop, report remaining findings, hand to user. Call `feature_implement_finished` with `completion_status: "abandoned_at_review"`.
 - **Completeness audit loops exceed 2 iterations** — report remaining gaps, let user decide. Call `feature_implement_finished` accordingly.

--- a/tests/test_feature_implement_routing_contract.py
+++ b/tests/test_feature_implement_routing_contract.py
@@ -238,6 +238,14 @@ class FeatureImplementRoutingContractTest(unittest.TestCase):
     self.assertIn("`commit_push_result`", FEATURE_IMPLEMENT_CONTENT)
     self.assertIn("`pr_result`", FEATURE_IMPLEMENT)
 
+  def test_feature_implement_decomposes_oversized_work_at_planning(self) -> None:
+    self.assertIn('`mode: "decompose"`', FEATURE_IMPLEMENT_CONTENT)
+    self.assertIn('"mode": "decompose"', FEATURE_IMPLEMENT)
+    self.assertIn("spec_subtask_1_foundation.md", FEATURE_IMPLEMENT)
+    self.assertIn("Once decomposition mode is selected, do not implement anything", FEATURE_IMPLEMENT)
+    self.assertIn('completion_status: "abandoned_at_planning"', FEATURE_IMPLEMENT)
+    self.assertIn("decomposed into N subtasks", FEATURE_IMPLEMENT)
+
   def test_pr_description_prefers_repo_native_templates(self) -> None:
     self.assertIn("## Repo-Native PR Template Search (mandatory)", PR_DESCRIPTION)
     self.assertIn("`.github/pull_request_template.md`", PR_DESCRIPTION)


### PR DESCRIPTION
## Summary

- Add an explicit decomposition path to `bill-feature-implement` for oversized work, including ordered subtask specs and acceptance criteria instead of forcing one large implementation pass.
- Update the Kotlin feature-implement workflow definition and tests so decomposition is represented in the runtime contract.
- Fix feature-implement lifecycle telemetry by exposing required MCP input schemas, rejecting incomplete/defaulted payloads, and keeping MCP test telemetry on a loopback proxy instead of the hosted relay.

## Why

Large feature-implement runs were drifting into counterintuitive implementation patterns. The workflow now stops oversized work at planning time, emits resumable subtask specs, and makes the dependency order explicit so each subtask can be run in its own feature-implement session.

The telemetry follow-up fixes two bugs found during SKILL-32 validation and PostHog inspection: mandatory lifecycle tools were discoverable with empty schemas, and Kotlin MCP tests were sending `test-install-id` events to production telemetry when `proxy_url` was blank.

## Validation

- `.venv/bin/python3 -m unittest tests.test_feature_implement_routing_contract`
- `.venv/bin/python3 scripts/validate_agent_configs.py`
- `npx --yes agnix --strict .`
- `(cd runtime-kotlin && ./gradlew :runtime-domain:check)`
- `(cd runtime-kotlin && ./gradlew :runtime-mcp:check)`

Note: full `(cd runtime-kotlin && ./gradlew check)` still hits the existing unrelated detekt return-count issue in `runtime-application/src/main/kotlin/skillbill/application/TelemetryService.kt`.
