### PR TITLE
[codex] Fix desktop app installer packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The installer:
 
 `./install.sh` is the terminal installer. It prompts for manual or detected
 agents, optional platform packs, telemetry level (`anonymous`, `full`, or
-`off`), and MCP registration, then delegates the actual install to
+`off`), and optional desktop app installation, then delegates the actual install to
 `skill-bill install apply`. The reusable runtime path owns staging, symlinks,
 native-agent output, telemetry configuration, MCP registration, and Windows
 symlink preflight outcomes.
@@ -122,6 +122,7 @@ Native package tasks are host/toolchain constrained:
 
 ```bash
 cd runtime-kotlin
+./gradlew :runtime-desktop:prepareDesktopAppDistributable
 ./gradlew :runtime-desktop:createDistributable
 ./gradlew :runtime-desktop:packageDistributionForCurrentOS
 ./gradlew :runtime-desktop:packageDmg   # macOS host
@@ -133,14 +134,32 @@ cd runtime-kotlin
 The package build stages a loose `skill-bill-runtime` app-resource bundle with
 `runtime-cli`, `runtime-mcp`, authored `skills/`, dynamic `platform-packs/`, and
 `orchestration/`. On Arch/CachyOS, prefer the RPM artifact when the local Linux
-toolchain can produce it; otherwise use `createDistributable` or
+toolchain can produce it; otherwise use `prepareDesktopAppDistributable` or
 `packageDistributionForCurrentOS` as the installable fallback. Packaged binary
 outputs are release artifacts and are not committed.
 
+The terminal installer can also install the desktop app for the current user:
+
+```bash
+./install.sh --with-desktop-app
+```
+
+This builds `:runtime-desktop:prepareDesktopAppDistributable` for the current host and
+copies the app into a per-user location: `~/Applications` on macOS,
+`${XDG_DATA_HOME:-~/.local/share}/skillbill/desktop` on Linux, and
+`%LOCALAPPDATA%/SkillBill/Desktop` on Windows shells. It also adds a
+`skillbill-desktop` launcher beside the normal `skill-bill` and
+`skill-bill-mcp` launchers. Use `--no-desktop-app` to keep the install CLI-only,
+or `--desktop-app-dir <path>` to choose a different desktop app install root.
+`./uninstall.sh` removes the same per-user desktop app, desktop launcher, and
+Linux desktop entry; pass the same `--desktop-app-dir <path>` when uninstalling a
+custom app root.
+
 On first launch, the desktop wizard asks for the same install choices as the
-terminal installer: supported agents, optional platform packs, telemetry level,
-and MCP registration. Base skills are always included, platform packs are
-discovered from manifests, installs stage rendered outputs under
+terminal installer: supported agents, optional platform packs, and telemetry
+level. MCP registration is always applied for supported agents. Base skills are
+always included, platform packs are discovered from manifests, installs stage
+rendered outputs under
 `~/.skill-bill/installed-skills/`, and generated `SKILL.md`, support pointers,
 and provider-native artifacts remain install/render output rather than source.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,7 +56,10 @@ Installer prompts cover:
 - platform packs: all packs, selected packs, or base skills only; selected
   packs are discovered from `platform-packs/` manifests
 - telemetry: `anonymous`, `full`, or `off`
-- MCP registration: register supported agent config entries or skip
+
+MCP registration is always applied for supported agent config entries so guided
+workflows, learnings, telemetry, and workflow resume are available after
+install.
 
 Base skills are always included. Optional platform packs add their declared
 review and quality-check skills after manifest validation. All installed
@@ -108,6 +111,33 @@ It is a Compose Desktop client over the same runtime contracts used by the CLI;
 it does not implement separate governance, manifest parsing, scaffold rules, or
 install staging.
 
+The canonical install path is still `./install.sh`. The script installs the
+runtime, agent links, telemetry, MCP registration, and, when selected, a
+per-user desktop app for the current host:
+
+```bash
+./install.sh --with-desktop-app
+```
+
+Use `--no-desktop-app` for a CLI-only install, or `--desktop-app-dir <path>` to
+override the app install root. The desktop app install uses the loose
+`prepareDesktopAppDistributable` output so the same script can work from macOS,
+Linux, and Windows shells. Native DMG/MSI/DEB/RPM outputs are release artifacts,
+not the only supported install path.
+
+Uninstall is symmetric for the per-user app install:
+
+```bash
+./uninstall.sh
+```
+
+If you installed the app with a custom root, pass the same path back to the
+uninstaller:
+
+```bash
+./uninstall.sh --desktop-app-dir <path>
+```
+
 Run from source:
 
 ```bash
@@ -119,7 +149,7 @@ Build a loose desktop distribution:
 
 ```bash
 cd runtime-kotlin
-./gradlew :runtime-desktop:createDistributable
+./gradlew :runtime-desktop:prepareDesktopAppDistributable
 ```
 
 Build a native package for the current host:
@@ -138,7 +168,7 @@ toolchain support them:
 | Windows     | `:runtime-desktop:packageMsi`         | MSI desktop installer                       |
 | Linux       | `:runtime-desktop:packageDeb`         | Debian/Ubuntu-style package                 |
 | Linux       | `:runtime-desktop:packageRpm`         | RPM package, the Arch/CachyOS-friendly path |
-| Any desktop | `:runtime-desktop:createDistributable` | Loose app directory fallback                |
+| Any desktop | `:runtime-desktop:prepareDesktopAppDistributable` | Loose app directory fallback     |
 
 Compose Desktop native packaging is host-limited: a Linux workstation should not
 be expected to produce the macOS DMG or Windows MSI locally. For Arch/CachyOS,
@@ -157,7 +187,8 @@ On first launch, the setup wizard asks for:
 - agents: detected or manually selected supported agents
 - platform packs: dynamically discovered packs, with base skills always included
 - telemetry: `anonymous`, `full`, or `off`, matching CLI behavior
-- MCP registration: an install intent for supported agent config files
+
+The wizard always includes MCP registration for supported agent config files.
 
 The wizard writes through shared install plan/apply behavior and preserves the
 governed source boundary. Authored `content.md`, manifests, add-ons, and

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,9 @@ RUNTIME_MCP_INSTALL_DIR="$RUNTIME_INSTALL_ROOT/runtime-mcp"
 RUNTIME_CLI_BIN="$RUNTIME_CLI_INSTALL_DIR/bin/runtime-cli"
 RUNTIME_MCP_BIN="$RUNTIME_MCP_INSTALL_DIR/bin/runtime-mcp"
 RUNTIME_LAUNCHER_BIN_DIR="${SKILL_BILL_BIN_DIR:-$HOME/.local/bin}"
+DESKTOP_APP_DEFAULT_NAME="SkillBill"
+DESKTOP_APP_INSTALL="prompt"
+DESKTOP_APP_INSTALL_DIR="${SKILL_BILL_DESKTOP_APP_DIR:-}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -40,7 +43,12 @@ MCP_REGISTRATION="register"
 
 usage() {
   cat <<USAGE
-Usage: ./install.sh
+Usage: ./install.sh [--with-desktop-app|--no-desktop-app] [--desktop-app-dir PATH]
+
+Options:
+  --with-desktop-app       Build and install the optional desktop app.
+  --no-desktop-app         Skip desktop app installation.
+  --desktop-app-dir PATH   Override the per-user desktop app install directory.
 USAGE
 }
 
@@ -51,10 +59,119 @@ parse_args() {
         usage
         exit 0
         ;;
+      --with-desktop-app|--install-desktop-app)
+        DESKTOP_APP_INSTALL="yes"
+        shift
+        ;;
+      --no-desktop-app|--skip-desktop-app)
+        DESKTOP_APP_INSTALL="no"
+        shift
+        ;;
+      --desktop-app-dir)
+        if [[ $# -lt 2 || -z "$(trim_string "$2")" ]]; then
+          err "--desktop-app-dir requires a path."
+          exit 1
+        fi
+        DESKTOP_APP_INSTALL_DIR="$2"
+        shift 2
+        ;;
+      --desktop-app-dir=*)
+        DESKTOP_APP_INSTALL_DIR="${1#--desktop-app-dir=}"
+        if [[ -z "$(trim_string "$DESKTOP_APP_INSTALL_DIR")" ]]; then
+          err "--desktop-app-dir requires a path."
+          exit 1
+        fi
+        shift
+        ;;
       *)
         err "Unknown argument: $1"
         usage
         exit 1
+        ;;
+    esac
+  done
+}
+
+host_path() {
+  local path="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$path"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+desktop_host_os() {
+  local uname_s
+  uname_s="$(uname -s 2>/dev/null || printf 'unknown')"
+  case "$uname_s" in
+    Darwin*)
+      printf 'macos'
+      ;;
+    Linux*)
+      printf 'linux'
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      printf 'windows'
+      ;;
+    *)
+      printf 'unknown'
+      ;;
+  esac
+}
+
+default_desktop_app_install_dir() {
+  local os="$1"
+  case "$os" in
+    macos)
+      printf '%s' "$HOME/Applications"
+      ;;
+    linux)
+      printf '%s' "${XDG_DATA_HOME:-$HOME/.local/share}/skillbill/desktop"
+      ;;
+    windows)
+      if [[ -n "${LOCALAPPDATA:-}" ]]; then
+        host_path "$LOCALAPPDATA/SkillBill/Desktop"
+      else
+        printf '%s' "$HOME/AppData/Local/SkillBill/Desktop"
+      fi
+      ;;
+    *)
+      printf '%s' "$HOME/.skill-bill/desktop"
+      ;;
+  esac
+}
+
+prompt_for_desktop_app_install() {
+  local input
+  local normalized
+
+  if [[ "$DESKTOP_APP_INSTALL" != "prompt" ]]; then
+    return 0
+  fi
+
+  while true; do
+    echo ""
+    info "Install the optional Skill Bill desktop app for this user?"
+    printf "  1. install (default)\n"
+    printf "  2. skip\n"
+    printf "${CYAN}▸${NC} Enter desktop app choice [1]: "
+    if ! read -r input; then
+      input=""
+    fi
+
+    normalized="$(printf '%s' "$(trim_string "$input")" | tr '[:upper:]' '[:lower:]')"
+    case "$normalized" in
+      ""|1|install|yes|y)
+        DESKTOP_APP_INSTALL="yes"
+        return 0
+        ;;
+      2|skip|no|n)
+        DESKTOP_APP_INSTALL="no"
+        return 0
+        ;;
+      *)
+        warn "Enter 1, 2, install, skip, or press Enter for install."
         ;;
     esac
   done
@@ -173,6 +290,157 @@ install_runtime_launchers() {
     warn "  launcher directory is not on PATH: $RUNTIME_LAUNCHER_BIN_DIR"
     warn "  set SKILL_BILL_BIN_DIR to a PATH directory before running ./install.sh, or add this directory to PATH"
   fi
+}
+
+build_desktop_app_distribution() {
+  local gradlew="$RUNTIME_KOTLIN_DIR/gradlew"
+
+  if [[ "$DESKTOP_APP_INSTALL" != "yes" ]]; then
+    return 0
+  fi
+
+  if [[ ! -x "$gradlew" ]]; then
+    err "Missing Gradle wrapper: $gradlew"
+    return 1
+  fi
+
+  info "Building desktop app distributable for the current host..."
+  (
+    cd "$RUNTIME_KOTLIN_DIR"
+    ./gradlew -q :runtime-desktop:prepareDesktopAppDistributable
+  )
+  ok "Desktop app distributable ready"
+}
+
+desktop_app_source_path() {
+  local app_root="$RUNTIME_KOTLIN_DIR/runtime-desktop/build/compose/binaries/main/app"
+  local os="$1"
+
+  if [[ "$os" == "macos" && -d "$app_root/$DESKTOP_APP_DEFAULT_NAME.app" ]]; then
+    printf '%s' "$app_root/$DESKTOP_APP_DEFAULT_NAME.app"
+    return 0
+  fi
+
+  printf '%s' "$app_root/$DESKTOP_APP_DEFAULT_NAME"
+}
+
+make_desktop_binaries_executable() {
+  local app_path="$1"
+  find "$app_path" -type f \( \
+    -path '*/Contents/MacOS/*' -o \
+    -path '*/bin/*' \
+  \) -exec chmod u+x {} + 2>/dev/null || true
+}
+
+install_desktop_launcher() {
+  local os="$1"
+  local app_target="$2"
+  local launcher_path
+  local executable
+  local windows_executable
+
+  mkdir -p "$RUNTIME_LAUNCHER_BIN_DIR"
+  case "$os" in
+    macos)
+      launcher_path="$RUNTIME_LAUNCHER_BIN_DIR/skillbill-desktop"
+      executable="$app_target/Contents/MacOS/$DESKTOP_APP_DEFAULT_NAME"
+      ;;
+    windows)
+      launcher_path="$RUNTIME_LAUNCHER_BIN_DIR/skillbill-desktop.cmd"
+      executable="$app_target/bin/$DESKTOP_APP_DEFAULT_NAME.bat"
+      if command -v cygpath >/dev/null 2>&1; then
+        windows_executable="$(cygpath -w "$executable")"
+      else
+        windows_executable="$executable"
+      fi
+      cat > "$launcher_path" <<CMD
+@echo off
+call "$windows_executable" %*
+CMD
+      ok "  linked desktop launcher → $launcher_path"
+      return 0
+      ;;
+    *)
+      launcher_path="$RUNTIME_LAUNCHER_BIN_DIR/skillbill-desktop"
+      executable="$app_target/bin/$DESKTOP_APP_DEFAULT_NAME"
+      ;;
+  esac
+
+  if [[ ! -x "$executable" ]]; then
+    warn "  skipped desktop launcher because executable is missing: $executable"
+    return 0
+  fi
+  ln -sfn "$executable" "$launcher_path"
+  ok "  linked desktop launcher → $executable"
+}
+
+install_linux_desktop_entry() {
+  local app_target="$1"
+  local desktop_file="${XDG_DATA_HOME:-$HOME/.local/share}/applications/skillbill.desktop"
+  local icon_file="${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/512x512/apps/skillbill.png"
+  local executable="$app_target/bin/$DESKTOP_APP_DEFAULT_NAME"
+  local icon_src="$RUNTIME_KOTLIN_DIR/runtime-desktop/icons/icon.png"
+
+  if [[ ! -x "$executable" ]]; then
+    warn "  skipped Linux desktop entry because executable is missing: $executable"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$desktop_file")" "$(dirname "$icon_file")"
+  cp "$icon_src" "$icon_file"
+  cat > "$desktop_file" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=SkillBill
+GenericName=SkillBill Desktop Runtime
+Comment=Compose Desktop runtime for SkillBill
+Exec=$executable
+Icon=skillbill
+Terminal=false
+Categories=Development;IDE;
+StartupWMClass=SkillBill
+DESKTOP
+  ok "  installed Linux desktop entry → $desktop_file"
+}
+
+install_desktop_app() {
+  local os
+  local source_path
+  local install_root
+  local target_path
+
+  if [[ "$DESKTOP_APP_INSTALL" != "yes" ]]; then
+    return 0
+  fi
+
+  os="$(desktop_host_os)"
+  source_path="$(desktop_app_source_path "$os")"
+  if [[ ! -d "$source_path" ]]; then
+    err "Missing desktop app distributable: $source_path"
+    return 1
+  fi
+
+  install_root="${DESKTOP_APP_INSTALL_DIR:-$(default_desktop_app_install_dir "$os")}"
+  install_root="$(host_path "$install_root")"
+  case "$os" in
+    macos)
+      target_path="$install_root/$DESKTOP_APP_DEFAULT_NAME.app"
+      ;;
+    *)
+      target_path="$install_root/$DESKTOP_APP_DEFAULT_NAME"
+      ;;
+  esac
+
+  info "Installing desktop app to: $target_path"
+  rm -rf "$target_path"
+  mkdir -p "$install_root"
+  cp -R "$source_path" "$target_path"
+  make_desktop_binaries_executable "$target_path"
+  install_desktop_launcher "$os" "$target_path"
+  if [[ "$os" == "linux" ]]; then
+    install_linux_desktop_entry "$target_path"
+  fi
+  ok "Desktop app installed"
 }
 
 get_agent_path() {
@@ -584,37 +852,6 @@ prompt_for_telemetry_preference() {
   done
 }
 
-prompt_for_mcp_registration() {
-  local input
-  local normalized
-
-  while true; do
-    echo ""
-    info "Register the Skill Bill MCP server for selected agents?"
-    printf "  1. register (default)\n"
-    printf "  2. skip\n"
-    printf "${CYAN}▸${NC} Enter MCP choice [1]: "
-    if ! read -r input; then
-      input=""
-    fi
-
-    normalized="$(printf '%s' "$(trim_string "$input")" | tr '[:upper:]' '[:lower:]')"
-    case "$normalized" in
-      ""|1|register|yes|y)
-        MCP_REGISTRATION="register"
-        return 0
-        ;;
-      2|skip|no|n)
-        MCP_REGISTRATION="skip"
-        return 0
-        ;;
-      *)
-        warn "Enter 1, 2, register, skip, or press Enter for register."
-        ;;
-    esac
-  done
-}
-
 build_runtime_install_args() {
   local i
 
@@ -698,8 +935,9 @@ info "Install behavior: collect choices, then delegate planning and apply to the
 prompt_for_agent_selection
 prompt_for_platform_selection
 prompt_for_telemetry_preference
-prompt_for_mcp_registration
+prompt_for_desktop_app_install
 install_runtime_launchers
+build_desktop_app_distribution
 build_runtime_install_args
 
 echo ""
@@ -709,9 +947,11 @@ info "Agents:         $(selected_agent_label)"
 info "Platforms:      $SELECTED_PLATFORM_LABEL"
 info "Telemetry:      $TELEMETRY_LEVEL"
 info "MCP:            $MCP_REGISTRATION"
+info "Desktop app:    $DESKTOP_APP_INSTALL"
 echo ""
 
 apply_runtime_install
+install_desktop_app
 
 printf "${GREEN}━━━ Installation complete ━━━${NC}\n"
 echo ""
@@ -721,6 +961,11 @@ info "Platforms:       $SELECTED_PLATFORM_LABEL"
 info "Launchers:       $RUNTIME_LAUNCHER_BIN_DIR/skill-bill, $RUNTIME_LAUNCHER_BIN_DIR/skill-bill-mcp"
 info "Telemetry:       $TELEMETRY_LEVEL"
 info "MCP:             $MCP_REGISTRATION"
+if [[ "$DESKTOP_APP_INSTALL" == "yes" ]]; then
+  info "Desktop app:     installed for $(desktop_host_os)"
+else
+  info "Desktop app:     skipped"
+fi
 
 if [[ "$AGENT_SELECTION_MODE" == "manual" && ${#AGENT_NAMES[@]} -gt 0 ]]; then
   for i in "${!AGENT_NAMES[@]}"; do
@@ -735,5 +980,5 @@ info "Edit skills in: $PLUGIN_DIR/skills/"
 if [[ "$TELEMETRY_LEVEL" != "off" ]]; then
   info "Telemetry uses the default Skill Bill relay automatically. Override it with SKILL_BILL_TELEMETRY_PROXY_URL or ~/.skill-bill/config.json."
 fi
-info "Run './install.sh' again to reinstall with different agent, platform, telemetry, or MCP choices."
+info "Run './install.sh' again to reinstall with different agent, platform, telemetry, or desktop app choices."
 echo ""

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -287,31 +287,7 @@ class InstallerShellDelegationTest {
       seedUninstallerRuntime(repoRoot)
     }
 
-    val os = currentDesktopOs()
-    val appTarget = when (os) {
-      "macos" -> desktopRoot.resolve("SkillBill.app")
-      else -> desktopRoot.resolve("SkillBill")
-    }
-    val executable = when (os) {
-      "macos" -> appTarget.resolve("Contents/MacOS/SkillBill")
-      "windows" -> appTarget.resolve("bin/SkillBill.bat")
-      else -> appTarget.resolve("bin/SkillBill")
-    }
-    Files.createDirectories(executable.parent)
-    Files.writeString(executable, "")
-    executable.toFile().setExecutable(true)
-    val launcherPath = when (os) {
-      "windows" -> {
-        val launcher = binDir.resolve("skillbill-desktop.cmd")
-        Files.writeString(launcher, "@echo off\ncall \"${executable}\" %*\n")
-        launcher
-      }
-      else -> {
-        val launcher = binDir.resolve("skillbill-desktop")
-        Files.createSymbolicLink(launcher, executable)
-        launcher
-      }
-    }
+    val desktopInstall = seedDesktopInstall(desktopRoot, binDir)
 
     val process = ProcessBuilder(
       "bash",
@@ -332,11 +308,41 @@ class InstallerShellDelegationTest {
     val exitCode = process.waitFor()
 
     return UninstallerShellRun(
-      appTarget = appTarget,
-      launcherPath = launcherPath,
+      appTarget = desktopInstall.appTarget,
+      launcherPath = desktopInstall.launcherPath,
       exitCode = exitCode,
       output = output,
     )
+  }
+
+  private fun seedDesktopInstall(desktopRoot: Path, binDir: Path): DesktopInstallFixture {
+    val os = currentDesktopOs()
+    val appTarget = when (os) {
+      "macos" -> desktopRoot.resolve("SkillBill.app")
+      else -> desktopRoot.resolve("SkillBill")
+    }
+    val executable = when (os) {
+      "macos" -> appTarget.resolve("Contents/MacOS/SkillBill")
+      "windows" -> appTarget.resolve("bin/SkillBill.bat")
+      else -> appTarget.resolve("bin/SkillBill")
+    }
+    Files.createDirectories(executable.parent)
+    Files.writeString(executable, "")
+    executable.toFile().setExecutable(true)
+    return DesktopInstallFixture(appTarget, seedDesktopLauncher(os, binDir, executable))
+  }
+
+  private fun seedDesktopLauncher(os: String, binDir: Path, executable: Path): Path = when (os) {
+    "windows" -> {
+      val launcher = binDir.resolve("skillbill-desktop.cmd")
+      Files.writeString(launcher, "@echo off\ncall \"${executable}\" %*\n")
+      launcher
+    }
+    else -> {
+      val launcher = binDir.resolve("skillbill-desktop")
+      Files.createSymbolicLink(launcher, executable)
+      launcher
+    }
   }
 
   private fun seedUninstallerRuntime(repoRoot: Path) {
@@ -410,5 +416,10 @@ class InstallerShellDelegationTest {
     val launcherPath: Path,
     val exitCode: Int,
     val output: String,
+  )
+
+  private data class DesktopInstallFixture(
+    val appTarget: Path,
+    val launcherPath: Path,
   )
 }

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -31,6 +31,12 @@ class InstallerShellDelegationTest {
     assertContains(installScript, "--telemetry \"\$TELEMETRY_LEVEL\"")
     assertContains(installScript, "--mcp \"\$MCP_REGISTRATION\"")
     assertContains(installScript, "--runtime-mcp-bin \"\$RUNTIME_MCP_BIN\"")
+    assertContains(installScript, "build_desktop_app_distribution")
+    assertContains(installScript, ":runtime-desktop:prepareDesktopAppDistributable")
+    assertContains(installScript, "install_desktop_app")
+    assertContains(installScript, "desktop_host_os")
+    assertFalse(installScript.contains("prompt_for_mcp_registration"))
+    assertFalse(installScript.contains("Enter MCP choice"))
     assertFalse(installScript.contains("install register-mcp"))
     assertFalse(installScript.contains("install link-skill"))
     assertFalse(installScript.contains("install link-codex-agents"))
@@ -41,12 +47,30 @@ class InstallerShellDelegationTest {
   }
 
   @Test
+  fun `uninstaller removes desktop app install and launcher`() {
+    val run = runUninstallerShellWithDesktopInstall()
+
+    assertEquals(0, run.exitCode, run.output)
+    assertFalse(Files.exists(run.appTarget), "desktop app should be removed")
+    assertFalse(Files.exists(run.launcherPath), "desktop launcher should be removed")
+  }
+
+  @Test
+  fun `uninstaller removes desktop app before runtime dependent cleanup`() {
+    val run = runUninstallerShellWithDesktopInstall(seedRuntime = false)
+
+    assertFalse(run.exitCode == 0, "runtime-dependent cleanup should still fail without a runtime")
+    assertFalse(Files.exists(run.appTarget), "desktop app should be removed")
+    assertFalse(Files.exists(run.launcherPath), "desktop launcher should be removed")
+  }
+
+  @Test
   fun `installer shell builds base-only all-agent runtime apply argv`() {
     val run = runInstallerShell(input = "1\nall\nbase only\noff\nskip\n")
 
     assertEquals(
       expectedApplyArgs(
-        ExpectedApply(run, agentMode = "manual", platformMode = "none", telemetry = "off", mcp = "skip"),
+        ExpectedApply(run, agentMode = "manual", platformMode = "none", telemetry = "off", mcp = "register"),
       ) + listOf(
         "--agent",
         "copilot",
@@ -75,7 +99,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `installer shell builds selected platform runtime apply argv`() {
-    val run = runInstallerShell(input = "1\ncodex\nkotlin\nfull\nregister\n")
+    val run = runInstallerShell(input = "1\ncodex\nkotlin\nfull\nskip\n")
 
     assertEquals(
       expectedApplyArgs(
@@ -94,7 +118,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `installer shell selected platform argv comes from discovered platform manifests`() {
-    val run = runInstallerShell(input = "1\ncodex\npython\nfull\nregister\n")
+    val run = runInstallerShell(input = "1\ncodex\npython\nfull\nskip\n")
 
     assertEquals(
       expectedApplyArgs(
@@ -113,7 +137,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `installer shell builds detected all-platform runtime apply argv`() {
-    val run = runInstallerShell(input = "detected\nall\nanonymous\nregister\n")
+    val run = runInstallerShell(input = "detected\nall\nanonymous\nskip\n")
 
     assertEquals(
       expectedApplyArgs(
@@ -248,6 +272,112 @@ class InstallerShellDelegationTest {
     Files.writeString(packRoot.resolve("platform.yaml"), "platform: \"$slug\"\n")
   }
 
+  private fun runUninstallerShellWithDesktopInstall(seedRuntime: Boolean = true): UninstallerShellRun {
+    val repoRoot = Files.createTempDirectory("skillbill-uninstaller-shell-repo")
+    val home = Files.createTempDirectory("skillbill-uninstaller-shell-home")
+    val binDir = Files.createTempDirectory("skillbill-uninstaller-shell-bin")
+    val desktopRoot = Files.createTempDirectory("skillbill-uninstaller-shell-desktop")
+    val logPath = Files.createTempFile("skillbill-uninstaller-shell-runtime", ".log")
+    Files.writeString(repoRoot.resolve("uninstall.sh"), Files.readString(runtimeRoot.parent.resolve("uninstall.sh")))
+    repoRoot.resolve("uninstall.sh").toFile().setExecutable(true)
+    Files.createDirectories(repoRoot.resolve("skills/bill-test"))
+    Files.writeString(repoRoot.resolve("skills/bill-test/content.md"), "# Test\n")
+    seedInstallerPlatformPack(repoRoot, "kotlin")
+    if (seedRuntime) {
+      seedUninstallerRuntime(repoRoot)
+    }
+
+    val os = currentDesktopOs()
+    val appTarget = when (os) {
+      "macos" -> desktopRoot.resolve("SkillBill.app")
+      else -> desktopRoot.resolve("SkillBill")
+    }
+    val executable = when (os) {
+      "macos" -> appTarget.resolve("Contents/MacOS/SkillBill")
+      "windows" -> appTarget.resolve("bin/SkillBill.bat")
+      else -> appTarget.resolve("bin/SkillBill")
+    }
+    Files.createDirectories(executable.parent)
+    Files.writeString(executable, "")
+    executable.toFile().setExecutable(true)
+    val launcherPath = when (os) {
+      "windows" -> {
+        val launcher = binDir.resolve("skillbill-desktop.cmd")
+        Files.writeString(launcher, "@echo off\ncall \"${executable}\" %*\n")
+        launcher
+      }
+      else -> {
+        val launcher = binDir.resolve("skillbill-desktop")
+        Files.createSymbolicLink(launcher, executable)
+        launcher
+      }
+    }
+
+    val process = ProcessBuilder(
+      "bash",
+      repoRoot.resolve("uninstall.sh").toString(),
+      "--desktop-app-dir",
+      desktopRoot.toString(),
+    )
+      .directory(repoRoot.toFile())
+      .redirectErrorStream(true)
+      .apply {
+        environment()["HOME"] = home.toString()
+        environment()["SKILL_BILL_BIN_DIR"] = binDir.toString()
+        environment()["SKILL_BILL_SKIP_RUNTIME_DISTRIBUTION_BUILD"] = "1"
+        environment()["SKILL_BILL_TEST_RUNTIME_LOG"] = logPath.toString()
+      }
+      .start()
+    val output = process.inputStream.bufferedReader().readText()
+    val exitCode = process.waitFor()
+
+    return UninstallerShellRun(
+      appTarget = appTarget,
+      launcherPath = launcherPath,
+      exitCode = exitCode,
+      output = output,
+    )
+  }
+
+  private fun seedUninstallerRuntime(repoRoot: Path) {
+    val cliBin = repoRoot.resolve("runtime-kotlin/runtime-cli/build/install/runtime-cli/bin/runtime-cli")
+    Files.createDirectories(cliBin.parent)
+    Files.writeString(
+      cliBin,
+      """
+      |#!/usr/bin/env bash
+      |set -euo pipefail
+      |{
+      |  echo CALL
+      |  for arg in "${'$'}@"; do
+      |    printf 'ARG\t%s\n' "${'$'}arg"
+      |  done
+      |} >> "${'$'}{SKILL_BILL_TEST_RUNTIME_LOG:?}"
+      |if [[ "${'$'}{1:-}" == "--home" ]]; then
+      |  shift 2
+      |fi
+      |case "${'$'}{1:-} ${'$'}{2:-}" in
+      |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unregister-mcp")
+      |    exit 0
+      |    ;;
+      |esac
+      |exit 2
+      |
+      """.trimMargin(),
+    )
+    cliBin.toFile().setExecutable(true)
+  }
+
+  private fun currentDesktopOs(): String {
+    val osName = System.getProperty("os.name").lowercase()
+    return when {
+      osName.contains("mac") -> "macos"
+      osName.contains("win") -> "windows"
+      osName.contains("linux") -> "linux"
+      else -> "unknown"
+    }
+  }
+
   private fun parseRuntimeCalls(logPath: Path): List<List<String>> {
     val calls = mutableListOf<MutableList<String>>()
     Files.readAllLines(logPath).forEach { line ->
@@ -273,5 +403,12 @@ class InstallerShellDelegationTest {
     val home: Path,
     val binDir: Path,
     val applyArgs: List<String>,
+  )
+
+  private data class UninstallerShellRun(
+    val appTarget: Path,
+    val launcherPath: Path,
+    val exitCode: Int,
+    val output: String,
   )
 }

--- a/runtime-kotlin/runtime-desktop/build.gradle.kts
+++ b/runtime-kotlin/runtime-desktop/build.gradle.kts
@@ -1,9 +1,65 @@
+import org.gradle.api.DefaultTask
 import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.Sync
+import org.gradle.api.tasks.TaskAction
+import java.nio.file.Files
+import java.nio.file.Path
 
 plugins {
   id("skillbill.kmp-application")
+}
+
+abstract class FixRuntimeScriptPermissionsTask : DefaultTask() {
+  @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val appImageRoot: DirectoryProperty
+
+  @TaskAction
+  fun fixPermissions() {
+    if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+      return
+    }
+
+    val root = appImageRoot.get().asFile.toPath()
+    val launchScripts = runtimeLaunchScriptsUnder(root)
+    if (launchScripts.isEmpty()) {
+      throw GradleException(
+        "No bundled runtime launch scripts were found under ${root.toAbsolutePath()}.",
+      )
+    }
+    launchScripts.forEach { script ->
+      if (!script.toFile().setExecutable(true, false)) {
+        throw GradleException(
+          "Failed to mark bundled runtime launch script executable: ${script.toAbsolutePath()}",
+        )
+      }
+    }
+  }
+
+  private fun runtimeLaunchScriptsUnder(root: Path): List<Path> =
+    if (!Files.exists(root)) {
+      emptyList()
+    } else {
+      Files.walk(root).use { paths ->
+        paths
+          .filter(::isRuntimeLaunchScript)
+          .toList()
+      }
+    }
+
+  private fun isRuntimeLaunchScript(path: Path): Boolean {
+    val binDir = path.parent ?: return false
+    val runtimeDir = binDir.parent ?: return false
+    return Files.isRegularFile(path) &&
+      binDir.fileName.toString() == "bin" &&
+      runtimeDir.fileName.toString() in setOf("runtime-cli", "runtime-mcp") &&
+      !path.fileName.toString().endsWith(".bat")
+  }
 }
 
 val repoRoot = rootProject.projectDir.parentFile
@@ -38,25 +94,40 @@ val prepareDesktopRuntimeBundle by tasks.registering(Sync::class) {
   duplicatesStrategy = DuplicatesStrategy.FAIL
   dependsOn(":runtime-cli:installDist", ":runtime-mcp:installDist")
 
-  into(desktopAppResourcesDir.map { dir -> dir.dir(runtimeResourceDirName).asFile })
+  into(desktopAppResourcesDir)
 
   from(runtimeCliInstallDir) {
-    into("runtime-cli")
+    into("common/$runtimeResourceDirName/runtime-cli")
   }
   from(runtimeMcpInstallDir) {
-    into("runtime-mcp")
+    into("common/$runtimeResourceDirName/runtime-mcp")
   }
   from(repoRoot.resolve("skills")) {
-    into("skills")
+    into("common/$runtimeResourceDirName/skills")
     excludeGeneratedSkillBillArtifacts()
   }
   from(repoRoot.resolve("platform-packs")) {
-    into("platform-packs")
+    into("common/$runtimeResourceDirName/platform-packs")
     excludeGeneratedSkillBillArtifacts()
   }
   from(repoRoot.resolve("orchestration")) {
-    into("orchestration")
+    into("common/$runtimeResourceDirName/orchestration")
   }
+}
+
+val fixDesktopRuntimeScriptPermissions by tasks.registering(
+  FixRuntimeScriptPermissionsTask::class,
+) {
+  group = "distribution"
+  description = "Mark bundled Skill Bill runtime scripts executable in desktop app images."
+  appImageRoot.set(layout.buildDirectory.dir("compose/binaries/main/app"))
+  dependsOn("createDistributable")
+}
+
+tasks.register("prepareDesktopAppDistributable") {
+  group = "distribution"
+  description = "Create a desktop app image with bundled runtime scripts ready to execute."
+  dependsOn(fixDesktopRuntimeScriptPermissions)
 }
 
 kotlin {
@@ -125,4 +196,14 @@ tasks.matching { task ->
     task.name.startsWith("packageRpm")
 }.configureEach {
   dependsOn(prepareDesktopRuntimeBundle)
+}
+
+tasks.matching { task ->
+  task.name == "packageDistributionForCurrentOS" ||
+    task.name.startsWith("packageDmg") ||
+    task.name.startsWith("packageMsi") ||
+    task.name.startsWith("packageDeb") ||
+    task.name.startsWith("packageRpm")
+}.configureEach {
+  dependsOn(fixDesktopRuntimeScriptPermissions)
 }

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
@@ -174,12 +174,8 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
       ),
       telemetryLevel = request.telemetryLevel.toInstallTelemetryLevel(),
       mcpRegistrationChoice = McpRegistrationChoice(
-        register = request.registerMcp,
-        runtimeMcpBin = if (request.registerMcp) {
-          runtimeAssets.runtimeMcpBin() ?: defaultRuntimeMcpBin(home)
-        } else {
-          null
-        },
+        register = true,
+        runtimeMcpBin = runtimeAssets.runtimeMcpBin() ?: defaultRuntimeMcpBin(home),
       ),
       runtimeDistributionInputs = RuntimeDistributionInputs(
         runtimeInstallRoot = home.resolve(".skill-bill/runtime"),

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
@@ -37,13 +37,12 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class JvmDesktopFirstRunGatewayTest {
   @Test
-  fun `plan maps desktop request into shared install plan request`() = runBlocking {
+  fun `plan maps desktop request into shared install plan request with MCP registration`() = runBlocking {
     val root = Files.createTempDirectory("skillbill-first-run-root")
     var capturedRequest: InstallPlanRequest? = null
     val gateway = JvmDesktopFirstRunGateway().apply {
@@ -71,7 +70,11 @@ class JvmDesktopFirstRunGatewayTest {
     assertEquals(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX), request.agentSelection.manualAgents)
     assertEquals(setOf("kotlin"), request.platformPackSelection.selectedSlugs)
     assertEquals("full", request.telemetryLevel.id)
-    assertFalse(request.mcpRegistrationChoice.register)
+    assertTrue(request.mcpRegistrationChoice.register)
+    assertEquals(
+      root.resolve("runtime-mcp/bin/runtime-mcp").toAbsolutePath().normalize(),
+      request.mcpRegistrationChoice.runtimeMcpBin,
+    )
     assertEquals(root.resolve("skills").toAbsolutePath().normalize(), request.targetPaths.skillsRoot)
     assertEquals(root.resolve("platform-packs").toAbsolutePath().normalize(), request.targetPaths.platformPacksRoot)
     assertEquals(

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
@@ -71,7 +71,7 @@ class LocalDesktopPreferenceStore : DesktopPreferenceStore {
     selectedAgentIds = properties.getProperty(KEY_FIRST_RUN_AGENTS).toSetProperty(),
     selectedPlatformSlugs = properties.getProperty(KEY_FIRST_RUN_PLATFORMS).toSetProperty(),
     telemetryLevelId = properties.getProperty(KEY_FIRST_RUN_TELEMETRY, "anonymous"),
-    registerMcp = properties.getProperty(KEY_FIRST_RUN_MCP)?.toBooleanStrictOrNull() ?: true,
+    registerMcp = true,
   )
 
   private fun persistFirstRunPreferences(preferences: DesktopFirstRunPreferences) {
@@ -79,8 +79,8 @@ class LocalDesktopPreferenceStore : DesktopPreferenceStore {
     properties.setProperty(KEY_FIRST_RUN_AGENTS, preferences.selectedAgentIds.toPropertyValue())
     properties.setProperty(KEY_FIRST_RUN_PLATFORMS, preferences.selectedPlatformSlugs.toPropertyValue())
     properties.setProperty(KEY_FIRST_RUN_TELEMETRY, preferences.telemetryLevelId)
-    properties.setProperty(KEY_FIRST_RUN_MCP, preferences.registerMcp.toString())
-    firstRunState.value = preferences
+    properties.remove(KEY_FIRST_RUN_MCP)
+    firstRunState.value = preferences.copy(registerMcp = true)
     saveProperties()
   }
 

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
@@ -4,7 +4,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -75,7 +74,7 @@ class LocalDesktopPreferenceStoreTest {
       assertEquals(setOf("claude", "codex"), reloaded.selectedAgentIds)
       assertEquals(setOf("kotlin"), reloaded.selectedPlatformSlugs)
       assertEquals("full", reloaded.telemetryLevelId)
-      assertFalse(reloaded.registerMcp)
+      assertTrue(reloaded.registerMcp)
     }
   }
 

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
@@ -162,6 +162,6 @@ data class FirstRunSetupState(
     selectedAgentIds = selectedAgentIds,
     selectedPlatformSlugs = selectedPlatformSlugs,
     telemetryLevel = telemetryLevel,
-    registerMcp = registerMcp,
+    registerMcp = true,
   )
 }

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
@@ -752,15 +752,6 @@ class SkillBillViewModel(
     return currentState
   }
 
-  fun setFirstRunMcpRegistration(register: Boolean): SkillBillState {
-    val setup = firstRunSetup ?: return currentState
-    if (!setup.busy) {
-      firstRunSetup = setup.copy(registerMcp = register, plan = null, outcome = null, errorMessage = null)
-      currentState = createState()
-    }
-    return currentState
-  }
-
   fun advanceFirstRunStep(): SkillBillState {
     val setup = firstRunSetup ?: return currentState
     if (!setup.canContinue || setup.step == FirstRunSetupStep.RESULT) {
@@ -3066,7 +3057,7 @@ private fun DesktopFirstRunPreferences.toFirstRunSetupState(): FirstRunSetupStat
   selectedAgentIds = selectedAgentIds,
   selectedPlatformSlugs = selectedPlatformSlugs,
   telemetryLevel = FirstRunTelemetryLevel.fromId(telemetryLevelId),
-  registerMcp = registerMcp,
+  registerMcp = true,
 )
 
 private fun FirstRunSetupState.applyDiscovery(
@@ -3091,7 +3082,7 @@ private fun FirstRunSetupState.applyDiscovery(
     selectedAgentIds = selectedAgents,
     selectedPlatformSlugs = selectedPlatforms,
     telemetryLevel = FirstRunTelemetryLevel.fromId(preferences.telemetryLevelId),
-    registerMcp = preferences.registerMcp,
+    registerMcp = true,
   )
 }
 
@@ -3100,7 +3091,7 @@ private fun FirstRunSetupState.toPreferences(): DesktopFirstRunPreferences = Des
   selectedAgentIds = selectedAgentIds,
   selectedPlatformSlugs = selectedPlatformSlugs,
   telemetryLevelId = telemetryLevel.id,
-  registerMcp = registerMcp,
+  registerMcp = true,
 )
 
 private fun FirstRunSetupStep.next(): FirstRunSetupStep = when (this) {

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialog.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialog.kt
@@ -44,7 +44,6 @@ data class FirstRunSetupCallbacks(
   val onAgentSelectionChanged: (String, Boolean) -> Unit,
   val onPlatformSelectionChanged: (String, Boolean) -> Unit,
   val onTelemetryChanged: (FirstRunTelemetryLevel) -> Unit,
-  val onMcpRegistrationChanged: (Boolean) -> Unit,
   val onBack: () -> Unit,
   val onNext: () -> Unit,
   val onApply: () -> Unit,
@@ -209,12 +208,10 @@ private fun PreferencesStep(state: FirstRunSetupState, callbacks: FirstRunSetupC
   }
   Spacer(modifier = Modifier.height(4.dp))
   SectionTitle("MCP")
-  ToggleRow(
-    label = "Register MCP server",
-    selected = state.registerMcp,
-    enabled = !state.busy,
-    detail = "Update selected agent configs during install",
-    onClick = { callbacks.onMcpRegistrationChanged(!state.registerMcp) },
+  Text(
+    text = "Skill Bill MCP server will be registered for selected agents.",
+    color = SetupMuted,
+    fontSize = 12.sp,
   )
 }
 
@@ -229,7 +226,7 @@ private fun ApplyStep(state: FirstRunSetupState) {
     },
   )
   SummaryLine(label = "Telemetry", value = state.telemetryLevel.id)
-  SummaryLine(label = "MCP", value = if (state.registerMcp) "register" else "skip")
+  SummaryLine(label = "MCP", value = "register")
 }
 
 @Composable

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillRoute.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillRoute.kt
@@ -906,9 +906,6 @@ fun SkillBillRoute(
       onTelemetryChanged = { level ->
         state = viewModel.selectFirstRunTelemetry(level)
       },
-      onMcpRegistrationChanged = { register ->
-        state = viewModel.setFirstRunMcpRegistration(register)
-      },
       onBack = {
         state = viewModel.retreatFirstRunStep()
       },

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
@@ -70,7 +70,6 @@ class SkillBillViewModelFirstRunTest {
     viewModel.selectFirstRunPlatform("kotlin", selected = true)
     viewModel.advanceFirstRunStep()
     viewModel.selectFirstRunTelemetry(FirstRunTelemetryLevel.FULL)
-    viewModel.setFirstRunMcpRegistration(register = false)
     val ready = viewModel.advanceFirstRunStep()
     assertEquals(FirstRunSetupStep.APPLY, ready.firstRunSetup?.step)
 
@@ -80,7 +79,7 @@ class SkillBillViewModelFirstRunTest {
     assertEquals(setOf("claude", "codex"), gateway.planRequests.single().selectedAgentIds)
     assertEquals(setOf("kotlin"), gateway.planRequests.single().selectedPlatformSlugs)
     assertEquals(FirstRunTelemetryLevel.FULL, gateway.planRequests.single().telemetryLevel)
-    assertFalse(gateway.planRequests.single().registerMcp)
+    assertTrue(gateway.planRequests.single().registerMcp)
     assertEquals(1, gateway.applyCallCount)
     assertEquals(FirstRunInstallStatus.WARNING, applied.firstRunSetup?.outcome?.status)
     assertTrue(preferences.firstRunPreferences.value.completed)
@@ -156,7 +155,7 @@ class SkillBillViewModelFirstRunTest {
     assertEquals(setOf("claude"), reopened.selectedAgentIds)
     assertEquals(setOf("kotlin"), reopened.selectedPlatformSlugs)
     assertEquals(FirstRunTelemetryLevel.FULL, reopened.telemetryLevel)
-    assertFalse(reopened.registerMcp)
+    assertTrue(reopened.registerMcp)
 
     val discoveryRequest = assertNotNull(viewModel.beginFirstRunDiscovery())
     val discovered = viewModel.finishFirstRunDiscovery(viewModel.runFirstRunDiscovery(discoveryRequest))
@@ -164,7 +163,7 @@ class SkillBillViewModelFirstRunTest {
     assertEquals(setOf("claude"), discovered.firstRunSetup?.selectedAgentIds)
     assertEquals(setOf("kotlin"), discovered.firstRunSetup?.selectedPlatformSlugs)
     assertEquals(FirstRunTelemetryLevel.FULL, discovered.firstRunSetup?.telemetryLevel)
-    assertFalse(discovered.firstRunSetup?.registerMcp ?: true)
+    assertTrue(discovered.firstRunSetup?.registerMcp ?: false)
   }
 
   @Test

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialogOutcomeStepTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialogOutcomeStepTest.kt
@@ -137,7 +137,6 @@ class FirstRunSetupDialogOutcomeStepTest {
       onAgentSelectionChanged = { _, _ -> },
       onPlatformSelectionChanged = { _, _ -> },
       onTelemetryChanged = {},
-      onMcpRegistrationChanged = {},
       onBack = {},
       onNext = {},
       onApply = {},

--- a/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
+++ b/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
@@ -18,7 +18,7 @@ _desktop_src="${_repo_root}/runtime-kotlin/runtime-desktop/packaging/arch/skillb
 prepare() {
   if [[ ! -d "${_dist_root}" ]]; then
     echo "error: distributable not found at ${_dist_root}" >&2
-    echo "       run './gradlew :runtime-desktop:createDistributable' first" >&2
+    echo "       run './gradlew :runtime-desktop:prepareDesktopAppDistributable' first" >&2
     return 1
   fi
 }

--- a/runtime-kotlin/runtime-desktop/src/jvmTest/kotlin/skillbill/desktop/DesktopPackagingConfigurationTest.kt
+++ b/runtime-kotlin/runtime-desktop/src/jvmTest/kotlin/skillbill/desktop/DesktopPackagingConfigurationTest.kt
@@ -33,8 +33,11 @@ class DesktopPackagingConfigurationTest {
     assertContains(buildFile, "appResourcesRootDir.set(desktopAppResourcesDir)")
     assertContains(buildFile, "runtimeResourceDirName = \"skill-bill-runtime\"")
     assertContains(buildFile, "dependsOn(\":runtime-cli:installDist\", \":runtime-mcp:installDist\")")
-    assertContains(buildFile, "into(\"runtime-cli\")")
-    assertContains(buildFile, "into(\"runtime-mcp\")")
+    assertContains(buildFile, "into(\"common/\$runtimeResourceDirName/runtime-cli\")")
+    assertContains(buildFile, "into(\"common/\$runtimeResourceDirName/runtime-mcp\")")
+    assertContains(buildFile, "into(\"common/\$runtimeResourceDirName/skills\")")
+    assertContains(buildFile, "into(\"common/\$runtimeResourceDirName/platform-packs\")")
+    assertContains(buildFile, "into(\"common/\$runtimeResourceDirName/orchestration\")")
     assertContains(buildFile, "repoRoot.resolve(\"skills\")")
     assertContains(buildFile, "repoRoot.resolve(\"platform-packs\")")
     assertContains(buildFile, "repoRoot.resolve(\"orchestration\")")
@@ -50,6 +53,17 @@ class DesktopPackagingConfigurationTest {
     assertContains(buildFile, "task.name == \"prepareAppResources\"")
     assertContains(buildFile, "task.name.startsWith(\"packageRpm\")")
     assertContains(buildFile, "dependsOn(prepareDesktopRuntimeBundle)")
+  }
+
+  @Test
+  fun `desktop app images keep bundled runtime launch scripts executable`() {
+    val buildFile = desktopBuildFile()
+
+    assertContains(buildFile, "runtimeLaunchScriptsUnder")
+    assertContains(buildFile, "fixDesktopRuntimeScriptPermissions")
+    assertContains(buildFile, "script.toFile().setExecutable(true, false)")
+    assertContains(buildFile, "tasks.register(\"prepareDesktopAppDistributable\")")
+    assertContains(buildFile, "dependsOn(fixDesktopRuntimeScriptPermissions)")
   }
 
   private fun desktopBuildFile(): String = Files.readString(runtimeRoot.resolve("runtime-desktop/build.gradle.kts"))

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -14,6 +14,8 @@ RUNTIME_MCP_INSTALL_DIR="$RUNTIME_INSTALL_ROOT/runtime-mcp"
 RUNTIME_CLI_BIN="$RUNTIME_CLI_INSTALL_DIR/bin/runtime-cli"
 RUNTIME_MCP_BIN="$RUNTIME_MCP_INSTALL_DIR/bin/runtime-mcp"
 RUNTIME_LAUNCHER_BIN_DIR="${SKILL_BILL_BIN_DIR:-$HOME/.local/bin}"
+DESKTOP_APP_DEFAULT_NAME="SkillBill"
+DESKTOP_APP_INSTALL_DIR="${SKILL_BILL_DESKTOP_APP_DIR:-}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -25,6 +27,104 @@ info()  { printf "${CYAN}▸${NC} %s\n" "$1"; }
 ok()    { printf "${GREEN}✓${NC} %s\n" "$1"; }
 warn()  { printf "${YELLOW}⚠${NC} %s\n" "$1"; }
 err()   { printf "${RED}✗${NC} %s\n" "$1"; }
+
+trim_string() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+usage() {
+  cat <<USAGE
+Usage: ./uninstall.sh [--desktop-app-dir PATH]
+
+Options:
+  --desktop-app-dir PATH   Remove the desktop app from a custom install root.
+USAGE
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      --desktop-app-dir)
+        if [[ $# -lt 2 || -z "$(trim_string "$2")" ]]; then
+          err "--desktop-app-dir requires a path."
+          exit 1
+        fi
+        DESKTOP_APP_INSTALL_DIR="$2"
+        shift 2
+        ;;
+      --desktop-app-dir=*)
+        DESKTOP_APP_INSTALL_DIR="${1#--desktop-app-dir=}"
+        if [[ -z "$(trim_string "$DESKTOP_APP_INSTALL_DIR")" ]]; then
+          err "--desktop-app-dir requires a path."
+          exit 1
+        fi
+        shift
+        ;;
+      *)
+        err "Unknown argument: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+}
+
+host_path() {
+  local path="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$path"
+  else
+    printf '%s' "$path"
+  fi
+}
+
+desktop_host_os() {
+  local uname_s
+  uname_s="$(uname -s 2>/dev/null || printf 'unknown')"
+  case "$uname_s" in
+    Darwin*)
+      printf 'macos'
+      ;;
+    Linux*)
+      printf 'linux'
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      printf 'windows'
+      ;;
+    *)
+      printf 'unknown'
+      ;;
+  esac
+}
+
+default_desktop_app_install_dir() {
+  local os="$1"
+  case "$os" in
+    macos)
+      printf '%s' "$HOME/Applications"
+      ;;
+    linux)
+      printf '%s' "${XDG_DATA_HOME:-$HOME/.local/share}/skillbill/desktop"
+      ;;
+    windows)
+      if [[ -n "${LOCALAPPDATA:-}" ]]; then
+        host_path "$LOCALAPPDATA/SkillBill/Desktop"
+      else
+        printf '%s' "$HOME/AppData/Local/SkillBill/Desktop"
+      fi
+      ;;
+    *)
+      printf '%s' "$HOME/.skill-bill/desktop"
+      ;;
+  esac
+}
 
 locate_packaged_runtime_bin() {
   if [[ ! -x "$RUNTIME_CLI_BIN" && ! -x "$RUNTIME_CLI_BUILD_BIN" ]]; then
@@ -92,6 +192,114 @@ remove_runtime_launchers() {
   info "Removing runtime launchers from: $RUNTIME_LAUNCHER_BIN_DIR"
   remove_runtime_launcher "skill-bill" "$RUNTIME_CLI_BIN"
   remove_runtime_launcher "skill-bill-mcp" "$RUNTIME_MCP_BIN"
+}
+
+desktop_app_install_path() {
+  local os="$1"
+  local install_root
+
+  install_root="${DESKTOP_APP_INSTALL_DIR:-$(default_desktop_app_install_dir "$os")}"
+  install_root="$(host_path "$install_root")"
+  case "$os" in
+    macos)
+      printf '%s' "$install_root/$DESKTOP_APP_DEFAULT_NAME.app"
+      ;;
+    *)
+      printf '%s' "$install_root/$DESKTOP_APP_DEFAULT_NAME"
+      ;;
+  esac
+}
+
+desktop_app_executable_path() {
+  local os="$1"
+  local app_target="$2"
+  case "$os" in
+    macos)
+      printf '%s' "$app_target/Contents/MacOS/$DESKTOP_APP_DEFAULT_NAME"
+      ;;
+    windows)
+      printf '%s' "$app_target/bin/$DESKTOP_APP_DEFAULT_NAME.bat"
+      ;;
+    *)
+      printf '%s' "$app_target/bin/$DESKTOP_APP_DEFAULT_NAME"
+      ;;
+  esac
+}
+
+remove_desktop_launcher() {
+  local os="$1"
+  local app_target="$2"
+  local expected_target
+  local link_path
+  local actual_target
+
+  expected_target="$(desktop_app_executable_path "$os" "$app_target")"
+  case "$os" in
+    windows)
+      link_path="$RUNTIME_LAUNCHER_BIN_DIR/skillbill-desktop.cmd"
+      if [[ -f "$link_path" ]]; then
+        rm -f "$link_path"
+        REMOVED_TARGETS+=("$link_path")
+        ok "  removed skillbill-desktop.cmd"
+      fi
+      ;;
+    *)
+      link_path="$RUNTIME_LAUNCHER_BIN_DIR/skillbill-desktop"
+      if [[ ! -L "$link_path" ]]; then
+        if [[ -e "$link_path" ]]; then
+          warn "  skipped $link_path (not a symlink)"
+          SKIPPED_TARGETS+=("$link_path")
+        fi
+        return 0
+      fi
+      actual_target="$(readlink "$link_path")"
+      if [[ "$actual_target" != "$expected_target" ]]; then
+        warn "  skipped $link_path (points outside this desktop install)"
+        SKIPPED_TARGETS+=("$link_path")
+        return 0
+      fi
+      rm -f "$link_path"
+      REMOVED_TARGETS+=("$link_path")
+      ok "  removed skillbill-desktop"
+      ;;
+  esac
+}
+
+remove_linux_desktop_entry() {
+  local desktop_file="${XDG_DATA_HOME:-$HOME/.local/share}/applications/skillbill.desktop"
+  local icon_file="${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/512x512/apps/skillbill.png"
+
+  if [[ -f "$desktop_file" ]] && grep -q '^Name=SkillBill$' "$desktop_file"; then
+    rm -f "$desktop_file"
+    REMOVED_TARGETS+=("$desktop_file")
+    ok "  removed Linux desktop entry"
+  fi
+  if [[ -f "$icon_file" ]]; then
+    rm -f "$icon_file"
+    REMOVED_TARGETS+=("$icon_file")
+    ok "  removed Linux desktop icon"
+  fi
+}
+
+remove_desktop_app() {
+  local os
+  local app_target
+
+  os="$(desktop_host_os)"
+  app_target="$(desktop_app_install_path "$os")"
+
+  info "Removing desktop app install for $os: $app_target"
+  remove_desktop_launcher "$os" "$app_target"
+  if [[ "$os" == "linux" ]]; then
+    remove_linux_desktop_entry
+  fi
+  if [[ -d "$app_target" ]]; then
+    rm -rf "$app_target"
+    REMOVED_TARGETS+=("$app_target")
+    ok "  removed desktop app"
+  else
+    info "  no desktop app install found"
+  fi
 }
 
 # SKILL-14 + SKILL-16: pure relocations whose skill directory name stays the
@@ -270,13 +478,18 @@ remove_from_agent_dir() {
   done <<< "$output"
 }
 
-build_kotlin_runtime_distribution
-build_skill_names
-build_legacy_skill_names
+parse_args "$@"
 
 echo ""
 printf "${CYAN}━━━ Skill Bill Uninstaller ━━━${NC}\n"
 echo ""
+
+remove_desktop_app
+
+build_kotlin_runtime_distribution
+build_skill_names
+build_legacy_skill_names
+
 info "Removing Skill Bill installs from supported agent paths."
 
 remove_from_agent_dir "copilot" "$HOME/.copilot/skills"


### PR DESCRIPTION
## Summary

Fixes the desktop app install path so the generated app is usable outside the checkout and makes installer cleanup symmetric.

- Stage Skill Bill runtime assets into Compose Desktop app resources, including runtime CLI/MCP distributions, authored skills, platform packs, and orchestration files.
- Ensure packaged runtime scripts are executable before native package creation.
- Add `install.sh --with-desktop-app` support for macOS, Linux, and Windows loose app installs with a `skillbill-desktop` launcher.
- Make MCP registration automatic in terminal and desktop install flows.
- Update `uninstall.sh` to remove the per-user desktop UI app, desktop launcher, and Linux desktop entry, including custom `--desktop-app-dir` roots.
- Update docs and shell/desktop tests for the new behavior.

## Root Cause

The DMG/app could launch the UI, but the app did not carry the runtime asset tree expected by first-run setup, so installation failed after packaging. The terminal installer also had no cross-platform desktop app install/remove path, leaving installed apps without a durable repo/runtime asset source.

## Validation

- `bash -n install.sh`
- `bash -n uninstall.sh`
- `git diff --check`
- `./gradlew :runtime-core:spotlessKotlinCheck :runtime-core:detekt :runtime-core:test --tests skillbill.architecture.InstallerShellDelegationTest`
- `./gradlew :runtime-core:test --tests skillbill.architecture.InstallerShellDelegationTest`
- `./gradlew :runtime-desktop:jvmTest --tests skillbill.desktop.DesktopPackagingConfigurationTest`
- `./gradlew :runtime-desktop:feature:skillbill:jvmTest --tests skillbill.desktop.feature.skillbill.state.SkillBillViewModelFirstRunTest --tests skillbill.desktop.feature.skillbill.ui.FirstRunSetupDialogOutcomeStepTest`
- `./gradlew :runtime-desktop:core:data:jvmTest --tests skillbill.desktop.core.data.service.JvmDesktopFirstRunGatewayTest :runtime-desktop:core:datastore:jvmTest --tests skillbill.desktop.core.datastore.LocalDesktopPreferenceStoreTest`
- `./gradlew :runtime-desktop:packageDmg`
- `hdiutil verify runtime-kotlin/runtime-desktop/build/compose/binaries/main/dmg/SkillBill-1.0.0.dmg`
- Temp-home smoke test for `./install.sh --with-desktop-app` confirmed no MCP prompt and installed the desktop launcher/app.
- GitHub Actions `Validate agent configs` passed for both push and pull_request runs on `e67b1bf`.
