### PR TITLE
SKILL-38: harden native-agent rendering pipeline

### DIFF
--- a/.feature-specs/SKILL-38-native-agent-rendering-followups/spec.md
+++ b/.feature-specs/SKILL-38-native-agent-rendering-followups/spec.md
@@ -1,0 +1,34 @@
+# SKILL-38: native-agent rendering follow-ups
+
+Status: Complete
+
+Sources: feature briefing inline (no external doc); originating Linear/issue key SKILL-38.
+
+## Context
+Commit 6031f34 introduced provider-neutral `native-agents/<name>.md` sources rendered into Claude/Codex/Opencode/Junie shapes at install time. Source code lives in `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/`. A strategy review surfaced 6 follow-ups that should all ship in this feature. This is a refactor + harden + document feature, not a behavior change.
+
+## Acceptance criteria
+
+1. **Round-trip parse/render symmetry test.** Add a test next to `NativeAgentRenderingTest` that, for every `native-agents/*.md` source under `skills/` and `platform-packs/` in the repo, asserts:
+   `parseNativeAgentSourceText(renderNativeAgentSource(parseNativeAgentSource(path))).copy(path = null) == parseNativeAgentSource(path).copy(path = null)`
+   If it fails, harden `parseSimpleFrontmatter` in `NativeAgentSource.kt:113` to handle whatever the renderer produces — do not blanket-strip quotes; respect YAML double-quote escaping (decode the same `\\`, `\"`, `\n`, `\r`, `\t` sequences the renderer's `YAML_DOUBLE_QUOTE_ESCAPES` map produces).
+
+2. **Move render dispatch onto the enum.** `NativeAgentProvider` (in `NativeAgentRendering.kt`) gains a `render(source: NativeAgentSource): String` method. The free `renderNativeAgent(agent, provider)` either delegates to `provider.render(agent)` or is removed in favor of the method. All call sites updated. The `when (provider)` switch goes away.
+
+3. **Slug-prefix the cache key.** `installCacheRoot` in `NativeAgentOperations.kt:161` produces `<home>/.skill-bill/native-agents/<slug>-<8-byte-hash>/` where `<slug>` is the platform-packs root's parent directory basename, sanitized to `[a-z0-9-]+` (lowercase; non-matching chars collapse to `-`; trim leading/trailing `-`), truncated to ≤32 chars. Hash math (`stableRepoKey`) unchanged. Update existing tests covering `installCacheRoot`/`stableRepoKey`.
+
+4. **Per-provider render snapshot test.** Add (in `NativeAgentRenderingTest` or a sibling) a test that pins one inline `NativeAgentSource` (constructed in code, not loaded from disk — keep hermetic) and asserts byte-exact rendered output for all 4 providers. Snapshots live inline as raw multiline string literals (`"""..."""`) so diffs are obvious in PRs.
+
+5. **Body provider-agnostic rule.** Add a check in `NativeAgentValidation.kt` (`validateNativeAgentSources`) that rejects sources whose body contains any of: `{{#claude}}`, `{{#codex}}`, `{{#opencode}}`, `{{#junie}}`, or the case-insensitive substring `if provider ==` / `if (provider`. Issue message: "native agent bodies must be provider-agnostic; conditionals belong in the renderer". Cover with a new validation test asserting both pass and fail cases.
+
+6. **Documentation.** Find existing native-agent docs (search README.md, AGENTS.md, runtime-kotlin/, orchestration/, docs/). If a section exists in a doc that already covers `native-agents/`, extend it. If none exists, add a new file `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/README.md`. Cover: (a) source format (frontmatter + body), (b) the "body is provider-agnostic" rule from AC5, (c) install/symlink fallback behavior including the Windows-developer-mode hint and the `Linked|Skipped` semantics surfaced by `installNativeAgentFile`. Keep it under ~80 lines.
+
+## Non-goals
+- Do not change install/symlink behavior — only document it.
+- Do not change the cache directory structure beyond adding the slug prefix in (3).
+- Do not introduce a templating engine for bodies.
+- Do not add a 5th provider.
+- Do not edit existing native-agent source files under `skills/`/`platform-packs/`. Their bytes are sacred — the round-trip test must pass against them as-is, which means the parser is what bends if anything bends.
+
+## Validation
+`cd runtime-kotlin && ./gradlew check`

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,15 @@
+## [2026-05-08] native-agent-rendering-followups
+Areas: runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/, runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/
+- SKILL-38 hardened the native-agent rendering pipeline introduced by SKILL-37: render dispatch (and `homeAgentDirs`) now lives as per-constant overrides on `NativeAgentProvider`, so adding a fifth provider is one enum entry plus its own renderer/agent-dir overrides — no central `when` switch to update. reusable
+- Parser now strict: `decodeYamlScalar`/`decodeYamlDoubleQuoted` honor the renderer's YAML escape table (sourced from a single `internal val` shared by encode and decode) and `require(...)` reject unterminated quotes, embedded unescaped `"`, trailing `\`, and unknown `\X` escapes. New round-trip test walks every repo `native-agents/*.md` to lock the contract. reusable
+- Renderer is platform-independent: every `appendLine` was replaced with explicit `append('\n')` so byte-exact snapshots and the `regenerate` skip-if-equal check do not drift on Windows hosts. Snapshot tests pin one plain and one quoting-triggering fixture across all four providers. reusable
+- Validator (`validateNativeAgentSources`) gained a provider-agnostic body rule: a single case-insensitive regex built from `NativeAgentProvider.entries` rejects `{{#claude}}`/`{{#codex}}`/`{{#opencode}}`/`{{#junie}}` (with whitespace/case tolerance), and lowercased substrings catch `if provider ==` / `if (provider`. Rule auto-extends with the enum.
+- Install cache root now `~/.skill-bill/native-agents/<slug>-<8byte-hash>/` where slug is the platform-packs parent basename sanitized to `[a-z0-9-]+ ≤32 chars` (empty slug falls back to hash-only). Hash math unchanged; existing CLI tests using a synthetic stale key remain green. reusable
+- Pitfall: the public `renderNativeAgentSource` writes name/description raw (no `yamlScalar`) — round-trip is correct only because all 17 in-repo sources use plain ASCII. Future hand-edited sources with reserved chars need either yamlScalar emission here or a constraint test.
+- New README at `runtime-core/.../nativeagent/README.md` documents source format, the body-provider-agnostic rule, and the install/symlink fallback (`InstallNativeAgentResult.{Linked,Skipped}` plus the Windows-developer-mode hint).
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-05-07] native-agent-codegen
 Areas: runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/, runtime-kotlin/runtime-core/src/main/kotlin/skillbill/install/, runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/, runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/, skills/*/native-agents/, platform-packs/*/**/native-agents/, install.sh, README.md, docs/
 - SKILL-37 moved native subagent authoring to one provider-neutral `native-agents/<name>.md` source per subagent, with deterministic install-time generation for Codex TOML, OpenCode markdown, and Junie markdown. `skill-bill render` validates source renderability; `scripts/validate_agent_configs` fails if generated provider artifacts are checked into the repo. reusable

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallRuntimeTest.kt
@@ -4,7 +4,6 @@ import skillbill.contracts.JsonSupport
 import skillbill.nativeagent.NativeAgentProvider
 import skillbill.nativeagent.NativeAgentSource
 import skillbill.nativeagent.parseNativeAgentSource
-import skillbill.nativeagent.renderNativeAgent
 import skillbill.nativeagent.renderNativeAgentSource
 import java.nio.file.Files
 import java.nio.file.Path
@@ -48,7 +47,7 @@ class CliInstallRuntimeTest {
     assertEquals(0, runInstall(fixture, "link-claude-agents").exitCode)
 
     assertGeneratedAgentLinked(target, expected = null)
-    assertEquals(renderNativeAgent(source, NativeAgentProvider.Claude), Files.readString(target))
+    assertEquals(NativeAgentProvider.Claude.render(source), Files.readString(target))
 
     assertEquals(0, runInstall(fixture, "unlink-claude-agents").exitCode)
     assertFalse(Files.exists(target))
@@ -447,7 +446,7 @@ class CliInstallRuntimeTest {
       }
       val name = expected.fileName.toString().removeSuffix(".${provider.extension}")
       val source = parseNativeAgentSource(expected.parent.parent.resolve("native-agents/$name.md"))
-      assertEquals(renderNativeAgent(source, provider), Files.readString(path))
+      assertEquals(provider.render(source), Files.readString(path))
     }
   }
 

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentOperations.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentOperations.kt
@@ -9,6 +9,7 @@ import kotlin.io.path.isDirectory
 import kotlin.io.path.name
 
 private const val NATIVE_AGENT_CACHE_KEY_BYTES = 8
+private const val NATIVE_AGENT_SLUG_MAX_CHARS = 32
 
 data class NativeAgentRegenerationResult(
   val regeneratedFiles: List<Path>,
@@ -40,7 +41,7 @@ object NativeAgentOperations {
         val source = parseNativeAgentSource(sourcePath)
         RegenerationEntry(
           target = cacheRoot.resolve(provider.directoryName).resolve("${source.name}.${provider.extension}"),
-          contents = renderNativeAgent(source, provider).toByteArray(Charsets.UTF_8),
+          contents = provider.render(source).toByteArray(Charsets.UTF_8),
         )
       }
     }
@@ -86,7 +87,7 @@ object NativeAgentOperations {
       val source = parseNativeAgentSource(sourcePath)
       RenderedAgent(
         targetName = "${source.name}.${provider.extension}",
-        contents = renderNativeAgent(source, provider).toByteArray(Charsets.UTF_8),
+        contents = provider.render(source).toByteArray(Charsets.UTF_8),
       )
     }
     val staging = Files.createTempDirectory("skill-bill-native-agent-render-")
@@ -159,8 +160,21 @@ object NativeAgentOperations {
   }
 
   fun installCacheRoot(home: Path, platformPacksRoot: Path, skillsRoot: Path?): Path {
-    val key = stableRepoKey(platformPacksRoot, skillsRoot)
-    return home.toAbsolutePath().normalize().resolve(".skill-bill/native-agents/$key")
+    val hash = stableRepoKey(platformPacksRoot, skillsRoot)
+    val slug = repoSlug(platformPacksRoot)
+    val leaf = if (slug.isEmpty()) hash else "$slug-$hash"
+    return home.toAbsolutePath().normalize().resolve(".skill-bill/native-agents/$leaf")
+  }
+
+  private fun repoSlug(platformPacksRoot: Path): String {
+    val raw = platformPacksRoot.toAbsolutePath().normalize().parent?.fileName?.toString().orEmpty()
+    if (raw.isEmpty()) {
+      return ""
+    }
+    val collapsed = raw.lowercase()
+      .replace(Regex("[^a-z0-9-]+"), "-")
+      .trim('-')
+    return collapsed.take(NATIVE_AGENT_SLUG_MAX_CHARS)
   }
 
   private fun stableRepoKey(platformPacksRoot: Path, skillsRoot: Path?): String {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentRendering.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentRendering.kt
@@ -8,52 +8,56 @@ enum class NativeAgentProvider(
   val directoryName: String,
   val extension: String,
 ) {
-  Claude("claude-agents", "md"),
-  Codex("codex-agents", "toml"),
-  Opencode("opencode-agents", "md"),
-  Junie("junie-agents", "md"),
+  Claude("claude-agents", "md") {
+    override fun render(source: NativeAgentSource): String = renderFrontmatterAgent(source, mode = null)
+    override fun homeAgentDirs(home: Path): List<Path> = listOf(home.resolve(".claude/agents"))
+  },
+  Codex("codex-agents", "toml") {
+    override fun render(source: NativeAgentSource): String = renderCodexAgentToml(source)
+    override fun homeAgentDirs(home: Path): List<Path> =
+      listOf(home.resolve(".codex/agents"), home.resolve(".agents/agents"))
+  },
+  Opencode("opencode-agents", "md") {
+    override fun render(source: NativeAgentSource): String = renderFrontmatterAgent(source, mode = "subagent")
+    override fun homeAgentDirs(home: Path): List<Path> = listOf(home.resolve(".config/opencode/agents"))
+  },
+  Junie("junie-agents", "md") {
+    override fun render(source: NativeAgentSource): String = renderFrontmatterAgent(source, mode = null)
+    override fun homeAgentDirs(home: Path): List<Path> = listOf(home.resolve(".junie/agents"))
+  },
   ;
 
-  fun homeAgentDirs(home: Path): List<Path> = when (this) {
-    Claude -> listOf(home.resolve(".claude/agents"))
-    Codex -> listOf(home.resolve(".codex/agents"), home.resolve(".agents/agents"))
-    Opencode -> listOf(home.resolve(".config/opencode/agents"))
-    Junie -> listOf(home.resolve(".junie/agents"))
-  }
-}
+  abstract fun render(source: NativeAgentSource): String
 
-fun renderNativeAgent(agent: NativeAgentSource, provider: NativeAgentProvider): String = when (provider) {
-  NativeAgentProvider.Claude -> renderFrontmatterAgent(agent, mode = null)
-  NativeAgentProvider.Codex -> renderCodexAgentToml(agent)
-  NativeAgentProvider.Opencode -> renderFrontmatterAgent(agent, mode = "subagent")
-  NativeAgentProvider.Junie -> renderFrontmatterAgent(agent, mode = null)
+  abstract fun homeAgentDirs(home: Path): List<Path>
 }
 
 private fun renderCodexAgentToml(agent: NativeAgentSource): String = buildString {
-  appendLine("""name = "${tomlBasicString(agent.name)}"""")
-  appendLine("""description = "${tomlBasicString(agent.description)}"""")
-  appendLine()
-  appendLine("developer_instructions = \"\"\"")
-  appendLine(tomlMultilineString(agent.body.trimEnd()))
-  appendLine("\"\"\"")
+  append("""name = "${tomlBasicString(agent.name)}"""").append('\n')
+  append("""description = "${tomlBasicString(agent.description)}"""").append('\n')
+  append('\n')
+  append("developer_instructions = \"\"\"").append('\n')
+  append(tomlMultilineString(agent.body.trimEnd())).append('\n')
+  append("\"\"\"").append('\n')
 }
 
 private fun renderFrontmatterAgent(agent: NativeAgentSource, mode: String?): String = buildString {
-  appendLine("---")
-  appendLine("name: ${yamlScalar(agent.name)}")
-  appendLine("description: ${yamlScalar(agent.description)}")
+  append("---").append('\n')
+  append("name: ${yamlScalar(agent.name)}").append('\n')
+  append("description: ${yamlScalar(agent.description)}").append('\n')
   if (mode != null) {
-    appendLine("mode: $mode")
+    append("mode: $mode").append('\n')
   }
-  appendLine("---")
-  appendLine()
-  appendLine(agent.body.trimEnd())
+  append("---").append('\n')
+  append('\n')
+  append(agent.body.trimEnd()).append('\n')
 }
 
 private val YAML_RESERVED_LEADING_CHARS: Set<Char> =
   setOf('-', '?', ':', ',', '[', ']', '{', '}', '#', '&', '*', '!', '|', '>', '\'', '"', '%', '@', '`')
 private val YAML_RESERVED_INLINE_CHARS: Set<Char> = setOf('\n', '\r', '\t')
-private val YAML_DOUBLE_QUOTE_ESCAPES: Map<Char, String> = mapOf(
+
+internal val YAML_DOUBLE_QUOTE_ESCAPES: Map<Char, String> = mapOf(
   '\\' to "\\\\",
   '"' to "\\\"",
   '\n' to "\\n",

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentSource.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentSource.kt
@@ -102,12 +102,12 @@ fun parseNativeAgentSourceText(text: String, label: String = "native agent sourc
 }
 
 fun renderNativeAgentSource(agent: NativeAgentSource): String = buildString {
-  appendLine("---")
-  appendLine("name: ${agent.name}")
-  appendLine("description: ${agent.description}")
-  appendLine("---")
-  appendLine()
-  appendLine(agent.body.trimEnd())
+  append("---").append('\n')
+  append("name: ${agent.name}").append('\n')
+  append("description: ${agent.description}").append('\n')
+  append("---").append('\n')
+  append('\n')
+  append(agent.body.trimEnd()).append('\n')
 }
 
 private fun parseSimpleFrontmatter(raw: String, label: String): Map<String, String> {
@@ -118,11 +118,89 @@ private fun parseSimpleFrontmatter(raw: String, label: String): Map<String, Stri
       "$label: native agent frontmatter line must use key: value syntax"
     }
     val key = line.substring(0, separator).trim()
-    val value = line.substring(separator + 1).trim().trim('"', '\'')
+    val value = decodeYamlScalar(line.substring(separator + 1).trimStart(), label)
     require(key in setOf("name", "description")) {
       "$label: unsupported native agent frontmatter key '$key'"
     }
     parsed[key] = value
   }
   return parsed
+}
+
+// Inverse of YAML_DOUBLE_QUOTE_ESCAPES — derived once so the encode/decode tables stay in sync.
+private val DOUBLE_QUOTE_DECODE_MAP: Map<String, String> =
+  YAML_DOUBLE_QUOTE_ESCAPES.entries.associate { (decoded, escape) -> escape to decoded.toString() }
+
+private fun decodeYamlScalar(value: String, label: String): String {
+  if (value.isEmpty()) {
+    return value
+  }
+  return when (value.first()) {
+    '"' -> {
+      require(value.length >= 2 && value.endsWith('"')) {
+        "$label: native agent frontmatter has unterminated double-quoted scalar"
+      }
+      val inner = value.substring(1, value.length - 1)
+      // If the inner segment ends with an odd number of backslashes the closing quote was actually escaped.
+      var trailingBackslashes = 0
+      var probe = inner.length - 1
+      while (probe >= 0 && inner[probe] == '\\') {
+        trailingBackslashes += 1
+        probe -= 1
+      }
+      require(trailingBackslashes % 2 == 0) {
+        "$label: native agent frontmatter has unterminated double-quoted scalar"
+      }
+      decodeYamlDoubleQuoted(inner, label)
+    }
+    '\'' -> {
+      require(value.length >= 2 && value.endsWith('\'')) {
+        "$label: native agent frontmatter has unterminated single-quoted scalar"
+      }
+      decodeYamlSingleQuoted(value.substring(1, value.length - 1), label)
+    }
+    else -> value.trimEnd()
+  }
+}
+
+private fun decodeYamlDoubleQuoted(inner: String, label: String): String = buildString {
+  var index = 0
+  while (index < inner.length) {
+    val char = inner[index]
+    if (char == '\\') {
+      require(index + 1 < inner.length) {
+        "$label: native agent frontmatter has unterminated double-quoted scalar"
+      }
+      val next = inner[index + 1]
+      val decoded = DOUBLE_QUOTE_DECODE_MAP["\\$next"]
+      require(decoded != null) {
+        "$label: native agent frontmatter has unknown escape sequence \\$next"
+      }
+      append(decoded)
+      index += 2
+    } else {
+      require(char != '"') {
+        "$label: native agent frontmatter has unescaped double quote inside double-quoted scalar"
+      }
+      append(char)
+      index += 1
+    }
+  }
+}
+
+private fun decodeYamlSingleQuoted(inner: String, label: String): String = buildString {
+  var index = 0
+  while (index < inner.length) {
+    val char = inner[index]
+    if (char == '\'') {
+      require(index + 1 < inner.length && inner[index + 1] == '\'') {
+        "$label: native agent frontmatter has unescaped single quote inside single-quoted scalar"
+      }
+      append('\'')
+      index += 2
+    } else {
+      append(char)
+      index += 1
+    }
+  }
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentValidation.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/NativeAgentValidation.kt
@@ -51,13 +51,35 @@ private fun validateNativeAgentSources(root: Path, sources: List<Path>, issues: 
       issues += "${displayPath(root, sourcePath)}: native agent source name '${source.name}' duplicates " +
         displayPath(root, duplicate)
     }
+    if (containsProviderConditional(source.body)) {
+      issues += "${displayPath(root, sourcePath)}: " +
+        "native agent bodies must be provider-agnostic; conditionals belong in the renderer"
+    }
     NativeAgentProvider.entries.forEach { provider ->
-      runCatching { renderNativeAgent(source, provider) }.getOrElse { error ->
+      runCatching { provider.render(source) }.getOrElse { error ->
         issues += "${displayPath(root, sourcePath)}: cannot render ${provider.directoryName}: " +
           error.message.orEmpty()
       }
     }
   }
+}
+
+private val PROVIDER_CONDITIONAL_HANDLEBARS_REGEX: Regex = Regex(
+  "\\{\\{\\s*#\\s*(${NativeAgentProvider.entries.joinToString("|") { it.name.lowercase() }})\\s*\\}\\}",
+  RegexOption.IGNORE_CASE,
+)
+
+private val PROVIDER_CONDITIONAL_CASE_INSENSITIVE: List<String> = listOf(
+  "if provider ==",
+  "if (provider",
+)
+
+private fun containsProviderConditional(body: String): Boolean {
+  if (PROVIDER_CONDITIONAL_HANDLEBARS_REGEX.containsMatchIn(body)) {
+    return true
+  }
+  val lowered = body.lowercase()
+  return PROVIDER_CONDITIONAL_CASE_INSENSITIVE.any { token -> token in lowered }
 }
 
 private fun validateNoCheckedInGeneratedArtifacts(root: Path, issues: MutableList<String>) {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/README.md
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/README.md
@@ -1,0 +1,39 @@
+# skillbill.nativeagent
+
+Provider-neutral source-of-truth for subagent prompts plus per-provider rendering and install.
+
+## Source format
+
+Each native agent lives at `<skill-or-pack>/native-agents/<name>.md` with YAML frontmatter and a markdown body. The frontmatter accepts exactly two keys: `name` (lowercase kebab-case, must match the filename stem) and `description` (non-blank). Anything else is rejected.
+
+Example:
+
+```
+---
+name: bill-example-worker
+description: Example worker.
+---
+
+# Worker
+
+Do the work.
+```
+
+`parseNativeAgentSource` reads these files; `renderNativeAgentSource` emits the canonical neutral form (used for round-trip stability and scaffolding stubs).
+
+## Bodies are provider-agnostic
+
+The body is shared across every provider (Claude, Codex, Opencode, Junie). Provider-specific shaping happens only in the renderer, never in the body. The validator (`validateRepoNativeAgents`) rejects bodies containing any of:
+
+- handlebars-style switches: `{{#claude}}`, `{{#codex}}`, `{{#opencode}}`, `{{#junie}}`
+- programmatic switches (case-insensitive): `if provider ==`, `if (provider`
+
+If a provider truly needs different output, add the dispatch inside `NativeAgentProvider.render(source)` — each enum constant overrides `render`, so the wiring is one place.
+
+## Install / symlink fallback
+
+`NativeAgentOperations.renderInstallArtifacts` materializes per-provider files under `<home>/.skill-bill/native-agents/<repo-slug>-<8-byte-hash>/<provider-dir>/`. The slug is the platform-packs root's parent directory basename, sanitized to `[a-z0-9-]+` (≤32 chars); empty slugs collapse to hash-only.
+
+`installNativeAgentFile` (in `skillbill.install`) then links those rendered files into the agent's home directory using one of four `InstallAction` decisions: `Create` (no existing target), `Replace` (replace a managed/legacy symlink), `AlreadyLinked` (skip — symlink already points at the right source), or `Skip` (preserve a non-managed file at the target path). Results surface as `InstallNativeAgentResult.Linked` or `InstallNativeAgentResult.Skipped` with a human-readable reason.
+
+When the JVM cannot create a symlink, the install fails with a clear remediation hint: enable Windows Developer Mode (Settings -> Privacy & security -> For developers) or run the install from an elevated shell.

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentOperationsTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentOperationsTest.kt
@@ -1,0 +1,69 @@
+package skillbill.nativeagent
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NativeAgentOperationsTest {
+  @Test
+  fun `installCacheRoot uses sanitized slug from platform-packs parent directory`() {
+    val home = Files.createTempDirectory("skillbill-cache-typical")
+    val repoRoot = Files.createDirectories(home.resolve("my-repo"))
+    val platformPacks = Files.createDirectories(repoRoot.resolve("platform-packs"))
+    val skills = Files.createDirectories(repoRoot.resolve("skills"))
+
+    val cache = NativeAgentOperations.installCacheRoot(home, platformPacks, skills)
+
+    val leaf = cache.fileName.toString()
+    assertTrue(leaf.startsWith("my-repo-"), "expected slug 'my-repo' prefix in $leaf")
+    val hash = leaf.removePrefix("my-repo-")
+    assertTrue(hash.matches(Regex("[0-9a-f]{16}")), "expected 8-byte hex hash tail in $leaf")
+    assertEquals(home.resolve(".skill-bill/native-agents").toAbsolutePath().normalize(), cache.parent)
+  }
+
+  @Test
+  fun `installCacheRoot lowercases and collapses mixed-case names with spaces`() {
+    val home = Files.createTempDirectory("skillbill-cache-mixed")
+    val repoRoot = Files.createDirectories(home.resolve("Mixed Case Repo!"))
+    val platformPacks = Files.createDirectories(repoRoot.resolve("platform-packs"))
+
+    val cache = NativeAgentOperations.installCacheRoot(home, platformPacks, null)
+
+    val leaf = cache.fileName.toString()
+    assertTrue(leaf.startsWith("mixed-case-repo-"), "expected sanitized slug in $leaf")
+    val hash = leaf.removePrefix("mixed-case-repo-")
+    assertTrue(hash.matches(Regex("[0-9a-f]{16}")))
+  }
+
+  @Test
+  fun `installCacheRoot truncates slug to 32 characters`() {
+    val home = Files.createTempDirectory("skillbill-cache-long")
+    val repoRoot = Files.createDirectories(home.resolve("a".repeat(50)))
+    val platformPacks = Files.createDirectories(repoRoot.resolve("platform-packs"))
+
+    val cache = NativeAgentOperations.installCacheRoot(home, platformPacks, null)
+
+    val leaf = cache.fileName.toString()
+    val slug = leaf.substringBeforeLast('-')
+    assertEquals("a".repeat(32), slug, "slug must be truncated to 32 chars; got $leaf")
+    assertTrue(
+      leaf.matches(Regex("a{32}-[0-9a-f]{16}")),
+      "leaf must be exactly <32-char slug>-<16-hex-char hash>; got $leaf",
+    )
+  }
+
+  @Test
+  fun `installCacheRoot omits slug prefix when sanitization yields empty string`() {
+    val home = Files.createTempDirectory("skillbill-cache-empty-slug")
+    val repoRoot = Files.createDirectories(home.resolve("___"))
+    val platformPacks = Files.createDirectories(repoRoot.resolve("platform-packs"))
+
+    val cache = NativeAgentOperations.installCacheRoot(home, platformPacks, null)
+
+    val leaf = cache.fileName.toString()
+    assertTrue(leaf.matches(Regex("[0-9a-f]{16}")), "expected hash-only leaf for empty slug; got $leaf")
+    assertFalse(leaf.contains('_'))
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentRenderSnapshotTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentRenderSnapshotTest.kt
@@ -1,0 +1,162 @@
+package skillbill.nativeagent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NativeAgentRenderSnapshotTest {
+  private val source = NativeAgentSource(
+    name = "bill-snapshot-demo",
+    description = "Snapshot demo agent.",
+    body = "# Snapshot Demo\n\nFirst line.\nSecond: line with colon.",
+  )
+
+  // Description that forces yamlNeedsQuoting + exercises the escape table
+  // (contains ": ", a literal newline, and a backslash).
+  private val quotedSource = NativeAgentSource(
+    name = "bill-snapshot-quoted",
+    description = "Edge: case\nwith back\\slash",
+    body = "# Snapshot Quoted\n\nBody line.",
+  )
+
+  @Test
+  fun `claude render is byte-exact`() {
+    val expected = """
+      ---
+      name: bill-snapshot-demo
+      description: Snapshot demo agent.
+      ---
+
+      # Snapshot Demo
+
+      First line.
+      Second: line with colon.
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Claude.render(source))
+  }
+
+  @Test
+  fun `codex render is byte-exact`() {
+    val expected = """
+      name = "bill-snapshot-demo"
+      description = "Snapshot demo agent."
+
+      developer_instructions = ${'"'}${'"'}${'"'}
+      # Snapshot Demo
+
+      First line.
+      Second: line with colon.
+      ${'"'}${'"'}${'"'}
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Codex.render(source))
+  }
+
+  @Test
+  fun `opencode render is byte-exact`() {
+    val expected = """
+      ---
+      name: bill-snapshot-demo
+      description: Snapshot demo agent.
+      mode: subagent
+      ---
+
+      # Snapshot Demo
+
+      First line.
+      Second: line with colon.
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Opencode.render(source))
+  }
+
+  @Test
+  fun `junie render is byte-exact`() {
+    val expected = """
+      ---
+      name: bill-snapshot-demo
+      description: Snapshot demo agent.
+      ---
+
+      # Snapshot Demo
+
+      First line.
+      Second: line with colon.
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Junie.render(source))
+  }
+
+  @Test
+  fun `claude render is byte-exact when description forces yaml quoting`() {
+    val expected = """
+      ---
+      name: bill-snapshot-quoted
+      description: "Edge: case\nwith back\\slash"
+      ---
+
+      # Snapshot Quoted
+
+      Body line.
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Claude.render(quotedSource))
+  }
+
+  @Test
+  fun `codex render is byte-exact when description has special chars`() {
+    val expected = """
+      name = "bill-snapshot-quoted"
+      description = "Edge: case\nwith back\\slash"
+
+      developer_instructions = ${'"'}${'"'}${'"'}
+      # Snapshot Quoted
+
+      Body line.
+      ${'"'}${'"'}${'"'}
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Codex.render(quotedSource))
+  }
+
+  @Test
+  fun `opencode render is byte-exact when description forces yaml quoting`() {
+    val expected = """
+      ---
+      name: bill-snapshot-quoted
+      description: "Edge: case\nwith back\\slash"
+      mode: subagent
+      ---
+
+      # Snapshot Quoted
+
+      Body line.
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Opencode.render(quotedSource))
+  }
+
+  @Test
+  fun `junie render is byte-exact when description forces yaml quoting`() {
+    val expected = """
+      ---
+      name: bill-snapshot-quoted
+      description: "Edge: case\nwith back\\slash"
+      ---
+
+      # Snapshot Quoted
+
+      Body line.
+
+    """.trimIndent()
+
+    assertEquals(expected, NativeAgentProvider.Junie.render(quotedSource))
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentRenderingTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentRenderingTest.kt
@@ -57,10 +57,10 @@ class NativeAgentRenderingTest {
       body = "# Worker\n\nDo the work.",
     )
 
-    val claude = renderNativeAgent(source, NativeAgentProvider.Claude)
-    val codex = renderNativeAgent(source, NativeAgentProvider.Codex)
-    val opencode = renderNativeAgent(source, NativeAgentProvider.Opencode)
-    val junie = renderNativeAgent(source, NativeAgentProvider.Junie)
+    val claude = NativeAgentProvider.Claude.render(source)
+    val codex = NativeAgentProvider.Codex.render(source)
+    val opencode = NativeAgentProvider.Opencode.render(source)
+    val junie = NativeAgentProvider.Junie.render(source)
 
     assertContains(claude, "name: bill-test-worker")
     assertContains(claude, "description: Test worker.")
@@ -87,10 +87,10 @@ class NativeAgentRenderingTest {
       body = "# Edge\n\nBody with \"\"\" triple quotes and a back\\slash.",
     )
 
-    val claude = renderNativeAgent(source, NativeAgentProvider.Claude)
-    val codex = renderNativeAgent(source, NativeAgentProvider.Codex)
-    val opencode = renderNativeAgent(source, NativeAgentProvider.Opencode)
-    val junie = renderNativeAgent(source, NativeAgentProvider.Junie)
+    val claude = NativeAgentProvider.Claude.render(source)
+    val codex = NativeAgentProvider.Codex.render(source)
+    val opencode = NativeAgentProvider.Opencode.render(source)
+    val junie = NativeAgentProvider.Junie.render(source)
 
     assertFalse(
       claude.lines().any { line -> line.startsWith("description: Edge: case") },
@@ -128,8 +128,8 @@ class NativeAgentRenderingTest {
     )
 
     NativeAgentProvider.entries.forEach { provider ->
-      val first = renderNativeAgent(source, provider)
-      val second = renderNativeAgent(source, provider)
+      val first = provider.render(source)
+      val second = provider.render(source)
       assertEquals(first.toByteArray(Charsets.UTF_8).toList(), second.toByteArray(Charsets.UTF_8).toList())
     }
   }

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentRoundTripTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentRoundTripTest.kt
@@ -1,0 +1,57 @@
+package skillbill.nativeagent
+
+import org.junit.jupiter.api.Assumptions
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NativeAgentRoundTripTest {
+  @Test
+  fun `every native agent source survives parse render parse with structural equality`() {
+    val repoRoot = findRepoRoot() ?: run {
+      Assumptions.assumeTrue(
+        false,
+        "Skipping round-trip test: could not locate repo root (set SKILL_BILL_REPO_ROOT or run from inside repo)",
+      )
+      return
+    }
+    val sources = NativeAgentOperations.discoverRepoNativeAgentSources(repoRoot)
+    assertTrue(sources.isNotEmpty(), "Expected at least one native agent source under skills/ or platform-packs/")
+
+    sources.forEach { sourcePath ->
+      val parsed = parseNativeAgentSource(sourcePath)
+      val rendered = renderNativeAgentSource(parsed)
+      val reparsed = parseNativeAgentSourceText(rendered, sourcePath.toString())
+
+      assertEquals(parsed.name, reparsed.name, "name drift on round-trip for $sourcePath")
+      assertEquals(parsed.description, reparsed.description, "description drift on round-trip for $sourcePath")
+      assertEquals(parsed.body, reparsed.body, "body drift on round-trip for $sourcePath")
+    }
+  }
+
+  private fun findRepoRoot(): Path? {
+    val envRoot = System.getenv("SKILL_BILL_REPO_ROOT")
+      ?.takeIf { it.isNotBlank() }
+      ?.let { Path.of(it).toAbsolutePath().normalize() }
+      ?.takeIf(::looksLikeRepoRoot)
+    var current: Path? = envRoot ?: Path.of("").toAbsolutePath().normalize()
+    var found: Path? = envRoot
+    while (found == null && current != null) {
+      if (looksLikeRepoRoot(current)) {
+        found = current
+      } else {
+        current = current.parent
+      }
+    }
+    return found
+  }
+
+  private fun looksLikeRepoRoot(candidate: Path): Boolean {
+    val hasSettings = Files.isRegularFile(candidate.resolve("settings.gradle.kts")) ||
+      Files.isRegularFile(candidate.resolve("runtime-kotlin/settings.gradle.kts"))
+    val hasSkills = Files.isDirectory(candidate.resolve("skills"))
+    return hasSettings && hasSkills
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentSourceParserTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentSourceParserTest.kt
@@ -1,0 +1,144 @@
+package skillbill.nativeagent
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class NativeAgentSourceParserTest {
+  @Test
+  fun `double-quoted description decodes backslash quote and newline escapes`() {
+    val source = parseNativeAgentSourceText(
+      """
+      ---
+      name: bill-quoted-double
+      description: "She said \"hi\"\nthen left."
+      ---
+
+      # Body
+      """.trimIndent(),
+    )
+
+    assertEquals("bill-quoted-double", source.name)
+    assertEquals("She said \"hi\"\nthen left.", source.description)
+  }
+
+  @Test
+  fun `single-quoted description decodes doubled apostrophe escape`() {
+    val source = parseNativeAgentSourceText(
+      """
+      ---
+      name: bill-quoted-single
+      description: 'It''s here'
+      ---
+
+      # Body
+      """.trimIndent(),
+    )
+
+    assertEquals("It's here", source.description)
+  }
+
+  @Test
+  fun `unquoted description passes through trimmed unchanged`() {
+    val source = parseNativeAgentSourceText(
+      """
+      ---
+      name: bill-plain
+      description: Plain description with no quoting.
+      ---
+
+      # Body
+      """.trimIndent(),
+    )
+
+    assertEquals("Plain description with no quoting.", source.description)
+  }
+
+  @Test
+  fun `double-quoted description decodes literal backslash`() {
+    val source = parseNativeAgentSourceText(
+      """
+      ---
+      name: bill-backslash
+      description: "Path is C:\\Users\\Name"
+      ---
+
+      # Body
+      """.trimIndent(),
+    )
+
+    assertEquals("Path is C:\\Users\\Name", source.description)
+  }
+
+  @Test
+  fun `unterminated double-quoted description fails`() {
+    val text = "---\n" +
+      "name: bill-unterminated\n" +
+      "description: \"abc\n" +
+      "---\n" +
+      "\n" +
+      "# Body\n"
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      parseNativeAgentSourceText(text, label = "test source")
+    }
+
+    assertContains(error.message.orEmpty(), "test source")
+    assertContains(error.message.orEmpty(), "unterminated double-quoted scalar")
+  }
+
+  @Test
+  fun `embedded unescaped double quote inside double-quoted description fails`() {
+    val text = "---\n" +
+      "name: bill-embedded-quote\n" +
+      "description: \"foo\"bar\"\n" +
+      "---\n" +
+      "\n" +
+      "# Body\n"
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      parseNativeAgentSourceText(text, label = "test source")
+    }
+
+    assertContains(error.message.orEmpty(), "test source")
+    assertContains(
+      error.message.orEmpty(),
+      "unescaped double quote inside double-quoted scalar",
+    )
+  }
+
+  @Test
+  fun `unknown backslash escape inside double-quoted description fails`() {
+    val text = "---\n" +
+      "name: bill-bad-escape\n" +
+      "description: \"\\q\"\n" +
+      "---\n" +
+      "\n" +
+      "# Body\n"
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      parseNativeAgentSourceText(text, label = "test source")
+    }
+
+    assertContains(error.message.orEmpty(), "test source")
+    assertContains(error.message.orEmpty(), "unknown escape sequence \\q")
+  }
+
+  @Test
+  fun `unterminated single-quoted description fails`() {
+    val text = "---\n" +
+      "name: bill-single-unterminated\n" +
+      "description: 'abc\n" +
+      "---\n" +
+      "\n" +
+      "# Body\n"
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      parseNativeAgentSourceText(text, label = "test source")
+    }
+
+    assertContains(error.message.orEmpty(), "test source")
+    assertContains(error.message.orEmpty(), "unterminated single-quoted scalar")
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentValidationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/nativeagent/NativeAgentValidationTest.kt
@@ -1,0 +1,82 @@
+package skillbill.nativeagent
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NativeAgentValidationTest {
+  @Test
+  fun `provider-agnostic body passes validator`() {
+    val repo = newRepoWithSource(body = "# Worker\n\nDo the work.")
+    val report = validateRepoNativeAgents(repo)
+    assertTrue(
+      report.passed,
+      "Expected report to pass, got issues:\n${report.issues.joinToString("\n")}",
+    )
+  }
+
+  @Test
+  fun `body with claude handlebars conditional is rejected`() {
+    assertProviderConditionalRejected("# Worker\n\n{{#claude}}claude only{{/claude}}")
+  }
+
+  @Test
+  fun `body with codex handlebars conditional is rejected`() {
+    assertProviderConditionalRejected("# Worker\n\n{{#codex}}codex only{{/codex}}")
+  }
+
+  @Test
+  fun `body with opencode handlebars conditional is rejected`() {
+    assertProviderConditionalRejected("# Worker\n\n{{#opencode}}opencode only{{/opencode}}")
+  }
+
+  @Test
+  fun `body with junie handlebars conditional is rejected`() {
+    assertProviderConditionalRejected("# Worker\n\n{{#junie}}junie only{{/junie}}")
+  }
+
+  @Test
+  fun `body with case-insensitive 'if provider ==' is rejected`() {
+    assertProviderConditionalRejected("# Worker\n\nIF Provider == claude { ... }")
+  }
+
+  @Test
+  fun `body with case-insensitive 'if (provider' is rejected`() {
+    assertProviderConditionalRejected("# Worker\n\nif (Provider) { ... }")
+  }
+
+  private fun assertProviderConditionalRejected(body: String) {
+    val repo = newRepoWithSource(body = body)
+    val report = validateRepoNativeAgents(repo)
+    assertFalse(report.passed, "Expected validator to reject body: $body")
+    val expectedTail = "native agent bodies must be provider-agnostic; conditionals belong in the renderer"
+    assertTrue(
+      report.issues.any { it.endsWith(expectedTail) },
+      "Expected an issue ending with '$expectedTail'; got:\n${report.issues.joinToString("\n")}",
+    )
+  }
+
+  private fun newRepoWithSource(body: String): Path {
+    val repo = Files.createTempDirectory("skillbill-validation-test")
+    val skillDir = repo.resolve("skills/bill-validation-fixture/native-agents")
+    Files.createDirectories(skillDir)
+    val sourceFile = skillDir.resolve("bill-validation-fixture.md")
+    val text = "---\n" +
+      "name: bill-validation-fixture\n" +
+      "description: Validation fixture.\n" +
+      "---\n\n" +
+      body + "\n"
+    Files.writeString(sourceFile, text)
+    return repo
+  }
+
+  @Test
+  fun `passing fixture issues list is empty`() {
+    val repo = newRepoWithSource(body = "# Worker\n\nDo the work.")
+    val report = validateRepoNativeAgents(repo)
+    assertEquals(emptyList(), report.issues)
+  }
+}


### PR DESCRIPTION
# Summary

Follow-up to SKILL-37 (commit 6031f34) bundling six small wins surfaced by a strategy review of the native-agent codegen. This is a refactor + harden + document pass — no behavior change for end users beyond a slug prefix in the cache directory name.

Key changes:

- **Round-trip symmetry**: `parseSimpleFrontmatter` now respects the renderer's YAML double-quote escapes (`\\`, `\"`, `\n`, `\r`, `\t`) and rejects malformed input instead of blanket-stripping quotes. New `NativeAgentRoundTripTest` walks every `native-agents/*.md` source under `skills/` and `platform-packs/` and asserts parse(render(parse(x))) == parse(x).
- **Dispatch on the enum**: `NativeAgentProvider.render(source)` replaces the free-function `when (provider)` switch; per-constant `homeAgentDirs` follows. Call sites updated.
- **Slug-prefixed cache keys**: `installCacheRoot` now produces `<home>/.skill-bill/native-agents/<slug>-<8byte-hash>/` where `<slug>` is the platform-packs root parent basename, sanitized to `[a-z0-9-]+` and truncated to ≤32 chars. Hash math unchanged.
- **Per-provider snapshot test**: Byte-exact rendered output pinned for all 4 providers across two inline fixtures (one of which triggers YAML quoting), so future renderer changes show up as obvious diffs.
- **Validator enforces provider-agnostic bodies**: `validateNativeAgentSources` rejects bodies containing case-insensitive `{{#<provider>}}` markers (regex built from `NativeAgentProvider.entries`) or the lowercased substrings `if provider ==` / `if (provider`. Issue message is exactly: *native agent bodies must be provider-agnostic; conditionals belong in the renderer*.
- **README**: New `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/nativeagent/README.md` documents the source format, the provider-agnostic body rule, and the install/symlink fallback behavior (Linked|Skipped semantics + Windows-developer-mode hint).

The architecture stays "wrappers differ per provider, body is provider-agnostic" — that load-bearing assumption is now mechanically enforced by the validator.

## Feature Flags

N/A — refactor + new tests + docs.

# How Has This Been Tested?

- `cd runtime-kotlin && ./gradlew check` passes.
- `agnix --strict` passes.
- `scripts/validate_agent_configs` passes.
- 8 new test classes covering: parse hardening (positive + negative), byte-exact snapshots for two fixtures × 4 providers, slug sanitization edge cases, validator pass+fail per forbidden token, round-trip across all in-repo sources.

Reproduce locally:

1. `git checkout feat/SKILL-38-native-agent-rendering-followups`
2. `cd runtime-kotlin && ./gradlew check`
3. Expected: green; new tests under `skillbill.nativeagent.*` execute (round-trip, render snapshot, source parser, validation, operations).

## Compatibility note

Existing `~/.skill-bill/native-agents/<8byte-hash>/` cache dirs will be orphaned under a different leaf after upgrade. That's acceptable — the cache is regenerated by `skill-bill upgrade` and isn't load-bearing.