### PR TITLE
feat: [SKILL-32] Port install and doctor commands

### DIFF
--- a/.feature-specs/SKILL-32-technical-stabilization/spec_subtask_3b_1_install-and-doctor-ports.md
+++ b/.feature-specs/SKILL-32-technical-stabilization/spec_subtask_3b_1_install-and-doctor-ports.md
@@ -1,0 +1,136 @@
+---
+Status: Complete
+Issue: SKILL-32
+Parent spec: [spec.md](spec.md)
+Parent subtask: [spec_subtask_3b_port-or-retire-python-backed-cli.md](spec_subtask_3b_port-or-retire-python-backed-cli.md)
+---
+
+# Subtask 3b_1: Install Ports + Doctor Subject Port (Foundation)
+
+## Goal
+
+Land the smallest, lowest-risk Python-bridge ports first: the three install
+subcommands (`InstallAgentPath`, `InstallDetectAgents`, `InstallLinkSkill`) and
+the `doctor <subject>` branch in `SystemCliCommands.kt:42`. As part of this
+subtask, expose any required surface from `skillbill.install.InstallPrimitives`
+so the CLI adapter can call native code without crossing module visibility
+boundaries. The bridge helpers (`runPythonCli`, `runPythonScaffoldCli`,
+`pythonProcess`) STAY in place — they will be deleted in 3b_4 once every
+caller has been ported.
+
+This is the foundation subtask for the 3b decomposition. Its ports are small,
+have zero new authoring logic, and exercise the test idiom (JUnit5 +
+kotlin-test, `CliRuntime.run(args, ctx)` against temp dirs) so later subtasks
+can copy the pattern.
+
+## Scope
+
+In scope:
+
+1. Visibility / facade work for `skillbill.install.InstallPrimitives` (locate
+   via grep for `InstallRuntime.contract` and the `InstallRuntime` object in
+   `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/install/`). If the
+   existing primitives are `internal` or otherwise not callable from
+   `runtime-cli`, widen visibility or introduce a thin facade. Do NOT change
+   their behavior; only adjust what `runtime-cli` can reach.
+2. Port `InstallAgentPath` (currently
+   `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt`
+   line ≈ 446) to call the native install runtime instead of `runPythonCli`.
+3. Port `InstallDetectAgents` (line ≈ 455) likewise.
+4. Port `InstallLinkSkill` (line ≈ 479) likewise.
+5. Port the `doctor <subject>` branch in
+   `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/SystemCliCommands.kt`
+   (line 42) — for each supported subject (verify which by reading the
+   Python-side doctor logic), call the matching native runtime / facade.
+   Where a subject has no native equivalent yet, retirement is acceptable
+   per the parent rules (clear user-facing error naming the replacement,
+   covered by a Kotlin test).
+6. Kotlin tests (JUnit5 + kotlin-test) covering each ported command's happy
+   path. Tests live under
+   `runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/`. Use the
+   existing `CliRuntime.run(args, ctx)`-against-temp-dirs idiom.
+
+Out of scope:
+
+- Deleting `runPythonCli` / `runPythonScaffoldCli` / `pythonProcess` (3b_4).
+- Removing the `java.nio.file.Files` import (3b_4).
+- Promoting the `runtime-cli` arch bans (3b_4).
+- Porting any scaffold / authoring / new-skill commands (3b_2 and 3b_3).
+- Any change under `skill_bill/` (3c).
+- Disposition of Python-side `tests/test_install*.py` etc. (3b_4 records the
+  full disposition; this subtask may delete tests whose subject is fully
+  covered by the new Kotlin tests, with the deletion rationale recorded in
+  the commit message).
+
+## Acceptance Criteria
+
+1. `InstallAgentPath`, `InstallDetectAgents`, `InstallLinkSkill` no longer
+   call `runPythonCli`. Each is implemented in terms of the native install
+   runtime and is covered by at least one Kotlin test exercising the new
+   code path.
+2. `SystemCliCommands.kt:42`'s `doctor <subject>` branch routes every
+   supported subject to a native code path. Subjects without a native
+   equivalent are retired with a stable user-facing error message naming
+   the replacement, and that message is asserted by a Kotlin test.
+3. The bridge helpers `runPythonCli`, `runPythonScaffoldCli`,
+   `pythonProcess` are still present (deletion is owned by 3b_4) — but no
+   command listed in this subtask's Scope still calls them. A repo grep
+   confirms.
+4. `InstallPrimitives` (or the facade introduced) is reachable from
+   `runtime-cli` without requiring `internal` visibility leaks. If a facade
+   was introduced, it lives next to `InstallPrimitives` in
+   `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/install/`.
+5. The four-command validation gate is green:
+   `(cd runtime-kotlin && ./gradlew check)`,
+   `.venv/bin/python3 -m unittest discover -s tests`,
+   `npx --yes agnix --strict .`,
+   `.venv/bin/python3 scripts/validate_agent_configs.py`.
+6. No new Detekt suppressions, no `kotlin.Result`, no `Any`, no
+   `Dispatchers.*`, no `relaxed=true` mocks, 2-space indent, `.orEmpty()`
+   instead of `?: ""`. JUnit5 + kotlin-test (NOT kotest) inside
+   `runtime-kotlin`. Use the `DispatcherProvider` abstraction.
+
+## Non-Goals
+
+- Bridge helper deletion.
+- Arch test ban promotion.
+- Any port of scaffold / authoring / new-* commands.
+- Any change to launcher Python-fallback resolution.
+
+## Dependencies
+
+- 3a complete (regression net in place).
+
+## Validation Strategy
+
+`bill-quality-check` plus the four-command validation gate. For each ported
+command, a Kotlin test must exercise the new code path. For each retired
+doctor subject, a Kotlin test must assert the user-facing error message.
+
+## Implementation Notes
+
+- File pointers:
+  - Install command call sites:
+    `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt`
+    around lines 446 (`InstallAgentPath`), 455 (`InstallDetectAgents`),
+    479 (`InstallLinkSkill`).
+  - `doctor <subject>`:
+    `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/SystemCliCommands.kt:42`.
+  - Install runtime entry point:
+    `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/install/InstallRuntime.kt`
+    plus sibling `InstallPrimitives.kt` (verify exact filename via grep).
+  - Test home: `runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/`.
+- Port pattern: each ported command should call directly into the Kotlin
+  runtime API (the same one the MCP adapter calls); no shelling out, no
+  reading or writing to disk outside the runtime's own primitives.
+- Retirement pattern: stable user-facing error message, e.g. "this subject
+  was retired in SKILL-32; use `skill-bill <replacement>` instead", exit
+  non-zero, assertion in a Kotlin test.
+- Constraints: 2-space indent, no `Any`, no `Dispatchers.*`, no
+  `kotlin.Result`, no `relaxed=true` mocks, no new suppressions,
+  `.orEmpty()` instead of `?: ""`. JUnit5 + kotlin-test, NOT kotest.
+
+## Handoff Prompt
+
+Run `bill-feature-implement` on
+`.feature-specs/SKILL-32-technical-stabilization/spec_subtask_3b_1_install-and-doctor-ports.md`.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-04-30] install-and-doctor-ports
+Areas: runtime-cli install commands, runtime-core install facade, runtime-cli doctor subject routing, CLI source-reference tests
+- Ported `install agent-path`, `install detect-agents`, and `install link-skill` from Python bridge calls to a public `InstallOperations` facade over internal install primitives. reusable
+- Retired `doctor skill` on the Kotlin CLI with a stable replacement message while leaving subjectless `doctor` on the native `SystemService` path.
+- Reusable guardrail: when bridge helpers must remain for deferred commands, add targeted source-reference tests around the newly ported command blocks instead of promoting broad architecture bans early.
+- Known limitation: scaffold/authoring commands and launcher Python fallback remain owned by later 3b/3c subtasks.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-04-30] kotlin-native-contract-tests
 Areas: runtime-cli golden fixtures, runtime-mcp golden fixtures, runtime architecture tests, runtime surface contracts
 - Added golden JSON contract coverage for Kotlin-native CLI/MCP surfaces while explicitly deferring Python-backed scaffold/authoring/install and `doctor <subject>` work to 3b.

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
@@ -14,6 +14,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.choice
 import me.tatarka.inject.annotations.Inject
 import skillbill.contracts.JsonSupport
+import skillbill.install.InstallOperations
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -443,7 +444,8 @@ class InstallAgentPathCommand(
   private val agent by argument(help = "Agent name.")
 
   override fun run() {
-    state.result = runPythonCli(listOf("install", "agent-path", agent), state)
+    val path = InstallOperations.agentPath(agent, state.userHome)
+    state.result = CliExecutionResult(exitCode = 0, stdout = "$path\n")
   }
 }
 
@@ -452,7 +454,10 @@ class InstallDetectAgentsCommand(
   private val state: CliRunState,
 ) : DocumentedCliCommand("detect-agents", "List detected agents as 'name\\tpath' lines.") {
   override fun run() {
-    state.result = runPythonCli(listOf("install", "detect-agents"), state)
+    val output =
+      InstallOperations.detectAgentTargets(state.userHome)
+        .joinToString(separator = "") { target -> "${target.name}\t${target.path}\n" }
+    state.result = CliExecutionResult(exitCode = 0, stdout = output)
   }
 }
 
@@ -468,15 +473,12 @@ class InstallLinkSkillCommand(
   private val agent by option("--agent", help = "Optional agent name to label the install.").default("")
 
   override fun run() {
-    val args =
-      buildList {
-        add("install")
-        add("link-skill")
-        addAll(listOf("--source", source))
-        addAll(listOf("--target-dir", targetDir))
-        if (agent.isNotEmpty()) addAll(listOf("--agent", agent))
-      }
-    state.result = runPythonCli(args, state)
+    InstallOperations.linkSkill(
+      source = Path.of(source),
+      targetDir = Path.of(targetDir),
+      agent = agent,
+    )
+    state.result = CliExecutionResult(exitCode = 0, stdout = "")
   }
 }
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/SystemCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/SystemCliCommands.kt
@@ -38,18 +38,25 @@ class DoctorCliCommand(
     if (subject == null) {
       state.complete(service.doctor(state.dbOverride), format)
     } else {
-      state.result =
-        runPythonCli(
-          buildList {
-            add("doctor")
-            add(subject.orEmpty())
-            skillName?.let { add(it) }
-            addAll(listOf("--repo-root", repoRoot))
-            addAll(listOf("--content", content))
-            addAll(listOf("--format", format.wireName))
-          },
-          state,
-        )
+      state.result = retiredSubjectResult(subject.orEmpty(), skillName.orEmpty(), repoRoot, content)
     }
   }
+}
+
+private fun retiredSubjectResult(
+  subject: String,
+  skillName: String,
+  repoRoot: String,
+  content: String,
+): CliExecutionResult {
+  val replacementSkillName = skillName.ifBlank { "<skill-name>" }
+  val replacement = when (subject) {
+    "skill" -> "skill-bill show $replacementSkillName --repo-root $repoRoot --content $content"
+    else -> "skill-bill doctor"
+  }
+  val message = when (subject) {
+    "skill" -> "doctor skill was retired in SKILL-32; use `$replacement` instead."
+    else -> "doctor subject '$subject' is unsupported; use `$replacement` instead."
+  }
+  return CliExecutionResult(exitCode = 1, stdout = message)
 }

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliAuthoringParityTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliAuthoringParityTest.kt
@@ -59,7 +59,7 @@ class CliAuthoringParityTest {
   }
 
   @Test
-  fun `python-backed authoring validation commands stay available through the kotlin cli`() {
+  fun `python-backed authoring validation command stays available through the kotlin cli`() {
     val repoRoot = outerRepoRoot()
     val tempDir = Files.createTempDirectory("skillbill-cli-python-backed-validation")
     val context = CliRuntimeContext(userHome = tempDir)
@@ -76,24 +76,8 @@ class CliAuthoringParityTest {
         ),
         context,
       )
-    val doctorSkill =
-      runJson(
-        listOf(
-          "doctor",
-          "skill",
-          "bill-feature-implement",
-          "--repo-root",
-          repoRoot.toString(),
-          "--content",
-          "none",
-          "--format",
-          "json",
-        ),
-        context,
-      )
 
     assertEquals("pass", validated["status"])
-    assertEquals("pass", doctorSkill["status"])
   }
 }
 

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
@@ -475,6 +475,7 @@ class CliRuntimeTest {
   @Test
   fun `install commands expose agent path lookup and link-skill`() {
     val tempDir = Files.createTempDirectory("skillbill-cli-install")
+    Files.createDirectories(tempDir.resolve(".claude"))
     val context = CliRuntimeContext(userHome = tempDir)
 
     val agentPathResult = CliRuntime.run(listOf("install", "agent-path", "codex"), context)
@@ -502,10 +503,52 @@ class CliRuntimeTest {
     assertEquals(0, agentPathResult.exitCode, agentPathResult.stdout)
     assertEquals(tempDir.resolve(".agents/skills").toString(), agentPathResult.stdout.trim())
     assertEquals(0, detectAgentsResult.exitCode, detectAgentsResult.stdout)
-    assertEquals("", detectAgentsResult.stdout.trim())
+    assertEquals("claude\t${tempDir.resolve(".claude/commands")}", detectAgentsResult.stdout.trim())
     assertEquals(0, linkResult.exitCode, linkResult.stdout)
     assertTrue(Files.isSymbolicLink(targetDir.resolve("skill-source")))
     assertEquals(sourceSkill.toRealPath(), targetDir.resolve("skill-source").toRealPath())
+  }
+
+  @Test
+  fun `doctor skill subject is retired with stable replacement`() {
+    val result =
+      CliRuntime.run(
+        listOf(
+          "doctor",
+          "skill",
+          "bill-feature-implement",
+          "--repo-root",
+          ".",
+          "--content",
+          "none",
+          "--format",
+          "json",
+        ),
+      )
+
+    assertEquals(1, result.exitCode)
+    assertEquals(
+      "doctor skill was retired in SKILL-32; use " +
+        "`skill-bill show bill-feature-implement --repo-root . --content none` instead.",
+      result.stdout,
+    )
+  }
+
+  @Test
+  fun `install and doctor subject commands do not call python bridge helpers`() {
+    val scaffoldSource = Files.readString(Path.of("src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt"))
+    val systemSource = Files.readString(Path.of("src/main/kotlin/skillbill/cli/SystemCliCommands.kt"))
+
+    listOf(
+      commandBlock(scaffoldSource, "class InstallAgentPathCommand", "class InstallDetectAgentsCommand"),
+      commandBlock(scaffoldSource, "class InstallDetectAgentsCommand", "class InstallLinkSkillCommand"),
+      commandBlock(scaffoldSource, "class InstallLinkSkillCommand", "internal fun runPythonCli"),
+      commandBlock(systemSource, "class DoctorCliCommand", "private fun retiredSubjectResult"),
+    ).forEach { commandSource ->
+      assertFalse(commandSource.contains("runPythonCli"), commandSource)
+      assertFalse(commandSource.contains("runPythonScaffoldCli"), commandSource)
+      assertFalse(commandSource.contains("pythonProcess"), commandSource)
+    }
   }
 
   @Test
@@ -677,6 +720,14 @@ private fun decodeJsonObject(rawJson: String): Map<String, Any?> {
   val decoded = JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(parsed))
   require(decoded != null) { "Expected decoded JSON object but got: $rawJson" }
   return decoded
+}
+
+private fun commandBlock(source: String, startMarker: String, endMarker: String): String {
+  val startIndex = source.indexOf(startMarker)
+  val endIndex = source.indexOf(endMarker, startIndex + startMarker.length)
+  require(startIndex >= 0) { "Missing source marker: $startMarker" }
+  require(endIndex > startIndex) { "Missing source marker: $endMarker" }
+  return source.substring(startIndex, endIndex)
 }
 
 private fun goldenJson(fileName: String, vararg replacements: Pair<String, String>): String {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/install/InstallOperations.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/install/InstallOperations.kt
@@ -1,0 +1,26 @@
+package skillbill.install
+
+import skillbill.install.model.AgentTarget
+import java.nio.file.Files
+import java.nio.file.Path
+
+/** Public CLI-facing install operations backed by the internal install primitives. */
+object InstallOperations {
+  fun agentPath(agent: String, home: Path? = null): Path {
+    require(agent in SUPPORTED_AGENTS) {
+      "Unknown agent '$agent'. Supported agents: ${SUPPORTED_AGENTS.joinToString(", ")}."
+    }
+    return agentPaths(home).getValue(agent)
+  }
+
+  fun detectAgentTargets(home: Path? = null): List<AgentTarget> = detectAgents(home)
+
+  fun linkSkill(source: Path, targetDir: Path, agent: String): List<Path> {
+    val resolvedTargetDir = targetDir.toAbsolutePath().normalize()
+    Files.createDirectories(resolvedTargetDir)
+    return installSkill(
+      skillPath = source,
+      agentTargets = listOf(AgentTarget(agent.ifBlank { "manual" }, resolvedTargetDir)),
+    )
+  }
+}


### PR DESCRIPTION
# Summary

Ports the SKILL-32 install and doctor command paths away from Python bridge execution so the Kotlin runtime owns the supported CLI behavior. This keeps install primitives reachable through a CLI-facing runtime-core facade, retires unsupported doctor subjects with stable errors, and adds guards so these command blocks do not regress to bridge helpers.

- Adds `InstallOperations` as the public runtime facade for CLI install operations.
- Ports `install agent-path`, `install detect-agents`, and `install link-skill` to native Kotlin operations.
- Retires `doctor skill` in the Kotlin CLI with a tested replacement message while keeping subjectless `doctor` native.
- Adds Kotlin runtime tests for native install behavior, retired doctor handling, and bridge-helper source-reference guards.

## Feature Flags

N/A

# How Has This Been Tested?

Validation passed through `bill-kotlin-quality-check` with zero failures.

Reproducible checks:
1. `(cd runtime-kotlin && ./gradlew check)`
2. `.venv/bin/python3 -m unittest discover -s tests`
3. `npx --yes agnix --strict .`
4. `.venv/bin/python3 scripts/validate_agent_configs.py`

Expected result: all commands pass without failures, new Detekt suppressions, or banned bridge-helper usage in the ported command blocks.
