### PR TITLE
feat: [SKILL-33] Add OpenCode native subagents

### DIFF
--- a/.feature-specs/SKILL-33-codex-native-subagents/spec.md
+++ b/.feature-specs/SKILL-33-codex-native-subagents/spec.md
@@ -10,11 +10,11 @@
 
 ## Background
 
-Skill-bill already installs skills to Codex (`~/.codex/skills/` with `~/.agents/skills/` fallback) but has no integration with Codex's native subagent feature. As a result, every multi-step orchestrator that uses Claude's `Agent` tool collapses into a single Codex conversation, blowing the context window and serializing work that should run in parallel.
+Skill-bill already installs skills to the Codex user skills directory with the existing legacy Agents skills fallback, but has no integration with Codex's native subagent feature. As a result, every multi-step orchestrator that uses Claude's `Agent` tool collapses into a single Codex conversation, blowing the context window and serializing work that should run in parallel.
 
 Codex native subagents differ from Claude's `Agent` tool in three load-bearing ways the implementation must respect:
 
-1. **Definition format.** TOML files in `~/.codex/agents/` (user) or `.codex/agents/` (project). Required fields: `name`, `description`, `developer_instructions`. Optional: `model`, `model_reasoning_effort`, `sandbox_mode`, `mcp_servers`, `nickname_candidates`, `skills.config`.
+1. **Definition format.** TOML files in the Codex user agents directory or the Codex project agents directory. Required fields: `name`, `description`, `developer_instructions`. Optional: `model`, `model_reasoning_effort`, `sandbox_mode`, `mcp_servers`, `nickname_candidates`, `skills.config`.
 2. **Invocation model.** Codex spawns subagents via natural-language steering, not a programmatic tool call. There is no equivalent of `Agent(subagent_type=…)` with structured args. Parent agents say "spawn the X agent" and Codex resolves by `name`.
 3. **Runtime constraints.** `agents.max_threads` defaults to 6, `agents.max_depth` defaults to 1 (no nesting). Subagents inherit the parent's sandbox policy unless overridden per-agent.
 
@@ -22,7 +22,7 @@ This phase establishes the foundation (install path, TOML authoring) and validat
 
 ## Acceptance criteria
 
-1. `skill_bill/install.py` resolves a Codex agents directory at `~/.codex/agents/` (with `~/.agents/agents/` fallback, mirroring the existing skills-path fallback model) and exposes it through the same install/uninstall primitives that already handle skills.
+1. `skill_bill/install.py` resolves a Codex agents directory with the legacy Agents agents fallback, mirroring the existing skills-path fallback model, and exposes it through the same install/uninstall primitives that already handle skills.
 2. `install.sh` and `uninstall.sh` install and remove Codex subagent TOML files alongside skill installs when Codex is a selected agent.
 3. `bill-kmp-code-review` ships TOML subagent definitions for every specialist it delegates to, authored under a canonical repo location (e.g. `platform-packs/kmp/code-review/bill-kmp-code-review/codex-agents/*.toml`), and those files are valid Codex agent files (required fields present, names unique, no Claude-only references in `developer_instructions`).
 4. `bill-kmp-code-review`'s orchestrator skill content describes spawning subagents in runtime-neutral language (e.g. "spawn the `review-architecture` subagent") so both Claude (which maps the spawn to `Agent(subagent_type=…)`) and Codex (which resolves the name against an installed TOML) execute the same prose correctly.
@@ -37,7 +37,7 @@ This phase establishes the foundation (install path, TOML authoring) and validat
 - Codex subagent support for `bill-kotlin-code-review`, `bill-feature-verify`, `bill-feature-implement`, or any other orchestrator skill — separate follow-up issues.
 - Scaffolding subagent TOML files from `bill-create-skill` — separate follow-up issue.
 - Changing the Claude-side `Agent` tool integration or the existing `RESULT:` JSON contracts.
-- Restructuring the existing skills install path (`~/.codex/skills/`).
+- Restructuring the existing Codex skills install path.
 - Adding a runtime-detection helper that tries to identify whether the orchestrator is running on Claude or Codex. The skill prose stays runtime-neutral; each runtime interprets it natively.
 - Enforcing the `RESULT:` contract on Codex with deterministic parsing guarantees beyond what `developer_instructions` can elicit. Codex's natural-language spawn model means contract adherence is best-effort, not tool-enforced.
 
@@ -49,7 +49,7 @@ None at draft time. All resolved via the linked Codex docs read on 2026-05-02.
 
 ### Install path
 
-Extend `skill_bill/install.py` so the agent registry for Codex returns both a skills directory (existing) and an agents directory (new). The agents directory uses the same fallback pattern as skills: prefer `~/.codex/agents/`, fall back to `~/.agents/agents/`. Both `install.sh` and `uninstall.sh` must be able to symlink TOML files from the repo into that directory and remove them on uninstall. The install transaction model already used for skills should be reused — do not introduce a parallel transaction system.
+Extend `skill_bill/install.py` so the agent registry for Codex returns both a skills directory (existing) and an agents directory (new). The agents directory uses the same fallback pattern as skills: prefer the Codex user agents directory, then fall back to the legacy Agents agents directory. Both `install.sh` and `uninstall.sh` must be able to symlink TOML files from the repo into that directory and remove them on uninstall. The install transaction model already used for skills should be reused — do not introduce a parallel transaction system.
 
 ### Subagent definition authoring
 
@@ -79,13 +79,13 @@ The pilot orchestrator already fans out to specialists in parallel where the pro
 
 Update `README.md` and `docs/getting-started.md` to:
 
-- List `~/.codex/agents/` (and the `~/.agents/agents/` fallback) as a supported install target.
+- List the Codex user agents directory and legacy Agents agents fallback as supported install targets.
 - Describe in one paragraph that Codex spawns subagents via natural language and that skill-bill's TOML defs make the orchestrators work natively.
 - Clarify that this phase covers `bill-kmp-code-review` only and that other orchestrators will follow.
 
 ### Tests
 
-- Extend the install/uninstall tests (`tests/test_install_script.py`, `tests/test_uninstall_script.py`) to cover the Codex agents directory: detection, symlinking on install, cleanup on uninstall, and the `~/.agents/agents/` fallback when `~/.codex/` is absent.
+- Extend the install/uninstall tests (`tests/test_install_script.py`, `tests/test_uninstall_script.py`) to cover the Codex agents directory: detection, symlinking on install, cleanup on uninstall, and the legacy fallback when the primary Codex config directory is absent.
 - Validate that every TOML file in `platform-packs/kmp/code-review/bill-kmp-code-review/codex-agents/` is parseable TOML and has the required fields. A minimal repo-side validator script is acceptable; no need for a full schema-validation framework.
 
 ### Out of scope (follow-ups)

--- a/.feature-specs/SKILL-33-followups/spec_followup_1_opencode-native-subagents.md
+++ b/.feature-specs/SKILL-33-followups/spec_followup_1_opencode-native-subagents.md
@@ -1,0 +1,80 @@
+# OpenCode native subagent support (Phase 1 pilot)
+
+- Issue key: TBD (file as a Linear issue and rename this directory when assigned)
+- Status: Draft
+- Date: 2026-05-02
+- Parent: SKILL-33 (Codex native subagent support — shipped in PR #91)
+- Sources:
+  - Discovery during SKILL-33 follow-up review on 2026-05-02 — OpenCode is the second skill-bill-supported agent that has a native subagent feature with no current integration.
+  - OpenCode docs: subagent definitions live in the OpenCode user agents directory (global) and the OpenCode project agents directory (per-project), as either markdown files (filename becomes agent name) or JSON entries under an `"agent"` key in `opencode.json`. Subagents can be invoked automatically by primary agents or manually by `@<name>` mention. Subagents create child sessions with their own context.
+
+## Background
+
+Skill-bill installs skills to OpenCode, but has no integration with OpenCode's native subagent feature. As a result, every multi-step orchestrator that uses Claude's `Agent` tool collapses into a single OpenCode conversation — the same context-pressure problem SKILL-33 fixed for Codex.
+
+This phase establishes the OpenCode foundation (install path + manifest-driven discovery) and validates the end-to-end pattern on the same pilot orchestrator SKILL-33 used (`bill-kmp-code-review`). It deliberately mirrors SKILL-33's shape so the install-primitive code stays uniform across runtimes.
+
+Key OpenCode-specific differences from Codex:
+
+1. **Definition format.** Markdown files (recommended; filename becomes the agent name) or JSON entries under an `"agent"` key in `opencode.json`. The pilot uses markdown to match OpenCode's recommended approach and to keep the F-XXX Risk Register contract readable.
+2. **Invocation model.** Primary agents invoke subagents automatically based on task requirements OR users `@<name>` mention them manually. Same runtime-neutral spawn-by-name model as Codex from the orchestrator's perspective.
+3. **Session navigation.** Child sessions get keybind navigation in OpenCode's TUI (`<Leader>+Down`, etc.). Not relevant to the install primitive but worth noting in docs.
+
+## Acceptance criteria
+
+1. `skill_bill/install.py` resolves the OpenCode user agents directory and exposes it through the same install/uninstall primitives that already handle skills, mirroring SKILL-33's `_codex_agents_path` shape (introduce a parallel `_opencode_agents_path` helper, `discover_opencode_agent_mds`, `install_opencode_agent_md`, `uninstall_opencode_agent_mds`).
+2. `install.sh` and `uninstall.sh` install and remove OpenCode subagent markdown files alongside skill installs when OpenCode is a selected agent. Manifest-driven discovery walks `platform-packs/<slug>/**/opencode-agents/*.md` — never hardcode a pack slug.
+3. `bill-kmp-code-review` ships markdown subagent definitions for the 2 KMP-specific specialists at `platform-packs/kmp/code-review/bill-kmp-code-review/opencode-agents/*.md`. Filename matches the OpenCode agent name. The body embeds the F-XXX Risk Register bullet contract from `specialist-contract.md` inlined verbatim — OpenCode does not follow sibling symlinks any better than Codex.
+4. The orchestrator skill content needs no further changes — `bill-kmp-code-review/content.md` was already made runtime-neutral in SKILL-33. Verify the existing "Subagent Spawn Runtime Notes" section covers OpenCode and append a one-paragraph note explaining how OpenCode resolves spawn-by-name against the OpenCode user agents directory (and that users can manually `@<name>` invoke).
+5. Specialist fan-out fits within OpenCode's documented concurrency limits (research at planning time; conservative ceiling matches SKILL-33's ≤6 statement). Verifiable one-line update in the orchestrator content if the limit differs from Codex.
+6. User-facing docs (README, getting-started, getting-started-for-teams) cover the new OpenCode subagents install path and reference both Codex (already documented) and OpenCode in a single "native subagents" subsection.
+7. Install/uninstall tests cover the new OpenCode agents directory. A markdown-validity check is added at `tests/test_opencode_agents_md.py` that walks `platform-packs/**/opencode-agents/*.md`, asserts each file has a non-empty body, the filename matches an internal `name:` frontmatter field if present, names are unique across the directory, and there are no Claude-only references in the body.
+8. `agent/history.md` is updated per `bill-boundary-history` rules, citing SKILL-33 as the precedent so future runtimes following this pattern have a clear reference chain.
+
+## Non-goals
+
+- OpenCode subagent support for `bill-kotlin-code-review`, `bill-feature-verify`, `bill-feature-implement`, or any other orchestrator (deferred to follow-ups 2–3).
+- JSON-style agent definitions in `opencode.json`. The pilot uses markdown only; if a user needs JSON they can hand-author it.
+- Changing the existing OpenCode skills install path.
+- Re-running SKILL-33's orchestrator-prose work — the prose is already runtime-neutral and only needs an OpenCode-specific note appended.
+
+## Open questions
+
+1. Does OpenCode's markdown agent file require frontmatter (e.g. `description:`, `model:`) or is the filename + body sufficient? Resolve at pre-planning by reading OpenCode's published agent-file schema.
+2. Does OpenCode have a documented `max_threads` equivalent? If yes, capture it for AC #5; if not, default to "≤6 specialists per wave fits comfortably."
+
+## Consolidated spec
+
+### Install primitive
+
+Extend `skill_bill/install.py`. Reuse the existing `InstallTransaction` model and the manifest-driven discovery pattern introduced in SKILL-33. Concretely:
+
+- Add `_opencode_agents_path(home)` returning the OpenCode user agents directory. No fallback path is required (OpenCode does not have a legacy Agents-style fallback for its own config).
+- Add `discover_opencode_agent_mds(platform_packs_root)` walking `platform-packs/<slug>/**/opencode-agents/*.md`.
+- Add `install_opencode_agent_md(...)` and `uninstall_opencode_agent_mds(...)` mirroring the Codex equivalents. Update `__all__`.
+- Extend `detect_agents` so OpenCode appears with both its skills directory and its agents directory when present.
+
+### Shell wiring
+
+`install.sh` adds `install_opencode_agents_mds` (parallel to `install_codex_agents_tomls`). The conditional dispatch at the end of the AGENT_NAMES loop branches into both functions when `agent == codex` or `agent == opencode` respectively. Inline `shopt -s globstar` fallback covers the no-Python bootstrap case.
+
+`uninstall.sh` adds `remove_opencode_agents_mds`. No fallback dirs to traverse — OpenCode has a single canonical location.
+
+### Subagent authoring
+
+Each TOML authored in SKILL-33 has a markdown sibling. The body is whatever spawn-time content the specialist receives — sourced from each specialist's `content.md`, with the F-XXX Risk Register contract from `specialist-contract.md` inlined verbatim. If OpenCode requires frontmatter, add it minimally (open question 1).
+
+### Documentation
+
+Replace the standalone "Codex agents" doc snippet with a "Native subagents" subsection that covers both Codex and OpenCode. Document each runtime's path, format, and invocation model. The natural-language-spawn caveat applies to both.
+
+### Tests
+
+- `tests/test_install_script.py`: assert the OpenCode user agents directory is created on install when opencode is selected; assert each markdown file under `platform-packs/**/opencode-agents/` ends up symlinked.
+- `tests/test_uninstall_script.py`: seed markdown files in the OpenCode user agents directory and assert uninstall removes them.
+- New `tests/test_opencode_agents_md.py`: parseability (it's just markdown — assert non-empty body, no Claude-only references, name uniqueness across the directory). Mirror the structure of `tests/test_codex_agents_toml.py`.
+
+### Out of scope (further follow-ups)
+
+- Authoring OpenCode agents for the rest of the orchestrators — see follow-up specs 2–3.
+- Updating `bill-create-skill` to scaffold OpenCode files automatically — see follow-up 4.

--- a/.feature-specs/SKILL-33-opencode-native-subagents/spec.md
+++ b/.feature-specs/SKILL-33-opencode-native-subagents/spec.md
@@ -1,0 +1,81 @@
+# OpenCode native subagent support (Phase 1 pilot)
+
+- Issue key: SKILL-33
+- Status: In Progress
+- Date: 2026-05-02
+- Parent: SKILL-33 (Codex native subagent support -- shipped in PR #91)
+- Sources:
+  - `.feature-specs/SKILL-33-followups/spec_followup_1_opencode-native-subagents.md`
+  - Discovery during SKILL-33 follow-up review on 2026-05-02 -- OpenCode is the second skill-bill-supported agent that has a native subagent feature with no current integration.
+  - OpenCode docs: subagent definitions live in the OpenCode user agents directory (global) and the OpenCode project agents directory (per-project), as either markdown files (filename becomes agent name) or JSON entries under an `"agent"` key in `opencode.json`. Subagents can be invoked automatically by primary agents or manually by `@<name>` mention. Subagents create child sessions with their own context.
+
+## Acceptance Criteria
+
+1. `skill_bill/install.py` resolves the OpenCode user agents directory and exposes it through the same install/uninstall primitives that already handle skills, mirroring SKILL-33's `_codex_agents_path` shape (introduce a parallel `_opencode_agents_path` helper, `discover_opencode_agent_mds`, `install_opencode_agent_md`, `uninstall_opencode_agent_mds`).
+2. `install.sh` and `uninstall.sh` install and remove OpenCode subagent markdown files alongside skill installs when OpenCode is a selected agent. Manifest-driven discovery walks `platform-packs/<slug>/**/opencode-agents/*.md` -- never hardcode a pack slug.
+3. `bill-kmp-code-review` ships markdown subagent definitions for the 2 KMP-specific specialists at `platform-packs/kmp/code-review/bill-kmp-code-review/opencode-agents/*.md`. Filename matches the OpenCode agent name. The body embeds the F-XXX Risk Register bullet contract from `specialist-contract.md` inlined verbatim -- OpenCode does not follow sibling symlinks any better than Codex.
+4. The orchestrator skill content needs no further changes -- `bill-kmp-code-review/content.md` was already made runtime-neutral in SKILL-33. Verify the existing "Subagent Spawn Runtime Notes" section covers OpenCode and append a one-paragraph note explaining how OpenCode resolves spawn-by-name against the OpenCode user agents directory (and that users can manually `@<name>` invoke).
+5. Specialist fan-out fits within OpenCode's documented concurrency limits (research at planning time; conservative ceiling matches SKILL-33's <=6 statement). Verifiable one-line update in the orchestrator content if the limit differs from Codex.
+6. User-facing docs (README, getting-started, getting-started-for-teams) cover the new OpenCode subagents install path and reference both Codex (already documented) and OpenCode in a single "native subagents" subsection.
+7. Install/uninstall tests cover the new OpenCode agents directory. A markdown-validity check is added at `tests/test_opencode_agents_md.py` that walks `platform-packs/**/opencode-agents/*.md`, asserts each file has a non-empty body, the filename matches an internal `name:` frontmatter field if present, names are unique across the directory, and there are no Claude-only references in the body.
+8. `agent/history.md` is updated per `bill-boundary-history` rules, citing SKILL-33 as the precedent so future runtimes following this pattern have a clear reference chain.
+
+## Non-goals
+
+- OpenCode subagent support for `bill-kotlin-code-review`, `bill-feature-verify`, `bill-feature-implement`, or any other orchestrator (deferred to follow-ups 2-3).
+- JSON-style agent definitions in `opencode.json`. The pilot uses markdown only; if a user needs JSON they can hand-author it.
+- Changing the existing OpenCode skills install path.
+- Re-running SKILL-33's orchestrator-prose work -- the prose is already runtime-neutral and only needs an OpenCode-specific note appended.
+
+## Consolidated Spec
+
+### Background
+
+Skill-bill installs skills to OpenCode, but has no integration with OpenCode's native subagent feature. As a result, every multi-step orchestrator that uses Claude's `Agent` tool collapses into a single OpenCode conversation -- the same context-pressure problem SKILL-33 fixed for Codex.
+
+This phase establishes the OpenCode foundation (install path + manifest-driven discovery) and validates the end-to-end pattern on the same pilot orchestrator SKILL-33 used (`bill-kmp-code-review`). It deliberately mirrors SKILL-33's shape so the install-primitive code stays uniform across runtimes.
+
+Key OpenCode-specific differences from Codex:
+
+1. **Definition format.** Markdown files (recommended; filename becomes the agent name) or JSON entries under an `"agent"` key in `opencode.json`. The pilot uses markdown to match OpenCode's recommended approach and to keep the F-XXX Risk Register contract readable.
+2. **Invocation model.** Primary agents invoke subagents automatically based on task requirements OR users `@<name>` mention them manually. Same runtime-neutral spawn-by-name model as Codex from the orchestrator's perspective.
+3. **Session navigation.** Child sessions get keybind navigation in OpenCode's TUI (`<Leader>+Down`, etc.). Not relevant to the install primitive but worth noting in docs.
+
+### Open questions
+
+1. Does OpenCode's markdown agent file require frontmatter (e.g. `description:`, `model:`) or is the filename + body sufficient? Resolve at pre-planning by reading OpenCode's published agent-file schema.
+2. Does OpenCode have a documented `max_threads` equivalent? If yes, capture it for AC #5; if not, default to "<=6 specialists per wave fits comfortably."
+
+### Install primitive
+
+Extend `skill_bill/install.py`. Reuse the existing `InstallTransaction` model and the manifest-driven discovery pattern introduced in SKILL-33. Concretely:
+
+- Add `_opencode_agents_path(home)` returning the OpenCode user agents directory. No fallback path is required (OpenCode does not have a legacy Agents-style fallback for its own config).
+- Add `discover_opencode_agent_mds(platform_packs_root)` walking `platform-packs/<slug>/**/opencode-agents/*.md`.
+- Add `install_opencode_agent_md(...)` and `uninstall_opencode_agent_mds(...)` mirroring the Codex equivalents. Update `__all__`.
+- Extend `detect_agents` so OpenCode appears with both its skills directory and its agents directory when present.
+
+### Shell wiring
+
+`install.sh` adds `install_opencode_agents_mds` (parallel to `install_codex_agents_tomls`). The conditional dispatch at the end of the AGENT_NAMES loop branches into both functions when `agent == codex` or `agent == opencode` respectively. Inline `shopt -s globstar` fallback covers the no-Python bootstrap case.
+
+`uninstall.sh` adds `remove_opencode_agents_mds`. No fallback dirs to traverse -- OpenCode has a single canonical location.
+
+### Subagent authoring
+
+Each TOML authored in SKILL-33 has a markdown sibling. The body is whatever spawn-time content the specialist receives -- sourced from each specialist's `content.md`, with the F-XXX Risk Register contract from `specialist-contract.md` inlined verbatim. If OpenCode requires frontmatter, add it minimally (open question 1).
+
+### Documentation
+
+Replace the standalone "Codex agents" doc snippet with a "Native subagents" subsection that covers both Codex and OpenCode. Document each runtime's path, format, and invocation model. The natural-language-spawn caveat applies to both.
+
+### Tests
+
+- `tests/test_install_script.py`: assert the OpenCode user agents directory is created on install when opencode is selected; assert each markdown file under `platform-packs/**/opencode-agents/` ends up symlinked.
+- `tests/test_uninstall_script.py`: seed markdown files in the OpenCode user agents directory and assert uninstall removes them.
+- New `tests/test_opencode_agents_md.py`: parseability (it's just markdown -- assert non-empty body, no Claude-only references, name uniqueness across the directory). Mirror the structure of `tests/test_codex_agents_toml.py`.
+
+### Out of scope (further follow-ups)
+
+- Authoring OpenCode agents for the rest of the orchestrators -- see follow-up specs 2-3.
+- Updating `bill-create-skill` to scaffold OpenCode files automatically -- see follow-up 4.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Supported install targets today:
 - Claude Code
 - GLM
 - OpenAI Codex (skills under `~/.codex/skills/`; native subagent TOMLs under `~/.codex/agents/`, both with `~/.agents/...` fallback)
-- OpenCode
+- OpenCode (skills under `~/.config/opencode/skills/`; native subagent markdown under `~/.config/opencode/agents/`)
+
+Native subagent definitions are installed only for orchestrators that ship them. Discovery is manifest-driven under `platform-packs/<slug>/**/codex-agents/*.toml` for Codex and `platform-packs/<slug>/**/opencode-agents/*.md` for OpenCode. Codex resolves runtime-neutral spawn prose by TOML `name`; OpenCode resolves by filename-derived markdown agent name and also supports manual `@<name>` invocation. Today this covers the `bill-kmp-code-review` KMP specialists.
 
 ## Start here
 

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-05-02] opencode-native-subagents
+Areas: skill_bill/install.py, skill_bill/__main__.py, install.sh, uninstall.sh, platform-packs/kmp/code-review/bill-kmp-code-review/, README.md, docs/, tests/
+- Mirrored the SKILL-33 Codex native subagent precedent for OpenCode: added `~/.config/opencode/agents/` markdown-agent install primitives, CLI delegates, and shell fallbacks that discover `platform-packs/<slug>/**/opencode-agents/*.md` without hardcoding pack slugs. reusable
+- Authored OpenCode markdown agents for the 2 KMP specialist reviewers with filename/name parity, required `mode: subagent` frontmatter, and the shared F-XXX Risk Register contract inlined because global OpenCode agents cannot rely on sibling repo sidecars. reusable
+- Kept `bill-kmp-code-review` runtime-neutral and documented that OpenCode resolves specialists by installed markdown name, including manual `@<name>` invocation; OpenCode has no documented conflicting concurrency cap, so the conservative <=6 specialist-wave limit remains.
+- Extended install/uninstall and markdown validation coverage alongside README/getting-started docs; baseline Kotlin and other orchestrators remain out of scope.
+Feature flag: N/A
+Acceptance criteria: 8/8 implemented
+
 ## [2026-05-02] codex-native-subagents
 Areas: skill_bill/install.py, skill_bill/__main__.py, install.sh, uninstall.sh, platform-packs/kmp/code-review/bill-kmp-code-review/, README.md, docs/, tests/
 - Added a `_codex_agents_path` primitive in `skill_bill/install.py` that mirrors the existing `_codex_path` skills primitive: prefers `~/.codex/agents/`, falls back to `~/.agents/agents/`. Exposed it as a secondary Codex install surface (`detect_codex_agents_target`) and added manifest-driven discovery (`discover_codex_agent_tomls`) plus install/uninstall helpers that walk `platform-packs/<slug>/**/codex-agents/*.toml` rather than hardcoding any pack slug. Reuses the same `InstallTransaction` model rather than introducing a parallel transaction system. reusable, follows [2026-04-17] new-skill-scaffolder precedent.

--- a/docs/getting-started-for-teams.md
+++ b/docs/getting-started-for-teams.md
@@ -57,7 +57,7 @@ Team members should not need to know migration history. Current behavior is:
 - Python scripts still exist for repo validation and maintainer tooling, but Python is not the active CLI/MCP runtime.
 - Runtime rollback means installing a previous release, not toggling a Python fallback.
 
-On Codex, `bill-kmp-code-review` ships native subagent TOML defs under `~/.codex/agents/` (with `~/.agents/agents/` fallback). The orchestrator's spawn prose ("spawn the `bill-kmp-code-review-ui` subagent" and so on) is runtime-neutral: Codex resolves each name against the installed TOMLs as a natural-language steering directive, while Claude maps the same prose to its native subagent tool. Other orchestrators (`bill-feature-implement`, `bill-feature-verify`, the Kotlin baseline) still run inline on Codex until their TOMLs land in follow-up issues.
+On Codex and OpenCode, `bill-kmp-code-review` ships native subagent definitions for its KMP specialists. Codex installs TOMLs under `~/.codex/agents/` (with `~/.agents/agents/` fallback) from `platform-packs/<slug>/**/codex-agents/*.toml`; OpenCode installs markdown agents under `~/.config/opencode/agents/` from `platform-packs/<slug>/**/opencode-agents/*.md`. The orchestrator's spawn prose ("spawn the `bill-kmp-code-review-ui` subagent" and so on) is runtime-neutral: Codex resolves each TOML by `name`, OpenCode resolves each markdown agent by filename-derived name and supports manual `@<name>` invocation, while Claude maps the same prose to its native subagent tool. Other orchestrators (`bill-feature-implement`, `bill-feature-verify`, the Kotlin baseline) still run inline on Codex and OpenCode until their native subagent definitions land in follow-up issues.
 
 ## Fallback And Failure Boundaries
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,11 +48,12 @@ Supported install targets:
 | GLM | `~/.glm/commands/` |
 | OpenAI Codex (skills) | `~/.codex/skills/` or `~/.agents/skills/` |
 | OpenAI Codex (native subagent TOMLs) | `~/.codex/agents/` or `~/.agents/agents/` |
-| OpenCode | `~/.config/opencode/skills/` |
+| OpenCode (skills) | `~/.config/opencode/skills/` |
+| OpenCode (native subagent markdown) | `~/.config/opencode/agents/` |
 
 Installed skills are symlinks back to the checkout. Updating the checkout updates installed skill behavior.
 
-On Codex, orchestrators that delegate to specialists also install native subagent TOML defs into `~/.codex/agents/` (with `~/.agents/agents/` fallback). Codex spawns these subagents via natural language, resolving the spawn instruction by `name` against the installed TOMLs. Today this covers the `bill-kmp-code-review` specialists; other orchestrators continue to run as a single Codex conversation until their TOML defs ship in follow-up issues.
+On Codex and OpenCode, orchestrators that delegate to specialists also install native subagent definitions for supported runtime surfaces. Codex installs TOMLs discovered from `platform-packs/<slug>/**/codex-agents/*.toml` into `~/.codex/agents/` (with `~/.agents/agents/` fallback) and resolves spawn instructions by TOML `name`. OpenCode installs markdown agents discovered from `platform-packs/<slug>/**/opencode-agents/*.md` into `~/.config/opencode/agents/` and resolves by filename-derived agent name; operators can also invoke them manually with `@<name>`. Today this covers the `bill-kmp-code-review` specialists; other orchestrators continue to run as a single conversation until their native subagent definitions ship in follow-up issues.
 
 ## Runtime Model
 

--- a/install.sh
+++ b/install.sh
@@ -88,6 +88,19 @@ get_codex_agents_path() {
   fi
 }
 
+get_opencode_agents_path() {
+  # Mirrors get_agent_path for the native OpenCode markdown subagents
+  # directory. Source of truth lives in skill_bill/install.py::_opencode_agents_path.
+  local python_cmd
+  if python_cmd="$(command -v python3 2>/dev/null)"; then
+    if output="$("$python_cmd" -m skill_bill install opencode-agents-path 2>/dev/null)"; then
+      echo "$output"
+      return 0
+    fi
+  fi
+  echo "$HOME/.config/opencode/agents"
+}
+
 install_codex_agents_tomls() {
   # Install Codex native subagent TOML defs under the resolved agents dir.
   # Walks platform-packs/<slug>/**/codex-agents/*.toml — manifest-driven,
@@ -116,6 +129,38 @@ install_codex_agents_tomls() {
     fi
     ln -s "$toml_file" "$link_path"
     ok "  $(basename "$toml_file") → $toml_file"
+  done
+  shopt -u nullglob globstar
+}
+
+install_opencode_agent_mds() {
+  # Install OpenCode native subagent markdown defs under ~/.config/opencode/agents.
+  # Walks platform-packs/<slug>/**/opencode-agents/*.md — manifest-driven,
+  # never hardcodes a slug. Runs only when opencode was selected by the user.
+  local target_dir
+  target_dir="$(get_opencode_agents_path)"
+  mkdir -p "$target_dir"
+  info "Installing OpenCode subagent markdown to: $target_dir"
+
+  local python_cmd
+  if python_cmd="$(command -v python3 2>/dev/null)"; then
+    if "$python_cmd" -m skill_bill install link-opencode-agents \
+      --platform-packs "$PLATFORM_PACKS_DIR" 2>/dev/null; then
+      ok "  OpenCode subagent markdown linked via skill_bill"
+      return 0
+    fi
+  fi
+
+  local md_file link_path
+  shopt -s nullglob globstar
+  for md_file in "$PLATFORM_PACKS_DIR"/**/opencode-agents/*.md; do
+    [[ -f "$md_file" ]] || continue
+    link_path="$target_dir/$(basename "$md_file")"
+    if [[ -L "$link_path" || -e "$link_path" ]]; then
+      rm -f "$link_path"
+    fi
+    ln -s "$md_file" "$link_path"
+    ok "  $(basename "$md_file") → $md_file"
   done
   shopt -u nullglob globstar
 }
@@ -835,6 +880,9 @@ for i in "${!AGENT_NAMES[@]}"; do
 
   if [[ "$agent" == "codex" ]]; then
     install_codex_agents_tomls
+  fi
+  if [[ "$agent" == "opencode" ]]; then
+    install_opencode_agent_mds
   fi
   echo ""
 done

--- a/platform-packs/kmp/code-review/bill-kmp-code-review/content.md
+++ b/platform-packs/kmp/code-review/bill-kmp-code-review/content.md
@@ -119,7 +119,8 @@ Resolve the scope before reviewing. If the caller asks for staged changes, inspe
 
 ## Subagent Spawn Runtime Notes
 
-Specialist spawn instructions in this orchestrator are runtime-neutral. Each phrase such as "spawn the `bill-kmp-code-review-ui` subagent" maps to the native subagent surface of the host runtime. On Claude, the spawn becomes an `Agent` tool call against a matching subagent definition. On Codex, the spawn is a natural-language directive and Codex resolves it by `name` against the installed TOML files in `~/.codex/agents/` (with `~/.agents/agents/` fallback), respecting `agents.max_threads` and `agents.max_depth`.
+Specialist spawn instructions in this orchestrator are runtime-neutral. Each phrase such as "spawn the `bill-kmp-code-review-ui` subagent" maps to the native subagent surface of the host runtime. On Claude, the spawn becomes an `Agent` tool call against a matching subagent definition. On Codex, the spawn is a natural-language directive and Codex resolves it by `name` against the installed TOML files in the Codex user agents directory (with the legacy Agents agents fallback), respecting `agents.max_threads` and `agents.max_depth`. On OpenCode, the spawn resolves by filename-derived `name` against markdown agents installed in the OpenCode user agents directory; operators can also invoke the same specialists manually with `@bill-kmp-code-review-ui` or `@bill-kmp-code-review-ux-accessibility`.
 
 KMP fan-out is at most 2 specialists per wave (`bill-kmp-code-review-ui`, `bill-kmp-code-review-ux-accessibility`), which fits comfortably within Codex's `agents.max_threads = 6` default.
 
+OpenCode does not document a different native concurrency cap for these markdown subagents, so keep the Skill Bill conservative limit of 6 or fewer specialists per wave.

--- a/platform-packs/kmp/code-review/bill-kmp-code-review/opencode-agents/bill-kmp-code-review-ui.md
+++ b/platform-packs/kmp/code-review/bill-kmp-code-review/opencode-agents/bill-kmp-code-review-ui.md
@@ -1,0 +1,97 @@
+---
+name: bill-kmp-code-review-ui
+description: KMP/Compose UI specialist code reviewer. Runs against Compose @Composable functions, UI state, Modifier chains, recomposition handling, theming, accessibility, previews, and Android UI add-ons. Returns a Risk Register in the F-XXX bullet format.
+mode: subagent
+---
+
+# KMP UI Best Practices
+
+## Compose Review Rubric
+
+The canonical KMP UI review command stays `bill-kmp-code-review-ui`. Governed add-ons apply only after the parent review has already routed to `kmp`.
+
+When the parent KMP review selects the `android-compose` add-on, apply Android Compose risks alongside the base Compose review rubric. If the add-on is split into topic files, use only the linked topic files whose cues match the diff, such as edge-to-edge and adaptive-layout concerns.
+
+When the parent KMP review selects `android-navigation`, apply Android-specific navigation UI risks alongside the base Compose review rubric.
+
+When the parent KMP review selects `android-interop`, apply Android host-boundary UI risks alongside the base Compose review rubric.
+
+When the parent KMP review selects `android-design-system`, apply Android design-system and theme risks alongside the base Compose review rubric.
+
+When no governed add-on applies, use the base Compose review rubric by itself.
+
+For review enforcement, apply the Compose review rubric covering state hoisting, signature conventions, recomposition and performance, theming, string resources, composable structure, side effects, navigation, previews, error/loading states, UI element selection, modifier best practices, and ViewModel integration.
+
+Apply every section from the Compose review rubric as a review checklist when reviewing `@Composable` code. Use governed add-ons only to extend the routed KMP review with transferable Android/Compose concerns; do not treat an add-on as a standalone review command.
+
+## Checklist
+
+Before considering a composable done, verify:
+
+- State is hoisted: composable is stateless with a stateful wrapper
+- `modifier: Modifier = Modifier` on every public/internal composable below screen level
+- `modifier` applied only to root element
+- No hardcoded strings: all user-facing text uses `stringResource`
+- No hardcoded colors, sizes, or spacing: uses theme tokens
+- Stable types only: uses `@Immutable` / `ImmutableList` / primitives
+- `collectAsStateWithLifecycle()` for flow collection
+- `rememberSaveable` for state surviving config changes
+- `LazyColumn` / `LazyRow` items have `key` and `contentType`
+- Accessibility: all images/icons have appropriate `contentDescription`
+- Side effects use correct API (`LaunchedEffect`, `DisposableEffect`, etc.)
+- No `NavController` in screen composables: navigation via lambdas
+- Preview annotations: light + dark mode minimum
+- All states handled: loading, content, error, empty
+- `Modifier.testTag` on key interactive elements
+- No unnecessary decomposition: extractions have a reason
+- File organization: screen, helpers, previews, from top to bottom
+
+# Shared Specialist Contract
+
+This is the delegated-worker subset of the full review-orchestrator contract. Orchestrators read the full `review-orchestrator.md`; delegated specialist subagents read this file instead.
+
+Do not reference this repo-relative path directly from installable skills — use the sibling symlink instead.
+
+## Shared Contract For Every Specialist
+
+- Review only changed code in the current PR or unit of work
+- Surface only meaningful issues such as bugs, logic flaws, security risks, regression risks, or architectural breakage
+- Flag newly introduced deprecated APIs or patterns when a supported alternative exists, or when deprecated usage is broad and unjustified
+- Ignore style-only nits, formatting preferences, and naming bikeshedding
+- Evidence is mandatory: include `file:line` and a short description
+- Include the user-visible or externally observable consequence for each finding
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Keep each specialist review pass to at most 7 findings
+- Include a minimal concrete fix for each finding
+
+## Shared Report Structure
+
+Section 1 summary must include `Review session ID: <review-session-id>`.
+Section 1 summary must include `Review run ID: <review-run-id>`.
+Section 1 summary must include `Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>`.
+Section 1 summary must include `Execution mode: inline | delegated`.
+Section 1 summary must include `Applied learnings: none | <learning references>`.
+
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
+
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
+
+After Section 1 in a stack-specific review skill, use:
+
+- `### 2. Risk Register`
+- `### 3. Action Items (Max 10, prioritized)`
+- `### 4. Verdict`
+
+Every finding in `### 2. Risk Register` must use this exact machine-readable bullet format:
+
+```text
+- [F-001] <Severity> | <Confidence> | <file:line> | <description>
+```
+
+Do NOT use markdown tables, numbered lists, or any other format for findings. The bullet format above is required for downstream tooling (triage, telemetry, stats) to parse findings correctly.
+
+- Severity must be one of: `Blocker`, `Major`, `Minor`
+- Confidence must be one of: `High`, `Medium`, `Low`
+- Finding ids must be unique within the current review run and stable enough for follow-up feedback or fix requests in the same workflow
+- Assign finding ids sequentially in risk-register order using `F-001`, `F-002`, `F-003`, and so on

--- a/platform-packs/kmp/code-review/bill-kmp-code-review/opencode-agents/bill-kmp-code-review-ux-accessibility.md
+++ b/platform-packs/kmp/code-review/bill-kmp-code-review/opencode-agents/bill-kmp-code-review-ux-accessibility.md
@@ -1,0 +1,95 @@
+---
+name: bill-kmp-code-review-ux-accessibility
+description: KMP UX and accessibility specialist code reviewer. Runs against user-facing UX states, accessibility semantics, screen-reader and keyboard usability, validation feedback, localization, and error/loading/empty state coverage. Returns a Risk Register in the F-XXX bullet format.
+mode: subagent
+---
+
+# UX And Accessibility Review Specialist
+
+Review only user-impacting UX/accessibility issues.
+
+## Focus
+
+- Broken or ambiguous UX states and recovery flows
+- Accessibility semantics, labels, focus order, and keyboard/talkback usability
+- Validation/error visibility and actionable feedback
+- Read-only/editable behavior mismatches
+- User-facing inconsistency with product intent
+
+## UI Delegation
+
+- If KMP UI files are in scope, run `bill-kmp-code-review-ui` and merge relevant findings.
+
+## Ignore
+
+- Pure visual preference debates without usability impact
+
+## Project-Specific Rules
+
+### Localization
+
+- All user-facing strings must use `stringResource(R.string.xxx)`: no hardcoded strings
+- Never delete existing translations or `strings.xml` files
+- Check for existing matching strings before creating new ones: reuse
+- When removing UI components, verify orphaned string resources are cleaned up
+
+### Previews
+
+- Screens and components must have `@Preview` annotations
+- Previews must use the project's theme composable
+
+### Error States
+
+- Screens must handle loading, content, error, and empty states
+- Error messages come from UI string resources, not ViewModel
+- In findings, make the user-visible accessibility or UX consequence explicit.
+
+# Shared Specialist Contract
+
+This is the delegated-worker subset of the full review-orchestrator contract. Orchestrators read the full `review-orchestrator.md`; delegated specialist subagents read this file instead.
+
+Do not reference this repo-relative path directly from installable skills — use the sibling symlink instead.
+
+## Shared Contract For Every Specialist
+
+- Review only changed code in the current PR or unit of work
+- Surface only meaningful issues such as bugs, logic flaws, security risks, regression risks, or architectural breakage
+- Flag newly introduced deprecated APIs or patterns when a supported alternative exists, or when deprecated usage is broad and unjustified
+- Ignore style-only nits, formatting preferences, and naming bikeshedding
+- Evidence is mandatory: include `file:line` and a short description
+- Include the user-visible or externally observable consequence for each finding
+- Severity: `Blocker | Major | Minor`
+- Confidence: `High | Medium | Low`
+- Keep each specialist review pass to at most 7 findings
+- Include a minimal concrete fix for each finding
+
+## Shared Report Structure
+
+Section 1 summary must include `Review session ID: <review-session-id>`.
+Section 1 summary must include `Review run ID: <review-run-id>`.
+Section 1 summary must include `Detected review scope: <staged changes / unstaged changes / working tree / commit range / PR diff / files>`.
+Section 1 summary must include `Execution mode: inline | delegated`.
+Section 1 summary must include `Applied learnings: none | <learning references>`.
+
+Generate one review session id per top-level review using the format `rvs-<uuid4>` (e.g. `rvs-550e8400-e29b-41d4-a716-446655440000`). If a parent reviewer already passed a `review_session_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same session id across the summary, parent-review handoff, and any learnings-resolution workflow for the current review lifecycle.
+
+Generate one review run id per concrete review output using the format `rvw-YYYYMMDD-HHMMSS-XXXX` where `XXXX` is a random 4-character alphanumeric suffix for uniqueness (e.g. `rvw-20260405-143022-b2e1`). If a parent reviewer already passed a `review_run_id` into a delegated or layered review, reuse it instead of generating a new one. Reuse that same run id across the summary, the risk register, and any parent-review handoff or follow-up feedback workflow for the current review output.
+
+After Section 1 in a stack-specific review skill, use:
+
+- `### 2. Risk Register`
+- `### 3. Action Items (Max 10, prioritized)`
+- `### 4. Verdict`
+
+Every finding in `### 2. Risk Register` must use this exact machine-readable bullet format:
+
+```text
+- [F-001] <Severity> | <Confidence> | <file:line> | <description>
+```
+
+Do NOT use markdown tables, numbered lists, or any other format for findings. The bullet format above is required for downstream tooling (triage, telemetry, stats) to parse findings correctly.
+
+- Severity must be one of: `Blocker`, `Major`, `Minor`
+- Confidence must be one of: `High`, `Medium`, `Low`
+- Finding ids must be unique within the current review run and stable enough for follow-up feedback or fix requests in the same workflow
+- Assign finding ids sequentially in risk-register order using `F-001`, `F-002`, `F-003`, and so on

--- a/skill_bill/__main__.py
+++ b/skill_bill/__main__.py
@@ -18,6 +18,8 @@ def install_main(argv: list[str]) -> int:
   subcommands.add_parser("detect-agents")
   subcommands.add_parser("codex-agents-path")
   subcommands.add_parser("detect-codex-agents")
+  subcommands.add_parser("opencode-agents-path")
+  subcommands.add_parser("detect-opencode-agents")
 
   link_skill = subcommands.add_parser("link-skill")
   link_skill.add_argument("--source", required=True)
@@ -29,6 +31,12 @@ def install_main(argv: list[str]) -> int:
 
   unlink_codex_agents = subcommands.add_parser("unlink-codex-agents")
   unlink_codex_agents.add_argument("--platform-packs", required=True)
+
+  link_opencode_agents = subcommands.add_parser("link-opencode-agents")
+  link_opencode_agents.add_argument("--platform-packs", required=True)
+
+  unlink_opencode_agents = subcommands.add_parser("unlink-opencode-agents")
+  unlink_opencode_agents.add_argument("--platform-packs", required=True)
 
   args = parser.parse_args(argv)
   if args.command == "agent-path":
@@ -49,6 +57,14 @@ def install_main(argv: list[str]) -> int:
     if target is not None:
       print(f"{target.name}\t{target.path}")
     return 0
+  if args.command == "opencode-agents-path":
+    print(install.opencode_agents_path())
+    return 0
+  if args.command == "detect-opencode-agents":
+    target = install.detect_opencode_agents_target()
+    if target is not None:
+      print(f"{target.name}\t{target.path}")
+    return 0
   if args.command == "link-skill":
     install.install_skill(
       Path(args.source),
@@ -65,6 +81,17 @@ def install_main(argv: list[str]) -> int:
     return 0
   if args.command == "unlink-codex-agents":
     install.uninstall_codex_agent_tomls(Path(args.platform_packs))
+    return 0
+  if args.command == "link-opencode-agents":
+    target = install.detect_opencode_agents_target()
+    if target is None:
+      return 0
+    md_files = install.discover_opencode_agent_mds(Path(args.platform_packs))
+    for md_file in md_files:
+      install.install_opencode_agent_md(md_file, target)
+    return 0
+  if args.command == "unlink-opencode-agents":
+    install.uninstall_opencode_agent_mds(Path(args.platform_packs))
     return 0
   parser.error("Unknown install command.")
   return 2

--- a/skill_bill/install.py
+++ b/skill_bill/install.py
@@ -12,7 +12,8 @@ Supported agents (mirrors ``install.sh::get_agent_path``):
 - ``copilot``  -> ``~/.copilot/skills``
 - ``claude``   -> ``~/.claude/commands``
 - ``glm``      -> ``~/.glm/commands``
-- ``opencode`` -> ``~/.config/opencode/skills``
+- ``opencode`` -> ``~/.config/opencode/skills``;
+   ``~/.config/opencode/agents`` for OpenCode markdown subagents
 - ``codex``    -> ``~/.codex/skills`` with ``~/.agents/skills`` fallback (skills);
    ``~/.codex/agents`` with ``~/.agents/agents`` fallback (TOML subagents)
 """
@@ -34,6 +35,7 @@ SUPPORTED_AGENTS: tuple[str, ...] = (
 
 
 CODEX_AGENTS_KIND: str = "codex-agents"
+OPENCODE_AGENTS_KIND: str = "opencode-agents"
 
 
 @dataclass(frozen=True)
@@ -93,6 +95,11 @@ def _codex_agents_path(home: Path) -> Path:
   return home / ".agents" / "agents"
 
 
+def _opencode_agents_path(home: Path) -> Path:
+  """Resolve the OpenCode native markdown subagents directory."""
+  return home / ".config" / "opencode" / "agents"
+
+
 def agent_paths(home: Path | None = None) -> dict[str, Path]:
   """Return the canonical agent -> install-directory mapping.
 
@@ -117,6 +124,12 @@ def codex_agents_path(home: Path | None = None) -> Path:
   """Public accessor for the resolved Codex agents TOML directory."""
   resolved_home = home if home is not None else Path.home()
   return _codex_agents_path(resolved_home)
+
+
+def opencode_agents_path(home: Path | None = None) -> Path:
+  """Public accessor for the resolved OpenCode agents markdown directory."""
+  resolved_home = home if home is not None else Path.home()
+  return _opencode_agents_path(resolved_home)
 
 
 def detect_agents(home: Path | None = None) -> list[AgentTarget]:
@@ -148,6 +161,15 @@ def detect_codex_agents_target(home: Path | None = None) -> AgentTarget | None:
   agents_dir = _codex_agents_path(resolved_home)
   if _agent_is_present(resolved_home, "codex", agents_dir):
     return AgentTarget(name=CODEX_AGENTS_KIND, path=agents_dir)
+  return None
+
+
+def detect_opencode_agents_target(home: Path | None = None) -> AgentTarget | None:
+  """Return the OpenCode agents-directory target when OpenCode is detected."""
+  resolved_home = home if home is not None else Path.home()
+  agents_dir = _opencode_agents_path(resolved_home)
+  if _agent_is_present(resolved_home, "opencode", agents_dir):
+    return AgentTarget(name=OPENCODE_AGENTS_KIND, path=agents_dir)
   return None
 
 
@@ -258,6 +280,23 @@ def discover_codex_agent_tomls(platform_packs_root: Path) -> list[Path]:
   return sorted(results)
 
 
+def discover_opencode_agent_mds(platform_packs_root: Path) -> list[Path]:
+  """Return every ``opencode-agents/*.md`` under ``platform-packs/``.
+
+  Manifest-driven: walks ``platform-packs/<slug>/**/opencode-agents/*.md``
+  rather than hardcoding any particular pack slug, so future packs that
+  ship native OpenCode subagent definitions are picked up automatically.
+  """
+  root = Path(platform_packs_root)
+  if not root.is_dir():
+    return []
+  results: list[Path] = []
+  for md_file in root.rglob("opencode-agents/*.md"):
+    if md_file.is_file():
+      results.append(md_file.resolve())
+  return sorted(results)
+
+
 def install_codex_agent_toml(
   toml_path: Path,
   agent_target: AgentTarget,
@@ -279,6 +318,32 @@ def install_codex_agent_toml(
   if link_path.is_symlink() or link_path.exists():
     link_path.unlink()
   link_path.symlink_to(toml_path)
+  if transaction is not None:
+    transaction.created_symlinks.append(link_path)
+  return link_path
+
+
+def install_opencode_agent_md(
+  md_path: Path,
+  agent_target: AgentTarget,
+  *,
+  transaction: InstallTransaction | None = None,
+) -> Path | None:
+  """Symlink a single markdown subagent file into the OpenCode agents directory.
+
+  Returns the created symlink path, or ``None`` when the existing symlink
+  already points at the same source.
+  """
+  md_path = Path(md_path).resolve()
+  if not md_path.is_file():
+    raise FileNotFoundError(f"Markdown file '{md_path}' does not exist.")
+  agent_target.path.mkdir(parents=True, exist_ok=True)
+  link_path = agent_target.path / md_path.name
+  if link_path.is_symlink() and link_path.resolve(strict=False) == md_path:
+    return None
+  if link_path.is_symlink() or link_path.exists():
+    link_path.unlink()
+  link_path.symlink_to(md_path)
   if transaction is not None:
     transaction.created_symlinks.append(link_path)
   return link_path
@@ -319,6 +384,36 @@ def uninstall_codex_agent_tomls(
   return removed
 
 
+def uninstall_opencode_agent_mds(
+  platform_packs_root: Path,
+  home: Path | None = None,
+) -> list[Path]:
+  """Remove every OpenCode markdown-agent symlink from the agents dir.
+
+  Iterates through the manifest-driven list of authored markdown filenames and
+  removes any matching symlink in ``~/.config/opencode/agents``. Idempotent:
+  missing or non-symlink entries are silently skipped.
+  """
+  resolved_home = home if home is not None else Path.home()
+  md_files = discover_opencode_agent_mds(platform_packs_root)
+  if not md_files:
+    return []
+  agents_dir = _opencode_agents_path(resolved_home)
+  removed: list[Path] = []
+  for md_path in md_files:
+    link_path = agents_dir / md_path.name
+    if not link_path.is_symlink():
+      continue
+    try:
+      if link_path.resolve(strict=False) != md_path:
+        continue
+    except OSError:
+      continue
+    link_path.unlink()
+    removed.append(link_path)
+  return removed
+
+
 def uninstall_targets(created_symlinks: Iterable[Path]) -> list[Path]:
   """Remove the exact symlinks recorded in an :class:`InstallTransaction`.
 
@@ -339,15 +434,22 @@ __all__ = [
   "AgentTarget",
   "CODEX_AGENTS_KIND",
   "InstallTransaction",
+  "OPENCODE_AGENTS_KIND",
   "SUPPORTED_AGENTS",
+  "_opencode_agents_path",
   "agent_paths",
   "codex_agents_path",
   "detect_agents",
   "detect_codex_agents_target",
+  "detect_opencode_agents_target",
   "discover_codex_agent_tomls",
+  "discover_opencode_agent_mds",
   "install_codex_agent_toml",
+  "install_opencode_agent_md",
   "install_skill",
+  "opencode_agents_path",
   "uninstall_codex_agent_tomls",
+  "uninstall_opencode_agent_mds",
   "uninstall_skill",
   "uninstall_targets",
 ]

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -420,6 +420,7 @@ class InstallScriptTest(unittest.TestCase):
       ".codex",
       ".codex/agents",
       ".config/opencode",
+      ".config/opencode/agents",
     ):
       (Path(temp_home) / relative_dir).mkdir(parents=True, exist_ok=True)
 
@@ -448,6 +449,32 @@ class InstallScriptTest(unittest.TestCase):
         link_path = agents_dir / toml_name
         self.assertTrue(link_path.is_symlink(), f"{link_path} should be a symlink")
         self.assertEqual(link_path.resolve(), pack_root / toml_name)
+
+  def test_install_links_opencode_native_subagent_markdown(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      result = self.run_installer(temp_home, "opencode\nKMP\n")
+      self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+      agents_dir = Path(temp_home) / ".config" / "opencode" / "agents"
+      self.assertTrue(agents_dir.is_dir(), agents_dir)
+
+      pilot_mds = (
+        "bill-kmp-code-review-ui.md",
+        "bill-kmp-code-review-ux-accessibility.md",
+      )
+      pack_root = (
+        ROOT
+        / "platform-packs"
+        / "kmp"
+        / "code-review"
+        / "bill-kmp-code-review"
+        / "opencode-agents"
+      )
+      for md_name in pilot_mds:
+        link_path = agents_dir / md_name
+        self.assertTrue(link_path.is_symlink(), f"{link_path} should be a symlink")
+        self.assertEqual(link_path.resolve(), pack_root / md_name)
 
   def telemetry_config(self, config_path: Path) -> dict[str, object]:
     return json.loads(config_path.read_text(encoding="utf-8"))

--- a/tests/test_opencode_agents_md.py
+++ b/tests/test_opencode_agents_md.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLATFORM_PACKS_DIR = ROOT / "platform-packs"
+
+REQUIRED_FRONTMATTER_FIELDS: tuple[str, ...] = ("description", "mode")
+
+CLAUDE_ONLY_FORBIDDEN: tuple[str, ...] = (
+  "Agent(subagent_type=",
+  "subagent_type=",
+  "@agent-",
+)
+
+
+def discover_opencode_agent_mds() -> list[Path]:
+  if not PLATFORM_PACKS_DIR.is_dir():
+    return []
+  return sorted(PLATFORM_PACKS_DIR.rglob("opencode-agents/*.md"))
+
+
+def parse_frontmatter(markdown: str, path: Path) -> tuple[dict[str, str], str]:
+  lines = markdown.splitlines()
+  if not lines or lines[0] != "---":
+    return {}, markdown
+
+  end_index: int | None = None
+  for index, line in enumerate(lines[1:], start=1):
+    if line == "---":
+      end_index = index
+      break
+  if end_index is None:
+    raise AssertionError(f"Unclosed frontmatter in {path}")
+
+  frontmatter: dict[str, str] = {}
+  for line in lines[1:end_index]:
+    if not line.strip() or line.lstrip().startswith("#"):
+      continue
+    if ":" not in line:
+      raise AssertionError(f"Invalid frontmatter line in {path}: {line}")
+    key, value = line.split(":", 1)
+    frontmatter[key.strip()] = value.strip().strip('"').strip("'")
+  body = "\n".join(lines[end_index + 1 :])
+  return frontmatter, body
+
+
+class OpenCodeAgentsMdTest(unittest.TestCase):
+  maxDiff = None
+
+  def setUp(self) -> None:
+    self.md_paths = discover_opencode_agent_mds()
+    self.assertGreater(
+      len(self.md_paths),
+      0,
+      "Expected at least one platform-packs/**/opencode-agents/*.md file",
+    )
+
+  def test_each_markdown_agent_has_required_frontmatter_and_body(self) -> None:
+    for md_path in self.md_paths:
+      with self.subTest(markdown=str(md_path.relative_to(ROOT))):
+        frontmatter, body = parse_frontmatter(md_path.read_text(encoding="utf-8"), md_path)
+        for field in REQUIRED_FRONTMATTER_FIELDS:
+          self.assertIn(field, frontmatter, f"missing field '{field}' in {md_path}")
+          self.assertTrue(frontmatter[field].strip(), f"field '{field}' must be non-empty in {md_path}")
+        self.assertEqual(frontmatter["mode"], "subagent")
+        self.assertTrue(body.strip(), f"markdown body must be non-empty in {md_path}")
+
+  def test_optional_name_frontmatter_matches_filename_stem(self) -> None:
+    for md_path in self.md_paths:
+      with self.subTest(markdown=str(md_path.relative_to(ROOT))):
+        frontmatter, _ = parse_frontmatter(md_path.read_text(encoding="utf-8"), md_path)
+        if "name" in frontmatter:
+          self.assertEqual(
+            frontmatter["name"],
+            md_path.stem,
+            f"name field must match filename stem for {md_path}",
+          )
+
+  def test_agent_names_are_unique_across_markdown_agents(self) -> None:
+    seen: dict[str, Path] = {}
+    for md_path in self.md_paths:
+      frontmatter, _ = parse_frontmatter(md_path.read_text(encoding="utf-8"), md_path)
+      name = frontmatter.get("name", md_path.stem)
+      if name in seen:
+        self.fail(
+          f"Duplicate OpenCode agent name '{name}' in {md_path} and {seen[name]}",
+        )
+      seen[name] = md_path
+
+  def test_markdown_agents_have_no_claude_only_references(self) -> None:
+    for md_path in self.md_paths:
+      with self.subTest(markdown=str(md_path.relative_to(ROOT))):
+        content = md_path.read_text(encoding="utf-8")
+        for forbidden in CLAUDE_ONLY_FORBIDDEN:
+          self.assertNotIn(
+            forbidden,
+            content,
+            f"{md_path} must not contain Claude-only token '{forbidden}'",
+          )
+
+  def test_markdown_agents_inline_specialist_contract(self) -> None:
+    required_markers = (
+      "Shared Contract For Every Specialist",
+      "Shared Report Structure",
+      "[F-001]",
+    )
+    for md_path in self.md_paths:
+      with self.subTest(markdown=str(md_path.relative_to(ROOT))):
+        content = md_path.read_text(encoding="utf-8")
+        for marker in required_markers:
+          self.assertIn(
+            marker,
+            content,
+            f"{md_path} must inline F-XXX contract marker '{marker}'",
+          )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1223,7 +1223,7 @@ class ScaffolderOwnedSectionsIdenticalTest(unittest.TestCase):
 
 
 class AgentDetectionTest(unittest.TestCase):
-  """Exercise :func:`detect_agents` with 0 / 1 / all five agent dirs present."""
+  """Exercise normal skill-target and explicit native subagent detection."""
 
   def setUp(self) -> None:
     self._tmpdir = tempfile.TemporaryDirectory()
@@ -1238,6 +1238,29 @@ class AgentDetectionTest(unittest.TestCase):
     (self.fake_home / ".claude").mkdir()
     detected = install_module.detect_agents(home=self.fake_home)
     self.assertEqual([target.name for target in detected], ["claude"])
+
+  def test_opencode_detect_agents_returns_only_skill_target(self) -> None:
+    (self.fake_home / ".config/opencode").mkdir(parents=True)
+    detected = install_module.detect_agents(home=self.fake_home)
+    self.assertEqual(
+      detected,
+      [
+        AgentTarget(
+          name="opencode",
+          path=self.fake_home / ".config" / "opencode" / "skills",
+        ),
+      ],
+    )
+
+  def test_opencode_agents_target_detected_explicitly(self) -> None:
+    (self.fake_home / ".config/opencode").mkdir(parents=True)
+    self.assertEqual(
+      install_module.detect_opencode_agents_target(home=self.fake_home),
+      AgentTarget(
+        name=install_module.OPENCODE_AGENTS_KIND,
+        path=self.fake_home / ".config" / "opencode" / "agents",
+      ),
+    )
 
   def test_all_five_agents_detected(self) -> None:
     for subdir in (".copilot", ".claude", ".glm", ".codex", ".config/opencode"):

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -107,6 +107,7 @@ class UninstallScriptTest(unittest.TestCase):
       ".agents/skills",
       ".agents/agents",
       ".config/opencode/skills",
+      ".config/opencode/agents",
     ):
       (Path(temp_home) / relative_dir).mkdir(parents=True, exist_ok=True)
 
@@ -135,6 +136,36 @@ class UninstallScriptTest(unittest.TestCase):
           link_path = parent / toml_name
           link_path.symlink_to(pack_root / toml_name)
           seeded_links.append(link_path)
+
+      uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
+      self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)
+
+      for link_path in seeded_links:
+        self.assertFalse(link_path.exists(), f"{link_path} should have been removed")
+        self.assertFalse(link_path.is_symlink(), f"{link_path} should have been unlinked")
+
+  def test_uninstall_removes_opencode_native_subagent_markdown(self) -> None:
+    with tempfile.TemporaryDirectory() as temp_home:
+      self.prepare_agent_homes(temp_home)
+      pack_root = (
+        ROOT
+        / "platform-packs"
+        / "kmp"
+        / "code-review"
+        / "bill-kmp-code-review"
+        / "opencode-agents"
+      )
+      pilot_mds = (
+        "bill-kmp-code-review-ui.md",
+        "bill-kmp-code-review-ux-accessibility.md",
+      )
+
+      seeded_links: list[Path] = []
+      parent = Path(temp_home) / ".config" / "opencode" / "agents"
+      for md_name in pilot_mds:
+        link_path = parent / md_name
+        link_path.symlink_to(pack_root / md_name)
+        seeded_links.append(link_path)
 
       uninstall = self.run_script(UNINSTALL_SCRIPT, temp_home)
       self.assertEqual(uninstall.returncode, 0, uninstall.stdout + uninstall.stderr)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -289,6 +289,38 @@ remove_codex_agents_tomls() {
 info "Removing Codex subagent TOML installs."
 remove_codex_agents_tomls
 
+remove_opencode_agent_mds() {
+  # Uninstall OpenCode native subagent markdown symlinks from
+  # ~/.config/opencode/agents. Manifest-driven: walks
+  # platform-packs/<slug>/**/opencode-agents/*.md and removes any matching
+  # filename in the OpenCode agents directory. Idempotent.
+  local python_cmd
+  if python_cmd="$(command -v python3 2>/dev/null)"; then
+    if "$python_cmd" -m skill_bill install unlink-opencode-agents \
+      --platform-packs "$PLATFORM_PACKS_DIR" 2>/dev/null; then
+      ok "  OpenCode subagent markdown removed via skill_bill"
+      return 0
+    fi
+  fi
+
+  local md_file link_path target_dir
+  target_dir="$HOME/.config/opencode/agents"
+  shopt -s nullglob globstar
+  for md_file in "$PLATFORM_PACKS_DIR"/**/opencode-agents/*.md; do
+    [[ -f "$md_file" ]] || continue
+    link_path="$target_dir/$(basename "$md_file")"
+    if [[ -L "$link_path" ]]; then
+      rm -f "$link_path"
+      REMOVED_TARGETS+=("$link_path")
+      ok "  removed $(basename "$link_path")"
+    fi
+  done
+  shopt -u nullglob globstar
+}
+
+info "Removing OpenCode subagent markdown installs."
+remove_opencode_agent_mds
+
 info "Removing MCP server registrations."
 unregister_mcp_json "$HOME/.claude.json" "claude"
 unregister_mcp_json "$HOME/.copilot/mcp-config.json" "copilot"


### PR DESCRIPTION
# Summary

Adds OpenCode native subagent support for the KMP code-review pilot, mirroring the Codex native subagent pattern from SKILL-33. This gives OpenCode a dedicated markdown-agent install surface while keeping normal OpenCode skills under the existing skills path.

- Adds OpenCode agent install/uninstall primitives, CLI commands, and install/uninstall shell wiring.
- Ships OpenCode markdown subagents for the two KMP code-review specialists with the shared F-XXX risk-register contract inlined.
- Documents Codex and OpenCode native subagents together and records boundary history for future runtime integrations.
- Adds install, uninstall, markdown-agent, and explicit OpenCode agents-target detection coverage.

## Feature Flags

N/A

# How Has This Been Tested?

Full validation gate passed:

1. `.venv/bin/python3 -m unittest discover -s tests`
2. `(cd runtime-kotlin && ./gradlew check)`
3. `npx --yes agnix --strict .`
4. `.venv/bin/python3 scripts/validate_agent_configs.py`

Focused checks also passed during implementation/review:

1. `.venv/bin/python3 -m unittest tests.test_install_script tests.test_uninstall_script tests.test_opencode_agents_md`
2. `.venv/bin/python3 -m unittest tests.test_scaffold.AgentDetectionTest`
