### PR TITLE
SKILL-36 Port contract scaffolding parity to Kotlin

### DIFF
--- a/.feature-specs/SKILL-36-retire-python-tooling/spec_subtask_1_kotlin-contract-parity.md
+++ b/.feature-specs/SKILL-36-retire-python-tooling/spec_subtask_1_kotlin-contract-parity.md
@@ -1,0 +1,35 @@
+# SKILL-36 Subtask 1: Kotlin Contract and Scaffold Parity
+
+Status: Complete
+
+Parent spec: [spec.md](spec.md)
+
+## Scope
+
+Complete the Kotlin implementation for the governed maintainer behavior that is still covered by Python modules and Python tests. Focus on shell-content-contract loading, scaffold/render/fill/upgrade behavior, manifest edits, loud-fail exceptions, and scaffold atomicity. The implementation should extend the existing `runtime-kotlin/runtime-core/skillbill/scaffold` and `runtime-kotlin/runtime-cli/ScaffoldCliCommands.kt` surfaces rather than adding bridge or fallback code.
+
+## Acceptance Criteria
+
+1. Remaining `skill_bill/` bootstrap and maintainer behavior for scaffold, shell-content-contract loading, render/fill, and upgrade has Kotlin API/CLI parity.
+2. Python tests for scaffold, shell-content-contract, manifest edits, rendering, fill/upgrade behavior, loud-fail paths, and scaffold atomicity are migrated to Kotlin tests or shell/script integration tests that exercise Kotlin commands.
+3. Governed contracts remain preserved: manifest-driven routing, shell contract version 1.1 lockstep, named loud-fail behavior for missing/wrong manifest/content/sections, and scaffold atomicity.
+4. No new runtime Python bridge/fallback markers are introduced.
+
+## Non-Goals
+
+- Do not update `install.sh`, `uninstall.sh`, or packaged runtime shims in this subtask except where tests need stable command invocation helpers.
+- Do not migrate repo-level scripts under `scripts/`; that is owned by subtask 3.
+- Do not delete `skill_bill/` or `pyproject.toml`; deletion is owned by subtask 4.
+- Do not change the shell contract version unless the parent spec is updated with an explicit migration requirement.
+
+## Dependencies
+
+None. This is the foundation subtask because later shell, script, and deletion work need Kotlin-owned governed contract behavior before Python modules can be removed.
+
+## Validation Strategy
+
+Run `bill-quality-check`. Add and run the most targeted repo-native Kotlin or shell tests for the migrated contract/scaffold behavior before the full quality check.
+
+## Recommended Next Prompt
+
+Run bill-feature-implement on .feature-specs/SKILL-36-retire-python-tooling/spec_subtask_1_kotlin-contract-parity.md.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-05-03] kotlin-contract-parity
+Areas: runtime-core scaffold/shell-content loader, runtime-cli scaffold commands, runtime-contracts errors, governed skill wrappers
+- Ported remaining scaffold, shell-content-contract loading, render/fill/upgrade, and authoring validation behavior onto Kotlin-owned APIs/CLI while keeping `skill_bill/` as reference-only for later subtasks.
+- Added canonical SKILL.md shape validation, render-drift validation, regular-file sidecar validation, feature-verify `audit-rubrics.md` ceremony support, and shared display-name derivation from manifest/fallback sources. reusable
+- Implemented Kotlin scaffold parity for `subagent_specialists` / `no_subagents`, Codex/OpenCode stub emission, create-and-fill multi-artifact rejection, quality-check manifest registration, and byte-identical rollback tests. reusable
+- Guardrail: feature-verify sidecars need both `requiredSupportingFilesForSkill` and `supportingFileTargets` entries; missing the target breaks newly scaffolded platform verify overrides even if existing wrappers render correctly.
+- Validation gate passed: focused scaffold/CLI tests, `runtime-kotlin ./gradlew check`, Python unittest suite, `agnix --strict`, and agent-config validation.
+Feature flag: N/A
+Acceptance criteria: 4/4 implemented
+
 ## [2026-05-01] adoption-docs-and-external-author-dry-run
 Areas: runtime-cli external-author tests, runtime-core scaffold manifest paths, docs adoption guides
 - Rewrote adoption docs around packaged Kotlin-only CLI/MCP behavior, fail-closed vs degraded boundaries, strict contract guarantees, and model-mediated review/planning limits.

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
@@ -445,7 +445,17 @@ private fun runNativeScaffoldPayload(
   format: CliFormat,
   state: CliRunState,
   transform: (Map<String, *>) -> Map<String, *> = { it },
-): CliExecutionResult = runNativeScaffoldPayload(transform(readScaffoldPayload(payloadPath, state)), dryRun, format)
+): CliExecutionResult {
+  val payload =
+    try {
+      transform(readScaffoldPayload(payloadPath, state))
+    } catch (error: SkillBillRuntimeException) {
+      return errorResult(error.message.orEmpty(), format)
+    } catch (error: IllegalArgumentException) {
+      return errorResult(error.message.orEmpty(), format)
+    }
+  return runNativeScaffoldPayload(payload, dryRun, format)
+}
 
 private fun runNativeScaffoldPayload(payload: Map<String, *>, dryRun: Boolean, format: CliFormat): CliExecutionResult {
   val sessionId = generateScaffoldSessionId()
@@ -493,7 +503,7 @@ private fun createAndFillResult(
   )
   body != null && bodyFile != null -> errorResult("--body and --body-file are mutually exclusive.", format)
   else -> runNativeScaffoldPayload(payload, dryRun, format, state) { scaffoldPayload ->
-    scaffoldPayload + createAndFillContentPayload(body, bodyFile, state)
+    createAndFillScaffoldPayload(scaffoldPayload, body, bodyFile, state)
   }
 }
 
@@ -546,6 +556,19 @@ private fun createAndFillContentPayload(body: String?, bodyFile: String?, state:
       readCliTextFile(path, state)
     }
   return if (contentBody == null) emptyMap() else mapOf("content_body" to contentBody)
+}
+
+private fun createAndFillScaffoldPayload(
+  scaffoldPayload: Map<String, *>,
+  body: String?,
+  bodyFile: String?,
+  state: CliRunState,
+): Map<String, *> {
+  val kind = scaffoldPayload["kind"]?.toString().orEmpty()
+  require(kind !in setOf("platform-pack", "add-on")) {
+    "create-and-fill can only scaffold one content-managed skill; kind '$kind' is not supported."
+  }
+  return scaffoldPayload + createAndFillContentPayload(body, bodyFile, state)
 }
 
 private fun newAddonPayload(

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliAuthoringParityTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliAuthoringParityTest.kt
@@ -81,6 +81,62 @@ class CliAuthoringParityTest {
   }
 
   @Test
+  fun `native authoring validation reports render drift and skill shape issues`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-authoring-validate-drift")
+    val repoRoot = authoringFixtureRepo(tempDir.resolve("drift-repo"), "bill-drift-fixture")
+    val skillFile = repoRoot.resolve("skills/bill-drift-fixture/SKILL.md")
+    Files.writeString(skillFile, Files.readString(skillFile) + "\n### Invalid nested heading\n")
+    val context = CliRuntimeContext(userHome = tempDir)
+
+    val result =
+      CliRuntime.run(
+        listOf(
+          "validate",
+          "--repo-root",
+          repoRoot.toString(),
+          "--skill-name",
+          "bill-drift-fixture",
+          "--format",
+          "json",
+        ),
+        context,
+      )
+    val payload = decodeJsonObject(result.stdout)
+    val issues = payload["issues"] as List<*>
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertEquals("fail", payload["status"])
+    assertEquals(true, issues.any { issue -> issue.toString().contains("render drift") })
+    assertEquals(true, issues.any { issue -> issue.toString().contains("H3+ heading") })
+  }
+
+  @Test
+  fun `native repo wide authoring validation reports render drift`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-authoring-validate-repo-drift")
+    val repoRoot = authoringFixtureRepo(tempDir.resolve("repo-drift"), "bill-repo-drift-fixture")
+    val context = CliRuntimeContext(userHome = tempDir)
+
+    val result =
+      CliRuntime.run(
+        listOf(
+          "validate",
+          "--repo-root",
+          repoRoot.toString(),
+          "--format",
+          "json",
+        ),
+        context,
+      )
+    val payload = decodeJsonObject(result.stdout)
+    val issues = payload["issues"] as List<*>
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertEquals("fail", payload["status"])
+    assertEquals("repo", payload["mode"])
+    assertEquals(true, issues.any { issue -> issue.toString().contains("render drift") })
+  }
+
+  @Test
   fun `native wrapper regeneration and content mutation commands stay available through the kotlin cli`() {
     val tempDir = Files.createTempDirectory("skillbill-cli-authoring-mutation")
     val context = CliRuntimeContext(userHome = tempDir)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliScaffoldRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliScaffoldRuntimeTest.kt
@@ -48,6 +48,39 @@ class CliScaffoldRuntimeTest {
   }
 
   @Test
+  fun `create-and-fill rejects multi artifact scaffold kinds with json diagnostics`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-scaffold-fill-reject")
+    listOf(
+      """
+      {
+        "scaffold_payload_version": "1.0",
+        "kind": "platform-pack",
+        "platform": "java"
+      }
+      """.trimIndent(),
+      """
+      {
+        "scaffold_payload_version": "1.0",
+        "kind": "add-on",
+        "platform": "kotlin",
+        "name": "review-helper"
+      }
+      """.trimIndent(),
+    ).forEach { stdin ->
+      val result =
+        CliRuntime.run(
+          listOf("create-and-fill", "--payload", "-", "--body", "Authored content.", "--dry-run", "--format", "json"),
+          CliRuntimeContext(stdinText = stdin, userHome = tempDir),
+        )
+      val payload = decodeJsonObject(result.stdout)
+
+      assertEquals(1, result.exitCode)
+      assertEquals("error", payload.stringValue("status"))
+      assertContains(payload.stringValue("error"), "one content-managed skill")
+    }
+  }
+
+  @Test
   fun `new addon dry run preserves scaffold payload contract`() {
     val tempDir = Files.createTempDirectory("skillbill-cli-scaffold-addon")
     val bodyFile = tempDir.resolve("addon-body.md")
@@ -91,6 +124,24 @@ class CliScaffoldRuntimeTest {
       listOf("new-addon", "--platform", "kmp", "--name", "android-conflict-addon"),
       CliRuntimeContext(userHome = tempDir),
     )
+  }
+
+  @Test
+  fun `native scaffold payload errors are reported as structured cli errors`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-scaffold-errors")
+    val result =
+      CliRuntime.run(
+        listOf("new-skill", "--payload", "-", "--dry-run", "--format", "json"),
+        CliRuntimeContext(
+          stdinText = """{"scaffold_payload_version":"9.99","kind":"horizontal"}""",
+          userHome = tempDir,
+        ),
+      )
+    val payload = decodeJsonObject(result.stdout)
+
+    assertEquals(1, result.exitCode)
+    assertEquals("error", payload.stringValue("status"))
+    assertContains(payload.stringValue("error"), "scaffold_payload_version")
   }
 
   @Test

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
@@ -50,6 +50,11 @@ class MissingShellCeremonyFileError(
   cause: Throwable? = null,
 ) : ShellContentContractException(message, cause)
 
+class InvalidSkillMdShapeError(
+  message: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(message, cause)
+
 open class ScaffoldError(
   message: String,
   cause: Throwable? = null,

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringDiscovery.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringDiscovery.kt
@@ -64,11 +64,13 @@ private fun restoreFiles(originalBytes: Map<Path, ByteArray>) {
 
 private fun recordPackTargets(discovered: MutableMap<String, AuthoringTarget>, pack: PlatformManifest) {
   val baseline = pack.declaredFiles.baseline
+  val displayName = pack.displayName ?: displayNameFromSlug(pack.slug)
   discovered[baseline.parent.name] =
     AuthoringTarget(
       baseline.parent.name,
       pack.slug,
       pack.slug,
+      displayName,
       "code-review",
       "",
       baseline,
@@ -80,6 +82,7 @@ private fun recordPackTargets(discovered: MutableMap<String, AuthoringTarget>, p
         skillFile.parent.name,
         pack.slug,
         pack.slug,
+        displayName,
         "code-review",
         area,
         skillFile,
@@ -92,6 +95,7 @@ private fun recordPackTargets(discovered: MutableMap<String, AuthoringTarget>, p
         skillFile.parent.name,
         pack.slug,
         pack.slug,
+        displayName,
         "quality-check",
         "",
         skillFile,
@@ -112,8 +116,20 @@ private fun recordSkillTarget(repoRoot: Path, discovered: MutableMap<String, Aut
   val platform = platformFromSkillPath(repoRoot.relativize(skillFile))
   val packageName = platform.ifBlank { "base" }
   val family = inferFamily(skillName)
+  val displayName =
+    platform.takeIf { it.isNotBlank() }?.let(::displayNameFromSlug)
+      ?: displayNameFromSlug(skillName.removePrefix("bill-"))
   discovered[skillName] =
-    AuthoringTarget(skillName, packageName, platform, family, inferArea(skillName, family), skillFile, contentFile)
+    AuthoringTarget(
+      skillName,
+      packageName,
+      platform,
+      displayName,
+      family,
+      inferArea(skillName, family),
+      skillFile,
+      contentFile,
+    )
 }
 
 private fun platformFromSkillPath(relative: Path): String = if (

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringMutation.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringMutation.kt
@@ -1,5 +1,6 @@
 package skillbill.scaffold
 
+import skillbill.error.ShellContentContractException
 import skillbill.error.SkillBillRuntimeException
 import java.io.IOException
 import java.nio.file.Files
@@ -18,12 +19,12 @@ internal fun mutateContent(repoRoot: Path, target: AuthoringTarget, replacementT
   }
 }
 
-internal fun validateTarget(target: AuthoringTarget): List<String> {
+internal fun validateTarget(target: AuthoringTarget, checkRenderDrift: Boolean = true): List<String> {
   val issues = mutableListOf<String>()
   when {
     !Files.isRegularFile(target.skillFile) -> issues += "${target.skillFile}: SKILL.md is missing"
     !Files.isRegularFile(target.contentFile) -> issues += "${target.contentFile}: content.md is missing"
-    else -> collectTargetIssues(target, issues)
+    else -> collectTargetIssues(target, issues, checkRenderDrift)
   }
   return issues
 }
@@ -51,7 +52,7 @@ private fun restoreContentFiles(target: AuthoringTarget, contentBefore: ByteArra
   Files.write(target.skillFile, wrapperBefore)
 }
 
-private fun collectTargetIssues(target: AuthoringTarget, issues: MutableList<String>) {
+private fun collectTargetIssues(target: AuthoringTarget, issues: MutableList<String>, checkRenderDrift: Boolean) {
   val skillText = Files.readString(target.skillFile)
   if (!skillText.contains("name: ${target.skillName}\n")) {
     issues += "${target.skillFile}: frontmatter name does not match directory '${target.skillName}'"
@@ -60,6 +61,20 @@ private fun collectTargetIssues(target: AuthoringTarget, issues: MutableList<Str
     if (!skillText.contains("$heading\n")) {
       issues += "${target.skillFile}: SKILL.md is missing required section '$heading'"
     }
+  }
+  requiredSupportingFilesForSkill(target.skillName).forEach { fileName ->
+    val sidecar = target.skillFile.resolveSibling(fileName)
+    if (!Files.isRegularFile(sidecar)) {
+      issues += "${target.skillFile}: required ceremony sidecar '$fileName' is missing"
+    }
+  }
+  try {
+    validateSkillMdShape(target.skillFile)
+  } catch (error: ShellContentContractException) {
+    issues += error.message.orEmpty()
+  }
+  if (checkRenderDrift && hasGenerationDrift(target)) {
+    issues += "${target.skillFile}: SKILL.md has scaffold-managed render drift"
   }
   val contentText = Files.readString(target.contentFile)
   if (contentText.isBlank()) {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringOperations.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringOperations.kt
@@ -12,6 +12,7 @@ data class AuthoringTarget(
   val skillName: String,
   val packageName: String,
   val platform: String,
+  val displayName: String,
   val family: String,
   val area: String,
   val skillFile: Path,
@@ -77,7 +78,10 @@ object AuthoringOperations {
   fun validate(repoRoot: Path, skillNames: List<String>): Map<String, Any?> {
     val resolvedRoot = repoRoot.toAbsolutePath().normalize()
     if (skillNames.isEmpty()) {
-      val issues = discoverTargets(resolvedRoot).values.flatMap { target -> validateTarget(target) }
+      val issues =
+        discoverTargets(resolvedRoot).values.flatMap { target ->
+          validateTarget(target)
+        }
       return mapOf(
         "repo_root" to resolvedRoot.toString(),
         "mode" to "repo",

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringRender.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringRender.kt
@@ -13,9 +13,7 @@ internal fun renderWrapper(target: AuthoringTarget): String {
       family = target.family,
       platform = target.platform,
       area = target.area,
-      displayName = target.platform.ifBlank {
-        target.skillName.removePrefix("bill-").replace("-", " ").replaceFirstChar { it.titlecase() }
-      },
+      displayName = target.displayName,
     )
   return buildString {
     append(frontmatter.trimEnd())
@@ -27,7 +25,7 @@ internal fun renderWrapper(target: AuthoringTarget): String {
     append(CANONICAL_EXECUTION_SECTION.trimEnd())
     appendLine()
     appendLine()
-    append(CANONICAL_CEREMONY_SECTION.trimEnd())
+    append(renderCeremonySection(context).trimEnd())
     appendLine()
   }
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldCeremonyRendering.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldCeremonyRendering.kt
@@ -1,0 +1,70 @@
+package skillbill.scaffold
+
+internal fun renderCeremonySection(context: TemplateContext): String = buildString {
+  append(CANONICAL_CEREMONY_SECTION)
+  if (skillRequiresReviewScope(context.skillName)) {
+    appendLine()
+    appendLine("Determine the review scope using [review-scope.md](review-scope.md).")
+  }
+  if (skillRequiresStackRouting(context.skillName)) {
+    appendLine()
+    appendLine("When stack routing applies, follow [stack-routing.md](stack-routing.md).")
+  }
+  if (skillRequiresSpecialistContract(context.skillName)) {
+    appendLine()
+    appendLine("When delegated specialist review applies, use [specialist-contract.md](specialist-contract.md).")
+  }
+  if (skillRequiresReviewDelegation(context.skillName)) {
+    appendLine()
+    appendLine("When delegated review execution applies, follow [review-delegation.md](review-delegation.md).")
+  }
+  if (skillRequiresShellContentContract(context.skillName)) {
+    appendLine()
+    appendLine(
+      "When the shell+content contract enforcement applies, follow " +
+        "[shell-content-contract.md](shell-content-contract.md).",
+    )
+  }
+  if (skillRequiresReviewOrchestrator(context.skillName)) {
+    appendLine()
+    appendLine("When review reporting applies, follow [review-orchestrator.md](review-orchestrator.md).")
+  }
+  if (skillRequiresTelemetryContract(context.skillName)) {
+    appendLine()
+    appendLine("When telemetry applies, follow [telemetry-contract.md](telemetry-contract.md).")
+  }
+  if (skillRequiresAuditRubrics(context.skillName)) {
+    appendLine()
+    appendLine("When feature verification audit rules apply, follow [audit-rubrics.md](audit-rubrics.md).")
+  }
+}
+
+private fun skillRequiresTelemetryContract(skillName: String): Boolean = skillName.startsWith("bill-") && (
+  skillName.endsWith("-code-review") ||
+    "-code-review-" in skillName ||
+    skillName.endsWith("-quality-check") ||
+    skillName.endsWith("-feature-implement") ||
+    skillName.endsWith("-feature-verify") ||
+    skillName == "bill-pr-description"
+  )
+
+private fun skillRequiresReviewScope(skillName: String): Boolean =
+  skillName == "bill-code-review" || (skillName.startsWith("bill-") && skillName.endsWith("-code-review"))
+
+private fun skillRequiresStackRouting(skillName: String): Boolean =
+  skillName.startsWith("bill-") && (skillName.endsWith("-code-review") || skillName.endsWith("-quality-check"))
+
+private fun skillRequiresSpecialistContract(skillName: String): Boolean =
+  skillName != "bill-code-review" && skillName.startsWith("bill-") && skillName.endsWith("-code-review")
+
+private fun skillRequiresReviewDelegation(skillName: String): Boolean =
+  skillName.startsWith("bill-") && skillName.endsWith("-code-review")
+
+private fun skillRequiresShellContentContract(skillName: String): Boolean = skillName == "bill-code-review"
+
+private fun skillRequiresAuditRubrics(skillName: String): Boolean =
+  skillName == "bill-feature-verify" || skillName.endsWith("-feature-verify")
+
+private fun skillRequiresReviewOrchestrator(skillName: String): Boolean =
+  skillName != "bill-code-review" && skillName.startsWith("bill-") &&
+    (skillName.endsWith("-code-review") || "-code-review-" in skillName)

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldContentStarters.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldContentStarters.kt
@@ -1,0 +1,54 @@
+package skillbill.scaffold
+
+internal fun qualityCheckContent(summary: String): String = buildString {
+  appendLine("## Purpose")
+  appendLine()
+  appendLine(summary)
+  appendLine()
+  appendLine("## Execution Steps")
+  appendLine()
+  appendLine("1. Determine the files in scope for the current unit of work.")
+  appendLine("2. Run the platform's quality-check entrypoint and capture the failures.")
+  appendLine("3. Fix only the failures that belong to the scoped work unless the contract says otherwise.")
+  appendLine("4. Re-run the quality check until the scoped failures are resolved.")
+  appendLine()
+  appendLine("## Fix Strategy")
+  appendLine()
+  appendLine("- Prefer root-cause fixes over suppressions or TODO comments.")
+  appendLine("- Keep changes aligned with the project's existing conventions and build tooling.")
+  appendLine("- Call out any blocker that requires a maintainer decision instead of guessing.")
+}
+
+internal fun areaReviewContent(summary: String, area: String): String {
+  val areaLabel = area.replace("-", " ")
+  return buildString {
+    appendLine("## Focus")
+    appendLine()
+    appendLine(summary)
+    appendLine()
+    appendLine("## Review Triggers")
+    appendLine()
+    appendLine("- Changes that primarily affect $areaLabel concerns for this platform.")
+    appendLine("- Project-specific cues, modules, or file patterns that should route into this specialist.")
+    appendLine()
+    appendLine("## Review Guidance")
+    appendLine()
+    appendLine("- Record the concrete risks this specialist should prioritize.")
+    appendLine("- Note any repo-specific heuristics, invariants, or failure modes worth checking.")
+    appendLine("- Keep output format, telemetry, and runtime ceremony in the wrapper or shared sidecars.")
+  }
+}
+
+internal fun baselineReviewContent(summary: String): String = buildString {
+  appendLine("## Review Focus")
+  appendLine()
+  appendLine(summary)
+  appendLine()
+  appendLine("## Review Guidance")
+  appendLine()
+  appendLine("- Document the project-specific risks, heuristics, and judgment calls this skill should apply.")
+  appendLine("- Call out any local modules, file patterns, frameworks, or product areas that should bias review.")
+  appendLine("- Capture repo-specific routing cues here only when they matter to review behavior after selection.")
+  appendLine("- Keep shell ceremony, output formatting rules, and telemetry mechanics out of this file.")
+  appendLine("- Reference governed add-ons here only when they enrich an already-routed platform skill.")
+}

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldService.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldService.kt
@@ -44,6 +44,9 @@ private val SUPPORTED_SKILL_KINDS =
 
 private val SHELLED_FAMILIES = setOf("code-review", "quality-check")
 private val PRE_SHELL_FAMILIES = setOf("feature-implement", "feature-verify")
+private val ORCHESTRATOR_KINDS_FOR_SUBAGENTS =
+  setOf(SKILL_KIND_HORIZONTAL, SKILL_KIND_PLATFORM_OVERRIDE_PILOTED, SKILL_KIND_PLATFORM_PACK)
+private val SUBAGENT_NAME_PATTERN = Regex("^[a-z][a-z0-9-]*$")
 
 private val PLATFORM_PACK_PRESETS: Map<String, PlatformPackPreset> =
   mapOf(
@@ -106,6 +109,8 @@ private data class ScaffoldPlan(
   val createdFiles: List<Path> = emptyList(),
   val contentBody: String? = null,
   val addonBody: String? = null,
+  val subagentSpecialists: List<String> = emptyList(),
+  val subagentsSuppressed: Boolean = false,
 )
 
 private data class ScaffoldExecutionResult(
@@ -171,7 +176,10 @@ private fun executeScaffold(txn: ScaffoldTransaction, plan: ScaffoldPlan, repoRo
     }
   validateScaffold(plan, repoRoot)
   val (installTargets, installNotes) = performInstall(txn, plan)
-  return execution.copy(installTargets = installTargets, notes = execution.notes + installNotes)
+  return execution.copy(
+    installTargets = installTargets,
+    notes = execution.notes + installNotes + subagentEmissionNotes(plan),
+  )
 }
 
 private fun validatePayloadVersion(payload: Map<String, Any?>) {
@@ -223,6 +231,7 @@ private fun planScaffold(payload: Map<String, Any?>, repoRoot: Path, kind: Strin
 private fun planHorizontal(payload: Map<String, Any?>, repoRoot: Path): ScaffoldPlan {
   val name = requireString(payload, "name")
   val skillPath = repoRoot.resolve("skills").resolve(name)
+  val subagents = optionalSpecialistSubagents(payload, SKILL_KIND_HORIZONTAL)
   return ScaffoldPlan(
     kind = SKILL_KIND_HORIZONTAL,
     skillName = name,
@@ -235,6 +244,8 @@ private fun planHorizontal(payload: Map<String, Any?>, repoRoot: Path): Scaffold
     isShelled = false,
     notes = emptyList(),
     contentBody = payload["content_body"] as? String,
+    subagentSpecialists = subagents.specialists,
+    subagentsSuppressed = subagents.suppressed,
   )
 }
 
@@ -242,6 +253,7 @@ private fun planPlatformOverridePiloted(payload: Map<String, Any?>, repoRoot: Pa
   val platform = requireString(payload, "platform")
   val family = requireString(payload, "family")
   val name = canonicalName(payload, defaultName = "bill-$platform-$family")
+  val subagents = optionalSpecialistSubagents(payload, SKILL_KIND_PLATFORM_OVERRIDE_PILOTED)
   val isShelled = family in SHELLED_FAMILIES
   val notes = mutableListOf<String>()
   if (!isShelled) {
@@ -267,6 +279,8 @@ private fun planPlatformOverridePiloted(payload: Map<String, Any?>, repoRoot: Pa
       isShelled = false,
       notes = notes,
       contentBody = payload["content_body"] as? String,
+      subagentSpecialists = subagents.specialists,
+      subagentsSuppressed = subagents.suppressed,
     )
   }
 
@@ -296,11 +310,14 @@ private fun planPlatformOverridePiloted(payload: Map<String, Any?>, repoRoot: Pa
     isShelled = true,
     notes = notes,
     displayName = pack.displayName ?: deriveDisplayName(platform),
+    subagentSpecialists = subagents.specialists,
+    subagentsSuppressed = subagents.suppressed,
   )
 }
 
 private fun planPlatformPack(payload: Map<String, Any?>, repoRoot: Path): ScaffoldPlan {
   val platform = requireString(payload, "platform")
+  val subagents = optionalSpecialistSubagents(payload, SKILL_KIND_PLATFORM_PACK)
   val defaults = resolvePlatformPackDefaults(payload, platform)
   val packRoot = repoRoot.resolve("platform-packs").resolve(platform)
   if (Files.exists(packRoot)) {
@@ -355,12 +372,76 @@ private fun planPlatformPack(payload: Map<String, Any?>, repoRoot: Path): Scaffo
       selectedAreas = selectedAreas,
     ),
     contentBody = payload["content_body"] as? String,
+    subagentSpecialists = subagents.specialists,
+    subagentsSuppressed = subagents.suppressed,
   )
 }
 
 private data class PlatformPackSelection(
   val selectedAreas: List<String>,
 )
+
+private data class OptionalSubagents(
+  val specialists: List<String>,
+  val suppressed: Boolean,
+)
+
+private fun optionalSpecialistSubagents(payload: Map<String, Any?>, kind: String): OptionalSubagents {
+  val rawSpecialists = payload["subagent_specialists"] ?: emptyList<String>()
+  val rawSuppressed = payload["no_subagents"] ?: false
+  if (rawSpecialists !is List<*>) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'subagent_specialists' must be a list of strings.",
+    )
+  }
+  val specialists = mutableListOf<String>()
+  val seen = mutableSetOf<String>()
+  rawSpecialists.forEach { raw ->
+    val specialist = raw as? String
+      ?: throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'subagent_specialists' must contain only non-empty strings.",
+      )
+    if (specialist.isBlank()) {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'subagent_specialists' must contain only non-empty strings.",
+      )
+    }
+    if (!SUBAGENT_NAME_PATTERN.matches(specialist)) {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'subagent_specialists' contains invalid name '$specialist'; " +
+          "names must match '^[a-z][a-z0-9-]*$'.",
+      )
+    }
+    if (!seen.add(specialist)) {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'subagent_specialists' contains duplicate name '$specialist'.",
+      )
+    }
+    specialists += specialist
+  }
+  val suppressed = rawSuppressed as? Boolean
+    ?: throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'no_subagents' must be a boolean when provided.",
+    )
+  if (suppressed && specialists.isNotEmpty()) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload may not set 'no_subagents=true' together with a non-empty 'subagent_specialists' list.",
+    )
+  }
+  if (specialists.isNotEmpty() && kind !in ORCHESTRATOR_KINDS_FOR_SUBAGENTS) {
+    throw InvalidScaffoldPayloadError(
+      "subagent_specialists is only valid for orchestrator kinds " +
+        "(horizontal, platform-override-piloted, platform-pack); got $kind",
+    )
+  }
+  return OptionalSubagents(specialists = specialists, suppressed = suppressed)
+}
+
+private fun rejectLeafSubagentSpecialists(payload: Map<String, Any?>, kind: String) {
+  if (payload["subagent_specialists"] != null) {
+    optionalSpecialistSubagents(payload, kind)
+  }
+}
 
 private fun resolvePlatformPackSelection(payload: Map<String, Any?>): PlatformPackSelection {
   val skeletonMode = requireStringOrDefault(payload, "skeleton_mode", "full")
@@ -387,7 +468,9 @@ private fun resolvePlatformPackSelection(payload: Map<String, Any?>): PlatformPa
     )
   }
   val selectedAreas =
-    specialistAreas
+    specialistAreas?.let { requested ->
+      APPROVED_CODE_REVIEW_AREAS.sorted().filter { area -> area in requested.toSet() }
+    }
       ?: if (skeletonMode == "full") APPROVED_CODE_REVIEW_AREAS.sorted() else emptyList()
   return PlatformPackSelection(selectedAreas = selectedAreas)
 }
@@ -410,6 +493,7 @@ private fun platformPackNotes(platform: String, presetUsed: Boolean, selectedAre
 }
 
 private fun planCodeReviewArea(payload: Map<String, Any?>, repoRoot: Path): ScaffoldPlan {
+  rejectLeafSubagentSpecialists(payload, SKILL_KIND_CODE_REVIEW_AREA)
   val platform = requireString(payload, "platform")
   val area = requireString(payload, "area")
   if (area !in APPROVED_CODE_REVIEW_AREAS) {
@@ -446,6 +530,7 @@ private fun planCodeReviewArea(payload: Map<String, Any?>, repoRoot: Path): Scaf
 }
 
 private fun planAddOn(payload: Map<String, Any?>, repoRoot: Path): ScaffoldPlan {
+  rejectLeafSubagentSpecialists(payload, SKILL_KIND_ADD_ON)
   val name = requireString(payload, "name")
   val platform = requireString(payload, "platform")
   val packRoot = repoRoot.resolve("platform-packs").resolve(platform)
@@ -522,6 +607,18 @@ private fun createPlatformPack(txn: ScaffoldTransaction, plan: ScaffoldPlan, rep
     ),
   )
   val symlinks = stagePlatformPackSkills(txn, plan, repoRoot, baselineSkillPath, qualityCheckSkillPath)
+  if (plan.shouldEmitSubagents()) {
+    appendRuntimeNotesToContent(
+      baselineSkillPath.resolve("content.md"),
+      renderSubagentSpawnRuntimeNotes(plan.baselineSkillName, plan.subagentSpecialists),
+    )
+    stageSubagentStubs(
+      txn,
+      orchestratorSkillPath = baselineSkillPath,
+      orchestratorName = plan.baselineSkillName,
+      specialists = plan.subagentSpecialists,
+    )
+  }
   return ScaffoldExecutionResult(
     createdFiles = txn.createdPaths.toList(),
     manifestEdits = listOf(manifestPath),
@@ -542,6 +639,19 @@ private fun stageSingleScaffold(txn: ScaffoldTransaction, plan: ScaffoldPlan, re
   }
   val manifestEdits = applyManifestEdits(txn, plan, repoRoot)
   val symlinks = stageSidecarSymlinks(txn, plan, repoRoot)
+  if (plan.shouldEmitSubagents()) {
+    val contentPath = plan.contentFile ?: plan.skillPath.resolve(CONTENT_BODY_FILENAME)
+    appendRuntimeNotesToContent(
+      contentPath,
+      renderSubagentSpawnRuntimeNotes(plan.skillName, plan.subagentSpecialists),
+    )
+    stageSubagentStubs(
+      txn,
+      orchestratorSkillPath = plan.skillPath,
+      orchestratorName = plan.skillName,
+      specialists = plan.subagentSpecialists,
+    )
+  }
   return ScaffoldExecutionResult(
     createdFiles = txn.createdPaths.toList(),
     manifestEdits = manifestEdits,
@@ -552,11 +662,11 @@ private fun stageSingleScaffold(txn: ScaffoldTransaction, plan: ScaffoldPlan, re
 }
 
 private fun renderSkillWrapper(plan: ScaffoldPlan): String =
-  renderSkillBody(skillContext(plan), plan.description, areaFocus(plan))
+  renderSkillBody(skillContext(plan), effectiveDescription(plan), areaFocus(plan))
 
 private fun renderContentSheet(plan: ScaffoldPlan): String = renderContentBody(
   skillContext(plan),
-  description = plan.description,
+  description = effectiveDescription(plan),
   contentBody = plan.contentBody,
 )
 
@@ -570,6 +680,11 @@ private fun skillContext(plan: ScaffoldPlan): TemplateContext = TemplateContext(
 
 private fun areaFocus(plan: ScaffoldPlan): String =
   plan.area.takeIf { it.isNotBlank() }?.let(::defaultAreaFocus).orEmpty()
+
+private fun effectiveDescription(plan: ScaffoldPlan): String {
+  val context = skillContext(plan)
+  return plan.description.ifBlank { inferSkillDescription(context, areaFocus(plan)) }
+}
 
 private fun stageFile(txn: ScaffoldTransaction, path: Path, content: String) {
   if (Files.exists(path)) {
@@ -589,6 +704,37 @@ private fun stageFile(txn: ScaffoldTransaction, path: Path, content: String) {
   }
   Files.writeString(path, content)
   txn.createdPaths.add(path)
+}
+
+private fun appendRuntimeNotesToContent(contentPath: Path, runtimeNotes: String) {
+  if (runtimeNotes.isBlank()) {
+    return
+  }
+  val existing = Files.readString(contentPath)
+  val separator = when {
+    existing.endsWith("\n\n") -> ""
+    existing.endsWith("\n") -> "\n"
+    else -> "\n\n"
+  }
+  Files.writeString(contentPath, existing + separator + runtimeNotes.trimEnd() + "\n")
+}
+
+private fun stageSubagentStubs(
+  txn: ScaffoldTransaction,
+  orchestratorSkillPath: Path,
+  orchestratorName: String,
+  specialists: List<String>,
+): List<Path> {
+  val staged = mutableListOf<Path>()
+  specialists.forEach { specialist ->
+    val codexPath = orchestratorSkillPath.resolve("codex-agents").resolve("$specialist.toml")
+    stageFile(txn, codexPath, renderCodexAgentTomlStub(specialist, orchestratorName))
+    staged.add(codexPath)
+    val opencodePath = orchestratorSkillPath.resolve("opencode-agents").resolve("$specialist.md")
+    stageFile(txn, opencodePath, renderOpencodeAgentMdStub(specialist, orchestratorName))
+    staged.add(opencodePath)
+  }
+  return staged
 }
 
 private fun snapshotManifest(txn: ScaffoldTransaction, manifestPath: Path) {
@@ -648,11 +794,12 @@ private fun stageSidecarSymlinksForSkill(
 }
 
 private fun previewCreatedFiles(plan: ScaffoldPlan): List<Path> = when (plan.kind) {
-  SKILL_KIND_PLATFORM_PACK -> previewPlatformPackCreatedFiles(plan)
+  SKILL_KIND_PLATFORM_PACK -> previewPlatformPackCreatedFiles(plan) + previewSubagentStubFiles(plan)
   SKILL_KIND_ADD_ON -> listOf(plan.skillFile)
   else -> buildList {
     add(plan.skillFile)
     plan.contentFile?.let(::add)
+    addAll(previewSubagentStubFiles(plan))
   }
 }
 
@@ -783,11 +930,7 @@ private fun requireStringList(value: Any?, fieldName: String): List<String> {
   }
 }
 
-private fun deriveDisplayName(platform: String): String = platform.split('-').joinToString(" ") { part ->
-  part.replaceFirstChar {
-    if (it.isLowerCase()) it.titlecase() else it.toString()
-  }
-}
+private fun deriveDisplayName(platform: String): String = displayNameFromSlug(platform)
 
 private fun defaultRepoRoot(): Path = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
 
@@ -911,6 +1054,42 @@ private fun previewPlatformPackCreatedFiles(plan: ScaffoldPlan): List<Path> = bu
     add(path.resolve("content.md"))
   }
 }
+
+private fun previewSubagentStubFiles(plan: ScaffoldPlan): List<Path> {
+  if (!plan.shouldEmitSubagents()) {
+    return emptyList()
+  }
+  val stubDir =
+    if (plan.kind == SKILL_KIND_PLATFORM_PACK) {
+      plan.baselineSkillPath ?: return emptyList()
+    } else {
+      plan.skillPath
+    }
+  return plan.subagentSpecialists.flatMap { specialist ->
+    listOf(
+      stubDir.resolve("codex-agents").resolve("$specialist.toml"),
+      stubDir.resolve("opencode-agents").resolve("$specialist.md"),
+    )
+  }
+}
+
+private fun subagentEmissionNotes(plan: ScaffoldPlan): List<String> {
+  if (!plan.shouldEmitSubagents()) {
+    return emptyList()
+  }
+  val stubDir =
+    if (plan.kind == SKILL_KIND_PLATFORM_PACK) {
+      plan.baselineSkillPath ?: plan.skillPath
+    } else {
+      plan.skillPath
+    }
+  return listOf(
+    "Subagent stubs emitted: ${plan.subagentSpecialists.size}. " +
+      "Fill in the TODO placeholders in $stubDir/codex-agents/ and $stubDir/opencode-agents/ before shipping.",
+  )
+}
+
+private fun ScaffoldPlan.shouldEmitSubagents(): Boolean = subagentSpecialists.isNotEmpty() && !subagentsSuppressed
 
 private fun rollbackInstallTargets(txn: ScaffoldTransaction, errors: MutableList<String>) {
   try {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldSupport.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldSupport.kt
@@ -37,10 +37,10 @@ internal val REQUIRED_CONTENT_SECTIONS: List<String> =
   )
 
 internal const val CANONICAL_EXECUTION_SECTION: String =
-  "## Execution\n\nRead the sibling `content.md` for authored execution guidance.\n"
+  "## Execution\n\nFollow the instructions in [content.md](content.md).\n"
 
 internal const val CANONICAL_CEREMONY_SECTION: String =
-  "## Ceremony\n\nKeep `shell-ceremony.md` as the shared ceremony sidecar.\n"
+  "## Ceremony\n\nFollow the shell ceremony in [shell-ceremony.md](shell-ceremony.md).\n"
 
 internal data class TemplateContext(
   val skillName: String,
@@ -50,94 +50,10 @@ internal data class TemplateContext(
   val displayName: String,
 )
 
-internal fun defaultAreaFocus(area: String): String = "Review ${area.replace('-', ' ')} regressions."
-
-internal fun inferSkillDescription(context: TemplateContext): String = when {
-  context.family == "code-review" && context.area.isNotBlank() ->
-    "Use when reviewing ${context.displayName} changes for ${context.area} risks."
-  context.family == "code-review" ->
-    "Use when reviewing changes in ${context.displayName} codebases."
-  context.family == "quality-check" ->
-    "Use when validating ${context.displayName} changes with the shared quality-check contract."
-  context.family == "feature-implement" ->
-    "Use when implementing ${context.displayName} changes end to end."
-  context.family == "feature-verify" ->
-    "Use when verifying ${context.displayName} changes before release."
-  else ->
-    "Use for ${context.displayName} work."
-}
-
-internal fun renderFrontmatter(skillName: String, description: String): String = buildString {
-  appendLine("---")
-  appendLine("name: $skillName")
-  appendLine("description: $description")
-  appendLine("---")
-}
-
-internal fun renderDescriptorSection(context: TemplateContext, areaFocus: String): String = buildString {
-  appendLine("## Descriptor")
-  appendLine()
-  appendLine("- Skill: ${context.skillName}")
-  appendLine("- Family: ${context.family}")
-  appendLine("- Platform: ${context.platform}")
-  if (context.area.isNotBlank()) {
-    appendLine("- Area: ${context.area}")
-    appendLine("- Focus: $areaFocus")
+internal fun displayNameFromSlug(slug: String): String = slug.split('-').joinToString(" ") { part ->
+  part.replaceFirstChar {
+    if (it.isLowerCase()) it.titlecase() else it.toString()
   }
-}
-
-internal fun renderContentBody(context: TemplateContext, description: String, contentBody: String? = null): String {
-  val specialistScope =
-    contentBody?.trimEnd().takeUnless { it.isNullOrBlank() }
-      ?: "Use this content surface to author the ${context.displayName} execution guidance."
-  return buildString {
-    append(renderFrontmatter(context.skillName, description))
-    appendLine("## Description")
-    appendLine()
-    appendLine(description)
-    appendLine()
-    appendLine("## Specialist Scope")
-    appendLine()
-    appendLine(specialistScope)
-    appendLine()
-    appendLine("## Inputs")
-    appendLine()
-    appendLine("- Repo context")
-    appendLine("- Relevant diffs or scope")
-    appendLine()
-    appendLine("## Outputs Contract")
-    appendLine()
-    appendLine("- Structured execution output")
-    appendLine()
-    appendLine("## Execution Mode Reporting")
-    appendLine()
-    appendLine("- Report the chosen execution mode in the wrapper.")
-    appendLine()
-    appendLine("## Telemetry Ceremony Hooks")
-    appendLine()
-    appendLine("- Keep telemetry hooks in the shared sidecar.")
-  }
-}
-
-internal fun renderSkillBody(context: TemplateContext, description: String, areaFocus: String = ""): String =
-  buildString {
-    append(renderFrontmatter(context.skillName, description))
-    append(renderDescriptorSection(context, areaFocus))
-    appendLine()
-    append(CANONICAL_EXECUTION_SECTION)
-    appendLine()
-    append(CANONICAL_CEREMONY_SECTION)
-  }
-
-internal fun renderAddonBody(skillName: String, description: String, explicitBody: String?): String {
-  val body = explicitBody?.takeIf { it.isNotBlank() } ?: buildString {
-    appendLine("# $skillName")
-    appendLine()
-    appendLine(description)
-    appendLine()
-    appendLine("TODO: author the add-on body.")
-  }
-  return if (body.endsWith('\n')) body else "$body\n"
 }
 
 internal val ORCHESTRATION_PLAYBOOKS: Map<String, String> =
@@ -163,6 +79,7 @@ internal fun supportingFileTargets(repoRoot: Path): Map<String, Path> = mapOf(
   "telemetry-contract.md" to repoRoot.resolve(ORCHESTRATION_PLAYBOOKS.getValue("telemetry-contract")),
   "shell-content-contract.md" to repoRoot.resolve(ORCHESTRATION_PLAYBOOKS.getValue("shell-content-contract")),
   "shell-ceremony.md" to repoRoot.resolve(ORCHESTRATION_SIDECARS.getValue("shell-ceremony")),
+  "audit-rubrics.md" to repoRoot.resolve("skills/bill-feature-verify/audit-rubrics.md"),
   "android-compose-implementation.md" to repoRoot.resolve(
     "platform-packs/kmp/addons/android-compose-implementation.md",
   ),
@@ -224,7 +141,11 @@ internal fun requiredSupportingFilesForSkill(skillName: String): List<String> = 
   )
   skillName.startsWith(
     "bill-",
-  ) && skillName.endsWith("-feature-verify") -> listOf("shell-ceremony.md", "telemetry-contract.md")
+  ) && skillName.endsWith("-feature-verify") -> listOf(
+    "shell-ceremony.md",
+    "telemetry-contract.md",
+    "audit-rubrics.md",
+  )
   skillName == "bill-pr-description" -> listOf("shell-ceremony.md", "telemetry-contract.md")
   else -> emptyList()
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldTemplateRendering.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldTemplateRendering.kt
@@ -1,0 +1,127 @@
+package skillbill.scaffold
+
+private val AREA_DESCRIPTION_PHRASES: Map<String, String> =
+  mapOf(
+    "architecture" to "architecture, boundaries, and dependency direction",
+    "performance" to "performance risks on hot paths, blocking I/O, and resource usage",
+    "platform-correctness" to "lifecycle, concurrency, threading, and logic correctness",
+    "security" to "secrets handling, auth, and sensitive-data exposure",
+    "testing" to "test coverage quality and regression protection",
+    "api-contracts" to "API contracts, request validation, and serialization",
+    "persistence" to "persistence, transactions, migrations, and data consistency",
+    "reliability" to "timeouts, retries, background work, and observability",
+    "ui" to "UI correctness and framework usage",
+    "ux-accessibility" to "UX correctness and accessibility",
+  )
+
+internal fun defaultAreaFocus(area: String): String =
+  AREA_DESCRIPTION_PHRASES[area] ?: "${area.replace('-', ' ')} risks"
+
+internal fun inferSkillDescription(context: TemplateContext, areaFocus: String = ""): String {
+  val label = context.displayName.ifBlank { context.platform }
+  return when (context.family) {
+    "code-review" -> codeReviewDescription(context, label, areaFocus)
+    "quality-check" -> if (label.isNotBlank()) {
+      "Use when validating $label changes with the shared quality-check contract."
+    } else {
+      "Use when validating changes with the shared quality-check contract."
+    }
+    "feature-implement" -> if (label.isNotBlank()) {
+      "Use when implementing a feature end-to-end in $label codebases, from design doc to verified code."
+    } else {
+      "Use when implementing a feature end-to-end from design doc to verified code."
+    }
+    "feature-verify" -> if (label.isNotBlank()) {
+      "Use when verifying a $label PR against its task spec."
+    } else {
+      "Use when verifying a PR against its task spec."
+    }
+    "add-on" -> if (label.isNotBlank()) {
+      "Pack-owned supporting asset for the $label platform pack."
+    } else {
+      "Pack-owned supporting asset."
+    }
+    else -> "Use for ${context.skillName.removePrefix("bill-").replace("-", " ")} work."
+  }
+}
+
+internal fun renderFrontmatter(skillName: String, description: String): String = buildString {
+  appendLine("---")
+  appendLine("name: $skillName")
+  appendLine("description: $description")
+  appendLine("---")
+}
+
+internal fun renderDescriptorSection(context: TemplateContext, areaFocus: String): String = buildString {
+  appendLine("## Descriptor")
+  appendLine()
+  appendLine("Governed skill: `${context.skillName}`")
+  appendLine("Family: `${context.family}`")
+  if (context.platform.isNotBlank()) {
+    appendLine("Platform pack: `${context.platform}` (${context.displayName.ifBlank { context.platform }})")
+  }
+  if (context.area.isNotBlank()) {
+    appendLine("Area: `${context.area}`")
+  }
+  appendLine("Description: ${inferSkillDescription(context, areaFocus)}")
+}
+
+internal fun renderContentBody(context: TemplateContext, description: String, contentBody: String? = null): String {
+  val body = contentBody?.trimEnd()?.plus("\n") ?: renderGovernedContentStarter(context, description)
+  return "# ${contentTitle(context)}\n\n${body.trimEnd()}\n"
+}
+
+internal fun renderSkillBody(context: TemplateContext, description: String, areaFocus: String = ""): String =
+  buildString {
+    append(renderFrontmatter(context.skillName, description))
+    appendLine()
+    append(renderDescriptorSection(context, areaFocus))
+    appendLine()
+    append(CANONICAL_EXECUTION_SECTION)
+    appendLine()
+    append(renderCeremonySection(context))
+  }
+
+internal fun renderAddonBody(skillName: String, description: String, explicitBody: String?): String {
+  val body = explicitBody?.takeIf { it.isNotBlank() } ?: buildString {
+    appendLine("# $skillName")
+    appendLine()
+    appendLine(description)
+    appendLine()
+    appendLine("TODO: author the add-on body.")
+  }
+  return if (body.endsWith('\n')) body else "$body\n"
+}
+
+private fun codeReviewDescription(context: TemplateContext, label: String, areaFocus: String): String {
+  if (context.area.isNotBlank()) {
+    val phrase = areaFocus.ifBlank { defaultAreaFocus(context.area) }
+    return if (label.isNotBlank()) {
+      "Use when reviewing $label changes for $phrase."
+    } else {
+      "Use when reviewing changes for $phrase."
+    }
+  }
+  return if (label.isNotBlank()) {
+    "Use when reviewing $label changes across code-review specialists."
+  } else {
+    "Use when reviewing code changes across code-review specialists."
+  }
+}
+
+private fun renderGovernedContentStarter(context: TemplateContext, description: String): String {
+  val summary = description.ifBlank { inferSkillDescription(context) }
+  return when {
+    context.family == "quality-check" -> qualityCheckContent(summary)
+    context.family == "code-review" && context.area.isNotBlank() -> areaReviewContent(summary, context.area)
+    else -> baselineReviewContent(summary)
+  }
+}
+
+private fun contentTitle(context: TemplateContext): String = when {
+  context.family == "quality-check" -> "Quality-Check Content"
+  context.family == "code-review" && context.area.isNotBlank() ->
+    "${context.area.replace('-', ' ').split(' ').joinToString(" ") { it.replaceFirstChar(Char::titlecase) }} Content"
+  context.family == "code-review" -> "Review Content"
+  else -> "Content"
+}

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
@@ -309,6 +309,7 @@ private fun validateGovernedSkill(
 
   val sections = collectTopLevelH2Sections(Files.readString(skillPath))
   ensureRequiredSections(pack.slug, skillPath, sections)
+  validateSkillMdShape(skillPath)
   ensureSiblingFiles(pack.slug, slot, skillPath)
 
   val context = governedContext(pack, skillPath.parent.fileName.toString(), family, area)
@@ -319,7 +320,7 @@ private fun validateGovernedSkill(
       "Platform pack '${pack.slug}': skill file '$skillPath' has a drifted ## Execution section.",
     )
   }
-  if (sections.getValue("## Ceremony") != CANONICAL_CEREMONY_SECTION) {
+  if (sections.getValue("## Ceremony") != renderCeremonySection(context)) {
     throw InvalidCeremonySectionError(
       "Platform pack '${pack.slug}': skill file '$skillPath' has a drifted ## Ceremony section.",
     )
@@ -413,5 +414,5 @@ private fun governedContext(pack: PlatformManifest, skillName: String, family: S
     family = family,
     platform = pack.slug,
     area = area,
-    displayName = pack.displayName ?: pack.slug.replace('-', ' ').replaceFirstChar { it.uppercaseChar() },
+    displayName = pack.displayName ?: displayNameFromSlug(pack.slug),
   )

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/SkillMdShapeValidator.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/SkillMdShapeValidator.kt
@@ -1,0 +1,106 @@
+package skillbill.scaffold
+
+import skillbill.error.InvalidSkillMdShapeError
+import java.nio.file.Files
+import java.nio.file.Path
+
+private val FRONTMATTER_PATTERN = Regex("""(?s)\A---\n(.*?)\n---\n""")
+private val ALLOWED_FRONTMATTER_KEYS = setOf("name", "description")
+private val FENCE_PATTERN = Regex("""^\s*(?:```|~~~)""")
+private val TABLE_PATTERN = Regex("""^\s*\|.*\|\s*$""")
+private val STEP_HEADING_PATTERN = Regex("""^##\s+Step\s+\d+[a-z]?\b""", RegexOption.IGNORE_CASE)
+private val MCP_INSTALL_PATTERN = Regex("""npm install -g|readian-mcp""", RegexOption.IGNORE_CASE)
+private val TELEMETRY_PATTERN =
+  Regex("""\b(?:_started|_finished)\b\s*MCP|telemetry_proxy_capabilities|skillbill_[a-z_]+_(?:started|finished)""")
+private val ROUTING_RULE_PATTERN = Regex("""^\s*(?:Route|Routing rule|Routing rules):""", RegexOption.IGNORE_CASE)
+private val RUN_CONTEXT_PATTERN = Regex("""^\s*`(?:Review session ID|Review run ID|Applied learnings):""")
+
+internal fun validateSkillMdShape(skillMdPath: Path) {
+  val text = Files.readString(skillMdPath)
+  val frontmatterMatch = FRONTMATTER_PATTERN.find(text)
+    ?: skillShapeFailure("$skillMdPath: SKILL.md must begin with a YAML frontmatter block.")
+
+  val frontmatter = parseFrontmatter(frontmatterMatch.groupValues[1])
+  val unknownKeys = (frontmatter.keys - ALLOWED_FRONTMATTER_KEYS).sorted()
+  if (unknownKeys.isNotEmpty()) {
+    skillShapeFailure(
+      "$skillMdPath: SKILL.md frontmatter contains disallowed keys $unknownKeys; " +
+        "only ${ALLOWED_FRONTMATTER_KEYS.sorted()} are allowed.",
+    )
+  }
+  listOf("name", "description").forEach { requiredKey ->
+    if (frontmatter[requiredKey].isNullOrBlank()) {
+      skillShapeFailure("$skillMdPath: SKILL.md frontmatter is missing required key '$requiredKey'.")
+    }
+  }
+
+  val body = text.substring(frontmatterMatch.range.last + 1)
+  val bodyStartLine = text.substring(0, frontmatterMatch.range.last + 1).count { it == '\n' } + 1
+  val headings = mutableListOf<String>()
+  var foundFirstH2 = false
+  body.lineSequence().forEachIndexed { index, line ->
+    val fileLine = bodyStartLine + index
+    val stripped = line.trim()
+    if (FENCE_PATTERN.containsMatchIn(line)) {
+      skillShapeFailure("$skillMdPath:$fileLine: fenced code blocks are not allowed in SKILL.md.")
+    }
+    if (line.startsWith("## ")) {
+      headings += stripped
+      foundFirstH2 = true
+      return@forEachIndexed
+    }
+    if (!foundFirstH2) {
+      if (stripped.isNotBlank()) {
+        skillShapeFailure(
+          "$skillMdPath:$fileLine: intro paragraph or content is not allowed before the first H2.",
+        )
+      }
+      return@forEachIndexed
+    }
+    validateBodyLine(skillMdPath, fileLine, line)
+  }
+
+  if (headings.isEmpty()) {
+    skillShapeFailure(
+      "$skillMdPath: SKILL.md must contain the canonical H2 sections $REQUIRED_GOVERNED_SECTIONS.",
+    )
+  }
+  if (headings != REQUIRED_GOVERNED_SECTIONS) {
+    skillShapeFailure(
+      "$skillMdPath: SKILL.md must contain exactly the H2 sections $REQUIRED_GOVERNED_SECTIONS " +
+        "in that order; got $headings.",
+    )
+  }
+}
+
+private fun parseFrontmatter(frontmatter: String): Map<String, String> = frontmatter.lineSequence()
+  .mapNotNull { line ->
+    val separator = line.indexOf(':')
+    if (separator < 0) {
+      null
+    } else {
+      line.substring(0, separator).trim() to line.substring(separator + 1).trim().trim('"', '\'')
+    }
+  }
+  .toMap()
+
+private fun validateBodyLine(skillMdPath: Path, fileLine: Int, line: String) {
+  val matchedLabel = when {
+    TABLE_PATTERN.containsMatchIn(line) -> "markdown table"
+    STEP_HEADING_PATTERN.containsMatchIn(line) -> "'## Step N:' heading"
+    MCP_INSTALL_PATTERN.containsMatchIn(line) -> "MCP install gate"
+    TELEMETRY_PATTERN.containsMatchIn(line) -> "telemetry instructions"
+    ROUTING_RULE_PATTERN.containsMatchIn(line) -> "routing rule"
+    RUN_CONTEXT_PATTERN.containsMatchIn(line) -> "run-context placeholder line"
+    line.startsWith("# ") -> "H1 heading"
+    Regex("""^#{3,}\s+""").containsMatchIn(line) -> "H3+ heading"
+    else -> null
+  }
+  if (matchedLabel != null) {
+    skillShapeFailure(
+      "$skillMdPath:$fileLine: SKILL.md body must not contain $matchedLabel; matched '${line.trimEnd()}'.",
+    )
+  }
+}
+
+private fun skillShapeFailure(message: String): Nothing = throw InvalidSkillMdShapeError(message)

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/SubagentScaffoldRendering.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/SubagentScaffoldRendering.kt
@@ -1,0 +1,79 @@
+package skillbill.scaffold
+
+private const val DEFAULT_CODEX_MAX_THREADS = 6
+
+internal fun renderCodexAgentTomlStub(name: String, parentSkill: String): String {
+  val description = "TODO: one-line description for the $name specialist subagent. Fill in before shipping."
+  return buildString {
+    appendLine("name = \"$name\"")
+    appendLine("description = \"$description\"")
+    appendLine()
+    appendLine("developer_instructions = \"\"\"")
+    appendLine("# ${titleCaseSpecialist(name)} Specialist")
+    appendLine()
+    appendLine("TODO: replace this placeholder with the specialist briefing.")
+    appendLine()
+    appendLine(
+      "Specialist contract pointer: see specialist-contract.md for the F-XXX Risk Register format used by " +
+        "this orchestrator's review specialists (parent skill: $parentSkill).",
+    )
+    appendLine("\"\"\"")
+  }
+}
+
+internal fun renderOpencodeAgentMdStub(name: String, parentSkill: String): String {
+  val description = "TODO: one-line description for the $name specialist subagent. Fill in before shipping."
+  return buildString {
+    appendLine("---")
+    appendLine("name: $name")
+    appendLine("description: $description")
+    appendLine("mode: subagent")
+    appendLine("---")
+    appendLine()
+    appendLine("# ${titleCaseSpecialist(name)} Specialist")
+    appendLine()
+    appendLine("TODO: replace this placeholder with the specialist briefing.")
+    appendLine()
+    appendLine(
+      "Specialist contract pointer: see specialist-contract.md for the F-XXX Risk Register format used by " +
+        "this orchestrator's review specialists (parent skill: $parentSkill).",
+    )
+  }
+}
+
+internal fun renderSubagentSpawnRuntimeNotes(orchestratorName: String, specialists: List<String>): String {
+  if (specialists.isEmpty()) {
+    return ""
+  }
+  val paragraphs = mutableListOf(
+    "## Subagent Spawn Runtime Notes",
+    subagentResolutionParagraph(orchestratorName, specialists),
+  )
+  if (specialists.size > DEFAULT_CODEX_MAX_THREADS) {
+    paragraphs +=
+      "Selected fan-out exceeds Codex's `agents.max_threads = 6` default; run waves of at most 6 specialists, " +
+      "with the orchestrator merging wave outputs before final review."
+  }
+  paragraphs +=
+    "OpenCode does not document a different native concurrency cap; keep the conservative limit of 6 or fewer " +
+    "specialists per wave."
+  return paragraphs.joinToString("\n\n")
+}
+
+private fun subagentResolutionParagraph(orchestratorName: String, specialists: List<String>): String {
+  val exampleSpecialist = specialists.first()
+  val backticked = specialists.joinToString(", ") { "`@$it`" }
+  return "Specialist spawn instructions in this orchestrator are runtime-neutral. Each phrase such as " +
+    "\"spawn the `$exampleSpecialist` subagent\" maps to the native subagent surface of the host runtime. " +
+    "On Claude, the spawn becomes an `Agent` tool call against a matching subagent definition for " +
+    "`$orchestratorName`. On Codex, the spawn is a natural-language directive and Codex resolves it by " +
+    "`name` against the installed TOML files in the Codex user agents directory (with the legacy Agents " +
+    "agents fallback), respecting `agents.max_threads` and `agents.max_depth`. On OpenCode, the spawn " +
+    "resolves by filename-derived `name` against markdown agents installed in the OpenCode user agents " +
+    "directory; operators can also invoke the same specialists manually with $backticked."
+}
+
+private fun titleCaseSpecialist(name: String): String =
+  name.split("-").filter { it.isNotBlank() }.joinToString(" ") { part ->
+    part.replaceFirstChar { first -> if (first.isLowerCase()) first.titlecase() else first.toString() }
+  }

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldServiceParityTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldServiceParityTest.kt
@@ -1,0 +1,386 @@
+package skillbill.scaffold
+
+import skillbill.error.InvalidScaffoldPayloadError
+import skillbill.error.MissingShellCeremonyFileError
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.name
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ScaffoldServiceParityTest {
+  @Test
+  fun `horizontal subagent specialists emit runtime notes and native stubs`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result =
+      scaffold(
+        payload(repo, "horizontal", "name" to "bill-foo-orchestrator") +
+          mapOf("subagent_specialists" to listOf("foo-arch", "foo-perf")),
+      )
+    val skillDir = repo.resolve("skills").resolve("bill-foo-orchestrator")
+    val content = Files.readString(skillDir.resolve("content.md"))
+
+    assertEquals("horizontal", result.kind)
+    assertContains(content, "## Subagent Spawn Runtime Notes")
+    assertContains(content, "`@foo-arch`")
+    assertContains(content, "`@foo-perf`")
+    assertCodexStub(skillDir.resolve("codex-agents/foo-arch.toml"), "foo-arch")
+    assertCodexStub(skillDir.resolve("codex-agents/foo-perf.toml"), "foo-perf")
+    assertOpencodeStub(skillDir.resolve("opencode-agents/foo-arch.md"), "foo-arch")
+    assertOpencodeStub(skillDir.resolve("opencode-agents/foo-perf.md"), "foo-perf")
+    assertTrue(result.notes.any { note -> "Subagent stubs emitted: 2." in note }, result.notes.toString())
+  }
+
+  @Test
+  fun `platform pack subagent specialists attach only to baseline orchestrator`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result =
+      scaffold(
+        payload(repo, "platform-pack", "platform" to "java") +
+          mapOf("skeleton_mode" to "starter", "subagent_specialists" to listOf("arch", "perf")),
+      )
+    val packRoot = repo.resolve("platform-packs").resolve("java")
+    val baseline = packRoot.resolve("code-review/bill-java-code-review")
+    val qualityCheck = packRoot.resolve("quality-check/bill-java-quality-check")
+
+    assertEquals("platform-pack", result.kind)
+    assertCodexStub(baseline.resolve("codex-agents/arch.toml"), "arch")
+    assertOpencodeStub(baseline.resolve("opencode-agents/perf.md"), "perf")
+    assertFalse(Files.exists(qualityCheck.resolve("codex-agents")))
+    assertFalse(Files.exists(qualityCheck.resolve("opencode-agents")))
+    assertContains(Files.readString(baseline.resolve("content.md")), "## Subagent Spawn Runtime Notes")
+  }
+
+  @Test
+  fun `platform pack custom specialist areas are approved sorted and registered`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result =
+      scaffold(
+        payload(repo, "platform-pack", "platform" to "php") +
+          mapOf("specialist_areas" to listOf("security", "architecture")),
+      )
+    val manifest = Files.readString(repo.resolve("platform-packs/php/platform.yaml"))
+
+    assertEquals("platform-pack", result.kind)
+    assertTrue(
+      Files.isRegularFile(repo.resolve("platform-packs/php/code-review/bill-php-code-review-architecture/SKILL.md")),
+    )
+    assertTrue(
+      Files.isRegularFile(repo.resolve("platform-packs/php/code-review/bill-php-code-review-security/SKILL.md")),
+    )
+    assertTrue(manifest.indexOf("  - \"architecture\"") < manifest.indexOf("  - \"security\""))
+    assertContains(manifest, "architecture: \"code-review/bill-php-code-review-architecture/SKILL.md\"")
+    assertContains(manifest, "security: \"code-review/bill-php-code-review-security/SKILL.md\"")
+  }
+
+  @Test
+  fun `subagent payload validation rejects invalid combinations and leaf kinds`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    listOf(
+      mapOf("subagent_specialists" to "foo") to "list of strings",
+      mapOf("subagent_specialists" to listOf("")) to "non-empty strings",
+      mapOf("subagent_specialists" to listOf("foo", "foo")) to "duplicate",
+      mapOf("subagent_specialists" to listOf("../foo")) to "invalid name",
+      mapOf("no_subagents" to "yes") to "must be a boolean",
+      mapOf("subagent_specialists" to listOf("foo"), "no_subagents" to true) to "no_subagents=true",
+    ).forEach { (extraPayload, expected) ->
+      assertContains(
+        assertFailsWith<InvalidScaffoldPayloadError> {
+          scaffold(payload(repo, "horizontal", "name" to "bill-mixed-orchestrator") + extraPayload)
+        }.message.orEmpty(),
+        expected,
+      )
+    }
+    assertContains(
+      assertFailsWith<InvalidScaffoldPayloadError> {
+        scaffold(
+          payload(repo, "code-review-area", "platform" to "kotlin", "area" to "performance") +
+            mapOf("name" to "bill-kotlin-code-review-performance", "subagent_specialists" to listOf("x")),
+        )
+      }.message.orEmpty(),
+      "subagent_specialists is only valid for orchestrator kinds",
+    )
+    assertContains(
+      assertFailsWith<InvalidScaffoldPayloadError> {
+        scaffold(
+          payload(repo, "add-on", "platform" to "kotlin", "name" to "review-helper") +
+            mapOf("subagent_specialists" to listOf("x")),
+        )
+      }.message.orEmpty(),
+      "subagent_specialists is only valid for orchestrator kinds",
+    )
+    assertContains(
+      assertFailsWith<InvalidScaffoldPayloadError> {
+        scaffold(payload(repo, "platform-pack", "platform" to "java") + mapOf("specialist_areas" to listOf("mobile")))
+      }.message.orEmpty(),
+      "unknown areas",
+    )
+  }
+
+  @Test
+  fun `authoring render preserves platform display name and base shell ceremony sidecars`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val packSkill = repo.resolve("platform-packs/kotlin/code-review/bill-kotlin-code-review/SKILL.md")
+    val packTarget =
+      AuthoringTarget(
+        skillName = "bill-kotlin-code-review",
+        packageName = "kotlin",
+        platform = "kotlin",
+        displayName = "Kotlin",
+        family = "code-review",
+        area = "",
+        skillFile = packSkill,
+        contentFile = packSkill.resolveSibling("content.md"),
+      )
+    val baseSkill = repo.resolve("skills/bill-code-review")
+    Files.createDirectories(baseSkill)
+    Files.writeString(
+      baseSkill.resolve("SKILL.md"),
+      renderSkillBody(
+        TemplateContext("bill-code-review", "code-review", "", "", "code review"),
+        "Use when reviewing code changes across stack-specific review specialists.",
+      ),
+    )
+    Files.writeString(baseSkill.resolve("content.md"), baselineReviewContent("Base shell content."))
+    Files.writeString(baseSkill.resolve("shell-ceremony.md"), "# ceremony\n")
+    Files.writeString(baseSkill.resolve("shell-content-contract.md"), "# contract\n")
+    val baseTarget =
+      AuthoringTarget(
+        skillName = "bill-code-review",
+        packageName = "base",
+        platform = "",
+        displayName = "code review",
+        family = "code-review",
+        area = "",
+        skillFile = baseSkill.resolve("SKILL.md"),
+        contentFile = baseSkill.resolve("content.md"),
+      )
+
+    assertContains(renderWrapper(packTarget), "Platform pack: `kotlin` (Kotlin)")
+    val renderedBase = renderWrapper(baseTarget)
+
+    assertContains(renderedBase, "shell-content-contract.md")
+    assertFalse("review-orchestrator.md" in renderedBase)
+  }
+
+  @Test
+  fun `authoring render and loader share multi word platform display name fallback`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result =
+      scaffold(
+        payload(repo, "platform-pack", "platform" to "foo-bar") +
+          mapOf("skeleton_mode" to "starter", "routing_signals" to mapOf("strong" to listOf(".foobar"))),
+      )
+    val target = resolveTarget(repo, "bill-foo-bar-code-review")
+    val rendered = renderWrapper(target)
+
+    assertEquals("platform-pack", result.kind)
+    assertContains(rendered, "Platform pack: `foo-bar` (Foo Bar)")
+    assertFalse(hasGenerationDrift(target))
+    loadPlatformPack(repo.resolve("platform-packs/foo-bar"))
+  }
+
+  @Test
+  fun `feature verify render preserves audit rubrics sidecar and validates regular files`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val skillDir = repo.resolve("skills/bill-feature-verify")
+    Files.createDirectories(skillDir)
+    val context = TemplateContext("bill-feature-verify", "feature-verify", "", "", "feature verify")
+    Files.writeString(skillDir.resolve("SKILL.md"), renderSkillBody(context, inferSkillDescription(context)))
+    Files.writeString(skillDir.resolve("content.md"), baselineReviewContent("Feature verify content."))
+    Files.writeString(skillDir.resolve("shell-ceremony.md"), "# ceremony\n")
+    Files.writeString(skillDir.resolve("telemetry-contract.md"), "# telemetry\n")
+    Files.writeString(skillDir.resolve("audit-rubrics.md"), "# audit\n")
+    val target = resolveTarget(repo, "bill-feature-verify")
+    val rendered = renderWrapper(target)
+
+    assertContains(rendered, "audit-rubrics.md")
+    Files.writeString(skillDir.resolve("SKILL.md"), rendered)
+    assertEquals(emptyList(), validateTarget(target))
+
+    Files.delete(skillDir.resolve("audit-rubrics.md"))
+    Files.createDirectories(skillDir.resolve("audit-rubrics.md"))
+
+    assertTrue(validateTarget(target).any { issue -> "audit-rubrics.md" in issue })
+  }
+
+  @Test
+  fun `feature verify override links shared audit rubrics supporting file`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result =
+      scaffold(
+        payload(
+          repo,
+          "platform-override-piloted",
+          "platform" to "kmp",
+          "family" to "feature-verify",
+          "name" to "bill-kmp-feature-verify",
+        ),
+      )
+    val skillDir = repo.resolve("skills/kmp/bill-kmp-feature-verify")
+    val rubricLink = skillDir.resolve("audit-rubrics.md")
+
+    assertEquals("bill-kmp-feature-verify", result.skillName)
+    assertContains(Files.readString(skillDir.resolve("SKILL.md")), "audit-rubrics.md")
+    assertTrue(Files.isSymbolicLink(rubricLink))
+    assertEquals(repo.resolve("skills/bill-feature-verify/audit-rubrics.md"), Files.readSymbolicLink(rubricLink))
+  }
+
+  @Test
+  fun `no subagents opt out skips stub emission`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    scaffold(payload(repo, "horizontal", "name" to "bill-bar-orchestrator") + mapOf("no_subagents" to true))
+    val skillDir = repo.resolve("skills").resolve("bill-bar-orchestrator")
+
+    assertFalse(Files.exists(skillDir.resolve("codex-agents")))
+    assertFalse(Files.exists(skillDir.resolve("opencode-agents")))
+    assertFalse("## Subagent Spawn Runtime Notes" in Files.readString(skillDir.resolve("content.md")))
+  }
+
+  @Test
+  fun `quality check override registers declared manifest file`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result =
+      scaffold(
+        payload(
+          repo,
+          "platform-override-piloted",
+          "platform" to "kotlin",
+          "family" to "quality-check",
+          "name" to "bill-kotlin-quality-check",
+        ),
+      )
+    val manifest = Files.readString(repo.resolve("platform-packs/kotlin/platform.yaml"))
+
+    assertEquals("bill-kotlin-quality-check", result.skillName)
+    assertContains(manifest, "declared_quality_check_file: \"quality-check/bill-kotlin-quality-check/SKILL.md\"")
+  }
+
+  @Test
+  fun `scaffold rollback restores manifest files symlinks and directories byte identically`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val unrelated = repo.resolve("notes/unrelated.txt")
+    Files.createDirectories(unrelated.parent)
+    Files.writeString(unrelated, "keep me")
+    Files.delete(repo.resolve("orchestration/shell-content-contract/shell-ceremony.md"))
+    val before = snapshotTree(repo)
+
+    assertFailsWith<MissingShellCeremonyFileError> {
+      scaffold(
+        payload(
+          repo,
+          "code-review-area",
+          "platform" to "kotlin",
+          "area" to "performance",
+          "name" to "bill-kotlin-code-review-performance",
+        ),
+      )
+    }
+
+    assertEquals(before, snapshotTree(repo))
+    assertEquals("keep me", Files.readString(unrelated))
+    assertFalse(Files.exists(repo.resolve("platform-packs/kotlin/code-review/bill-kotlin-code-review-performance")))
+  }
+}
+
+private fun payload(repo: Path, kind: String, vararg pairs: Pair<String, Any?>): Map<String, Any?> =
+  mapOf("scaffold_payload_version" to "1.0", "kind" to kind, "repo_root" to repo.toString()) + pairs
+
+private fun seedRepo(): Path {
+  val repo = Files.createTempDirectory("skillbill-scaffold-repo")
+  supportingFileTargets(repo).values.forEach { target ->
+    Files.createDirectories(target.parent)
+    Files.writeString(target, "# ${target.fileName}\n")
+  }
+  seedKotlinPack(repo)
+  seedKmpPack(repo)
+  return repo
+}
+
+private fun seedKotlinPack(repo: Path) {
+  val packRoot = repo.resolve("platform-packs/kotlin")
+  val baseline = packRoot.resolve("code-review/bill-kotlin-code-review")
+  Files.createDirectories(baseline)
+  val context = TemplateContext("bill-kotlin-code-review", "code-review", "kotlin", "", "Kotlin")
+  Files.writeString(
+    packRoot.resolve("platform.yaml"),
+    renderPlatformPackManifest(
+      platform = "kotlin",
+      displayName = "Kotlin",
+      strongSignals = listOf(".kt"),
+      baselineContentPath = "code-review/bill-kotlin-code-review/SKILL.md",
+    ),
+  )
+  Files.writeString(baseline.resolve("SKILL.md"), renderSkillBody(context, inferSkillDescription(context)))
+  Files.writeString(baseline.resolve("content.md"), renderContentBody(context, inferSkillDescription(context)))
+  Files.writeString(baseline.resolve("shell-ceremony.md"), "# ceremony\n")
+}
+
+private fun seedKmpPack(repo: Path) {
+  val packRoot = repo.resolve("platform-packs/kmp")
+  val baseline = packRoot.resolve("code-review/bill-kmp-code-review")
+  Files.createDirectories(baseline)
+  val context = TemplateContext("bill-kmp-code-review", "code-review", "kmp", "", "KMP")
+  Files.writeString(
+    packRoot.resolve("platform.yaml"),
+    renderPlatformPackManifest(
+      platform = "kmp",
+      displayName = "KMP",
+      strongSignals = listOf(".kt"),
+      baselineContentPath = "code-review/bill-kmp-code-review/SKILL.md",
+    ),
+  )
+  Files.writeString(baseline.resolve("SKILL.md"), renderSkillBody(context, inferSkillDescription(context)))
+  Files.writeString(baseline.resolve("content.md"), renderContentBody(context, inferSkillDescription(context)))
+  Files.writeString(baseline.resolve("shell-ceremony.md"), "# ceremony\n")
+}
+
+private fun assertCodexStub(path: Path, name: String) {
+  val text = Files.readString(path)
+  assertContains(text, "name = \"$name\"")
+  assertContains(text, "developer_instructions")
+  assertContains(text, "TODO: replace this placeholder")
+}
+
+private fun assertOpencodeStub(path: Path, name: String) {
+  val text = Files.readString(path)
+  assertContains(text, "name: $name")
+  assertContains(text, "mode: subagent")
+  assertContains(text, "TODO: replace this placeholder")
+}
+
+private fun withIsolatedUserHome(block: () -> Unit) {
+  val originalHome = System.getProperty("user.home")
+  val tempHome = Files.createTempDirectory("skillbill-no-agents-home")
+  try {
+    System.setProperty("user.home", tempHome.toString())
+    block()
+  } finally {
+    System.setProperty("user.home", originalHome)
+  }
+}
+
+private fun snapshotTree(root: Path): Map<String, String> {
+  if (!Files.exists(root)) {
+    return emptyMap()
+  }
+  return Files.walk(root).use { stream ->
+    stream
+      .filter { path -> path != root }
+      .sorted()
+      .toList()
+      .associate { path ->
+        val key = root.relativize(path).toString()
+        val value = when {
+          Files.isSymbolicLink(path) -> "symlink:${Files.readSymbolicLink(path)}"
+          Files.isDirectory(path) -> "dir"
+          else -> "file:${Files.readString(path)}"
+        }
+        key to value
+      }
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ShellContentLoaderParityTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ShellContentLoaderParityTest.kt
@@ -1,0 +1,185 @@
+package skillbill.scaffold
+
+import skillbill.error.ContractVersionMismatchError
+import skillbill.error.InvalidDescriptorSectionError
+import skillbill.error.InvalidManifestSchemaError
+import skillbill.error.InvalidSkillMdShapeError
+import skillbill.error.MissingContentFileError
+import skillbill.error.MissingManifestError
+import skillbill.error.MissingRequiredSectionError
+import skillbill.error.MissingShellCeremonyFileError
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.name
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ShellContentLoaderParityTest {
+  @Test
+  fun `loads valid pack through manifest driven shell contract`() {
+    val pack = loadPlatformPack(fixture("valid_pack"))
+
+    assertEquals("valid_pack", pack.slug)
+    assertEquals(SHELL_CONTRACT_VERSION, pack.contractVersion)
+    assertEquals(listOf("architecture"), pack.declaredCodeReviewAreas)
+    assertEquals(listOf(".fixture"), pack.routingSignals.strong)
+    assertEquals("code-review", pack.declaredFiles.baseline.parent.name)
+  }
+
+  @Test
+  fun `loads optional quality check content without fallback`() {
+    val pack = loadPlatformPack(fixture("code_review_and_quality_check"))
+    val contentPath = loadQualityCheckContent(pack)
+
+    assertEquals(pack.declaredQualityCheckFile?.resolveSibling("content.md"), contentPath)
+    assertTrue(Files.isRegularFile(contentPath))
+  }
+
+  @Test
+  fun `loud fails with named shell content contract errors`() {
+    assertNamedFailure<MissingManifestError>("missing_manifest", "platform.yaml")
+    assertNamedFailure<MissingContentFileError>("missing_content_file", "baseline")
+    assertNamedFailure<ContractVersionMismatchError>("bad_version", "9.99")
+    assertNamedFailure<MissingRequiredSectionError>("missing_section", "## Ceremony")
+    assertNamedFailure<InvalidManifestSchemaError>("invalid_schema", "routing_signals")
+    assertNamedFailure<InvalidManifestSchemaError>("schema_areas_wrong_type", "declared_code_review_areas")
+    assertNamedFailure<InvalidManifestSchemaError>("schema_unapproved_area", "laravel")
+    assertNamedFailure<InvalidManifestSchemaError>("extra_area", "performance")
+    assertNamedFailure<MissingRequiredSectionError>("heading_in_fence", "## Descriptor")
+  }
+
+  @Test
+  fun `quality check declaration fails loudly when file or wrapper section is invalid`() {
+    val missingFilePack = loadPlatformManifest(fixture("quality_check_missing_file"))
+    val missingFileError = assertFailsWith<MissingContentFileError> {
+      loadQualityCheckContent(missingFilePack)
+    }
+    assertContains(missingFileError.message.orEmpty(), "does-not-exist.md")
+
+    val missingSectionPack = loadPlatformManifest(fixture("quality_check_missing_section"))
+    val missingSectionError = assertFailsWith<MissingRequiredSectionError> {
+      loadQualityCheckContent(missingSectionPack)
+    }
+    assertContains(missingSectionError.message.orEmpty(), "## Ceremony")
+  }
+
+  @Test
+  fun `missing shell ceremony fails before descriptor drift`() {
+    val fixtureRoot = copyFixture("valid_pack")
+    val skillPath = fixtureRoot.resolve("code-review").resolve("SKILL.md")
+    Files.writeString(
+      skillPath,
+      Files.readString(skillPath).replace("Governed skill: `code-review`", "Governed skill: `drifted`"),
+    )
+    Files.delete(fixtureRoot.resolve("code-review").resolve("shell-ceremony.md"))
+
+    assertFailsWith<MissingShellCeremonyFileError> {
+      loadPlatformPack(fixtureRoot)
+    }
+  }
+
+  @Test
+  fun `descriptor drift and invalid skill md shape are distinct named failures`() {
+    val driftRoot = copyFixture("valid_pack")
+    val driftSkill = driftRoot.resolve("code-review").resolve("SKILL.md")
+    Files.writeString(
+      driftSkill,
+      Files.readString(driftSkill).replace("Governed skill: `code-review`", "Governed skill: `drifted`"),
+    )
+    val driftError = assertFailsWith<InvalidDescriptorSectionError> {
+      loadPlatformPack(driftRoot)
+    }
+    assertContains(driftError.message.orEmpty(), "## Descriptor")
+
+    val shapeRoot = copyFixture("valid_pack")
+    val shapeSkill = shapeRoot.resolve("code-review").resolve("SKILL.md")
+    Files.writeString(shapeSkill, Files.readString(shapeSkill) + "\n### Not allowed here\n")
+    val shapeError = assertFailsWith<InvalidSkillMdShapeError> {
+      loadPlatformPack(shapeRoot)
+    }
+    assertContains(shapeError.message.orEmpty(), "H3+ heading")
+  }
+
+  @Test
+  fun `invalid skill md shape rejects high value governed wrapper drift categories`() {
+    listOf(
+      "disallowed frontmatter" to { text: String -> text.replace("---\n", "---\nextra: nope\n") },
+      "intro content" to { text: String -> text.replace("## Descriptor", "Intro paragraph.\n\n## Descriptor") },
+      "fenced code block" to { text: String -> text.replace("## Ceremony", "```\ncode\n```\n\n## Ceremony") },
+      "markdown table" to { text: String -> text.replace("## Ceremony", "| a | b |\n| - | - |\n\n## Ceremony") },
+      "H1 heading" to { text: String -> text.replace("## Ceremony", "# Heading\n\n## Ceremony") },
+      "telemetry instruction" to { text: String ->
+        text.replace("## Ceremony", "skillbill_review_finished\n\n## Ceremony")
+      },
+      "wrong H2 order" to ::moveExecutionBeforeDescriptor,
+    ).forEach { (label, mutate) ->
+      val root = copyFixture("valid_pack")
+      val skill = root.resolve("code-review").resolve("SKILL.md")
+      Files.writeString(skill, mutate(Files.readString(skill)))
+
+      val error = assertFailsWith<InvalidSkillMdShapeError>(label) {
+        loadPlatformPack(root)
+      }
+      assertTrue(error.message.orEmpty().contains("SKILL.md"), error.message.orEmpty())
+    }
+  }
+}
+
+private fun moveExecutionBeforeDescriptor(text: String): String {
+  val descriptorStart = text.indexOf("## Descriptor")
+  val executionStart = text.indexOf("## Execution")
+  val ceremonyStart = text.indexOf("## Ceremony")
+  check(descriptorStart >= 0 && executionStart > descriptorStart && ceremonyStart > executionStart)
+  return buildString {
+    append(text.substring(0, descriptorStart))
+    append(text.substring(executionStart, ceremonyStart))
+    append("\n")
+    append(text.substring(descriptorStart, executionStart))
+    append(text.substring(ceremonyStart))
+  }
+}
+
+private inline fun <reified T : Throwable> assertNamedFailure(fixtureName: String, expectedMessage: String) {
+  val error = assertFailsWith<T> {
+    loadPlatformPack(fixture(fixtureName))
+  }
+  assertContains(error.message.orEmpty(), fixtureName)
+  assertContains(error.message.orEmpty(), expectedMessage)
+}
+
+private fun fixture(name: String): Path =
+  repoRoot().resolve("tests").resolve("fixtures").resolve("shell_content_contract").resolve(name)
+
+private fun copyFixture(name: String): Path {
+  val source = fixture(name)
+  val target = Files.createTempDirectory("skillbill-shell-content-fixture").resolve(name)
+  Files.walk(source).use { stream ->
+    stream.sorted().forEach { path ->
+      val relative = source.relativize(path)
+      val destination = target.resolve(relative)
+      when {
+        Files.isDirectory(path) -> Files.createDirectories(destination)
+        Files.isSymbolicLink(path) -> Files.createSymbolicLink(destination, Files.readSymbolicLink(path))
+        else -> {
+          Files.createDirectories(destination.parent)
+          Files.copy(path, destination)
+        }
+      }
+    }
+  }
+  return target
+}
+
+private fun repoRoot(): Path {
+  var current = Path.of("").toAbsolutePath().normalize()
+  while (current.parent != null) {
+    if (Files.isDirectory(current.resolve("skill_bill")) && Files.isDirectory(current.resolve("runtime-kotlin"))) {
+      return current
+    }
+    current = current.parent
+  }
+  error("Could not locate skill-bill repository root from ${Path.of("").toAbsolutePath().normalize()}")
+}

--- a/skills/bill-boundary-decisions/SKILL.md
+++ b/skills/bill-boundary-decisions/SKILL.md
@@ -7,7 +7,7 @@ description: Use when recording architectural or implementation decisions in a m
 
 Governed skill: `bill-boundary-decisions`
 Family: `advisor`
-Description: Use when recording architectural or implementation decisions in a boundary `agent/decisions.md` file.
+Description: Use for boundary decisions work.
 
 ## Execution
 

--- a/skills/bill-boundary-history/SKILL.md
+++ b/skills/bill-boundary-history/SKILL.md
@@ -7,7 +7,7 @@ description: Use when updating module/package/area agent/history.md files with r
 
 Governed skill: `bill-boundary-history`
 Family: `advisor`
-Description: Use when updating boundary `agent/history.md` files with reusable, high-signal feature history entries.
+Description: Use for boundary history work.
 
 ## Execution
 

--- a/skills/bill-code-review/SKILL.md
+++ b/skills/bill-code-review/SKILL.md
@@ -7,7 +7,7 @@ description: Use when you want a generic code-review entry point that detects th
 
 Governed skill: `bill-code-review`
 Family: `advisor`
-Description: Use when reviewing code changes across stack-specific review specialists.
+Description: Use for code review work.
 
 ## Execution
 

--- a/skills/bill-create-skill/SKILL.md
+++ b/skills/bill-create-skill/SKILL.md
@@ -7,7 +7,7 @@ description: Use when scaffolding a new skill or platform skill set and syncing 
 
 Governed skill: `bill-create-skill`
 Family: `advisor`
-Description: Use when scaffolding a new skill or platform skill set through the `skill-bill` CLI.
+Description: Use for create skill work.
 
 ## Execution
 

--- a/skills/bill-feature-guard-cleanup/SKILL.md
+++ b/skills/bill-feature-guard-cleanup/SKILL.md
@@ -7,7 +7,7 @@ description: Remove feature flags and legacy code after a feature is fully rolle
 
 Governed skill: `bill-feature-guard-cleanup`
 Family: `advisor`
-Description: Use when removing a fully rolled-out feature flag and inlining the winning code path.
+Description: Use for feature guard cleanup work.
 
 ## Execution
 

--- a/skills/bill-feature-guard/SKILL.md
+++ b/skills/bill-feature-guard/SKILL.md
@@ -7,7 +7,7 @@ description: Enable feature flag mode - all code changes will be guarded by feat
 
 Governed skill: `bill-feature-guard`
 Family: `advisor`
-Description: Use when guarding new features behind flags for gradual rollout, A/B testing, or safe rollback.
+Description: Use for feature guard work.
 
 ## Execution
 

--- a/skills/bill-feature-verify/SKILL.md
+++ b/skills/bill-feature-verify/SKILL.md
@@ -7,7 +7,7 @@ description: Verify a PR against a task spec — extract acceptance criteria, de
 
 Governed skill: `bill-feature-verify`
 Family: `workflow`
-Description: Use when verifying a PR against its task spec.
+Description: Use for feature verify work.
 
 ## Execution
 
@@ -19,4 +19,4 @@ Follow the shell ceremony in [shell-ceremony.md](shell-ceremony.md).
 
 When telemetry applies, follow [telemetry-contract.md](telemetry-contract.md).
 
-When audit rubrics or PR comment formats apply, follow [audit-rubrics.md](audit-rubrics.md).
+When feature verification audit rules apply, follow [audit-rubrics.md](audit-rubrics.md).

--- a/skills/bill-grill-plan/SKILL.md
+++ b/skills/bill-grill-plan/SKILL.md
@@ -7,7 +7,7 @@ description: Stress-test a plan or design by walking every branch of the decisio
 
 Governed skill: `bill-grill-plan`
 Family: `advisor`
-Description: Use when stress-testing a plan or design by walking every branch of the decision tree.
+Description: Use for grill plan work.
 
 ## Execution
 

--- a/skills/bill-pr-description/SKILL.md
+++ b/skills/bill-pr-description/SKILL.md
@@ -7,7 +7,7 @@ description: Use when generating a PR title, description, and QA steps from the 
 
 Governed skill: `bill-pr-description`
 Family: `advisor`
-Description: Use when generating a PR title, description, and QA steps from the current branch changes.
+Description: Use for pr description work.
 
 ## Execution
 

--- a/skills/bill-quality-check/SKILL.md
+++ b/skills/bill-quality-check/SKILL.md
@@ -7,7 +7,7 @@ description: Use when you want a generic quality-check entry point that detects 
 
 Governed skill: `bill-quality-check`
 Family: `advisor`
-Description: Use when validating changes with the shared quality-check contract.
+Description: Use for quality check work.
 
 ## Execution
 

--- a/skills/bill-skill-remove/SKILL.md
+++ b/skills/bill-skill-remove/SKILL.md
@@ -7,7 +7,7 @@ description: Use when removing an existing skill or platform skill set and clean
 
 Governed skill: `bill-skill-remove`
 Family: `advisor`
-Description: Use when removing an existing skill or platform skill set and cleaning up agent installs.
+Description: Use for skill remove work.
 
 ## Execution
 

--- a/skills/bill-unit-test-value-check/SKILL.md
+++ b/skills/bill-unit-test-value-check/SKILL.md
@@ -7,7 +7,7 @@ description: Use when reviewing unit tests in a file, current changes, or a comm
 
 Governed skill: `bill-unit-test-value-check`
 Family: `advisor`
-Description: Use when reviewing unit tests for low-value, tautological, or coverage-only patterns.
+Description: Use for unit test value check work.
 
 ## Execution
 


### PR DESCRIPTION
# Summary

Completes SKILL-36 subtask 1 by moving the remaining governed scaffold, shell-content-contract loading, render/fill, and upgrade behavior onto Kotlin-owned runtime APIs and CLI paths. This preserves the shell contract and maintainer workflows without adding new Python bridge or fallback paths.

- Adds Kotlin SKILL.md shape validation, render-drift checks, sidecar regular-file checks, dynamic ceremony rendering, and feature-verify audit-rubrics support.
- Implements scaffold parity for subagent_specialists/no_subagents, native Codex/OpenCode stub emission, create-and-fill multi-artifact rejection, platform display-name consistency, manifest edits, and rollback behavior.
- Migrates contract/scaffold/loud-fail coverage into Kotlin runtime-core and runtime-cli tests, and records reusable boundary history.

## Feature Flags

N/A

# How Has This Been Tested?

- `(cd runtime-kotlin && ./gradlew :runtime-core:test --tests 'skillbill.scaffold.*' :runtime-cli:test --tests 'skillbill.cli.CliAuthoringParityTest' --tests 'skillbill.cli.CliScaffoldRuntimeTest' --tests 'skillbill.cli.CliExternalAuthorDryRunTest')`
- `(cd runtime-kotlin && ./gradlew check)`
- `.venv/bin/python3 -m unittest discover -s tests`
- `npx --yes agnix --strict .`
- `.venv/bin/python3 scripts/validate_agent_configs.py`
- Runtime source scan for Python bridge/fallback markers; only non-runtime documentation wording was found.
