### PR TITLE
[codex] Fix desktop install flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,8 @@ RUNTIME_LAUNCHER_BIN_DIR="${SKILL_BILL_BIN_DIR:-$HOME/.local/bin}"
 DESKTOP_APP_DEFAULT_NAME="SkillBill"
 DESKTOP_APP_INSTALL="prompt"
 DESKTOP_APP_INSTALL_DIR="${SKILL_BILL_DESKTOP_APP_DIR:-}"
+DESKTOP_APP_INSTALLED_PATH=""
+DESKTOP_APP_LAUNCHER_PATH=""
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -124,7 +126,7 @@ default_desktop_app_install_dir() {
   local os="$1"
   case "$os" in
     macos)
-      printf '%s' "$HOME/Applications"
+      printf '%s' "/Applications"
       ;;
     linux)
       printf '%s' "${XDG_DATA_HOME:-$HOME/.local/share}/skillbill/desktop"
@@ -357,6 +359,7 @@ install_desktop_launcher() {
 @echo off
 call "$windows_executable" %*
 CMD
+      DESKTOP_APP_LAUNCHER_PATH="$launcher_path"
       ok "  linked desktop launcher → $launcher_path"
       return 0
       ;;
@@ -371,7 +374,8 @@ CMD
     return 0
   fi
   ln -sfn "$executable" "$launcher_path"
-  ok "  linked desktop launcher → $executable"
+  DESKTOP_APP_LAUNCHER_PATH="$launcher_path"
+  ok "  linked desktop launcher → $launcher_path"
 }
 
 install_linux_desktop_entry() {
@@ -430,6 +434,7 @@ install_desktop_app() {
       target_path="$install_root/$DESKTOP_APP_DEFAULT_NAME"
       ;;
   esac
+  DESKTOP_APP_INSTALLED_PATH="$target_path"
 
   info "Installing desktop app to: $target_path"
   rm -rf "$target_path"
@@ -962,7 +967,10 @@ info "Launchers:       $RUNTIME_LAUNCHER_BIN_DIR/skill-bill, $RUNTIME_LAUNCHER_B
 info "Telemetry:       $TELEMETRY_LEVEL"
 info "MCP:             $MCP_REGISTRATION"
 if [[ "$DESKTOP_APP_INSTALL" == "yes" ]]; then
-  info "Desktop app:     installed for $(desktop_host_os)"
+  info "Desktop app:     ${DESKTOP_APP_INSTALLED_PATH:-installed for $(desktop_host_os)}"
+  if [[ -n "$DESKTOP_APP_LAUNCHER_PATH" ]]; then
+    info "Desktop launcher: $DESKTOP_APP_LAUNCHER_PATH"
+  fi
 else
   info "Desktop app:     skipped"
 fi

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -35,6 +35,7 @@ class InstallerShellDelegationTest {
     assertContains(installScript, ":runtime-desktop:prepareDesktopAppDistributable")
     assertContains(installScript, "install_desktop_app")
     assertContains(installScript, "desktop_host_os")
+    assertContains(installScript, "printf '%s' \"/Applications\"")
     assertFalse(installScript.contains("prompt_for_mcp_registration"))
     assertFalse(installScript.contains("Enter MCP choice"))
     assertFalse(installScript.contains("install register-mcp"))

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
@@ -66,7 +66,7 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
     Files.list(stagingRoot).use { entries ->
       entries.anyMatch { entry: Path ->
         !entry.fileName.toString().startsWith(".") &&
-        Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS) &&
+          Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS) &&
           Files.isRegularFile(entry.resolve("SKILL.md"), LinkOption.NOFOLLOW_LINKS) &&
           Files.isRegularFile(entry.resolve(".content-hash"), LinkOption.NOFOLLOW_LINKS)
       }

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
@@ -39,6 +39,8 @@ import skillbill.install.model.WindowsSymlinkDecision
 import skillbill.install.model.WindowsSymlinkPreflight
 import skillbill.install.model.WindowsSymlinkPreflightState
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 @Inject
@@ -52,6 +54,24 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
   internal var detectedAgentTargets: (
     Path,
   ) -> List<skillbill.install.model.AgentTarget> = InstallOperations::detectAgentTargets
+
+  override fun hasExistingInstall(): Boolean = runCatching {
+    val stagingRoot = homeProvider()
+      .toAbsolutePath()
+      .normalize()
+      .resolve(".skill-bill/installed-skills")
+    if (!Files.isDirectory(stagingRoot, LinkOption.NOFOLLOW_LINKS)) {
+      return@runCatching false
+    }
+    Files.list(stagingRoot).use { entries ->
+      entries.anyMatch { entry: Path ->
+        !entry.fileName.toString().startsWith(".") &&
+        Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS) &&
+          Files.isRegularFile(entry.resolve("SKILL.md"), LinkOption.NOFOLLOW_LINKS) &&
+          Files.isRegularFile(entry.resolve(".content-hash"), LinkOption.NOFOLLOW_LINKS)
+      }
+    }
+  }.getOrDefault(false)
 
   override suspend fun discoverSetup(): FirstRunDiscoveryResult = try {
     val home = homeProvider().toAbsolutePath().normalize()

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
@@ -37,10 +37,38 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class JvmDesktopFirstRunGatewayTest {
+  @Test
+  fun `existing install is detected from staged skill cache`() {
+    val home = Files.createTempDirectory("skillbill-first-run-installed")
+    val stagedSkill = home.resolve(".skill-bill/installed-skills/bill-code-review-0123456789abcdef")
+    Files.createDirectories(stagedSkill)
+    Files.writeString(stagedSkill.resolve("SKILL.md"), "# bill-code-review\n")
+    Files.writeString(stagedSkill.resolve(".content-hash"), "0123456789abcdef")
+    val gateway = JvmDesktopFirstRunGateway().apply {
+      homeProvider = { home }
+    }
+
+    assertTrue(gateway.hasExistingInstall())
+  }
+
+  @Test
+  fun `existing install ignores incomplete staging residue`() {
+    val home = Files.createTempDirectory("skillbill-first-run-empty")
+    val stagedSkill = home.resolve(".skill-bill/installed-skills/.staging-tmp-1")
+    Files.createDirectories(stagedSkill)
+    Files.writeString(stagedSkill.resolve(".content-hash"), "0123456789abcdef")
+    val gateway = JvmDesktopFirstRunGateway().apply {
+      homeProvider = { home }
+    }
+
+    assertFalse(gateway.hasExistingInstall())
+  }
+
   @Test
   fun `plan maps desktop request into shared install plan request with MCP registration`() = runBlocking {
     val root = Files.createTempDirectory("skillbill-first-run-root")

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/service/DesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/service/DesktopFirstRunGateway.kt
@@ -7,6 +7,8 @@ import skillbill.desktop.core.domain.model.FirstRunPlanResult
 import skillbill.desktop.core.domain.model.FirstRunSetupRequest
 
 interface DesktopFirstRunGateway {
+  fun hasExistingInstall(): Boolean
+
   suspend fun discoverSetup(): FirstRunDiscoveryResult
 
   suspend fun planSetup(request: FirstRunSetupRequest): FirstRunPlanResult

--- a/runtime-kotlin/runtime-desktop/core/testing/src/commonMain/kotlin/skillbill/desktop/core/testing/install/FakeDesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/testing/src/commonMain/kotlin/skillbill/desktop/core/testing/install/FakeDesktopFirstRunGateway.kt
@@ -11,6 +11,7 @@ class FakeDesktopFirstRunGateway(
   var discoveryResult: FirstRunDiscoveryResult,
   var planResult: FirstRunPlanResult,
   var applyResult: FirstRunApplyResult,
+  var existingInstall: Boolean = false,
 ) : DesktopFirstRunGateway {
   val planRequests: MutableList<FirstRunSetupRequest> = mutableListOf()
   val appliedPlans: MutableList<FirstRunInstallPlan> = mutableListOf()
@@ -23,6 +24,8 @@ class FakeDesktopFirstRunGateway(
 
   var applyCallCount: Int = 0
     private set
+
+  override fun hasExistingInstall(): Boolean = existingInstall
 
   override suspend fun discoverSetup(): FirstRunDiscoveryResult {
     discoveryCallCount += 1

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
@@ -165,7 +165,7 @@ class SkillBillViewModel(
     skillbill.desktop.core.domain.model.ValidateAgentConfigsSummary.empty
   private var activeValidateAgentConfigsToken: Long = 0L
   private var firstRunSetup: FirstRunSetupState? =
-    if (desktopPreferenceStore.firstRunPreferences.value.completed) {
+    if (desktopPreferenceStore.firstRunPreferences.value.completed || firstRunGateway.hasExistingInstall()) {
       null
     } else {
       desktopPreferenceStore.firstRunPreferences.value.toFirstRunSetupState()

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
@@ -38,6 +38,27 @@ import kotlin.test.assertTrue
 
 class SkillBillViewModelFirstRunTest {
   @Test
+  fun `first launch skips setup when install already exists`() {
+    val preferences = FakeDesktopPreferenceStore(
+      initialFirstRunPreferences = DesktopFirstRunPreferences(completed = false),
+    )
+    val viewModel = newViewModel(
+      firstRunGateway = FakeDesktopFirstRunGateway(
+        discoveryResult = FirstRunDiscoveryResult.Success(discovery()),
+        planResult = FirstRunPlanResult.Planned(plan()),
+        applyResult = FirstRunApplyResult.Applied(
+          FirstRunInstallOutcome(status = FirstRunInstallStatus.SUCCESS, title = "Setup completed."),
+        ),
+        existingInstall = true,
+      ),
+      preferenceStore = preferences,
+    )
+
+    assertNull(viewModel.state().firstRunSetup)
+    assertFalse(preferences.firstRunPreferences.value.completed)
+  }
+
+  @Test
   fun `first launch discovers setup choices and applies selected request`() = runBlocking {
     val gateway = FakeDesktopFirstRunGateway(
       discoveryResult = FirstRunDiscoveryResult.Success(discovery()),

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -108,7 +108,7 @@ default_desktop_app_install_dir() {
   local os="$1"
   case "$os" in
     macos)
-      printf '%s' "$HOME/Applications"
+      printf '%s' "/Applications"
       ;;
     linux)
       printf '%s' "${XDG_DATA_HOME:-$HOME/.local/share}/skillbill/desktop"


### PR DESCRIPTION
## Summary

This PR fixes the desktop install flow in two related places.

First, the desktop first-run wizard now checks for an existing Skill Bill install under `~/.skill-bill/installed-skills` before opening. This prevents the app from forcing setup when `install.sh` already installed skills and generated staging output but desktop preferences have not been marked complete.

Second, the macOS desktop app install default now targets `/Applications/SkillBill.app` instead of `~/Applications/SkillBill.app`. The installer also records and prints the resolved desktop app path and `skillbill-desktop` launcher path in the final summary, and the uninstaller uses the same macOS default so cleanup stays aligned.

## Validation

- `bash -n install.sh && bash -n uninstall.sh`
- `./gradlew :runtime-core:test --tests 'skillbill.architecture.InstallerShellDelegationTest'`
- `./gradlew :runtime-desktop:core:data:jvmTest --tests 'skillbill.desktop.core.data.service.JvmDesktopFirstRunGatewayTest' :runtime-desktop:feature:skillbill:jvmTest --tests 'skillbill.desktop.feature.skillbill.state.SkillBillViewModelFirstRunTest'`

## Notes

The app was also moved locally from `~/Applications/SkillBill.app` to `/Applications/SkillBill.app`, and `~/.local/bin/skillbill-desktop` was repointed to the new bundle executable.
