### PR TITLE
[codex] finalize SKILL-33/34 specs

### DIFF
--- a/.feature-specs/SKILL-33-codex-native-subagents/spec.md
+++ b/.feature-specs/SKILL-33-codex-native-subagents/spec.md
@@ -1,8 +1,9 @@
 # Codex native subagent support (Phase 1: foundation + pilot)
 
 - Issue key: SKILL-33
-- Status: In Progress
+- Status: Complete
 - Date: 2026-05-02
+- Implementation: PR #91
 - Sources:
   - User request: "are we using native subagents for codex?" → "lets support proper coded subagents"
   - User decision: pilot with `bill-kmp-code-review` first, defer feature-implement and other orchestrators to follow-up issues

--- a/.feature-specs/SKILL-33-followups/spec_followup_1_opencode-native-subagents.md
+++ b/.feature-specs/SKILL-33-followups/spec_followup_1_opencode-native-subagents.md
@@ -1,9 +1,10 @@
 # OpenCode native subagent support (Phase 1 pilot)
 
-- Issue key: TBD (file as a Linear issue and rename this directory when assigned)
-- Status: Draft
+- Issue key: SKILL-33
+- Status: Complete
 - Date: 2026-05-02
 - Parent: SKILL-33 (Codex native subagent support — shipped in PR #91)
+- Implementation: PR #92
 - Sources:
   - Discovery during SKILL-33 follow-up review on 2026-05-02 — OpenCode is the second skill-bill-supported agent that has a native subagent feature with no current integration.
   - OpenCode docs: subagent definitions live in the OpenCode user agents directory (global) and the OpenCode project agents directory (per-project), as either markdown files (filename becomes agent name) or JSON entries under an `"agent"` key in `opencode.json`. Subagents can be invoked automatically by primary agents or manually by `@<name>` mention. Subagents create child sessions with their own context.

--- a/.feature-specs/SKILL-33-followups/spec_followup_2_kotlin-review-and-feature-verify.md
+++ b/.feature-specs/SKILL-33-followups/spec_followup_2_kotlin-review-and-feature-verify.md
@@ -1,0 +1,71 @@
+# Multi-runtime subagents for bill-kotlin-code-review and bill-feature-verify
+
+- Issue key: SKILL-33
+- Status: Complete
+- Date: 2026-05-02
+- Parent: SKILL-33 (Codex pilot) and follow-up 1 (OpenCode pilot)
+- Implementation: PR #93
+- Verification: `.feature-specs/SKILL-33-multi-runtime-subagents-kotlin-review-feature-verify/spec.md`
+- Sources:
+  - SKILL-33 spec, non-goals: "Codex subagent support for `bill-kotlin-code-review`, `bill-feature-verify`, `bill-feature-implement`, or any other orchestrator skill — separate follow-up issues."
+  - The pilot established install primitive + authoring conventions for Codex (SKILL-33) and (after follow-up 1) for OpenCode. This issue spreads that pattern to the next two orchestrators.
+
+## Background
+
+`bill-kmp-code-review` was the SKILL-33 pilot because it has a small specialist surface (2 KMP-specific specialists). `bill-kotlin-code-review` is the larger sibling: it spawns 7+ specialist subagents (architecture, correctness, security, performance, testing, reliability, persistence, api-contracts, platform-correctness — exact count to be confirmed at pre-planning). `bill-feature-verify` is review-shaped and reuses similar specialist delegation against the verify-specific contract.
+
+Both orchestrators today degrade on Codex/OpenCode the same way the KMP review did before SKILL-33: serialized into the parent thread, no per-specialist context budget, no parallelism. This issue authors the missing TOML (Codex) and markdown (OpenCode) subagent definitions for both orchestrators and verifies the prose is runtime-neutral.
+
+This issue depends on SKILL-33 (Codex install primitive) and follow-up 1 (OpenCode install primitive) — both must be merged before this can ship.
+
+## Acceptance criteria
+
+1. `bill-kotlin-code-review` ships Codex TOML + OpenCode markdown subagent definitions for every specialist it delegates to. Files live under `platform-packs/kotlin/code-review/bill-kotlin-code-review/codex-agents/*.toml` and `.../opencode-agents/*.md`. Each file is valid for its runtime (required fields, name matches filename) and embeds the F-XXX Risk Register bullet contract inlined verbatim from `specialist-contract.md`.
+2. `bill-kotlin-code-review`'s orchestrator content (`platform-packs/kotlin/code-review/bill-kotlin-code-review/content.md`) is verified runtime-neutral re: spawn instructions; missing native-subagent runtime notes are appended in the same shape SKILL-33 used.
+3. `bill-feature-verify` ships Codex TOML + OpenCode markdown subagent definitions for every specialist it delegates to (verify-specific specialists, distinct from review specialists). Files live under the analogous `codex-agents/` and `opencode-agents/` directories within the verify skill's repo location.
+4. `bill-feature-verify`'s orchestrator content is verified runtime-neutral with subagent-runtime notes appended.
+5. Specialist fan-out for both orchestrators is documented and chunked if it exceeds Codex's `max_threads = 6` (or OpenCode's documented limit). The Kotlin review with 7+ specialists almost certainly requires explicit chunking — this AC is the gate that proves the prose handles it correctly.
+6. Existing TOML and markdown validity tests (introduced in SKILL-33 / follow-up 1) automatically cover the new files via their manifest-driven walks. No new test scaffolding is required, but the assertions must continue to pass on the expanded set.
+7. User-facing docs are updated to list the orchestrators that now have native-subagent coverage.
+8. `agent/history.md` is updated per `bill-boundary-history` rules.
+
+## Non-goals
+
+- Codex/OpenCode subagent support for `bill-feature-implement` (follow-up 3).
+- Bill-create-skill scaffolding (follow-up 4).
+- Restructuring the specialist taxonomy or rewriting any specialist prompt logic. The TOML/markdown files are derived from existing `content.md` + `specialist-contract.md`; they should not introduce new review heuristics.
+- Re-running the SKILL-33 install-primitive work — that primitive is already in place.
+
+## Open questions
+
+1. Confirm exact count and names of `bill-kotlin-code-review`'s specialists at pre-planning. The repo currently has skill directories for: `bill-kotlin-code-review-architecture`, `-correctness` (or `-platform-correctness`), `-security`, `-performance`, `-testing`, `-reliability`, `-persistence`, `-api-contracts`. Pre-planning must enumerate the actual delegated set from `content.md`.
+2. Does `bill-feature-verify` delegate to the same specialist set as `bill-kotlin-code-review`, or a verify-specific subset? Pre-planning must read the verify orchestrator's content and enumerate.
+3. If a specialist already has a Codex TOML from SKILL-33 (the 2 KMP specialists), this issue must NOT duplicate it. Pre-planning verifies the specialist roster does not overlap.
+
+## Consolidated spec
+
+### Codex TOML authoring
+
+For each specialist `bill-kotlin-code-review` delegates to, author a TOML file at the orchestrator-local `codex-agents/` directory. Required fields per SKILL-33: `name`, `description`, `developer_instructions`. The `developer_instructions` block sources the specialist's existing `content.md` and inlines the F-XXX contract from `specialist-contract.md` verbatim.
+
+Repeat for `bill-feature-verify`'s specialists.
+
+### OpenCode markdown authoring
+
+For each specialist, author a markdown file at the orchestrator-local `opencode-agents/` directory. Filename = OpenCode agent name. Body = the same content as the Codex TOML's `developer_instructions`, with frontmatter only as required by OpenCode (resolved by follow-up 1's open question).
+
+### Orchestrator prose verification
+
+Read each orchestrator's `content.md`. If the runtime-neutral spawn language and native-subagent notes from SKILL-33 are missing, append them. Add the explicit fan-out chunking statement required by AC #5 if the specialist count exceeds the known concurrency ceiling.
+
+### Tests
+
+The validity tests added in SKILL-33 (`tests/test_codex_agents_toml.py`) and follow-up 1 (`tests/test_opencode_agents_md.py`) use manifest-driven walks (`platform-packs/**/codex-agents/*.toml`, etc.) and will automatically cover the new files. Verify they continue to pass after the new files are added. No new test files are required.
+
+### Documentation
+
+Add the two orchestrators to whichever docs page enumerates which orchestrators have native-subagent coverage on which runtimes. Keep the wording mechanical so the matrix is easy to update as more orchestrators ship.
+
+### Boundary history
+
+Append a single entry covering both orchestrators. Cite SKILL-33 and follow-up 1 as the install-primitive precedents and reference the parent install-primitive entry rather than duplicating its content.

--- a/.feature-specs/SKILL-33-followups/spec_followup_3_feature-implement-multi-runtime.md
+++ b/.feature-specs/SKILL-33-followups/spec_followup_3_feature-implement-multi-runtime.md
@@ -1,9 +1,11 @@
 # Multi-runtime subagents for bill-feature-implement
 
-- Issue key: TBD (file as a Linear issue and rename when assigned)
-- Status: Draft
+- Issue key: SKILL-33
+- Status: Complete
 - Date: 2026-05-02
 - Parent: SKILL-33 (install primitive) and follow-ups 1–2
+- Implementation: PR #94 (foundation + authoring), PR #95 (validation)
+- Verification: `.feature-specs/SKILL-33-multi-runtime-subagents-feature-implement/smoke_test_results.md`
 - Sources:
   - SKILL-33 spec, non-goals: bill-feature-implement is named as "the hardest" — sequential phases and structured-return parsing are load-bearing.
   - bill-feature-implement reference contract in the user's Claude command directory — defines the per-phase briefing templates and `RESULT: { … }` JSON return contracts for pre-planning, planning, implementation, completeness audit, quality-check, and PR-description subagents.

--- a/.feature-specs/SKILL-33-followups/spec_followup_4_create-skill-scaffolds-subagents.md
+++ b/.feature-specs/SKILL-33-followups/spec_followup_4_create-skill-scaffolds-subagents.md
@@ -1,0 +1,75 @@
+# bill-create-skill emits subagent defs for Codex and OpenCode
+
+- Issue key: SKILL-33
+- Status: Complete
+- Date: 2026-05-02
+- Parent: SKILL-33 (Codex install primitive) and follow-ups 1–3
+- Implementation: PR #96
+- Sources:
+  - SKILL-33 spec, non-goals: "Scaffolding subagent TOML files from `bill-create-skill` — separate follow-up issue."
+  - The `bill-create-skill` skill scaffolds new orchestrator skills today. After this issue, it also emits the matching Codex TOML and OpenCode markdown subagent definitions so authors don't have to add them by hand.
+
+## Background
+
+Once Codex and OpenCode subagents exist as first-class artifacts in skill-bill (via SKILL-33 and follow-ups 1–3), the natural next step is for `bill-create-skill` to emit them automatically when scaffolding a new orchestrator skill. Today the scaffolder produces `SKILL.md`, `content.md`, and supporting files; it does not produce subagent definitions.
+
+This issue updates the scaffolder so a single `bill-create-skill` run produces a skill that ships natively on Claude, Codex, and OpenCode out of the box.
+
+This issue depends on SKILL-33 + follow-ups 1–3 because the scaffolder must know:
+
+1. The repo conventions for where TOML and markdown subagent files live (`<skill-dir>/codex-agents/`, `<skill-dir>/opencode-agents/`).
+2. The required field set for each format (Codex TOML: `name`, `description`, `developer_instructions`; OpenCode markdown: depends on follow-up 1's open-question resolution).
+3. The runtime-neutral orchestrator-prose conventions established in SKILL-33's "Subagent Spawn Runtime Notes" section.
+
+## Acceptance criteria
+
+1. `bill-create-skill`, when scaffolding a new orchestrator skill that delegates to specialist subagents, prompts the author for the specialist names (or accepts them as an argument) and emits one Codex TOML stub and one OpenCode markdown stub per specialist.
+2. Each emitted Codex TOML stub contains the required fields (`name`, `description` placeholder, `developer_instructions` placeholder) and includes a commented pointer to the specialist-contract pattern (where to inline the F-XXX Risk Register bullet contract).
+3. Each emitted OpenCode markdown stub contains the conventions resolved by follow-up 1 (frontmatter if required, body placeholder, F-XXX contract pointer).
+4. The scaffolder updates the orchestrator's `content.md` to include the runtime-neutral "Subagent Spawn Runtime Notes" section verbatim from SKILL-33's pattern, with the orchestrator's specialist names substituted in.
+5. The scaffolder verifies that the emitted files satisfy the manifest-driven discovery (i.e. they land under `<skill-dir>/codex-agents/*.toml` and `<skill-dir>/opencode-agents/*.md` so the install primitive picks them up automatically).
+6. Scaffolder tests are extended (`tests/test_scaffold.py`) to assert that a scaffolded orchestrator skill emits the expected subagent files for both runtimes, with valid contents that pass the existing `tests/test_codex_agents_toml.py` and `tests/test_opencode_agents_md.py` checks.
+7. User-facing scaffolder docs are updated to describe the new prompts/arguments and the expected output structure.
+8. `agent/history.md` is updated per `bill-boundary-history` rules.
+
+## Non-goals
+
+- Generating subagent definitions for SPECIALIST skills (the leaves) — only the orchestrators that delegate to them. Specialist skills already have their own `SKILL.md` + `content.md`; the scaffolder copies their content into the parent orchestrator's TOML/markdown when needed.
+- Backfilling subagent definitions for orchestrators that already exist (the existing orchestrators get their subagent definitions via SKILL-33 + follow-ups 1–3, not via re-running the scaffolder).
+- Inferring specialist names automatically from the orchestrator's `content.md`. The author supplies them; the scaffolder does not parse prose to discover delegation.
+
+## Open questions
+
+1. Should the scaffolder emit Codex + OpenCode files unconditionally, or only when the user opts in? Default proposal: unconditional, since shipping subagent definitions is now the expected baseline for orchestrator skills. Make it suppressible with a `--no-subagents` flag for cases where the author wants to author them by hand.
+2. Where in the scaffolder's interactive flow should specialist-name collection live? Proposal: a single comma-separated prompt after the skill description, with a sane default of "(none — this is a leaf skill, no subagents emitted)" when the author confirms the skill does not delegate.
+
+## Consolidated spec
+
+### Scaffolder changes
+
+Read the current scaffolder implementation (likely in `skill_bill/` or `runtime-kotlin/`) at pre-planning time. The change-set is:
+
+- Add a specialist-collection step (interactive prompt or CLI argument).
+- For each specialist, emit a Codex TOML stub at `<skill-dir>/codex-agents/<specialist-name>.toml` with required fields filled in as placeholders.
+- For each specialist, emit an OpenCode markdown stub at `<skill-dir>/opencode-agents/<specialist-name>.md` with placeholders.
+- Inject the runtime-neutral "Subagent Spawn Runtime Notes" section into the new orchestrator's `content.md` with the specialist names listed.
+
+### Stub contents
+
+Stubs must be valid enough to pass the existing TOML/markdown validity tests (parseable, required fields present, name = filename) but ship with placeholder bodies that clearly indicate "fill this in." Authors must NOT be expected to ship a scaffolded orchestrator without filling the stubs in; the scaffolder prints a clear next-step message after generation.
+
+### Tests
+
+Extend `tests/test_scaffold.py` to:
+
+- Run the scaffolder against a synthetic orchestrator with two specialists.
+- Assert that the expected files are created at the expected paths.
+- Assert that each emitted file passes the existing validity tests (`tests/test_codex_agents_toml.py` and `tests/test_opencode_agents_md.py` rules — invoke the same assertion logic, do not duplicate it).
+
+### Documentation
+
+Update `bill-create-skill`'s `content.md` (or `SKILL.md` if that's the authored surface) to describe the new prompts, the new files emitted, and the expected next steps (filling in the stubs).
+
+### Boundary history
+
+Append a single entry citing SKILL-33 + follow-ups 1–3 as the install-primitive and authoring-convention precedents that this scaffolder change builds on.

--- a/.feature-specs/SKILL-33-multi-runtime-subagents-feature-implement/smoke_test_results.md
+++ b/.feature-specs/SKILL-33-multi-runtime-subagents-feature-implement/smoke_test_results.md
@@ -109,3 +109,7 @@ Posture (chosen for AC6):
 ## Conclusion
 
 Smoke test passes. All 14 native subagent definitions install correctly under both Codex and OpenCode, all symlinks resolve to the `skills/bill-feature-implement/{codex,opencode}-agents/` source tree, and Codex 0.128.0 boots and runs a non-interactive prompt successfully with the new agents on disk. Fix-loop and parsing-tolerance behavior verified structurally; full end-to-end review respawn execution remains a follow-up.
+
+## Final Verification Posture
+
+Accepted for SKILL-33 follow-up 3: install/load smoke coverage plus structural verification of the fix-loop and parsing-tolerance contracts is the final verification bar for this issue. A full Codex/OpenCode feature-implement run that intentionally produces Blocker/Major review findings and respawns the fix subagent is useful future hardening work, but it is not remaining work for SKILL-33.

--- a/.feature-specs/SKILL-33-opencode-native-subagents/spec.md
+++ b/.feature-specs/SKILL-33-opencode-native-subagents/spec.md
@@ -1,9 +1,10 @@
 # OpenCode native subagent support (Phase 1 pilot)
 
 - Issue key: SKILL-33
-- Status: In Progress
+- Status: Complete
 - Date: 2026-05-02
 - Parent: SKILL-33 (Codex native subagent support -- shipped in PR #91)
+- Implementation: PR #92
 - Sources:
   - `.feature-specs/SKILL-33-followups/spec_followup_1_opencode-native-subagents.md`
   - Discovery during SKILL-33 follow-up review on 2026-05-02 -- OpenCode is the second skill-bill-supported agent that has a native subagent feature with no current integration.

--- a/.feature-specs/SKILL-34-remove-glm-supported-agent/spec.md
+++ b/.feature-specs/SKILL-34-remove-glm-supported-agent/spec.md
@@ -1,0 +1,97 @@
+# Remove GLM as a first-class supported agent
+
+- Issue key: SKILL-34
+- Status: Complete
+- Date: 2026-05-02
+- Implementation: PR #97
+- Deprecation posture: hard removal from supported agents; legacy uninstall cleanup only, with no first-class GLM install surface retained.
+- Sources:
+  - User reconsideration during SKILL-33 follow-up review on 2026-05-02: "stating GLM as supported agent for skill-bill doesn't really make sense — since it has to be used by things like Claude Code or OpenCode."
+  - Git history: GLM was present in skill-bill since the initial commit (`2bff151`, Feb 2026) with a GLM commands directory under the user's home config as its install target. No documented rationale exists for which concrete tool that path corresponds to.
+  - External research (2026-05-02): Three distinct things share the "GLM" name in the CLI ecosystem, none of which cleanly own that GLM commands directory:
+    1. **GLM the model family** (Z.ai's GLM-4.5/4.6/4.7/5/5.1) — runs *inside* a host harness like Claude Code or Cline, the same way GPT-4 or Sonnet does. Not a harness.
+    2. **GLM CLI launchers** like `xqsit94/glm` — thin wrappers that boot Claude Code preconfigured against the GLM model. Auth uses the GLM user config file, but skill commands land in the Claude Code commands directory because Claude Code is the actual harness underneath.
+    3. **Z.AI's own CLI** (`@guizmo-ai/zai-cli`) — an independent terminal agent that stores config in the Z.AI user config directory, not the GLM commands directory.
+
+## Background
+
+skill-bill's supported-agent list today is `claude, copilot, glm, codex, opencode`. After investigating each, GLM is the only entry that does not correspond to a verified host harness with a public per-skill or per-subagent install convention. The GLM commands install path skill-bill ships against does not match any of the three real CLI tools that share the "GLM" name. It is most likely a speculative placeholder from the initial skill-bill commit that was never validated against a concrete tool.
+
+Keeping GLM as a peer of `claude`, `codex`, and `opencode` causes three concrete problems:
+
+1. **Misleading docs.** Users see GLM in the supported-agent list and assume skill-bill knows where their GLM-powered workflow lives. In practice, anyone running GLM-the-model inside Claude Code already gets full skill-bill coverage via the Claude Code commands directory; the GLM commands install does nothing useful for them.
+2. **Implementation drag.** Every install-target change (recent example: SKILL-33's Codex native agents primitive) carries a parallel GLM branch, parallel test fixtures, and parallel doc rows that exist only because the GLM entry exists.
+3. **Wrong shape if Z.AI's CLI is the real target.** Z.AI's own CLI uses its own Z.AI config directory, not the GLM commands directory. If someone wants real Z.AI CLI support, the right move is a new `zai` agent target — not bending the existing GLM target. That's a separate follow-up issue, not part of this work.
+
+This issue removes GLM as a first-class supported agent, leaving Claude Code, Codex, OpenCode, and Copilot as the documented harnesses. It explicitly does NOT add Z.AI CLI support — that's a separate future issue.
+
+## Acceptance criteria
+
+1. `skill_bill/install.py` no longer treats `glm` as a member of `SUPPORTED_AGENTS`. The `glm` entry is removed from the agent registry, from `agent_paths`, from `detect_agents` (and from any helper such as `_glm_path` if one exists), and from `__all__` if exported.
+2. `install.sh` no longer offers `glm` as a selectable agent. The `get_agent_path()` shell-case branch for `glm`, the `AGENT_NAMES` registration, the supported-agents echo, and any `glm`-specific code paths are removed.
+3. `uninstall.sh` continues to clean up an existing GLM commands install path for users who installed under the previous version of skill-bill, and prints a one-line note explaining that GLM is no longer a first-class supported agent. The cleanup branch is removed in a follow-up after a deprecation window (out of scope here — see non-goals).
+4. README.md no longer lists GLM in the supported-agents list. A short note ("Using GLM as a model? Install via the Claude Code path — GLM is a model, not a harness.") is added either in the supported-agents section or in a small "Models vs harnesses" subsection.
+5. `docs/getting-started.md` removes the GLM install-path table row and adds the same explanatory note.
+6. `docs/getting-started-for-teams.md` is updated to drop any GLM references.
+7. `AGENTS.md` is updated to drop GLM from the supported-agents enumeration if it appears there.
+8. Tests no longer create GLM home-directory fixtures or assert on GLM-specific install/uninstall behavior. `tests/test_install_script.py`, `tests/test_uninstall_script.py`, `tests/test_validate_agent_configs_e2e.py`, and any other test that mentions `glm` are updated. The uninstall test continues to assert that an existing GLM commands install (seeded by the test) is cleaned up correctly to satisfy AC #3.
+9. `agent/history.md` is updated per `bill-boundary-history` rules with a single entry citing the user-reconsideration source and explaining the practical reason (GLM is a model, not a harness; speculative path that did not correspond to a real tool).
+10. Validation gate passes: `python3 -m unittest discover -s tests`, `python3 scripts/validate_agent_configs.py`, and `npx --yes agnix --strict .` all return without regressions vs main.
+
+## Non-goals
+
+- Adding Z.AI CLI support as a new supported agent. That's a separate future issue and depends on confirming the zai CLI's per-skill install convention.
+- Investigating GitHub Copilot's agent-mode subagent surface (separate parking-lot item from the SKILL-33 follow-up review).
+- Removing the GLM commands cleanup branch from `uninstall.sh` immediately. Per AC #3, the cleanup branch stays for one deprecation window so existing installs can be removed cleanly. A follow-up issue removes the cleanup branch after a documented sunset date.
+- Re-running the SKILL-33 install-primitive work or touching the Codex / OpenCode install paths.
+- Changing the skill content or specialist contracts of any platform pack.
+
+## Open questions
+
+1. Is there any user who actually relies on the GLM commands install path today? If yes, the deprecation note in AC #3 should be louder. If no (most likely — the path was speculative), a quiet single-line note suffices. Defer to pre-planning to scan recent issues / Slack / repo for any explicit GLM usage; if nothing found, ship the quiet variant.
+2. How long is the deprecation window for AC #3's cleanup branch? Proposal: until the next minor release after this ships. Pre-planning sets the concrete sunset date in the docs.
+
+## Consolidated spec
+
+### Code removal
+
+`skill_bill/install.py`:
+- Drop `"glm"` from the `SUPPORTED_AGENTS` tuple.
+- Drop the `glm` entry from `agent_paths` (and the corresponding `_glm_path` helper if one exists).
+- Drop the `glm` branch from `_agent_is_present` / `detect_agents`.
+- Update the module docstring listing supported agents.
+- Update `__all__` if any GLM-specific name was exported.
+
+`install.sh`:
+- Drop the `glm)` case from `get_agent_path`.
+- Drop `glm` from any inline `SUPPORTED_AGENTS` array or echo.
+- Drop the `glm` branch from any per-agent dispatch.
+
+`uninstall.sh`:
+- Keep one-shot cleanup logic for the GLM commands path so existing installs are removed cleanly. The cleanup runs unconditionally (idempotent — does nothing if that path does not exist) and prints a single info line: "GLM is no longer a first-class supported agent. If you used Skill Bill with GLM as a model inside Claude Code, your skills are unaffected — they live under the Claude Code commands directory."
+- A follow-up issue removes this cleanup branch after the deprecation window.
+
+### Documentation
+
+- `README.md`: remove the GLM bullet from the supported-agents list. Add a one-line note: "Using GLM as a model in Claude Code? Skill Bill installs to the Claude Code commands directory — no separate target needed. GLM is a model, not a harness."
+- `docs/getting-started.md`: remove the GLM install-path table row. Add the same note in prose form.
+- `docs/getting-started-for-teams.md`: remove any `--agent glm` examples. If a "Runtime expectations" section exists (introduced in SKILL-33), update it to drop GLM.
+- `AGENTS.md`: drop GLM from the supported-agents enumeration if it appears there.
+
+### Tests
+
+- `tests/test_install_script.py`: drop GLM home-directory setup from `prepare_agent_homes`. Drop any GLM-specific assertions.
+- `tests/test_uninstall_script.py`: keep one assertion that an existing GLM commands directory is cleaned up correctly (this exercises AC #3's deprecation cleanup branch). All other GLM assertions are removed.
+- `tests/test_validate_agent_configs_e2e.py`: drop GLM-specific cases.
+
+### Boundary history
+
+Append a single entry to `agent/history.md` explaining:
+- GLM was a speculative supported-agent target since the initial commit (Feb 2026) with no documented concrete tool behind the GLM commands directory.
+- Removed because GLM is a model family, not a harness; users running GLM models inside Claude Code already get full coverage via the Claude Code commands directory.
+- Z.AI's actual CLI uses its own Z.AI config directory and is a candidate for a future `zai` supported-agent target — not part of this work.
+- Cleanup branch in `uninstall.sh` retained one deprecation window so existing installs sunset cleanly.
+
+### Validation
+
+The standard validation gate from SKILL-33 applies: `python3 -m unittest discover -s tests && python3 scripts/validate_agent_configs.py && npx --yes agnix --strict .`. No new test infrastructure is required; this issue is a pure removal plus a doc note.


### PR DESCRIPTION
## Summary

Finalizes the local SKILL-33 and SKILL-34 spec artifacts after the implementation PRs were merged.

- Marks the shipped SKILL-33 Codex/OpenCode/native-subagent follow-up specs and SKILL-34 GLM removal spec as complete.
- Adds the previously untracked SKILL-33 follow-up 2, SKILL-33 follow-up 4, and SKILL-34 spec files so the spec tree reflects the completed work.
- Documents the accepted verification posture for SKILL-33 feature-implement: install/load smoke plus structural fix-loop and parsing-tolerance verification is final for SKILL-33, while a full intentional Blocker/Major respawn E2E remains future hardening.
- Records SKILL-34 as hard removal from supported agents, retaining only legacy uninstall cleanup.

## Validation

- `git diff --check`
- `.venv/bin/python3 -m unittest discover -s tests` (232 tests)
- `(cd runtime-kotlin && ./gradlew check)`
- `.venv/bin/python3 scripts/validate_agent_configs.py`
- `npx --yes agnix --strict .`
