### PR TITLE
SKILL-50: Add platform-pack review composition authoring

### DIFF
--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec.md
@@ -1,0 +1,189 @@
+# SKILL-50 — Platform-pack review composition contract
+
+Status: Proposed
+
+## Sources
+
+- User design discussion on making KMP's dependency on the Kotlin review
+  baseline structured and machine-checkable instead of prose-only.
+- Current KMP/Kotlin review behavior:
+  - `platform-packs/kmp/platform.yaml` routes KMP over generic Kotlin and says
+    KMP layers the Kotlin baseline internally.
+  - `platform-packs/kmp/code-review/bill-kmp-code-review/content.md` manually
+    instructs KMP review to run `bill-kotlin-code-review` first.
+  - `platform-packs/kotlin/code-review/bill-kotlin-code-review/content.md`
+    manually accepts `bill-kmp-code-review` as a caller and switches to
+    `kmp-baseline`.
+- Existing platform-pack contract rules in
+  `orchestration/contracts/platform-pack-schema.yaml`,
+  `ShellContentLoader.buildPack`, scaffold payloads, render/install staging,
+  and desktop scaffold wizard flows.
+
+## Problem
+
+KMP review composition currently works, but the KMP -> Kotlin baseline
+relationship is only a prose contract. The manifest routes to `kmp`; the KMP
+skill body then tells the runtime to call `bill-kotlin-code-review`; the Kotlin
+skill body reciprocally recognizes that caller as `kmp-baseline`.
+
+That is understandable to humans, but it is not strong enough for Skill Bill's
+core philosophy:
+
+- manifests should declare machine-checkable platform contracts
+- content should carry human judgment and domain heuristics
+- generated wrappers should expose runtime contracts consistently
+- scaffolders and desktop authoring should produce valid manifests without
+  asking users to hand-write YAML
+- invalid pack relationships should fail loudly before review execution
+
+SKILL-50 makes cross-pack review composition a first-class governed contract.
+The KMP pack will declare its Kotlin baseline layer in `platform.yaml`; the
+runtime validates the relationship; generated `SKILL.md` renders the
+composition contract mechanically; scaffold and desktop creation flows expose a
+friendly "baseline review layer" UI instead of raw YAML.
+
+## Target manifest shape
+
+Initial shape:
+
+```yaml
+code_review_composition:
+  baseline_layers:
+    - platform: kotlin
+      skill: bill-kotlin-code-review
+      mode: kmp-baseline
+      scope: same-review-scope
+      required: true
+```
+
+Field meaning:
+
+- `platform`: referenced platform-pack slug.
+- `skill`: referenced code-review skill declared by that pack.
+- `mode`: caller-visible mode passed to the baseline skill.
+- `scope`: enum, initially only `same-review-scope`.
+- `required`: whether the routed review must stop if the layer cannot run.
+
+The field is optional. Packs with no composed baseline continue to behave as
+they do today.
+
+## Acceptance criteria
+
+### Contract and loader
+
+1. `orchestration/contracts/platform-pack-schema.yaml` defines
+   `code_review_composition.baseline_layers` with strict JSON Schema shape,
+   no unknown nested fields, and the existing contract-version parity rules.
+2. `code_review_composition` is runtime-anchored because the shell consumes it
+   by name.
+3. `PlatformManifest` exposes typed composition data for baseline layers.
+4. `ShellContentLoader.buildPack` parses and validates the new field.
+5. Coherence checks reject:
+   - referenced pack missing
+   - referenced skill missing or not declared by the referenced pack
+   - self-reference
+   - composition cycles
+   - duplicate baseline layers
+   - unsupported `scope`
+   - unsupported `mode` for the referenced skill
+6. The shipped KMP manifest declares the Kotlin baseline layer.
+7. Existing packs without composition still load.
+
+### Runtime and render behavior
+
+8. Generated `SKILL.md` for a code-review orchestrator renders a
+   manifest-derived "Review Composition" section before authored `content.md`.
+9. The rendered section instructs runtime agents to execute required baseline
+   layers before pack-local specialists, passing review scope, changed files,
+   review IDs, applied learnings, AGENTS.md guidance, and stack signals.
+10. KMP `content.md` no longer carries the hard dependency as the only source
+    of truth. It may refer to "manifest-declared baseline layers" but should
+    keep only KMP-specific judgment.
+11. Kotlin `content.md` keeps the `kmp-baseline` behavior, but the accepted
+    mode should be documented as a manifest-declared mode rather than a
+    caller-name special case.
+12. Snapshot/render tests prove the generated wrapper includes the manifest
+    composition section for KMP and omits it for packs without composition.
+
+### Scaffolder and CLI authoring
+
+13. Scaffold payloads can express baseline review layers for
+    `kind=platform-pack`.
+14. `skill-bill new --payload` writes `code_review_composition` into the
+    manifest and validates it atomically.
+15. Invalid payload references fail before mutation or roll back byte-for-byte.
+16. Existing payloads without baseline layers remain valid.
+17. `skill-bill show` / authoring inspection surfaces composition enough for
+    agents and users to understand what will run.
+
+### Desktop UI
+
+18. Platform-pack creation wizard includes a friendly "Baseline review layers"
+    section without exposing raw YAML as the primary authoring path.
+19. The section lists discovered packs that declare code-review baselines.
+20. The wizard can add a baseline layer with pack, skill, mode, scope, and
+    required flag, using safe defaults.
+21. For KMP/Android-like signals, the UI suggests "Use Kotlin baseline review
+    layer" in product language.
+22. Form validation blocks missing packs, missing skills, cycles when detectable
+    locally, and unsupported mode/scope before Run.
+23. Dry-run preview shows the manifest composition edit.
+24. Execute uses the same scaffold payload path as CLI; desktop never edits the
+    manifest directly.
+
+### Documentation
+
+25. `AGENTS.md` documents the composition contract and the rule that hard
+    cross-pack delegation belongs in the manifest, not only in `content.md`.
+26. User-facing docs explain baseline layers as a wizard concept and mention
+    raw YAML only as an advanced/manual path.
+
+## Non-goals
+
+- No freeform manifest editor in the desktop UI.
+- No attempt to encode every review heuristic in `platform.yaml`.
+- No replacement of `content.md` as the authored domain-guidance surface.
+- No composition support for quality-check in this feature. KMP quality-check
+  fallback remains the explicit `kmp` -> `kotlin` rule until separately
+  designed.
+- No multi-version compatibility shim for old durable records or old manifests.
+  Schema mismatch remains loud-fail by design.
+- No marketplace or remote-pack dependency resolution.
+
+## Design principles
+
+- Manifest declares mandatory composition.
+- Rendered `SKILL.md` turns manifest composition into runtime instructions.
+- `content.md` describes platform judgment after required layers have run.
+- UI/scaffolder owns friendly authoring and writes strict contracts.
+- Validators enforce cross-pack integrity before runtime execution.
+
+## Implementation order
+
+1. **Subtask 1: schema and loader contract.**
+   Add the manifest field, typed model, parser, coherence validation, and KMP
+   manifest declaration.
+2. **Subtask 2: render and skill prose migration.**
+   Generate the Review Composition wrapper section and trim KMP/Kotlin
+   `content.md` so the dependency is not prose-only.
+3. **Subtask 3: scaffold payload and CLI authoring.**
+   Add baseline-layer payload support and atomic manifest writes.
+4. **Subtask 4: desktop wizard authoring.**
+   Add friendly baseline-layer controls backed by the same scaffold payload.
+
+Each subtask should be implemented and reviewed independently. Subtask 4
+depends on Subtask 3; Subtask 2 depends on Subtask 1.
+
+## Validation
+
+Full final validation:
+
+```bash
+skill-bill validate
+(cd runtime-kotlin && ./gradlew check)
+npx --yes agnix --strict .
+scripts/validate_agent_configs
+```
+
+Subtasks may use narrower Gradle targets, but the final integration must run
+the full project validation set above.

--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_1_schema-loader-contract.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_1_schema-loader-contract.md
@@ -1,0 +1,81 @@
+# SKILL-50 Subtask 1 — Schema and loader contract
+
+Status: Complete
+
+Parent spec: [spec.md](./spec.md)
+
+## Scope
+
+Add machine-checkable platform-pack review composition to the manifest contract
+and runtime loader. This subtask establishes the source of truth but does not
+yet change generated wrappers, scaffold payloads, or desktop UI.
+
+## Required behavior
+
+Introduce optional manifest field:
+
+```yaml
+code_review_composition:
+  baseline_layers:
+    - platform: kotlin
+      skill: bill-kotlin-code-review
+      mode: kmp-baseline
+      scope: same-review-scope
+      required: true
+```
+
+The KMP pack must declare the Kotlin baseline layer through this field.
+
+## Acceptance criteria
+
+1. `orchestration/contracts/platform-pack-schema.yaml` defines
+   `code_review_composition.baseline_layers`.
+2. Nested composition fields are strict: no unknown properties.
+3. `scope` is an enum with initial value `same-review-scope`.
+4. `required` is required or defaults deterministically in the parser; pick one
+   and test it.
+5. The top-level field is marked `x-runtime-anchored: true`.
+6. Kotlin model types represent the composition contract, preferably as typed
+   values under `PlatformManifest`.
+7. `ShellContentLoader.buildPack` parses the field.
+8. Coherence validation checks referenced packs and referenced code-review
+   skills against loaded manifests.
+9. Coherence validation rejects self-reference, duplicate baseline layers, and
+   composition cycles.
+10. Coherence validation rejects unsupported `mode` for the referenced skill.
+    For this subtask, support `kmp-baseline` only for
+    `bill-kotlin-code-review`.
+11. Existing packs without `code_review_composition` still load.
+12. KMP manifest declares the Kotlin baseline layer.
+13. Tests cover valid KMP composition and every major rejection path.
+
+## Boundaries touched
+
+- `orchestration/contracts/platform-pack-schema.yaml`
+- `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt`
+- platform manifest model classes under runtime scaffold/domain model packages
+- platform-pack schema tests under `runtime-kotlin/runtime-core/src/test`
+- `platform-packs/kmp/platform.yaml`
+- `AGENTS.md` if the runtime-contract rule needs an interim note
+
+## Non-goals
+
+- Do not generate runtime instructions into `SKILL.md` yet.
+- Do not change scaffold payloads yet.
+- Do not change desktop wizard behavior yet.
+- Do not add quality-check composition.
+- Do not move review heuristics from `content.md` into the manifest.
+
+## Validation strategy
+
+Run focused schema/loader tests first, then:
+
+```bash
+(cd runtime-kotlin && ./gradlew :runtime-core:check)
+skill-bill validate
+```
+
+## Handoff prompt
+
+Run `bill-feature-implement` on
+`.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_1_schema-loader-contract.md`.

--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_2_render-runtime-instructions.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_2_render-runtime-instructions.md
@@ -1,6 +1,6 @@
 # SKILL-50 Subtask 2 — Render runtime composition instructions
 
-Status: Proposed
+Status: Complete
 
 Parent spec: [spec.md](./spec.md)
 

--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_2_render-runtime-instructions.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_2_render-runtime-instructions.md
@@ -1,0 +1,91 @@
+# SKILL-50 Subtask 2 — Render runtime composition instructions
+
+Status: Proposed
+
+Parent spec: [spec.md](./spec.md)
+
+Depends on:
+[spec_subtask_1_schema-loader-contract.md](./spec_subtask_1_schema-loader-contract.md)
+
+## Scope
+
+Make manifest-declared review composition visible to runtime agents through
+generated `SKILL.md` wrappers. After this subtask, the hard KMP -> Kotlin
+baseline rule must be generated from `platform.yaml`, not only described in
+KMP `content.md`.
+
+## Required generated section
+
+For code-review orchestrators with baseline layers, generated `SKILL.md` should
+include a section like:
+
+```md
+## Manifest-Declared Review Composition
+
+This pack declares required baseline review layers:
+
+1. `bill-kotlin-code-review`
+   - platform: `kotlin`
+   - mode: `kmp-baseline`
+   - scope: `same-review-scope`
+   - required: `true`
+
+Run all required baseline layers before this pack's local review specialists.
+Pass the same review scope, changed files, review IDs, applied learnings,
+AGENTS.md guidance, and detected stack signals.
+```
+
+Exact wording can differ, but the generated text must be deterministic and
+must carry the same machine data.
+
+## Acceptance criteria
+
+1. Rendered KMP `SKILL.md` includes a manifest-derived Review Composition
+   section before authored platform-specific review guidance.
+2. Packs with no composition do not render an empty/noisy section.
+3. The generated section tells runtime agents to run required baseline layers
+   before pack-local specialists.
+4. The generated section names scope propagation, review IDs, applied
+   learnings, AGENTS guidance, changed files, and stack signals.
+5. KMP `content.md` no longer carries the hard dependency as the only source of
+   truth. It may refer to "manifest-declared baseline layers" and then focus on
+   KMP-specific classification, add-ons, and specialists.
+6. Kotlin `content.md` keeps `kmp-baseline` behavior, but describes it as a
+   manifest-declared mode rather than a caller-name exception.
+7. Snapshot tests cover KMP rendered output.
+8. Snapshot tests cover a pack without composition and prove the section is
+   omitted.
+9. `./install.sh` or render/install staging still produces no committed
+   generated wrappers under source directories.
+
+## Boundaries touched
+
+- authoring render code in `runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold`
+- render snapshots under `runtime-kotlin/runtime-core/src/test/resources/snapshots`
+- `platform-packs/kmp/code-review/bill-kmp-code-review/content.md`
+- `platform-packs/kotlin/code-review/bill-kotlin-code-review/content.md`
+- install/render validation tests if wrapper shape changes
+
+## Non-goals
+
+- Do not change the schema shape from Subtask 1 unless a bug is found.
+- Do not add desktop controls.
+- Do not add scaffold payload fields.
+- Do not encode KMP specialist trigger tables in the manifest.
+
+## Validation strategy
+
+Run render and snapshot tests, then:
+
+```bash
+(cd runtime-kotlin && ./gradlew :runtime-core:check)
+skill-bill validate
+```
+
+Re-run `./install.sh` after source skill or renderer changes so local agent
+installs pick up the new staging hash.
+
+## Handoff prompt
+
+Run `bill-feature-implement` on
+`.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_2_render-runtime-instructions.md`.

--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_3_scaffold-payload-cli.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_3_scaffold-payload-cli.md
@@ -1,6 +1,6 @@
 # SKILL-50 Subtask 3 — Scaffold payload and CLI authoring
 
-Status: Proposed
+Status: Complete
 
 Parent spec: [spec.md](./spec.md)
 

--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_3_scaffold-payload-cli.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_3_scaffold-payload-cli.md
@@ -1,0 +1,88 @@
+# SKILL-50 Subtask 3 — Scaffold payload and CLI authoring
+
+Status: Proposed
+
+Parent spec: [spec.md](./spec.md)
+
+Depends on:
+[spec_subtask_1_schema-loader-contract.md](./spec_subtask_1_schema-loader-contract.md)
+
+## Scope
+
+Teach governed platform-pack scaffolding to create manifest-declared baseline
+review layers through the typed scaffold payload. This is the shared authoring
+surface that desktop will use later; desktop must not hand-edit manifests.
+
+## Payload shape
+
+Extend `kind=platform-pack` payloads with an optional baseline-layer list.
+Suggested JSON shape:
+
+```json
+{
+  "kind": "platform-pack",
+  "platform": "kmp",
+  "display_name": "KMP",
+  "baseline_layers": [
+    {
+      "platform": "kotlin",
+      "skill": "bill-kotlin-code-review",
+      "mode": "kmp-baseline",
+      "scope": "same-review-scope",
+      "required": true
+    }
+  ]
+}
+```
+
+Field names can align with existing scaffold naming conventions, but they must
+round-trip deterministically into `platform.yaml`.
+
+## Acceptance criteria
+
+1. Scaffold payload schema/documentation describes optional baseline layers for
+   `kind=platform-pack`.
+2. `skill-bill new --payload` accepts valid baseline-layer payloads.
+3. Scaffold writes `code_review_composition.baseline_layers` into the new pack
+   manifest.
+4. Existing platform-pack payloads without baseline layers remain valid and
+   generate no composition section.
+5. Invalid references fail before mutation or roll back byte-for-byte:
+   missing referenced pack, missing referenced skill, unsupported mode,
+   unsupported scope, self-reference, duplicate layer.
+6. Dry-run output shows the manifest edit in a user-readable way.
+7. Execute and dry-run use the same payload model.
+8. `skill-bill show` or equivalent authoring inspection surfaces composition
+   enough for users and agents to understand what will run.
+9. Tests cover valid write, no-composition legacy payload, and invalid payload
+   rollback.
+
+## Boundaries touched
+
+- `orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md`
+- scaffold payload model/parsing in runtime Kotlin
+- scaffold manifest rendering/editing helpers
+- CLI scaffold commands and golden output, where applicable
+- scaffold service parity tests
+- README or getting-started docs only if they already document payload fields
+
+## Non-goals
+
+- Do not build desktop UI in this subtask.
+- Do not infer baseline layers from freeform prose.
+- Do not support baseline layers for non-platform-pack scaffold kinds yet.
+- Do not implement remote dependency installation.
+
+## Validation strategy
+
+Run scaffold-focused tests and CLI golden tests, then:
+
+```bash
+(cd runtime-kotlin && ./gradlew :runtime-core:check :runtime-cli:check)
+skill-bill validate
+```
+
+## Handoff prompt
+
+Run `bill-feature-implement` on
+`.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_3_scaffold-payload-cli.md`.

--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_4_desktop-wizard-authoring.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_4_desktop-wizard-authoring.md
@@ -1,6 +1,6 @@
 # SKILL-50 Subtask 4 — Desktop wizard baseline-layer authoring
 
-Status: Proposed
+Status: Complete
 
 Parent spec: [spec.md](./spec.md)
 

--- a/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_4_desktop-wizard-authoring.md
+++ b/.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_4_desktop-wizard-authoring.md
@@ -1,0 +1,93 @@
+# SKILL-50 Subtask 4 — Desktop wizard baseline-layer authoring
+
+Status: Proposed
+
+Parent spec: [spec.md](./spec.md)
+
+Depends on:
+[spec_subtask_3_scaffold-payload-cli.md](./spec_subtask_3_scaffold-payload-cli.md)
+
+## Scope
+
+Add friendly desktop authoring for platform-pack baseline review layers. The UI
+must let users create structured composition without learning the raw manifest
+shape. It must still route all writes through the governed scaffolder payload.
+
+## UX model
+
+In the platform-pack creation wizard, add a section named "Baseline review
+layers" or equivalent product-language label.
+
+Controls:
+
+- Toggle or add button: "Run another pack's review first"
+- Baseline pack dropdown from discovered platform packs
+- Baseline skill dropdown from the selected pack's declared code-review
+  baseline and eligible review skills
+- Mode dropdown with safe values for the selected skill
+- Scope fixed/defaulted to `same-review-scope`
+- Required checkbox defaulted to true
+
+For KMP/Android-like routing signals, suggest:
+
+> Use Kotlin baseline review layer
+
+Helper text should explain:
+
+> Run Kotlin review first for shared language risks, then add this pack's
+> platform-specific reviewers.
+
+Do not show raw YAML as the primary authoring path.
+
+## Acceptance criteria
+
+1. Platform-pack wizard can add, edit, and remove baseline review layers before
+   dry-run.
+2. Options are discovered from platform manifests rather than hardcoded to
+   Kotlin, except for optional suggestion heuristics.
+3. Packs without declared code-review baselines are not offered as baseline
+   packs.
+4. Mode options are constrained to values supported by the referenced skill.
+5. Scope defaults to `same-review-scope`.
+6. Required defaults to true.
+7. KMP/Android-like signals produce a Kotlin baseline suggestion when the
+   Kotlin pack is available.
+8. Form validation blocks missing pack, missing skill, unsupported mode/scope,
+   duplicate layers, and locally detectable cycles.
+9. Dry-run preview includes the planned `code_review_composition` manifest edit.
+10. Execute sends the same scaffold payload model introduced in Subtask 3.
+11. Desktop code does not hand-write `platform.yaml`.
+12. Tests cover state transitions, payload mapping, validation failures,
+    suggestion behavior, and dry-run/execute parity.
+
+## Boundaries touched
+
+- desktop scaffold wizard state and domain models
+- desktop scaffold gateway payload mapping
+- desktop scaffold wizard UI
+- fake scaffold gateway/testing helpers
+- desktop feature tests for wizard state and UI rendering
+
+## Non-goals
+
+- No raw manifest editor.
+- No marketplace or remote-pack discovery.
+- No automatic installation of missing referenced packs.
+- No support for quality-check composition.
+- No support for arbitrary custom modes typed by hand in the UI.
+
+## Validation strategy
+
+Run desktop scaffold wizard tests, then:
+
+```bash
+(cd runtime-kotlin && ./gradlew :runtime-desktop:core:data:jvmTest :runtime-desktop:feature:skillbill:jvmTest)
+```
+
+Final integration should also run the parent spec's full validation command
+set.
+
+## Handoff prompt
+
+Run `bill-feature-implement` on
+`.feature-specs/SKILL-50-platform-pack-review-composition/spec_subtask_4_desktop-wizard-authoring.md`.

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-05-22] scaffold-payload-cli
+Areas: orchestration/shell-content-contract, runtime-kotlin/runtime-core scaffold, runtime-kotlin/runtime-cli, docs
+- SKILL-50 subtask 3 extended platform-pack scaffold payloads with optional `baseline_layers`, validating references before mutation and rendering them as `code_review_composition.baseline_layers`. reusable
+- Dry-run and execute now share the same planned manifest model; dry-run exposes `manifest_edit_previews`, while legacy payloads without `baseline_layers` still omit composition.
+- `skill-bill show` now surfaces manifest-declared review composition with required/optional layer counts, preserving `baseline_layers[].required` semantics. reusable
+- Pitfall fixed in review: composition mode support lives behind shared `unsupportedCompositionModeReason` so scaffold payload validation and manifest loading cannot drift.
+- Tests cover valid write, legacy no-composition payloads, structural invalid payloads, invalid-reference rollback, non-platform-pack rejection, dry-run preview, and show visibility.
+Feature flag: N/A
+Acceptance criteria: 9/9 implemented
+
 ## [2026-05-17] final-integration-docs-validation
 Areas: README.md, docs/getting-started.md, docs/desktop-skill-bill-app, docs/skill-source-generation.md, runtime-kotlin install/desktop validation
 - Closed SKILL-45 parent traceability in user-facing docs, including native package host/toolchain limits for DMG/MSI/Deb/RPM production and Arch/CachyOS RPM or loose-distribution fallback guidance.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,6 +65,9 @@ Base skills are always included. Optional platform packs add their declared
 review and quality-check skills after manifest validation. All installed
 content-managed skills are rendered into `~/.skill-bill/installed-skills/` and
 agent entries link to that staging cache, not directly to source directories.
+When a platform pack declares `code_review_composition.baseline_layers`, the
+rendered baseline review skill includes review-composition instructions so the
+referenced baseline layer runs before pack-local specialists.
 
 On Windows, Skill Bill uses explicit symlink preflight outcomes. If symlink
 support is not available, install output tells the operator to enable Developer
@@ -247,7 +250,7 @@ Strict and loud-fail guarantees:
 
 - MCP tools publish strict schemas for priority workflow, telemetry, review, learning, scaffold, and workflow-state tools. Unknown top-level arguments are rejected before handler dispatch when the schema is strict.
 - Shell and platform-pack fixtures enforce the governed contract version, manifest shape, declared files, generated wrapper sections, and generated support pointers.
-- Scaffold and validation commands operate on structured manifests and `content.md` source files; invalid payloads, source-shape violations, or render drift fail the command.
+- Scaffold and validation commands operate on structured manifests and `content.md` source files; invalid payloads, source-shape violations, or render drift fail the command. `skill-bill new --payload <file> --dry-run` previews planned files and manifest edits, including platform-pack baseline composition blocks, and `skill-bill show <skill>` exposes manifest-declared review composition for inspection. Legacy platform-pack payloads without `baseline_layers` continue to produce manifests with no composition section.
 - `install link-skill` creates real symlinks to staged rendered skill directories and is covered by Kotlin CLI tests.
 
 Model-mediated guarantees:

--- a/docs/skill-source-generation.md
+++ b/docs/skill-source-generation.md
@@ -234,7 +234,9 @@ Supported scaffold kinds:
 - `horizontal`: creates `skills/<name>/content.md`
 - `platform-pack`: creates `platform-packs/<slug>/platform.yaml`, baseline
   code-review content, quality-check content, and optional specialist content
-  stubs
+  stubs. Payloads may also declare `baseline_layers`; the scaffolder validates
+  those references before mutation and writes them as
+  `code_review_composition.baseline_layers` in the new manifest.
 - `platform-override-piloted`: creates a governed platform override or
   pre-shell source depending on family
 - `code-review-area`: creates one approved specialist content file and
@@ -243,6 +245,14 @@ Supported scaffold kinds:
 
 Scaffolding writes source files only. It does not stage generated `SKILL.md`
 wrappers or support pointer files into source.
+
+Use `skill-bill new --payload <file> --dry-run` to inspect planned files and
+manifest edits before mutation. For platform-pack composition payloads, dry-run
+output includes a preview of the generated `platform.yaml` block. After
+creation, `skill-bill show <baseline-skill>` surfaces any manifest-declared
+review composition so users and agents can understand which baseline review
+layers run. Legacy platform-pack payloads that omit `baseline_layers` remain
+valid and generate no `code_review_composition` section.
 
 When `subagent_specialists` are requested for orchestrator scaffolds, the
 scaffolder writes `native-agents/agents.yaml` stubs. Render and install output

--- a/orchestration/contracts/platform-pack-schema.yaml
+++ b/orchestration/contracts/platform-pack-schema.yaml
@@ -186,6 +186,57 @@ properties:
     description: >
       Optional pack-relative path to the quality-check specialist's
       `content.md`. Must end in `content.md` when present.
+  code_review_composition:
+    type: object
+    additionalProperties: false
+    x-runtime-anchored: true
+    description: >
+      Optional code-review composition contract. Baseline layers let one
+      pack explicitly layer another pack's code-review skill into the same
+      review run. Cross-pack reference coherence is enforced in Kotlin after
+      all manifests are loaded.
+    required:
+      - baseline_layers
+    properties:
+      baseline_layers:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - platform
+            - skill
+            - scope
+            - required
+            - mode
+          properties:
+            platform:
+              type: string
+              minLength: 1
+              description: Referenced platform pack slug.
+            skill:
+              type: string
+              minLength: 1
+              description: Referenced code-review skill name from the target pack.
+            scope:
+              type: string
+              enum:
+                - same-review-scope
+              description: Initial scope mode; the baseline runs on the same review scope.
+            required:
+              type: boolean
+              description: >
+                Whether this baseline layer is required for a valid composed review.
+                This field is explicit by contract and is not defaulted by the parser.
+            mode:
+              type: string
+              enum:
+                - kmp-baseline
+              description: >
+                Composition behavior mode. Kotlin coherence currently accepts
+                `kmp-baseline` only for `kotlin/bill-kotlin-code-review`.
   pointers:
     type: object
     x-runtime-anchored: true
@@ -256,3 +307,25 @@ x-coherence-checks:
       Within a single skill-relative directory in `pointers`, every pointer
       `name` must be unique. Enforced in
       `ShellContentLoader.parsePointers`.
+  composition-references-resolve:
+    description: >
+      Every `code_review_composition.baseline_layers[]` entry must reference
+      an existing platform pack and an existing code-review skill from that
+      pack. Enforced after all manifests are loaded.
+  composition-no-self-reference:
+    description: >
+      A pack must not declare a baseline layer that references its own
+      code-review skill. Enforced after all manifests are loaded.
+  composition-no-duplicate-layers:
+    description: >
+      A pack must not declare duplicate baseline layers for the same
+      referenced pack and skill. Enforced after all manifests are loaded.
+  composition-no-cycles:
+    description: >
+      Baseline-layer references must not form cycles across platform packs.
+      Enforced after all manifests are loaded.
+  composition-mode-supported:
+    description: >
+      `kmp-baseline` is currently supported only when the referenced platform
+      and skill are `kotlin/bill-kotlin-code-review`. Enforced after all
+      manifests are loaded.

--- a/orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md
+++ b/orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md
@@ -89,6 +89,20 @@ Every payload MUST include:
     code-review area and registers them in the generated manifest, including
     the `area_metadata` entries used to auto-render governed `## Descriptor`
     sections.
+- `baseline_layers` — optional list for `platform-pack` only. When present,
+  the scaffolder writes `code_review_composition.baseline_layers` into the
+  new pack's `platform.yaml`. Each entry must include:
+  - `platform` — existing referenced platform pack slug.
+  - `skill` — existing code-review skill from the referenced pack.
+  - `scope` — currently only `same-review-scope`.
+  - `required` — explicit boolean.
+  - `mode` — currently only `kmp-baseline`, supported only for
+    `kotlin/bill-kotlin-code-review`.
+  Supplying this field for any kind other than `platform-pack` raises
+  `InvalidScaffoldPayloadError`. Invalid references fail before mutation:
+  missing referenced pack, missing referenced skill, unsupported `mode`,
+  unsupported `scope`, self-reference to the new pack, and duplicate
+  `platform` + `skill` layers are rejected.
 - `body` — optional string for `add-on`. When provided, the scaffolder
   writes this markdown body verbatim to the target add-on file instead of
   rendering the default placeholder template.
@@ -210,6 +224,35 @@ This creates only the baseline Java pack without the approved specialist
 stubs. Direct payload callers can still opt into `starter`, but the
 user-facing intake defaults to `full`. The generated files are intentionally
 minimal so the user can enrich the authored `content.md` files afterwards.
+
+### Platform pack with baseline review composition
+
+```json
+{
+  "scaffold_payload_version": "1.0",
+  "kind": "platform-pack",
+  "platform": "kmp",
+  "display_name": "KMP",
+  "routing_signals": {
+    "strong": ["kotlin(\"multiplatform\")", "androidMain", "iosMain"]
+  },
+  "baseline_layers": [
+    {
+      "platform": "kotlin",
+      "skill": "bill-kotlin-code-review",
+      "scope": "same-review-scope",
+      "required": true,
+      "mode": "kmp-baseline"
+    }
+  ]
+}
+```
+
+Dry-run and execute use this same payload shape. In dry-run mode, CLI output
+includes the planned `platform.yaml` edit so users and agents can inspect the
+`code_review_composition.baseline_layers` block before mutation. Payloads that
+omit `baseline_layers` remain valid and generate no
+`code_review_composition` section.
 
 ### Governed skill with concrete authored content
 

--- a/platform-packs/kmp/code-review/bill-kmp-code-review/content.md
+++ b/platform-packs/kmp/code-review/bill-kmp-code-review/content.md
@@ -1,13 +1,13 @@
 ---
 name: bill-kmp-code-review
-description: Use when conducting a thorough Android/KMP PR code review. Preserve mobile review depth by running the appropriate Kotlin baseline review layer first, then add Android/KMP-specific specialists such as UI and UX/accessibility. Produces a structured review with risk register and prioritized action items. Use when user mentions Android review, KMP review, mobile review, or asks to review Android/KMP changes.
+description: Use when conducting a thorough Android/KMP PR code review. Preserve mobile review depth by running the manifest-declared baseline review layer first, then add Android/KMP-specific specialists such as UI and UX/accessibility. Produces a structured review with risk register and prioritized action items. Use when user mentions Android review, KMP review, mobile review, or asks to review Android/KMP changes.
 ---
 
 # Android/KMP PR Review
 
 You are an experienced Android/KMP architect conducting a code review.
 
-Your job is to preserve Android/KMP review depth without duplicating the shared Kotlin review logic.
+Your job is to preserve Android/KMP review depth without duplicating shared Kotlin review logic. The generated Review Composition section is the source of truth for required baseline layers; apply this authored KMP guidance after those baseline instructions have been handled.
 ---
 
 ## Project Classification
@@ -32,7 +32,7 @@ Classify the review as one of:
 
 - If Android/KMP signals are strong, keep the Android/KMP route.
 - If Android/KMP signals are weak or absent, delegate to `bill-kotlin-code-review` and stop instead of pretending mobile-specific coverage exists.
-- If backend/server files are also touched, keep the `kmp` route and use `bill-kotlin-code-review` as the baseline layer so shared Kotlin concerns are still reviewed before this skill adds mobile-specific specialists.
+- If backend/server files are also touched, keep the `kmp` route and rely on the manifest-declared baseline layer so shared Kotlin concerns are still reviewed before this skill adds mobile-specific specialists.
 - When uncertain, prefer the safer route that preserves Android/KMP review depth.
 
 ## Governed Add-On Resolution
@@ -61,18 +61,17 @@ After the stack is already classified as `kmp`, resolve governed add-ons before 
 - For small, low-risk Android/KMP diffs, keep the review compact.
 - For larger, mixed, or higher-risk diffs, split the work into focused baseline and specialist passes.
 
-### Step 2: Choose and run the baseline Kotlin-family review
+### Step 2: Confirm the manifest-declared baseline layer
 
-Use the same scope to run exactly one baseline review layer:
-- Use `bill-kotlin-code-review`
+The generated Review Composition section defines the required baseline layer sequence. Treat that section as authoritative for which baseline skill to run, the mode to use, and the context that must be forwarded.
 
-That baseline review layer owns:
+That baseline layer owns:
 - shared Kotlin architecture, correctness, security, performance, and testing review
 - backend/server risk coverage within the Kotlin specialist set when backend signals are present
 - the baseline Kotlin findings that every Android/KMP review should inherit
 
-When invoking the baseline review:
-- tell it that Android/KMP scope is valid
+When invoking the baseline layer:
+- tell it that Android/KMP scope is valid for the manifest-declared baseline mode
 - tell it to keep KMP-only review concerns out of scope
 - pass the same diff source, changed files, and relevant override guidance
 

--- a/platform-packs/kmp/platform.yaml
+++ b/platform-packs/kmp/platform.yaml
@@ -33,6 +33,14 @@ area_metadata:
   ux-accessibility:
     focus: "UX correctness and accessibility"
 
+code_review_composition:
+  baseline_layers:
+    - platform: kotlin
+      skill: bill-kotlin-code-review
+      scope: same-review-scope
+      required: true
+      mode: kmp-baseline
+
 # Pointer files (single-line markdown files containing only a relative path) are generated
 # from this block during render/install output. Targets are repo-rooted; the renderer computes
 # the correct ../-prefixed relative path. Never commit pointer files — add or modify entries here

--- a/platform-packs/kotlin/code-review/bill-kotlin-code-review/content.md
+++ b/platform-packs/kotlin/code-review/bill-kotlin-code-review/content.md
@@ -29,7 +29,8 @@ Classify the review as one of:
 
 ### Decision Rules
 
-- If this skill is invoked from `bill-kmp-code-review`, accept Android/KMP scope and classify it as `kmp-baseline`. In that mode, review only shared Kotlin concerns and let `bill-kmp-code-review` add mobile-specific specialists.
+- If this skill is invoked as a manifest-declared composition baseline with mode `kmp-baseline`, accept Android/KMP scope and classify it as `kmp-baseline`. In that mode, review only shared Kotlin concerns and let the platform-specific review add mobile-specific specialists.
+- Do not infer `kmp-baseline` from caller name alone; require the manifest-declared baseline mode from the generated Review Composition instructions.
 - If strong Android/KMP markers are present and this skill is invoked standalone, clearly say that `bill-kmp-code-review` is required for full Android/KMP coverage. Continue only if the caller explicitly wants the baseline Kotlin layer.
 - Backend/server markers stay on the `kotlin` route. Select backend-focused Kotlin specialists for API contracts, persistence, and reliability when backend/server signals are present.
 - Otherwise use the `kotlin` route.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-05-22] SKILL-50 render-runtime-composition-instructions
+Areas: runtime-kotlin/runtime-core/scaffold, runtime-kotlin/runtime-domain/scaffold/model, platform-packs/kmp, platform-packs/kotlin
+- Generated `SKILL.md` render output now carries manifest-declared code-review composition before authored execution guidance; `AuthoringTarget` receives `PlatformManifest.codeReviewComposition` only for pack baseline skills. reusable
+- KMP rendered snapshots pin the generated Review Composition section and required baseline metadata; a fixture pack without composition pins omission so empty/noisy sections do not regress.
+- KMP/Kotlin review content now treats `kmp-baseline` as manifest-declared mode, not a caller-name exception; the KMP authored body focuses on local specialist behavior after generated baseline instructions.
+- Render/install source hygiene remains enforced by render-output tests: no source-tree `SKILL.md` wrappers or generated pointer files are written during render.
+Feature flag: N/A
+Acceptance criteria: 9/9 implemented
+
 ## [2026-05-21] SKILL-50 schema-loader-contract
 Areas: orchestration/contracts, runtime-kotlin/runtime-core/scaffold, runtime-kotlin/runtime-domain/scaffold/model, platform-packs/kmp
 - `platform-pack-schema.yaml` now has anchored `code_review_composition.baseline_layers` for code-review composition; nested layer objects stay strict, `scope` is `"same-review-scope"`, and `required` is explicit. reusable: runtime-consumed top-level pack fields still start in schema with `x-runtime-anchored: true`.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,14 @@
+## [2026-05-21] SKILL-50 schema-loader-contract
+Areas: orchestration/contracts, runtime-kotlin/runtime-core/scaffold, runtime-kotlin/runtime-domain/scaffold/model, platform-packs/kmp
+- `platform-pack-schema.yaml` now has anchored `code_review_composition.baseline_layers` for code-review composition; nested layer objects stay strict, `scope` is `"same-review-scope"`, and `required` is explicit. reusable: runtime-consumed top-level pack fields still start in schema with `x-runtime-anchored: true`.
+- `PlatformManifest` now carries typed `CodeReviewComposition` / `CodeReviewBaselineLayer` values; `code_review_composition` is filtered out of `customFields` like other anchored fields.
+- `ShellContentLoader` parses composition in `buildPack` and validates references after manifests are loaded; collection discovery validates all packs, and `loadPlatformPack` validates the reachable composition closure so single-pack callers cannot bypass missing-target, duplicate, self-reference, or cycle failures. reusable
+- `kmp-baseline` mode is intentionally narrow: accepted only for `kotlin/bill-kotlin-code-review`, not for same-named skills in other packs or Kotlin specialist skills.
+- KMP's manifest declares the Kotlin baseline layer; this only records the contract source of truth and does not generate runtime `SKILL.md` instructions yet.
+- Regression coverage lives in `PlatformPackCompositionTest`, plus anchored bijection/customFields tests; cleanup test now skips migrated source paths that no longer exist.
+Feature flag: N/A
+Acceptance criteria: 13/13 implemented
+
 ## [2026-05-19] SKILL-48 subtask-3 per-repo-schema-customization
 Areas: orchestration/contracts, runtime-kotlin/runtime-core/scaffold, runtime-kotlin/runtime-domain/scaffold/model, AGENTS.md
 - `orchestration/contracts/platform-pack-schema.yaml` now treats the TOP-LEVEL mapping as the per-repo extension surface: `additionalProperties: true` at root. Every TOP-LEVEL field the Kotlin runtime consumes by name carries `x-runtime-anchored: true` (10 total: `platform`, `contract_version`, `display_name`, `notes`, `routing_signals`, `declared_code_review_areas`, `declared_files`, `area_metadata`, `declared_quality_check_file`, `pointers`). Nested objects (`routing_signals`, `declared_files`, `area_metadata.<area>`, `$defs.codeReviewArea`, `pointers` entries) stay strict (`additionalProperties: false`) — per-repo extensions only relax the top-level mapping. reusable: the `x-runtime-anchored` marker is exclusive to platform-pack-schema; other runtime contracts (telemetry/workflow/install/native-agent) stay runtime-anchored end-to-end.

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
@@ -524,11 +524,16 @@ private fun runNativeScaffoldPayload(payload: Map<String, *>, dryRun: Boolean, f
     } catch (error: SkillBillRuntimeException) {
       return errorResult(error.message.orEmpty(), format)
     }
+  val created = result.run { createdFiles }.map { path -> path.toString() }
   val presentation =
     mapOf(
       "status" to "ok",
       "session_id" to sessionId,
       "skill_path" to result.skillPath.toString(),
+      "dry_run" to dryRun,
+      "created_files" to created,
+      "manifest_edits" to result.manifestEdits.map { path -> path.toString() },
+      "manifest_edit_previews" to result.manifestPreviews.mapKeys { (path, _) -> path.toString() },
       "notes" to result.notes,
     )
   return CliExecutionResult(

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliScaffoldRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliScaffoldRuntimeTest.kt
@@ -2,6 +2,8 @@ package skillbill.cli
 
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import skillbill.contracts.JsonSupport
 import java.nio.file.Files
@@ -122,6 +124,95 @@ class CliScaffoldRuntimeTest {
     assertNativeBodyConflictErrors(
       listOf("new-addon", "--platform", "kmp", "--name", "android-conflict-addon"),
       CliRuntimeContext(userHome = tempDir),
+    )
+  }
+
+  @Test
+  fun `new platform pack dry run shows composition manifest preview`() {
+    val repoRoot = compositionFixtureRepo()
+    val tempDir = Files.createTempDirectory("skillbill-cli-scaffold-composition")
+    val platform = "cli-composition-${System.nanoTime()}"
+    val result =
+      CliRuntime.run(
+        listOf("new", "--payload", "-", "--dry-run", "--format", "json"),
+        CliRuntimeContext(
+          stdinText =
+          """
+          {
+            "scaffold_payload_version": "1.0",
+            "kind": "platform-pack",
+            "platform": "$platform",
+            "repo_root": "$repoRoot",
+            "skeleton_mode": "starter",
+            "routing_signals": {
+              "strong": ["$platform.marker"]
+            },
+            "baseline_layers": [
+              {
+                "platform": "kotlin",
+                "skill": "bill-kotlin-code-review",
+                "scope": "same-review-scope",
+                "required": true,
+                "mode": "kmp-baseline"
+              }
+            ]
+          }
+          """.trimIndent(),
+          userHome = tempDir,
+        ),
+      )
+    val payload = decodeJsonObject(result.stdout)
+    val manifestPath = repoRoot.resolve("platform-packs/$platform/platform.yaml").toString()
+    val preview =
+      payload["manifest_edit_previews"]
+        ?.jsonObject
+        ?.get(manifestPath)
+        ?.jsonPrimitive
+        ?.contentOrNull
+        .orEmpty()
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertEquals("ok", payload.stringValue("status"))
+    assertEquals("true", payload["dry_run"]?.jsonPrimitive?.contentOrNull)
+    assertEquals(manifestPath, payload["manifest_edits"]?.jsonArray?.single()?.jsonPrimitive?.contentOrNull)
+    assertContains(preview, "code_review_composition:")
+    assertContains(preview, "baseline_layers:")
+    assertContains(preview, "platform: \"kotlin\"")
+    assertTrue(Files.notExists(repoRoot.resolve("platform-packs/$platform")))
+  }
+
+  @Test
+  fun `show surfaces manifest declared review composition`() {
+    val repoRoot = compositionFixtureRepo(kmpLayerRequired = false)
+    val tempDir = Files.createTempDirectory("skillbill-cli-show-composition")
+    val result =
+      CliRuntime.run(
+        listOf(
+          "show",
+          "bill-kmp-code-review",
+          "--repo-root",
+          repoRoot.toString(),
+          "--content",
+          "none",
+          "--format",
+          "json",
+        ),
+        CliRuntimeContext(userHome = tempDir),
+      )
+    val payload = decodeJsonObject(result.stdout)
+    val composition = payload["review_composition"]?.jsonObject
+    val layer = composition?.get("baseline_layers")?.jsonArray?.single()?.jsonObject
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertEquals("platform.yaml", composition?.get("source")?.jsonPrimitive?.contentOrNull)
+    assertEquals("kotlin", layer?.get("platform")?.jsonPrimitive?.contentOrNull)
+    assertEquals("bill-kotlin-code-review", layer?.get("skill")?.jsonPrimitive?.contentOrNull)
+    assertEquals("same-review-scope", layer?.get("scope")?.jsonPrimitive?.contentOrNull)
+    assertEquals("false", layer?.get("required")?.jsonPrimitive?.contentOrNull)
+    assertEquals("kmp-baseline", layer?.get("mode")?.jsonPrimitive?.contentOrNull)
+    assertEquals(
+      "Run 1 optional baseline layer(s) before pack-local specialists.",
+      composition?.get("summary")?.jsonPrimitive?.contentOrNull,
     )
   }
 
@@ -290,4 +381,69 @@ private fun goldenJson(fileName: String, vararg replacements: Pair<String, Strin
 
 private fun assertMatchesPattern(pattern: Regex, value: String, label: String) {
   assertTrue(pattern.matches(value), "Expected $label to match ${pattern.pattern}, got $value")
+}
+
+private fun compositionFixtureRepo(kmpLayerRequired: Boolean = true): Path {
+  val repoRoot = Files.createTempDirectory("skillbill-cli-composition-repo")
+  seedCompositionPack(repoRoot, "kotlin")
+  seedCompositionPack(
+    repoRoot = repoRoot,
+    slug = "kmp",
+    composition =
+    """
+    |code_review_composition:
+    |  baseline_layers:
+    |    - platform: "kotlin"
+    |      skill: "bill-kotlin-code-review"
+    |      scope: "same-review-scope"
+    |      required: $kmpLayerRequired
+    |      mode: "kmp-baseline"
+    """.trimMargin(),
+  )
+  return repoRoot
+}
+
+private fun seedCompositionPack(repoRoot: Path, slug: String, composition: String = "") {
+  val skillName = "bill-$slug-code-review"
+  val packRoot = repoRoot.resolve("platform-packs").resolve(slug)
+  val skillRoot = packRoot.resolve("code-review").resolve(skillName)
+  Files.createDirectories(skillRoot)
+  Files.writeString(
+    packRoot.resolve("platform.yaml"),
+    """
+    |platform: "$slug"
+    |contract_version: "1.1"
+    |display_name: "$slug"
+    |
+    |routing_signals:
+    |  strong:
+    |    - "$slug.marker"
+    |  tie_breakers: []
+    |
+    |declared_code_review_areas: []
+    |
+    |declared_files:
+    |  baseline: "code-review/$skillName/content.md"
+    |  areas: {}
+    |area_metadata: {}
+    |$composition
+    """.trimMargin(),
+  )
+  Files.writeString(
+    skillRoot.resolve("content.md"),
+    """
+    |---
+    |name: $skillName
+    |description: Fixture $slug code review.
+    |---
+    |
+    |## Review Focus
+    |
+    |Review $slug changes with fixture guidance.
+    |
+    |## Review Guidance
+    |
+    |- Keep fixture behavior explicit.
+    """.trimMargin(),
+  )
 }

--- a/runtime-kotlin/runtime-cli/src/test/resources/golden/cli-new-skill-scaffold-dry-run.json
+++ b/runtime-kotlin/runtime-cli/src/test/resources/golden/cli-new-skill-scaffold-dry-run.json
@@ -1,4 +1,10 @@
 {
+  "created_files": [
+    "<SKILL_PATH>/content.md"
+  ],
+  "dry_run": true,
+  "manifest_edit_previews": {},
+  "manifest_edits": [],
   "notes": [
     "Dry run - no filesystem changes applied."
   ],

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringDiscovery.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringDiscovery.kt
@@ -89,6 +89,7 @@ private fun recordPackTargets(discovered: MutableMap<String, AuthoringTarget>, p
         "",
         baselineContent.resolveSibling("SKILL.md"),
         baselineContent,
+        pack.codeReviewComposition,
       )
   }
   pack.declaredFiles.areas.forEach { (area, declaredFile) ->

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringOperations.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringOperations.kt
@@ -2,6 +2,7 @@ package skillbill.scaffold
 
 import skillbill.error.SkillBillRuntimeException
 import skillbill.nativeagent.NativeAgentOperations
+import skillbill.scaffold.model.CodeReviewComposition
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -20,6 +21,7 @@ data class AuthoringTarget(
   // skillFile remains for transient consumers until SKILL-40 subtask 4 deletes the wrapper.
   val skillFile: Path,
   val contentFile: Path,
+  val codeReviewComposition: CodeReviewComposition? = null,
 )
 
 object AuthoringOperations {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringRender.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringRender.kt
@@ -3,6 +3,7 @@ package skillbill.scaffold
 import skillbill.nativeagent.NATIVE_AGENT_BUNDLE_FILE
 import skillbill.nativeagent.NATIVE_AGENT_SOURCE_DIR
 import skillbill.nativeagent.parseNativeAgentSourceFile
+import skillbill.scaffold.model.CodeReviewBaselineLayer
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
@@ -35,6 +36,12 @@ internal fun renderWrapper(target: AuthoringTarget): String {
       appendLine()
       appendLine()
     }
+    val reviewComposition = renderReviewCompositionSection(target)
+    if (reviewComposition.isNotBlank()) {
+      append(reviewComposition.trimEnd())
+      appendLine()
+      appendLine()
+    }
     appendLine("## Execution")
     if (executionBody.isNotBlank()) {
       appendLine()
@@ -52,6 +59,42 @@ internal fun renderWrapper(target: AuthoringTarget): String {
     appendLine()
   }
 }
+
+private fun renderReviewCompositionSection(target: AuthoringTarget): String {
+  val baselineLayers = target.codeReviewComposition?.baselineLayers.orEmpty()
+  return if (baselineLayers.isEmpty()) {
+    ""
+  } else {
+    buildString {
+      appendLine("## Review Composition")
+      appendLine()
+      appendLine(
+        "This platform pack declares code-review composition in `platform.yaml`. Runtime agents MUST run each " +
+          "required baseline layer before selecting or running pack-local specialists.",
+      )
+      appendLine()
+      appendLine(
+        "Scope propagation is mandatory: pass the same review IDs, applied learnings, AGENTS guidance, " +
+          "changed files, and stack signals into every baseline layer and then into any pack-local " +
+          "specialist review.",
+      )
+      appendLine(
+        "Keep baseline-layer findings attributed to that layer before merging and deduplicating them with pack-local " +
+          "specialist findings.",
+      )
+      appendLine()
+      appendLine("### Required Baseline Layers")
+      appendLine()
+      baselineLayers.forEach { layer ->
+        appendLine("- ${renderBaselineLayerLabel(layer)}")
+      }
+    }
+  }
+}
+
+private fun renderBaselineLayerLabel(layer: CodeReviewBaselineLayer): String =
+  "`" + layer.platform + "/" + layer.skill + "` with scope `" + layer.scope.wireValue + "`, mode `" +
+    layer.mode.wireValue + "`, required `" + layer.required + "`."
 
 private fun renderGeneratedSubagentSpawnRuntimeNotes(target: AuthoringTarget): String {
   val nativeAgentDir = target.contentFile.parent.resolve(NATIVE_AGENT_SOURCE_DIR)

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringStatus.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringStatus.kt
@@ -1,5 +1,6 @@
 package skillbill.scaffold
 
+import skillbill.scaffold.model.CodeReviewBaselineLayer
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -27,6 +28,14 @@ internal fun statusPayload(
       "sections" to sectionPayloads(contentText),
       "recommended_commands" to recommendedCommands(repoRoot, target, completionStatus, issues),
     )
+  target.codeReviewComposition?.baselineLayers?.takeIf { it.isNotEmpty() }?.let { baselineLayers ->
+    payload["review_composition"] =
+      mapOf(
+        "source" to "platform.yaml",
+        "summary" to baselineLayerSummary(baselineLayers),
+        "baseline_layers" to baselineLayers.map(::baselineLayerPayload),
+      )
+  }
   when (contentMode) {
     "preview" -> payload["content_preview"] = previewText(contentText, CONTENT_PREVIEW_LIMIT)
     "full" -> payload["content"] = contentText
@@ -36,6 +45,24 @@ internal fun statusPayload(
   }
   return payload
 }
+
+private fun baselineLayerSummary(baselineLayers: List<CodeReviewBaselineLayer>): String {
+  val requiredCount = baselineLayers.count { it.required }
+  val optionalCount = baselineLayers.size - requiredCount
+  val layerText = buildList {
+    if (requiredCount > 0) add("$requiredCount required")
+    if (optionalCount > 0) add("$optionalCount optional")
+  }.joinToString(" and ")
+  return "Run $layerText baseline layer(s) before pack-local specialists."
+}
+
+private fun baselineLayerPayload(layer: CodeReviewBaselineLayer): Map<String, Any?> = mapOf(
+  "platform" to layer.platform,
+  "skill" to layer.skill,
+  "scope" to layer.scope.wireValue,
+  "required" to layer.required,
+  "mode" to layer.mode.wireValue,
+)
 
 internal fun recommendedCommands(
   repoRoot: Path,

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldCatalog.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldCatalog.kt
@@ -1,5 +1,13 @@
 package skillbill.scaffold
 
+import skillbill.scaffold.model.BaselineReviewCatalog
+import skillbill.scaffold.model.BaselineReviewCompositionEdge
+import skillbill.scaffold.model.BaselineReviewLayerSuggestion
+import skillbill.scaffold.model.BaselineReviewPackEntry
+import skillbill.scaffold.model.BaselineReviewSkillEntry
+import skillbill.scaffold.model.CodeReviewBaselineLayer
+import skillbill.scaffold.model.CodeReviewCompositionMode
+import skillbill.scaffold.model.CodeReviewCompositionScope
 import skillbill.scaffold.model.PlatformManifest
 import java.nio.file.Path
 
@@ -43,4 +51,105 @@ object ScaffoldCatalog {
    * scaffold-package manifest discovery so callers do not need to depend on internal helpers.
    */
   fun discoverPilotedPlatformPacks(packsRoot: Path): List<PlatformManifest> = discoverPlatformPackManifests(packsRoot)
+
+  /**
+   * Manifest-driven catalog of code-review baseline layers that desktop authoring can compose
+   * into a new platform pack. This is intentionally projected by runtime-core so UI code does not
+   * mirror manifest semantics such as declared code-review skill names, composition graph edges,
+   * or mode support.
+   */
+  fun discoverBaselineReviewCatalog(packsRoot: Path): BaselineReviewCatalog {
+    val packs = discoverPlatformPackManifests(packsRoot)
+    return BaselineReviewCatalog(
+      packs = packs
+        .filter { pack -> pack.declaredFiles.baseline != null }
+        .map { pack ->
+          BaselineReviewPackEntry(
+            platform = pack.slug,
+            displayName = pack.displayName ?: pack.slug,
+            strongRoutingSignals = pack.routingSignals.strong,
+            skills = pack.declaredCodeReviewSkillNames()
+              .sorted()
+              .map { skill -> baselineSkillEntry(pack.slug, skill) },
+          )
+        }
+        .sortedBy { pack -> pack.platform },
+      compositionEdges = packs.flatMap { pack ->
+        pack.codeReviewComposition?.baselineLayers.orEmpty().map { layer ->
+          BaselineReviewCompositionEdge(
+            sourcePlatform = pack.slug,
+            targetPlatform = layer.platform,
+            targetSkill = layer.skill,
+          )
+        }
+      }.sortedWith(compareBy({ it.sourcePlatform }, { it.targetPlatform }, { it.targetSkill })),
+      layerSuggestions = baselineLayerSuggestions(packs),
+    )
+  }
+}
+
+private const val KOTLIN_BASELINE_PLATFORM = "kotlin"
+private const val KOTLIN_BASELINE_SKILL = "bill-kotlin-code-review"
+private const val KMP_BASELINE_MODE = "kmp-baseline"
+private const val SAME_REVIEW_SCOPE = "same-review-scope"
+
+private val KMP_ANDROID_SUGGESTION_SIGNALS = listOf(
+  "kmp",
+  "android",
+  "com.android",
+  "kotlin-multiplatform",
+  "multiplatform",
+)
+
+private fun baselineLayerSuggestions(packs: List<PlatformManifest>): List<BaselineReviewLayerSuggestion> {
+  val kotlinPack = packs.firstOrNull { pack ->
+    pack.slug == KOTLIN_BASELINE_PLATFORM &&
+      pack.declaredFiles.baseline != null &&
+      KOTLIN_BASELINE_SKILL in pack.declaredCodeReviewSkillNames()
+  }
+  val kotlinSkill = kotlinPack?.let { pack -> baselineSkillEntry(pack.slug, KOTLIN_BASELINE_SKILL) }
+  val supportsKmpBaseline = kotlinSkill != null &&
+    KMP_BASELINE_MODE in kotlinSkill.supportedModes &&
+    SAME_REVIEW_SCOPE in kotlinSkill.supportedScopes
+  return if (supportsKmpBaseline) {
+    listOf(
+      BaselineReviewLayerSuggestion(
+        label = "Kotlin baseline",
+        triggerSignals = KMP_ANDROID_SUGGESTION_SIGNALS,
+        platform = KOTLIN_BASELINE_PLATFORM,
+        skill = KOTLIN_BASELINE_SKILL,
+        scope = SAME_REVIEW_SCOPE,
+        required = true,
+        mode = KMP_BASELINE_MODE,
+      ),
+    )
+  } else {
+    emptyList()
+  }
+}
+
+private fun baselineSkillEntry(platform: String, skill: String): BaselineReviewSkillEntry {
+  val supportedModes = CodeReviewCompositionMode.entries
+    .filter { mode ->
+      unsupportedCompositionModeReason(
+        CodeReviewBaselineLayer(
+          platform = platform,
+          skill = skill,
+          scope = CodeReviewCompositionScope.SameReviewScope,
+          required = true,
+          mode = mode,
+        ),
+      ) == null
+    }
+    .map { mode -> mode.wireValue }
+  val supportedScopes = if (supportedModes.isEmpty()) {
+    emptyList()
+  } else {
+    CodeReviewCompositionScope.entries.map { scope -> scope.wireValue }
+  }
+  return BaselineReviewSkillEntry(
+    name = skill,
+    supportedModes = supportedModes,
+    supportedScopes = supportedScopes,
+  )
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldManifestEdits.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldManifestEdits.kt
@@ -3,6 +3,7 @@
 package skillbill.scaffold
 
 import skillbill.error.InvalidScaffoldPayloadError
+import skillbill.scaffold.model.CodeReviewBaselineLayer
 import java.nio.file.Path
 
 private val AREAS_EMPTY_INLINE_PATTERN =
@@ -61,6 +62,7 @@ internal fun renderPlatformPackManifest(
   declaredAreaFiles: Map<String, String> = emptyMap(),
   declaredQualityCheckFile: String? = null,
   areaMetadata: Map<String, String> = emptyMap(),
+  baselineLayers: List<CodeReviewBaselineLayer> = emptyList(),
   notes: String? = null,
 ): String {
   val lines = mutableListOf<String>()
@@ -68,6 +70,22 @@ internal fun renderPlatformPackManifest(
   lines += "contract_version: ${yamlScalar(SHELL_CONTRACT_VERSION)}"
   lines += "display_name: ${yamlScalar(displayName)}"
   lines += ""
+  appendRoutingSignals(lines, strongSignals, tieBreakers)
+  lines += ""
+  appendDeclaredCodeReviewAreas(lines, declaredCodeReviewAreas)
+  lines += ""
+  appendDeclaredFiles(lines, baselineContentPath, declaredCodeReviewAreas, declaredAreaFiles)
+  appendAreaMetadata(lines, declaredCodeReviewAreas, areaMetadata)
+  appendQualityCheckDeclaration(lines, declaredQualityCheckFile)
+  appendBaselineLayers(lines, baselineLayers)
+  if (notes != null) {
+    lines += ""
+    lines += "notes: ${yamlScalar(notes)}"
+  }
+  return lines.joinToString("\n") + "\n"
+}
+
+private fun appendRoutingSignals(lines: MutableList<String>, strongSignals: List<String>, tieBreakers: List<String>) {
   lines += "routing_signals:"
   lines += "  strong:"
   strongSignals.forEach { lines += "    - ${yamlScalar(it)}" }
@@ -77,14 +95,23 @@ internal fun renderPlatformPackManifest(
     lines += "  tie_breakers:"
     tieBreakers.forEach { lines += "    - ${yamlScalar(it)}" }
   }
-  lines += ""
+}
+
+private fun appendDeclaredCodeReviewAreas(lines: MutableList<String>, declaredCodeReviewAreas: List<String>) {
   if (declaredCodeReviewAreas.isEmpty()) {
     lines += "declared_code_review_areas: []"
   } else {
     lines += "declared_code_review_areas:"
     declaredCodeReviewAreas.forEach { lines += "  - ${yamlScalar(it)}" }
   }
-  lines += ""
+}
+
+private fun appendDeclaredFiles(
+  lines: MutableList<String>,
+  baselineContentPath: String,
+  declaredCodeReviewAreas: List<String>,
+  declaredAreaFiles: Map<String, String>,
+) {
   lines += "declared_files:"
   lines += "  baseline: ${yamlScalar(baselineContentPath)}"
   if (declaredAreaFiles.isEmpty()) {
@@ -95,6 +122,13 @@ internal fun renderPlatformPackManifest(
       declaredAreaFiles[area]?.let { lines += "    $area: ${yamlScalar(it)}" }
     }
   }
+}
+
+private fun appendAreaMetadata(
+  lines: MutableList<String>,
+  declaredCodeReviewAreas: List<String>,
+  areaMetadata: Map<String, String>,
+) {
   if (areaMetadata.isEmpty()) {
     lines += "area_metadata: {}"
   } else {
@@ -106,15 +140,27 @@ internal fun renderPlatformPackManifest(
       }
     }
   }
+}
+
+private fun appendQualityCheckDeclaration(lines: MutableList<String>, declaredQualityCheckFile: String?) {
   if (declaredQualityCheckFile != null) {
     lines += ""
     lines += "declared_quality_check_file: ${yamlScalar(declaredQualityCheckFile)}"
   }
-  if (notes != null) {
-    lines += ""
-    lines += "notes: ${yamlScalar(notes)}"
+}
+
+private fun appendBaselineLayers(lines: MutableList<String>, baselineLayers: List<CodeReviewBaselineLayer>) {
+  if (baselineLayers.isEmpty()) return
+  lines += ""
+  lines += "code_review_composition:"
+  lines += "  baseline_layers:"
+  baselineLayers.forEach { layer ->
+    lines += "    - platform: ${yamlScalar(layer.platform)}"
+    lines += "      skill: ${yamlScalar(layer.skill)}"
+    lines += "      scope: ${yamlScalar(layer.scope.wireValue)}"
+    lines += "      required: ${layer.required}"
+    lines += "      mode: ${yamlScalar(layer.mode.wireValue)}"
   }
-  return lines.joinToString("\n") + "\n"
 }
 
 private fun appendAreaToList(text: String, area: String): String {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldService.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldService.kt
@@ -24,6 +24,9 @@ import skillbill.install.detectAgents
 import skillbill.install.installSkill
 import skillbill.install.model.InstallTransaction
 import skillbill.install.uninstallTargets
+import skillbill.scaffold.model.CodeReviewBaselineLayer
+import skillbill.scaffold.model.CodeReviewCompositionMode
+import skillbill.scaffold.model.CodeReviewCompositionScope
 import skillbill.scaffold.model.ScaffoldResult
 import java.nio.file.Files
 import java.nio.file.Path
@@ -117,6 +120,7 @@ private data class ScaffoldPlan(
   val createdFiles: List<Path> = emptyList(),
   val contentBody: String? = null,
   val addonBody: String? = null,
+  val baselineLayers: List<CodeReviewBaselineLayer> = emptyList(),
   val subagentSpecialists: List<String> = emptyList(),
   val subagentDescriptions: Map<String, String> = emptyMap(),
   val subagentsSuppressed: Boolean = false,
@@ -152,6 +156,7 @@ private fun renderDryRunResult(plan: ScaffoldPlan, repoRoot: Path): ScaffoldResu
   skillPath = plan.skillPath,
   createdFiles = previewCreatedFiles(plan),
   manifestEdits = previewManifestEdits(plan, repoRoot),
+  manifestPreviews = previewManifestPreviews(plan, repoRoot),
   symlinks = emptyList(),
   installTargets = emptyList(),
   notes = plan.notes + listOf("Dry run - no filesystem changes applied."),
@@ -229,11 +234,23 @@ private fun resolveRepoRoot(payload: Map<String, Any?>): Path {
 }
 
 private fun planScaffold(payload: Map<String, Any?>, repoRoot: Path, kind: String): ScaffoldPlan = when (kind) {
-  SKILL_KIND_HORIZONTAL -> planHorizontal(payload, repoRoot)
-  SKILL_KIND_PLATFORM_OVERRIDE_PILOTED -> planPlatformOverridePiloted(payload, repoRoot)
+  SKILL_KIND_HORIZONTAL -> {
+    rejectBaselineLayersForNonPlatformPack(payload, kind)
+    planHorizontal(payload, repoRoot)
+  }
+  SKILL_KIND_PLATFORM_OVERRIDE_PILOTED -> {
+    rejectBaselineLayersForNonPlatformPack(payload, kind)
+    planPlatformOverridePiloted(payload, repoRoot)
+  }
   SKILL_KIND_PLATFORM_PACK -> planPlatformPack(payload, repoRoot)
-  SKILL_KIND_CODE_REVIEW_AREA -> planCodeReviewArea(payload, repoRoot)
-  SKILL_KIND_ADD_ON -> planAddOn(payload, repoRoot)
+  SKILL_KIND_CODE_REVIEW_AREA -> {
+    rejectBaselineLayersForNonPlatformPack(payload, kind)
+    planCodeReviewArea(payload, repoRoot)
+  }
+  SKILL_KIND_ADD_ON -> {
+    rejectBaselineLayersForNonPlatformPack(payload, kind)
+    planAddOn(payload, repoRoot)
+  }
   else -> throw UnknownSkillKindError("Scaffold payload declares unsupported kind '$kind'.")
 }
 
@@ -337,6 +354,7 @@ private fun planPlatformPack(payload: Map<String, Any?>, repoRoot: Path): Scaffo
   }
   val baselineName = canonicalName(payload, defaultName = "bill-$platform-code-review")
   val qualityCheckName = "bill-$platform-quality-check"
+  val baselineLayers = optionalBaselineLayers(payload, repoRoot, platform)
   val selection = resolvePlatformPackSelection(payload)
   val selectedAreas = selection.selectedAreas
   val specialistNames =
@@ -399,10 +417,19 @@ private fun planPlatformPack(payload: Map<String, Any?>, repoRoot: Path): Scaffo
       selectedAreas = selectedAreas,
     ),
     contentBody = payload["content_body"] as? String,
+    baselineLayers = baselineLayers,
     subagentSpecialists = platformPackSubagents,
     subagentDescriptions = platformPackSubagentDescriptions,
     subagentsSuppressed = subagents.suppressed,
   )
+}
+
+private fun rejectBaselineLayersForNonPlatformPack(payload: Map<String, Any?>, kind: String) {
+  if (payload.containsKey("baseline_layers")) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'baseline_layers' is only supported for kind 'platform-pack'; got '$kind'.",
+    )
+  }
 }
 
 private data class PlatformPackSelection(
@@ -413,6 +440,110 @@ private data class OptionalSubagents(
   val specialists: List<String>,
   val suppressed: Boolean,
 )
+
+private fun optionalBaselineLayers(
+  payload: Map<String, Any?>,
+  repoRoot: Path,
+  newPlatform: String,
+): List<CodeReviewBaselineLayer> {
+  val raw = payload["baseline_layers"] ?: return emptyList()
+  if (raw !is List<*>) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'baseline_layers' must be a list of baseline layer objects.",
+    )
+  }
+  if (raw.isEmpty()) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'baseline_layers' must contain at least one layer when provided.",
+    )
+  }
+  val layers = raw.mapIndexed { index, entry -> parseBaselineLayerPayload(index, entry) }
+  validateBaselineLayerPayloadReferences(layers, repoRoot, newPlatform)
+  return layers
+}
+
+private fun parseBaselineLayerPayload(index: Int, raw: Any?): CodeReviewBaselineLayer {
+  val layer = raw as? Map<*, *>
+    ?: throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'baseline_layers[$index]' must be an object.",
+    )
+  val fieldPrefix = "baseline_layers[$index]"
+  val scopeValue = requireStringInPayloadMap(layer, "$fieldPrefix.scope", "scope")
+  val modeValue = requireStringInPayloadMap(layer, "$fieldPrefix.mode", "mode")
+  val required = layer["required"] as? Boolean
+    ?: throw InvalidScaffoldPayloadError(
+      "Scaffold payload field '$fieldPrefix.required' must be an explicit boolean.",
+    )
+  return CodeReviewBaselineLayer(
+    platform = requireStringInPayloadMap(layer, "$fieldPrefix.platform", "platform"),
+    skill = requireStringInPayloadMap(layer, "$fieldPrefix.skill", "skill"),
+    scope = CodeReviewCompositionScope.fromWireValue(scopeValue)
+      ?: throw InvalidScaffoldPayloadError(
+        "Scaffold payload field '$fieldPrefix.scope' has unsupported value '$scopeValue'. " +
+          "Supported values: ${CodeReviewCompositionScope.entries.map { it.wireValue }}.",
+      ),
+    required = required,
+    mode = CodeReviewCompositionMode.fromWireValue(modeValue)
+      ?: throw InvalidScaffoldPayloadError(
+        "Scaffold payload field '$fieldPrefix.mode' has unsupported value '$modeValue'. " +
+          "Supported values: ${CodeReviewCompositionMode.entries.map { it.wireValue }}.",
+      ),
+  )
+}
+
+private fun requireStringInPayloadMap(map: Map<*, *>, fieldLabel: String, key: String): String {
+  val value = map[key] as? String
+    ?: throw InvalidScaffoldPayloadError("Scaffold payload field '$fieldLabel' must be a non-empty string.")
+  if (value.isBlank()) {
+    throw InvalidScaffoldPayloadError("Scaffold payload field '$fieldLabel' must be a non-empty string.")
+  }
+  return value
+}
+
+private fun validateBaselineLayerPayloadReferences(
+  layers: List<CodeReviewBaselineLayer>,
+  repoRoot: Path,
+  newPlatform: String,
+) {
+  val seenTargets = mutableSetOf<Pair<String, String>>()
+  layers.forEachIndexed { index, layer ->
+    val targetLabel = "${layer.platform}/${layer.skill}"
+    if (layer.platform == newPlatform) {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'baseline_layers[$index]' self-references the new platform pack '$targetLabel'.",
+      )
+    }
+    if (!seenTargets.add(layer.platform to layer.skill)) {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'baseline_layers' contains duplicate layer '$targetLabel'.",
+      )
+    }
+    val targetRoot = repoRoot.resolve("platform-packs").resolve(layer.platform)
+    if (!Files.isDirectory(targetRoot) || !Files.isRegularFile(targetRoot.resolve("platform.yaml"))) {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'baseline_layers[$index]' references missing platform pack '${layer.platform}'.",
+      )
+    }
+    val targetPack = loadPlatformPack(targetRoot)
+    if (layer.skill !in targetPack.declaredCodeReviewSkillNames()) {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'baseline_layers[$index]' references missing code-review skill " +
+          "'${layer.skill}' in platform pack '${layer.platform}'.",
+      )
+    }
+    validateBaselineLayerModeSupport(index, layer)
+  }
+}
+
+private fun validateBaselineLayerModeSupport(index: Int, layer: CodeReviewBaselineLayer) {
+  val unsupportedReason = unsupportedCompositionModeReason(layer)
+  if (unsupportedReason != null) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'baseline_layers[$index].mode' uses mode '${layer.mode.wireValue}' with " +
+        "unsupported referenced skill '${layer.platform}/${layer.skill}'. $unsupportedReason",
+    )
+  }
+}
 
 private fun optionalSpecialistSubagents(payload: Map<String, Any?>, kind: String): OptionalSubagents {
   val rawSpecialists = payload["subagent_specialists"] ?: emptyList<String>()
@@ -784,9 +915,21 @@ private fun previewCreatedFiles(plan: ScaffoldPlan): List<Path> = when (plan.kin
 }
 
 private fun previewManifestEdits(plan: ScaffoldPlan, repoRoot: Path): List<Path> = when (plan.kind) {
+  SKILL_KIND_PLATFORM_PACK -> listOf(plan.manifestPath ?: platformPackManifestPath(repoRoot, plan.platform))
   SKILL_KIND_CODE_REVIEW_AREA, SKILL_KIND_PLATFORM_OVERRIDE_PILOTED ->
     listOf(platformPackManifestPath(repoRoot, plan.platform))
   else -> emptyList()
+}
+
+private fun previewManifestPreviews(plan: ScaffoldPlan, repoRoot: Path): Map<Path, String> = when (plan.kind) {
+  SKILL_KIND_PLATFORM_PACK -> {
+    val manifestPath = plan.manifestPath ?: platformPackManifestPath(repoRoot, plan.platform)
+    val baselineSkillPath = plan.baselineSkillPath ?: error("Platform pack plan missing baseline skill path.")
+    val qualityCheckSkillPath =
+      plan.qualityCheckSkillPath ?: error("Platform pack plan missing quality-check skill path.")
+    mapOf(manifestPath to renderPlatformPackManifestContent(plan, repoRoot, baselineSkillPath, qualityCheckSkillPath))
+  }
+  else -> emptyMap()
 }
 
 private fun validateScaffold(plan: ScaffoldPlan, repoRoot: Path) {
@@ -945,6 +1088,7 @@ private fun renderPlatformPackManifestContent(
       .toString()
       .replace('\\', '/'),
     areaMetadata = plan.specialistAreaMetadata,
+    baselineLayers = plan.baselineLayers,
   )
 }
 

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
@@ -177,14 +177,23 @@ private fun validateCompositionModeSupport(pack: PlatformManifest) {
 }
 
 private fun validateCompositionModeSupport(sourceSlug: String, index: Int, layer: CodeReviewBaselineLayer) {
-  val supportsKmpBaseline = layer.platform == "kotlin" && layer.skill == "bill-kotlin-code-review"
-  if (layer.mode == CodeReviewCompositionMode.KmpBaseline && !supportsKmpBaseline) {
+  val unsupportedReason = unsupportedCompositionModeReason(layer)
+  if (unsupportedReason != null) {
     throw InvalidManifestSchemaError(
       "Platform pack '$sourceSlug': code_review_composition.baseline_layers[$index] uses mode " +
         "'${layer.mode.wireValue}' with unsupported referenced skill '${layer.platform}/${layer.skill}'. " +
-        "Mode '${layer.mode.wireValue}' is supported only for 'kotlin/bill-kotlin-code-review'.",
+        unsupportedReason,
     )
   }
+}
+
+internal fun unsupportedCompositionModeReason(layer: CodeReviewBaselineLayer): String? = when (layer.mode) {
+  CodeReviewCompositionMode.KmpBaseline ->
+    if (layer.platform == "kotlin" && layer.skill == "bill-kotlin-code-review") {
+      null
+    } else {
+      "Mode '${layer.mode.wireValue}' is supported only for 'kotlin/bill-kotlin-code-review'."
+    }
 }
 
 private fun validateNoCompositionCycles(packs: List<PlatformManifest>) {
@@ -218,7 +227,7 @@ private fun validateNoCompositionCycles(packs: List<PlatformManifest>) {
   graph.keys.sorted().forEach(::visit)
 }
 
-private fun PlatformManifest.declaredCodeReviewSkillNames(): Set<String> {
+internal fun PlatformManifest.declaredCodeReviewSkillNames(): Set<String> {
   val names = linkedSetOf<String>()
   routedSkillName?.let(names::add)
   declaredFiles.baseline?.parent?.fileName?.toString()

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
@@ -8,6 +8,10 @@ import skillbill.error.InvalidManifestSchemaError
 import skillbill.error.MissingContentFileError
 import skillbill.error.MissingManifestError
 import skillbill.error.MissingRequiredSectionError
+import skillbill.scaffold.model.CodeReviewBaselineLayer
+import skillbill.scaffold.model.CodeReviewComposition
+import skillbill.scaffold.model.CodeReviewCompositionMode
+import skillbill.scaffold.model.CodeReviewCompositionScope
 import skillbill.scaffold.model.DeclaredFiles
 import skillbill.scaffold.model.GovernedAddonFile
 import skillbill.scaffold.model.PlatformManifest
@@ -29,16 +33,27 @@ internal fun loadPlatformManifest(packRoot: Path): PlatformManifest {
 
 internal fun loadPlatformPack(packRoot: Path): PlatformManifest {
   val pack = loadPlatformManifest(packRoot)
+  validatePlatformPackCompositions(loadCompositionClosure(pack))
   validatePlatformPack(pack, SHELL_CONTRACT_VERSION)
   pack.declaredQualityCheckFile?.let { loadQualityCheckContent(pack) }
   return pack
 }
 
-internal fun discoverPlatformPacks(platformPacksRoot: Path): List<PlatformManifest> =
-  childDirectories(platformPacksRoot).map(::loadPlatformPack)
+internal fun discoverPlatformPacks(platformPacksRoot: Path): List<PlatformManifest> {
+  val packs = childDirectories(platformPacksRoot).map(::loadPlatformManifest)
+  validatePlatformPackCompositions(packs)
+  packs.forEach { pack ->
+    validatePlatformPack(pack, SHELL_CONTRACT_VERSION)
+    pack.declaredQualityCheckFile?.let { loadQualityCheckContent(pack) }
+  }
+  return packs
+}
 
-internal fun discoverPlatformPackManifests(platformPacksRoot: Path): List<PlatformManifest> =
-  childDirectories(platformPacksRoot).map(::loadPlatformManifest)
+internal fun discoverPlatformPackManifests(platformPacksRoot: Path): List<PlatformManifest> {
+  val packs = childDirectories(platformPacksRoot).map(::loadPlatformManifest)
+  validatePlatformPackCompositions(packs)
+  return packs
+}
 
 fun discoverGovernedAddonFiles(repoRoot: Path): List<GovernedAddonFile> {
   val packsRoot = repoRoot.toAbsolutePath().normalize().resolve("platform-packs")
@@ -88,6 +103,136 @@ internal fun validatePlatformPack(pack: PlatformManifest, contractVersion: Strin
   }
 }
 
+internal fun validatePlatformPackCompositions(packs: List<PlatformManifest>) {
+  val packsBySlug = packs.associateBy { it.slug }
+  packs
+    .filter { it.codeReviewComposition != null }
+    .forEach { pack -> validateCompositionReferences(pack, packsBySlug) }
+  validateNoCompositionCycles(packs)
+  packs
+    .filter { it.codeReviewComposition != null }
+    .forEach(::validateCompositionModeSupport)
+}
+
+private fun loadCompositionClosure(rootPack: PlatformManifest): List<PlatformManifest> {
+  val packParent = rootPack.packRoot.parent
+  return if (packParent == null || !Files.isDirectory(packParent)) {
+    listOf(rootPack)
+  } else {
+    val loaded = linkedMapOf(rootPack.slug to rootPack)
+
+    fun collect(pack: PlatformManifest) {
+      pack.codeReviewComposition?.baselineLayers.orEmpty().forEach { layer ->
+        if (layer.platform in loaded) {
+          return@forEach
+        }
+        val targetRoot = packParent.resolve(layer.platform)
+        if (!Files.isDirectory(targetRoot)) {
+          return@forEach
+        }
+        val targetPack = loadPlatformManifest(targetRoot)
+        loaded[targetPack.slug] = targetPack
+        collect(targetPack)
+      }
+    }
+
+    collect(rootPack)
+    loaded.values.toList()
+  }
+}
+
+private fun validateCompositionReferences(pack: PlatformManifest, packsBySlug: Map<String, PlatformManifest>) {
+  val seenTargets = mutableSetOf<Pair<String, String>>()
+  pack.codeReviewComposition?.baselineLayers.orEmpty().forEachIndexed { index, layer ->
+    val targetLabel = "${layer.platform}/${layer.skill}"
+    if (layer.platform == pack.slug) {
+      throw InvalidManifestSchemaError(
+        "Platform pack '${pack.slug}': code_review_composition.baseline_layers[$index] self-references " +
+          "the same platform pack '$targetLabel'.",
+      )
+    }
+    if (!seenTargets.add(layer.platform to layer.skill)) {
+      throw InvalidManifestSchemaError(
+        "Platform pack '${pack.slug}': duplicate code_review_composition baseline layer '$targetLabel'.",
+      )
+    }
+    val targetPack = packsBySlug[layer.platform]
+      ?: throw InvalidManifestSchemaError(
+        "Platform pack '${pack.slug}': code_review_composition.baseline_layers[$index] references " +
+          "missing platform pack '${layer.platform}'.",
+      )
+    if (layer.skill !in targetPack.declaredCodeReviewSkillNames()) {
+      throw InvalidManifestSchemaError(
+        "Platform pack '${pack.slug}': code_review_composition.baseline_layers[$index] references " +
+          "missing code-review skill '${layer.skill}' in platform pack '${layer.platform}'.",
+      )
+    }
+  }
+}
+
+private fun validateCompositionModeSupport(pack: PlatformManifest) {
+  pack.codeReviewComposition?.baselineLayers.orEmpty().forEachIndexed { index, layer ->
+    validateCompositionModeSupport(pack.slug, index, layer)
+  }
+}
+
+private fun validateCompositionModeSupport(sourceSlug: String, index: Int, layer: CodeReviewBaselineLayer) {
+  val supportsKmpBaseline = layer.platform == "kotlin" && layer.skill == "bill-kotlin-code-review"
+  if (layer.mode == CodeReviewCompositionMode.KmpBaseline && !supportsKmpBaseline) {
+    throw InvalidManifestSchemaError(
+      "Platform pack '$sourceSlug': code_review_composition.baseline_layers[$index] uses mode " +
+        "'${layer.mode.wireValue}' with unsupported referenced skill '${layer.platform}/${layer.skill}'. " +
+        "Mode '${layer.mode.wireValue}' is supported only for 'kotlin/bill-kotlin-code-review'.",
+    )
+  }
+}
+
+private fun validateNoCompositionCycles(packs: List<PlatformManifest>) {
+  val graph: Map<String, List<String>> = packs.associate { pack ->
+    pack.slug to pack.codeReviewComposition?.baselineLayers.orEmpty().map { layer -> layer.platform }
+  }
+  val visited = mutableSetOf<String>()
+  val visiting = mutableSetOf<String>()
+  val stack = mutableListOf<String>()
+
+  fun visit(slug: String) {
+    if (slug in visited) return
+    if (slug in visiting) {
+      val cycleStart = stack.indexOf(slug).coerceAtLeast(0)
+      val cycle = (stack.drop(cycleStart) + slug).joinToString(" -> ")
+      throw InvalidManifestSchemaError(
+        "Platform pack '$slug': code_review_composition contains a composition cycle: $cycle.",
+      )
+    }
+
+    visiting += slug
+    stack += slug
+    graph.getValue(slug)
+      .filter { target -> target in graph }
+      .forEach(::visit)
+    stack.removeAt(stack.lastIndex)
+    visiting -= slug
+    visited += slug
+  }
+
+  graph.keys.sorted().forEach(::visit)
+}
+
+private fun PlatformManifest.declaredCodeReviewSkillNames(): Set<String> {
+  val names = linkedSetOf<String>()
+  routedSkillName?.let(names::add)
+  declaredFiles.baseline?.parent?.fileName?.toString()
+    ?.takeIf { it != "code-review" }
+    ?.let(names::add)
+  declaredCodeReviewAreas.forEach { area ->
+    names += "bill-$slug-code-review-$area"
+    declaredFiles.areas[area]?.parent?.fileName?.toString()
+      ?.takeIf { it != "code-review" }
+      ?.let(names::add)
+  }
+  return names
+}
+
 internal fun loadQualityCheckContent(pack: PlatformManifest): Path {
   val filePath = pack.declaredQualityCheckFile
     ?: throw MissingContentFileError(
@@ -135,6 +280,7 @@ private fun buildPack(slug: String, packRoot: Path, manifestPath: Path, raw: Any
   val displayName = parseOptionalString(manifest, slug, "display_name")
   val notes = parseOptionalString(manifest, slug, "notes")
   val declaredQualityCheckFile = parseOptionalPath(manifest, slug, "declared_quality_check_file", packRoot)
+  val codeReviewComposition = parseCodeReviewComposition(manifest, slug)
   val pointers = parsePointers(manifest, slug)
 
   // SKILL-48 Subtask 3: anchored top-level keys (those the runtime consumes by name) are
@@ -166,6 +312,7 @@ private fun buildPack(slug: String, packRoot: Path, manifestPath: Path, raw: Any
     displayName = displayName,
     notes = notes,
     declaredQualityCheckFile = declaredQualityCheckFile,
+    codeReviewComposition = codeReviewComposition,
     pointers = pointers,
     customFields = customFields,
   )
@@ -387,6 +534,60 @@ private fun parseAreaMetadata(manifest: Map<*, *>, slug: String, declaredAreas: 
   }
   declaredAreas.forEach { declaredArea -> areaMetadata.putIfAbsent(declaredArea, defaultAreaFocus(declaredArea)) }
   return areaMetadata
+}
+
+private fun parseCodeReviewComposition(manifest: Map<*, *>, slug: String): CodeReviewComposition? {
+  val raw = manifest["code_review_composition"] ?: return null
+  val composition = raw as? Map<*, *>
+    ?: throw InvalidManifestSchemaError(
+      "Platform pack '$slug': 'code_review_composition' must be a mapping when provided.",
+    )
+  val layersRaw = composition["baseline_layers"]
+    ?: throw InvalidManifestSchemaError(
+      "Platform pack '$slug': 'code_review_composition.baseline_layers' is required.",
+    )
+  val layers = layersRaw as? List<*>
+    ?: throw InvalidManifestSchemaError(
+      "Platform pack '$slug': 'code_review_composition.baseline_layers' must be a list.",
+    )
+  return CodeReviewComposition(
+    baselineLayers = layers.mapIndexed { index, entry -> parseCodeReviewBaselineLayer(slug, index, entry) },
+  )
+}
+
+private fun parseCodeReviewBaselineLayer(slug: String, index: Int, raw: Any?): CodeReviewBaselineLayer {
+  val layer = raw as? Map<*, *>
+    ?: throw InvalidManifestSchemaError(
+      "Platform pack '$slug': 'code_review_composition.baseline_layers[$index]' must be a mapping.",
+    )
+  val fieldPrefix = "code_review_composition.baseline_layers[$index]"
+  val scopeValue = requireStringInMap(slug, layer, "$fieldPrefix.scope", "scope")
+  val modeValue = requireStringInMap(slug, layer, "$fieldPrefix.mode", "mode")
+  val required = layer["required"] as? Boolean
+    ?: throw InvalidManifestSchemaError("Platform pack '$slug': '$fieldPrefix.required' must be an explicit boolean.")
+
+  return CodeReviewBaselineLayer(
+    platform = requireStringInMap(slug, layer, "$fieldPrefix.platform", "platform"),
+    skill = requireStringInMap(slug, layer, "$fieldPrefix.skill", "skill"),
+    scope = CodeReviewCompositionScope.fromWireValue(scopeValue)
+      ?: throw InvalidManifestSchemaError(
+        "Platform pack '$slug': '$fieldPrefix.scope' has unsupported value '$scopeValue'.",
+      ),
+    required = required,
+    mode = CodeReviewCompositionMode.fromWireValue(modeValue)
+      ?: throw InvalidManifestSchemaError(
+        "Platform pack '$slug': '$fieldPrefix.mode' has unsupported value '$modeValue'.",
+      ),
+  )
+}
+
+private fun requireStringInMap(slug: String, map: Map<*, *>, fieldLabel: String, key: String): String {
+  val value = map[key] as? String
+    ?: throw InvalidManifestSchemaError("Platform pack '$slug': '$fieldLabel' must be a non-empty string.")
+  if (value.isBlank()) {
+    throw InvalidManifestSchemaError("Platform pack '$slug': '$fieldLabel' must be a non-empty string.")
+  }
+  return value
 }
 
 private fun parseOptionalString(manifest: Map<*, *>, slug: String, key: String): String? = manifest[key]?.let {

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/AuthoringRenderOutputTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/AuthoringRenderOutputTest.kt
@@ -1,5 +1,6 @@
 package skillbill.scaffold
 
+import skillbill.testsupport.SnapshotAssertions
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.AfterTest
@@ -88,6 +89,11 @@ class AuthoringRenderOutputTest {
     )
     assertEquals(expectedZ, rendered.blocks[1].content)
     assertEquals(expectedA, rendered.blocks[2].content)
+    assertFalse("## Review Composition" in rendered.stdout)
+    SnapshotAssertions.assertMatchesSnapshot(
+      "snapshots/scaffold/bill-fixturepack-code-review-no-composition.render.txt",
+      rendered.stdout,
+    )
     assertFalse(Files.exists(fixture.zPointer), "render must not create pointer files")
     assertFalse(Files.exists(fixture.aPointer), "render must not create pointer files")
     assertFalse(Files.exists(fixture.skillDir.resolve("SKILL.md")), "render must not create source SKILL.md")

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/AuthoringRenderSnapshotTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/AuthoringRenderSnapshotTest.kt
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class AuthoringRenderSnapshotTest {
   @Test
@@ -41,6 +42,33 @@ class AuthoringRenderSnapshotTest {
     assertEquals(first, second, "render output must be deterministic across repeated in-memory renders")
     SnapshotAssertions.assertMatchesSnapshot(
       "snapshots/scaffold/bill-kotlin-code-review.render.txt",
+      first,
+    )
+  }
+
+  @Test
+  fun `kmp code-review render includes generated review composition before authored guidance`() {
+    val repoRoot = currentRepoRootForSnapshotTest()
+    val rendered = renderAuthoringTarget(repoRoot, "bill-kmp-code-review")
+    val first = rendered.stdout
+    val second = renderAuthoringTarget(repoRoot, "bill-kmp-code-review").stdout
+
+    assertEquals(
+      expectedHeadersFromManifest(repoRoot, packSlug = "kmp", skillRelativeDir = "code-review/bill-kmp-code-review"),
+      rendered.blocks.map { block -> block.header },
+    )
+    assertTrue(
+      first.indexOf("## Review Composition") < first.indexOf("## Execution"),
+      "generated review composition must render before authored execution guidance",
+    )
+    assertTrue(
+      "Scope propagation is mandatory: pass the same review IDs, applied learnings, AGENTS guidance, changed files, " +
+        "and stack signals" in first,
+      "generated review composition must forward required review context",
+    )
+    assertEquals(first, second, "render output must be deterministic across repeated in-memory renders")
+    SnapshotAssertions.assertMatchesSnapshot(
+      "snapshots/scaffold/bill-kmp-code-review.render.txt",
       first,
     )
   }

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackCompositionTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackCompositionTest.kt
@@ -1,0 +1,409 @@
+package skillbill.scaffold
+
+import skillbill.error.InvalidManifestSchemaError
+import skillbill.scaffold.model.CodeReviewCompositionMode
+import skillbill.scaffold.model.CodeReviewCompositionScope
+import skillbill.testing.repoRootFromTest
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class PlatformPackCompositionTest {
+  @Test
+  fun `buildPack parses code review composition into typed manifest values`() {
+    val pack = loadPlatformManifest(
+      newTempPackRoot(
+        "kmp",
+        manifest(
+          slug = "kmp",
+          composition = kotlinBaselineComposition(),
+        ),
+      ),
+    )
+
+    val composition = assertNotNull(pack.codeReviewComposition)
+    val layer = composition.baselineLayers.single()
+    assertEquals("kotlin", layer.platform)
+    assertEquals("bill-kotlin-code-review", layer.skill)
+    assertEquals(CodeReviewCompositionScope.SameReviewScope, layer.scope)
+    assertEquals(true, layer.required)
+    assertEquals(CodeReviewCompositionMode.KmpBaseline, layer.mode)
+  }
+
+  @Test
+  fun `pack without code review composition still loads`() {
+    val pack = loadPlatformManifest(newTempPackRoot("kotlin", manifest(slug = "kotlin")))
+
+    assertNull(pack.codeReviewComposition)
+  }
+
+  @Test
+  fun `shipped KMP manifest declares valid Kotlin baseline composition`() {
+    val repoRoot = repoRootFromTest()
+    val packs = discoverPlatformPackManifests(repoRoot.resolve("platform-packs"))
+    val kmp = packs.single { it.slug == "kmp" }
+    val kotlin = packs.single { it.slug == "kotlin" }
+
+    assertNull(kotlin.codeReviewComposition)
+    val layer = assertNotNull(kmp.codeReviewComposition).baselineLayers.single()
+    assertEquals("kotlin", layer.platform)
+    assertEquals("bill-kotlin-code-review", layer.skill)
+    assertEquals(CodeReviewCompositionScope.SameReviewScope, layer.scope)
+    assertEquals(true, layer.required)
+    assertEquals(CodeReviewCompositionMode.KmpBaseline, layer.mode)
+  }
+
+  @Test
+  fun `schema rejects unknown nested composition fields`() {
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPlatformManifest(
+        newTempPackRoot(
+          "kmp",
+          manifest(
+            slug = "kmp",
+            composition = """
+              code_review_composition:
+                baseline_layers:
+                  - platform: kotlin
+                    skill: bill-kotlin-code-review
+                    scope: same-review-scope
+                    required: true
+                    mode: kmp-baseline
+                    extra: nope
+            """.trimIndent(),
+          ),
+        ),
+      )
+    }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "code_review_composition")
+    assertContains(message, "extra")
+  }
+
+  @Test
+  fun `schema rejects missing explicit required on baseline layer`() {
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPlatformManifest(
+        newTempPackRoot(
+          "kmp",
+          manifest(
+            slug = "kmp",
+            composition = """
+              code_review_composition:
+                baseline_layers:
+                  - platform: kotlin
+                    skill: bill-kotlin-code-review
+                    scope: same-review-scope
+                    mode: kmp-baseline
+            """.trimIndent(),
+          ),
+        ),
+      )
+    }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "required")
+    assertContains(message, "code_review_composition")
+  }
+
+  @Test
+  fun `schema rejects unsupported baseline layer scope`() {
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPlatformManifest(
+        newTempPackRoot(
+          "kmp",
+          manifest(
+            slug = "kmp",
+            composition = """
+              code_review_composition:
+                baseline_layers:
+                  - platform: kotlin
+                    skill: bill-kotlin-code-review
+                    scope: different-scope
+                    required: true
+                    mode: kmp-baseline
+            """.trimIndent(),
+          ),
+        ),
+      )
+    }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "scope")
+    assertContains(message, "different-scope")
+  }
+
+  @Test
+  fun `schema rejects unsupported baseline layer mode`() {
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPlatformManifest(
+        newTempPackRoot(
+          "kmp",
+          manifest(
+            slug = "kmp",
+            composition = """
+              code_review_composition:
+                baseline_layers:
+                  - platform: kotlin
+                    skill: bill-kotlin-code-review
+                    scope: same-review-scope
+                    required: true
+                    mode: mystery-mode
+            """.trimIndent(),
+          ),
+        ),
+      )
+    }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "mode")
+    assertContains(message, "mystery-mode")
+  }
+
+  @Test
+  fun `loadPlatformPack validates composition references through single pack seam`() {
+    val packsRoot = newTempPacksRoot(
+      "kmp" to manifest(slug = "kmp", composition = kotlinBaselineComposition()),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { loadPlatformPack(packsRoot.resolve("kmp")) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "missing platform pack")
+    assertContains(message, "kotlin")
+  }
+
+  @Test
+  fun `composition rejects missing referenced platform pack`() {
+    val packsRoot = newTempPacksRoot(
+      "kmp" to manifest(slug = "kmp", composition = kotlinBaselineComposition()),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { discoverPlatformPackManifests(packsRoot) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "missing platform pack")
+    assertContains(message, "kotlin")
+  }
+
+  @Test
+  fun `composition rejects missing referenced code review skill`() {
+    val packsRoot = newTempPacksRoot(
+      "kotlin" to manifest(slug = "kotlin"),
+      "kmp" to manifest(
+        slug = "kmp",
+        composition = """
+          code_review_composition:
+            baseline_layers:
+              - platform: kotlin
+                skill: bill-kotlin-code-review-missing
+                scope: same-review-scope
+                required: true
+                mode: kmp-baseline
+        """.trimIndent(),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { discoverPlatformPackManifests(packsRoot) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "missing code-review skill")
+    assertContains(message, "bill-kotlin-code-review-missing")
+  }
+
+  @Test
+  fun `composition rejects self reference`() {
+    val packsRoot = newTempPacksRoot(
+      "kmp" to manifest(
+        slug = "kmp",
+        composition = """
+          code_review_composition:
+            baseline_layers:
+              - platform: kmp
+                skill: bill-kmp-code-review
+                scope: same-review-scope
+                required: true
+                mode: kmp-baseline
+        """.trimIndent(),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { discoverPlatformPackManifests(packsRoot) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "self-references")
+    assertContains(message, "kmp/bill-kmp-code-review")
+  }
+
+  @Test
+  fun `composition rejects duplicate baseline layers by target`() {
+    val packsRoot = newTempPacksRoot(
+      "kotlin" to manifest(slug = "kotlin"),
+      "kmp" to manifest(
+        slug = "kmp",
+        composition = """
+          code_review_composition:
+            baseline_layers:
+              - platform: kotlin
+                skill: bill-kotlin-code-review
+                scope: same-review-scope
+                required: true
+                mode: kmp-baseline
+              - platform: kotlin
+                skill: bill-kotlin-code-review
+                scope: same-review-scope
+                required: false
+                mode: kmp-baseline
+        """.trimIndent(),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { discoverPlatformPackManifests(packsRoot) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "duplicate")
+    assertContains(message, "kotlin/bill-kotlin-code-review")
+  }
+
+  @Test
+  fun `composition rejects cycles`() {
+    val packsRoot = newTempPacksRoot(
+      "kmp" to manifest(
+        slug = "kmp",
+        baselinePath = "code-review/bill-kotlin-code-review/content.md",
+        composition = kotlinBaselineComposition(),
+      ),
+      "kotlin" to manifest(
+        slug = "kotlin",
+        baselinePath = "code-review/bill-kotlin-code-review/content.md",
+        composition = """
+          code_review_composition:
+            baseline_layers:
+              - platform: kmp
+                skill: bill-kotlin-code-review
+                scope: same-review-scope
+                required: true
+                mode: kmp-baseline
+        """.trimIndent(),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { discoverPlatformPackManifests(packsRoot) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "composition cycle")
+    assertContains(message, "kmp")
+    assertContains(message, "kotlin")
+  }
+
+  @Test
+  fun `composition rejects kmp baseline mode for non Kotlin baseline skill`() {
+    val packsRoot = newTempPacksRoot(
+      "kotlin" to manifest(
+        slug = "kotlin",
+        areas = mapOf("testing" to "code-review/bill-kotlin-code-review-testing/content.md"),
+      ),
+      "kmp" to manifest(
+        slug = "kmp",
+        composition = """
+          code_review_composition:
+            baseline_layers:
+              - platform: kotlin
+                skill: bill-kotlin-code-review-testing
+                scope: same-review-scope
+                required: true
+                mode: kmp-baseline
+        """.trimIndent(),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { discoverPlatformPackManifests(packsRoot) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "unsupported referenced skill")
+    assertContains(message, "bill-kotlin-code-review")
+  }
+
+  @Test
+  fun `composition rejects kmp baseline mode for non Kotlin platform`() {
+    val packsRoot = newTempPacksRoot(
+      "other" to manifest(slug = "other", baselinePath = "code-review/bill-kotlin-code-review/content.md"),
+      "kmp" to manifest(
+        slug = "kmp",
+        composition = """
+          code_review_composition:
+            baseline_layers:
+              - platform: other
+                skill: bill-kotlin-code-review
+                scope: same-review-scope
+                required: true
+                mode: kmp-baseline
+        """.trimIndent(),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidManifestSchemaError> { discoverPlatformPackManifests(packsRoot) }
+
+    val message = error.message.orEmpty()
+    assertContains(message, "unsupported referenced skill")
+    assertContains(message, "kotlin/bill-kotlin-code-review")
+  }
+
+  private fun kotlinBaselineComposition(): String = """
+    code_review_composition:
+      baseline_layers:
+        - platform: kotlin
+          skill: bill-kotlin-code-review
+          scope: same-review-scope
+          required: true
+          mode: kmp-baseline
+  """.trimIndent()
+
+  private fun manifest(
+    slug: String,
+    baselinePath: String = "code-review/bill-$slug-code-review/content.md",
+    areas: Map<String, String> = emptyMap(),
+    composition: String = "",
+  ): String = buildString {
+    appendLine("platform: $slug")
+    appendLine("contract_version: \"1.1\"")
+    appendLine("routing_signals:")
+    appendLine("  strong: [\".$slug\"]")
+    appendLine("declared_code_review_areas:")
+    if (areas.isEmpty()) {
+      appendLine("  []")
+    } else {
+      areas.keys.forEach { area -> appendLine("  - $area") }
+    }
+    appendLine("declared_files:")
+    appendLine("  baseline: $baselinePath")
+    if (areas.isNotEmpty()) {
+      appendLine("  areas:")
+      areas.forEach { (area, path) -> appendLine("    $area: $path") }
+    }
+    if (composition.isNotBlank()) {
+      appendLine(composition)
+    }
+  }
+
+  private fun newTempPacksRoot(vararg manifests: Pair<String, String>): Path {
+    val root = Files.createTempDirectory("skillbill-platform-pack-composition-root-")
+    manifests.forEach { (slug, manifest) ->
+      val packRoot = root.resolve(slug)
+      Files.createDirectories(packRoot)
+      Files.writeString(packRoot.resolve("platform.yaml"), manifest)
+    }
+    return root
+  }
+
+  private fun newTempPackRoot(slug: String, manifest: String): Path {
+    val packsRoot = newTempPacksRoot(slug to manifest)
+    return packsRoot.resolve(slug)
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackCustomFieldsRoundTripTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackCustomFieldsRoundTripTest.kt
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -92,6 +93,39 @@ class PlatformPackCustomFieldsRoundTripTest {
     // Belt-and-suspenders: no anchored key snuck in.
     val anchored = anchoredTopLevelFieldNames()
     assertFalse(pack.customFields.keys.any { it in anchored })
+  }
+
+  @Test
+  fun `composition is typed and excluded from customFields`() {
+    val slug = "kmp"
+    val manifest = """
+      platform: $slug
+      contract_version: "1.1"
+      routing_signals:
+        strong: [".kt"]
+      declared_code_review_areas: []
+      declared_files:
+        baseline: code-review/bill-kmp-code-review/content.md
+      code_review_composition:
+        baseline_layers:
+          - platform: kotlin
+            skill: bill-kotlin-code-review
+            scope: same-review-scope
+            required: true
+            mode: kmp-baseline
+      custom_thing: "hello"
+    """.trimIndent()
+
+    val packRoot = newTempPackRoot(slug, manifest)
+    val pack = loadPlatformManifest(packRoot)
+
+    val composition = assertNotNull(pack.codeReviewComposition)
+    assertEquals("kotlin", composition.baselineLayers.single().platform)
+    assertEquals("hello", pack.customFields["custom_thing"])
+    assertFalse(
+      "code_review_composition" in pack.customFields,
+      "Anchored composition field must stay typed and never flow through customFields.",
+    )
   }
 
   private fun newTempPackRoot(slug: String, manifest: String): Path {

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaAnchoredBijectionTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaAnchoredBijectionTest.kt
@@ -42,6 +42,7 @@ class PlatformPackSchemaAnchoredBijectionTest {
     "declared_files",
     "area_metadata",
     "declared_quality_check_file",
+    "code_review_composition",
     "pointers",
   )
 

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaCleanupTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaCleanupTest.kt
@@ -282,7 +282,7 @@ class PlatformPackSchemaCleanupTest {
           "feature/skillbill/state/PlatformPackSchemaViewerStateTest.kt",
       ),
     )
-    migratedSources.forEach { source ->
+    migratedSources.filter(Files::exists).forEach { source ->
       val text = Files.readString(source)
       // Allow imports of the shared helper but reject any private/local re-declaration.
       val redeclared = Regex("""fun\s+repoRootFromTest\s*\(""").containsMatchIn(text)

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldBaselineLayerPayloadTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldBaselineLayerPayloadTest.kt
@@ -1,0 +1,290 @@
+package skillbill.scaffold
+
+import skillbill.error.InvalidScaffoldPayloadError
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class ScaffoldBaselineLayerPayloadTest {
+  @Test
+  fun `platform pack payload writes baseline layer composition to manifest`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result =
+      scaffold(
+        payload(repo, "platform-pack", "platform" to "androidx") +
+          mapOf(
+            "skeleton_mode" to "starter",
+            "routing_signals" to mapOf("strong" to listOf("androidx")),
+            "baseline_layers" to kotlinBaselinePayload(),
+          ),
+      )
+    val manifest = Files.readString(repo.resolve("platform-packs/androidx/platform.yaml"))
+    val pack = loadPlatformPack(repo.resolve("platform-packs/androidx"))
+
+    assertEquals("platform-pack", result.kind)
+    assertContains(manifest, "code_review_composition:")
+    assertContains(manifest, "baseline_layers:")
+    assertContains(manifest, "platform: \"kotlin\"")
+    assertContains(manifest, "skill: \"bill-kotlin-code-review\"")
+    assertContains(manifest, "scope: \"same-review-scope\"")
+    assertContains(manifest, "required: true")
+    assertContains(manifest, "mode: \"kmp-baseline\"")
+    assertEquals("kotlin", pack.codeReviewComposition?.baselineLayers?.single()?.platform)
+  }
+
+  @Test
+  fun `legacy platform pack payload without baseline layers omits composition section`() = withIsolatedUserHome {
+    val repo = seedRepo()
+
+    scaffold(
+      payload(repo, "platform-pack", "platform" to "legacy") +
+        mapOf("skeleton_mode" to "starter", "routing_signals" to mapOf("strong" to listOf("legacy.marker"))),
+    )
+
+    val manifest = Files.readString(repo.resolve("platform-packs/legacy/platform.yaml"))
+    assertFalse("code_review_composition:" in manifest)
+    assertEquals(null, loadPlatformPack(repo.resolve("platform-packs/legacy")).codeReviewComposition)
+  }
+
+  @Test
+  fun `platform pack dry run previews the same composition manifest execute writes`() = withIsolatedUserHome {
+    val dryRunRepo = seedRepo()
+    val executeRepo = seedRepo()
+    val payload =
+      mapOf(
+        "scaffold_payload_version" to "1.0",
+        "kind" to "platform-pack",
+        "platform" to "androidx",
+        "skeleton_mode" to "starter",
+        "routing_signals" to mapOf("strong" to listOf("androidx")),
+        "baseline_layers" to kotlinBaselinePayload(),
+      )
+
+    val dryRun = scaffold(payload + ("repo_root" to dryRunRepo.toString()), dryRun = true)
+    val execute = scaffold(payload + ("repo_root" to executeRepo.toString()), dryRun = false)
+    val executeManifest = Files.readString(executeRepo.resolve("platform-packs/androidx/platform.yaml"))
+
+    assertEquals(listOf(dryRunRepo.resolve("platform-packs/androidx/platform.yaml")), dryRun.manifestEdits)
+    assertFalse(Files.exists(dryRunRepo.resolve("platform-packs/androidx/platform.yaml")))
+    assertEquals(
+      executeManifest,
+      dryRun.manifestPreviews.getValue(dryRunRepo.resolve("platform-packs/androidx/platform.yaml")),
+    )
+    assertContains(executeManifest, "code_review_composition:")
+    assertContains(execute.manifestEdits, executeRepo.resolve("platform-packs/androidx/platform.yaml"))
+  }
+
+  @Test
+  fun `invalid baseline layer payloads fail before mutation and preserve repo bytes`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val invalidPayloads =
+      listOf(
+        mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("platform" to "missing"))) to
+          "missing platform pack",
+        mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("skill" to "bill-kotlin-code-review-missing"))) to
+          "missing code-review skill",
+        selfReferencePayload() to "self-references",
+        mapOf("baseline_layers" to kotlinBaselinePayload() + kotlinBaselinePayload()) to "duplicate layer",
+        mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("scope" to "other-scope"))) to
+          "unsupported value",
+        mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("mode" to "other-mode"))) to
+          "unsupported value",
+      )
+
+    invalidPayloads.forEachIndexed { index, (extraPayload, expectedMessage) ->
+      val before = snapshotTree(repo)
+      val platform = extraPayload["platform"] as? String ?: "androidx-$index"
+      val error = assertFailsWith<InvalidScaffoldPayloadError> {
+        scaffold(
+          payload(repo, "platform-pack", "platform" to platform) +
+            mapOf("skeleton_mode" to "starter", "routing_signals" to mapOf("strong" to listOf("marker-$index"))) +
+            extraPayload,
+        )
+      }
+
+      assertContains(error.message.orEmpty(), expectedMessage)
+      assertEquals(before, snapshotTree(repo))
+      assertFalse(Files.exists(repo.resolve("platform-packs/$platform")))
+    }
+  }
+
+  @Test
+  fun `structurally invalid baseline layer payloads fail before mutation and preserve repo bytes`() =
+    withIsolatedUserHome {
+      val repo = seedRepo()
+      val invalidPayloads =
+        listOf(
+          mapOf("baseline_layers" to "not-a-list") to "must be a list",
+          mapOf("baseline_layers" to emptyList<Map<String, Any?>>()) to "at least one layer",
+          mapOf("baseline_layers" to listOf("not-an-object")) to "must be an object",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry() - "platform")) to
+            "baseline_layers[0].platform",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("platform" to ""))) to
+            "baseline_layers[0].platform",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry() - "skill")) to
+            "baseline_layers[0].skill",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("skill" to " "))) to
+            "baseline_layers[0].skill",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry() - "scope")) to
+            "baseline_layers[0].scope",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("scope" to ""))) to
+            "baseline_layers[0].scope",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry() - "mode")) to
+            "baseline_layers[0].mode",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("mode" to " "))) to
+            "baseline_layers[0].mode",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry() - "required")) to
+            "baseline_layers[0].required",
+          mapOf("baseline_layers" to listOf(kotlinBaselinePayloadEntry("required" to "true"))) to
+            "baseline_layers[0].required",
+        )
+
+      invalidPayloads.forEachIndexed { index, (extraPayload, expectedMessage) ->
+        val before = snapshotTree(repo)
+        val platform = "androidx-structural-$index"
+        val error = assertFailsWith<InvalidScaffoldPayloadError> {
+          scaffold(
+            payload(repo, "platform-pack", "platform" to platform) +
+              mapOf("skeleton_mode" to "starter", "routing_signals" to mapOf("strong" to listOf("marker-$index"))) +
+              extraPayload,
+          )
+        }
+
+        assertContains(error.message.orEmpty(), expectedMessage)
+        assertEquals(before, snapshotTree(repo))
+        assertFalse(Files.exists(repo.resolve("platform-packs/$platform")))
+      }
+    }
+
+  @Test
+  fun `baseline layers are rejected for non platform pack payloads before mutation`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    listOf(
+      payload(repo, "horizontal", "name" to "bill-not-a-pack"),
+      payload(repo, "platform-override-piloted", "platform" to "kotlin", "family" to "quality-check"),
+      payload(repo, "code-review-area", "platform" to "kotlin", "area" to "performance"),
+      payload(repo, "add-on", "platform" to "kotlin", "name" to "review-helper"),
+    ).forEach { basePayload ->
+      val before = snapshotTree(repo)
+      val kind = basePayload.getValue("kind")
+      val error = assertFailsWith<InvalidScaffoldPayloadError> {
+        scaffold(basePayload + mapOf("baseline_layers" to kotlinBaselinePayload()))
+      }
+
+      assertContains(error.message.orEmpty(), "only supported for kind 'platform-pack'")
+      assertContains(error.message.orEmpty(), "got '$kind'")
+      assertEquals(before, snapshotTree(repo))
+    }
+  }
+}
+
+private fun selfReferencePayload(): Map<String, Any?> = mapOf(
+  "platform" to "androidx-self",
+  "baseline_layers" to listOf(
+    kotlinBaselinePayloadEntry(
+      "platform" to "androidx-self",
+      "skill" to "bill-androidx-self-code-review",
+    ),
+  ),
+)
+
+private fun payload(repo: Path, kind: String, vararg pairs: Pair<String, Any?>): Map<String, Any?> =
+  mapOf("scaffold_payload_version" to "1.0", "kind" to kind, "repo_root" to repo.toString()) + pairs
+
+private fun kotlinBaselinePayload(): List<Map<String, Any?>> = listOf(kotlinBaselinePayloadEntry())
+
+private fun kotlinBaselinePayloadEntry(vararg overrides: Pair<String, Any?>): Map<String, Any?> = mapOf(
+  "platform" to "kotlin",
+  "skill" to "bill-kotlin-code-review",
+  "scope" to "same-review-scope",
+  "required" to true,
+  "mode" to "kmp-baseline",
+) + overrides
+
+private fun seedRepo(): Path {
+  val repo = Files.createTempDirectory("skillbill-baseline-layer-scaffold-repo")
+  skillbill.testsupport.SkillClassFixtures.seedShippedSkillClasses(repo)
+  supportingFileTargets(repo).values.forEach { target ->
+    Files.createDirectories(target.parent)
+    Files.writeString(target, "# ${target.fileName}\n")
+  }
+  seedKotlinPack(repo)
+  seedKmpPack(repo)
+  return repo
+}
+
+private fun seedKotlinPack(repo: Path) {
+  val packRoot = repo.resolve("platform-packs/kotlin")
+  val baseline = packRoot.resolve("code-review/bill-kotlin-code-review")
+  Files.createDirectories(baseline)
+  val context = TemplateContext("bill-kotlin-code-review", "code-review", "kotlin", "", "Kotlin")
+  Files.writeString(
+    packRoot.resolve("platform.yaml"),
+    renderPlatformPackManifest(
+      platform = "kotlin",
+      displayName = "Kotlin",
+      strongSignals = listOf(".kt"),
+      baselineContentPath = "code-review/bill-kotlin-code-review/content.md",
+    ),
+  )
+  Files.writeString(
+    baseline.resolve("content.md"),
+    renderContentBody(context, inferSkillDescription(context)),
+  )
+}
+
+private fun seedKmpPack(repo: Path) {
+  val packRoot = repo.resolve("platform-packs/kmp")
+  val baseline = packRoot.resolve("code-review/bill-kmp-code-review")
+  Files.createDirectories(baseline)
+  val context = TemplateContext("bill-kmp-code-review", "code-review", "kmp", "", "KMP")
+  Files.writeString(
+    packRoot.resolve("platform.yaml"),
+    renderPlatformPackManifest(
+      platform = "kmp",
+      displayName = "KMP",
+      strongSignals = listOf(".kt"),
+      baselineContentPath = "code-review/bill-kmp-code-review/content.md",
+    ),
+  )
+  Files.writeString(
+    baseline.resolve("content.md"),
+    renderContentBody(context, inferSkillDescription(context)),
+  )
+}
+
+private fun withIsolatedUserHome(block: () -> Unit) {
+  val originalHome = System.getProperty("user.home")
+  val tempHome = Files.createTempDirectory("skillbill-baseline-layer-no-agents-home")
+  try {
+    System.setProperty("user.home", tempHome.toString())
+    block()
+  } finally {
+    System.setProperty("user.home", originalHome)
+  }
+}
+
+private fun snapshotTree(root: Path): Map<String, String> {
+  if (!Files.exists(root)) {
+    return emptyMap()
+  }
+  return Files.walk(root).use { stream ->
+    stream
+      .filter { path -> path != root }
+      .sorted()
+      .toList()
+      .associate { path ->
+        val key = root.relativize(path).toString()
+        val value = when {
+          Files.isSymbolicLink(path) -> "symlink:${Files.readSymbolicLink(path)}"
+          Files.isDirectory(path) -> "dir"
+          else -> "file:${Files.readString(path)}"
+        }
+        key to value
+      }
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldCatalogTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldCatalogTest.kt
@@ -1,0 +1,88 @@
+package skillbill.scaffold
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScaffoldCatalogTest {
+  @Test
+  fun `baseline review catalog projects manifest composition edges`() {
+    val packsRoot = Files.createTempDirectory("skillbill-scaffold-catalog-")
+    writeManifest(
+      packsRoot = packsRoot,
+      slug = "kotlin",
+      body = manifest(slug = "kotlin"),
+    )
+    writeManifest(
+      packsRoot = packsRoot,
+      slug = "kmp",
+      body = manifest(
+        slug = "kmp",
+        composition = """
+          code_review_composition:
+            baseline_layers:
+              - platform: kotlin
+                skill: bill-kotlin-code-review
+                scope: same-review-scope
+                required: true
+                mode: kmp-baseline
+        """.trimIndent(),
+      ),
+    )
+    writeManifest(
+      packsRoot = packsRoot,
+      slug = "docs",
+      body = """
+        platform: docs
+        contract_version: "1.1"
+        display_name: Docs
+        routing_signals:
+          strong:
+            - "docs/"
+          tie_breakers: []
+        declared_code_review_areas: []
+        area_metadata: {}
+      """.trimIndent(),
+    )
+
+    val catalog = ScaffoldCatalog.discoverBaselineReviewCatalog(packsRoot)
+
+    assertEquals(listOf("kmp", "kotlin"), catalog.packs.map { it.platform })
+    assertEquals(
+      listOf(BaselineEdge("kmp", "kotlin", "bill-kotlin-code-review")),
+      catalog.compositionEdges.map { edge ->
+        BaselineEdge(edge.sourcePlatform, edge.targetPlatform, edge.targetSkill)
+      },
+    )
+  }
+
+  private data class BaselineEdge(
+    val sourcePlatform: String,
+    val targetPlatform: String,
+    val targetSkill: String,
+  )
+
+  private fun writeManifest(packsRoot: java.nio.file.Path, slug: String, body: String) {
+    val packRoot = packsRoot.resolve(slug)
+    Files.createDirectories(packRoot)
+    Files.writeString(packRoot.resolve("platform.yaml"), body)
+  }
+
+  private fun manifest(slug: String, composition: String = ""): String = buildString {
+    appendLine("platform: $slug")
+    appendLine("contract_version: \"1.1\"")
+    appendLine("display_name: ${slug.replaceFirstChar { it.uppercase() }}")
+    appendLine("routing_signals:")
+    appendLine("  strong:")
+    appendLine("    - \".$slug\"")
+    appendLine("  tie_breakers: []")
+    appendLine("declared_code_review_areas: []")
+    appendLine("declared_files:")
+    appendLine("  baseline: code-review/bill-$slug-code-review/content.md")
+    appendLine("  areas: {}")
+    appendLine("area_metadata: {}")
+    if (composition.isNotBlank()) {
+      appendLine(composition)
+    }
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-fixturepack-code-review-no-composition.render.txt
+++ b/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-fixturepack-code-review-no-composition.render.txt
@@ -1,0 +1,23 @@
+===== SKILL.md: platform-packs/fixturepack/code-review/bill-fixturepack-code-review/SKILL.md =====
+---
+name: bill-fixturepack-code-review
+description: Fixture platform render skill.
+---
+
+## Descriptor
+
+Governed skill: `bill-fixturepack-code-review`
+Family: `code-review`
+Platform pack: `fixturepack` (Fixturepack)
+Description: Use when reviewing Fixturepack changes across code-review specialists.
+
+## Execution
+
+
+## Ceremony
+
+===== pointer: platform-packs/fixturepack/code-review/bill-fixturepack-code-review/z.md =====
+../../../../shared/z.md
+
+===== pointer: platform-packs/fixturepack/code-review/bill-fixturepack-code-review/a.md =====
+../../../../shared/a.md

--- a/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kmp-code-review.render.txt
+++ b/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kmp-code-review.render.txt
@@ -1,0 +1,198 @@
+===== SKILL.md: platform-packs/kmp/code-review/bill-kmp-code-review/SKILL.md =====
+---
+name: bill-kmp-code-review
+description: Use when conducting a thorough Android/KMP PR code review. Preserve mobile review depth by running the manifest-declared baseline review layer first, then add Android/KMP-specific specialists such as UI and UX/accessibility. Produces a structured review with risk register and prioritized action items. Use when user mentions Android review, KMP review, mobile review, or asks to review Android/KMP changes.
+---
+
+## Descriptor
+
+Governed skill: `bill-kmp-code-review`
+Family: `code-review`
+Platform pack: `kmp` (KMP)
+Description: Use when reviewing KMP changes across code-review specialists.
+
+## Review Composition
+
+This platform pack declares code-review composition in `platform.yaml`. Runtime agents MUST run each required baseline layer before selecting or running pack-local specialists.
+
+Scope propagation is mandatory: pass the same review IDs, applied learnings, AGENTS guidance, changed files, and stack signals into every baseline layer and then into any pack-local specialist review.
+Keep baseline-layer findings attributed to that layer before merging and deduplicating them with pack-local specialist findings.
+
+### Required Baseline Layers
+
+- `kotlin/bill-kotlin-code-review` with scope `same-review-scope`, mode `kmp-baseline`, required `true`.
+
+## Execution
+
+You are an experienced Android/KMP architect conducting a code review.
+
+Your job is to preserve Android/KMP review depth without duplicating shared Kotlin review logic. The generated Review Composition section is the source of truth for required baseline layers; apply this authored KMP guidance after those baseline instructions have been handled.
+---
+
+### Project Classification
+
+Inspect both the changed files and repo markers (`build.gradle*`, `settings.gradle*`, `gradle/libs.versions.toml`, `pom.xml`, source set layout, module names, imports).
+
+Classify the review as one of:
+- `kmp`
+- `mixed-kmp`
+- `not-kmp`
+
+#### Additional Backend/Server Signals
+
+- `io.ktor.server`, `routing {}`, `Application.module`
+- `spring-boot`, `@RestController`, `@Controller`, `@Service`, `@Repository`, `@Transactional`
+- Micronaut, Quarkus, http4k, Javalin, gRPC server code
+- `application.yml`, `application.yaml`, `application.conf`
+- SQL/ORM/data-access layers: Exposed, jOOQ, Hibernate/JPA, JDBC, R2DBC, Flyway, Liquibase
+- Queues, schedulers, consumers, caches, metrics, tracing, server auth middleware
+
+#### Decision Rules
+
+- If Android/KMP signals are strong, keep the Android/KMP route.
+- If Android/KMP signals are weak or absent, delegate to `bill-kotlin-code-review` and stop instead of pretending mobile-specific coverage exists.
+- If backend/server files are also touched, keep the `kmp` route and rely on the manifest-declared baseline layer so shared Kotlin concerns are still reviewed before this skill adds mobile-specific specialists.
+- When uncertain, prefer the safer route that preserves Android/KMP review depth.
+
+### Governed Add-On Resolution
+
+After the stack is already classified as `kmp`, resolve governed add-ons before selecting KMP-specific specialists.
+
+- If no add-on cues match, continue with the base KMP review without a governed add-on.
+- Select `android-compose` when the scoped diff contains Compose UI signals such as `@Composable`, Compose UI state, `Modifier` chains, previews, `remember*`, or Compose side effects.
+- Select `android-navigation` when the scoped diff changes route models, `NavHost`/`NavDisplay`, deep links, multi-back-stack behavior, scene destinations, or Android navigation ownership.
+- Select `android-interop` when the scoped diff mixes Compose with legacy Views, Fragments, `ComposeView`, `AndroidView`, `AndroidViewBinding`, or other Android host-boundary glue.
+- Select `android-design-system` when the scoped diff changes Android theme layers, `MaterialTheme`, design tokens, styled components, or XML-theme-to-Compose translation.
+- Select `android-r8` when the scoped diff changes Android keep rules, shrinker config, `proguardFiles`, `isMinifyEnabled`, `isShrinkResources`, or release-only R8 settings.
+- Scan [android-compose-review.md](android-compose-review.md) first. If the add-on is split into topic files, open only the linked topic files whose cues match the scoped diff when `android-compose` is selected, such as [android-compose-edge-to-edge.md](android-compose-edge-to-edge.md) and [android-compose-adaptive-layouts.md](android-compose-adaptive-layouts.md).
+- Scan [android-navigation-review.md](android-navigation-review.md) when `android-navigation` is selected.
+- Scan [android-interop-review.md](android-interop-review.md) when `android-interop` is selected.
+- Scan [android-design-system-review.md](android-design-system-review.md) when `android-design-system` is selected.
+- Scan [android-r8-review.md](android-r8-review.md) when `android-r8` is selected.
+- Add-ons enrich the routed KMP review; they do not create standalone reviewer names or bypass the `kmp` route.
+
+---
+
+### Layered Review Plan
+
+#### Step 1: Scale review depth
+
+- For small, low-risk Android/KMP diffs, keep the review compact.
+- For larger, mixed, or higher-risk diffs, split the work into focused baseline and specialist passes.
+
+#### Step 2: Confirm the manifest-declared baseline layer
+
+The generated Review Composition section defines the required baseline layer sequence. Treat that section as authoritative for which baseline skill to run, the mode to use, and the context that must be forwarded.
+
+That baseline layer owns:
+- shared Kotlin architecture, correctness, security, performance, and testing review
+- backend/server risk coverage within the Kotlin specialist set when backend signals are present
+- the baseline Kotlin findings that every Android/KMP review should inherit
+
+When invoking the baseline layer:
+- tell it that Android/KMP scope is valid for the manifest-declared baseline mode
+- tell it to keep KMP-only review concerns out of scope
+- pass the same diff source, changed files, and relevant override guidance
+
+#### Step 3: Analyze the diff and select KMP-specific agents
+
+- Preserve Android/KMP specialists for any Android/KMP files even when backend files are changed in the same PR
+- A single PR may spawn both the baseline review and KMP-only specialists, but keep the KMP-specific specialist count at 2 or fewer
+- Pass any selected governed add-ons into the chosen KMP specialist review passes
+
+##### Android/KMP Route
+
+Keep the mobile triggers focused on what the baseline review does not cover:
+
+| Signal in the diff                                                                                               | Specialist review to run                |
+|------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| `@Composable` functions, UI state classes, Modifier chains, `remember`, `LaunchedEffect`                         | `bill-kmp-code-review-ui`               |
+| User-facing UI changes, `stringResource`, accessibility attributes, navigation, error states, localization files | `bill-kmp-code-review-ux-accessibility` |
+
+#### Step 3.5: Scope diff per KMP specialist when review depth increases
+
+When the review is split into focused KMP specialist passes, build a per-specialist file list first:
+
+1. Scan each changed file's name and imports for the KMP routing-table signals from Step 3
+2. Map each file to the KMP specialists whose signals it matches
+3. If a specialist's scoped file list is empty, drop it from the selected set
+
+This is a lightweight file-level classification (names + imports), not a full review.
+
+#### Step 4: Run KMP specialist reviews
+
+- Run each selected KMP specialist lane against its scoped files.
+- Read each KMP specialist skill file as the primary rubric for that lane.
+- Keep findings attributed to each layer before merging and deduplicating them into the final review.
+
+If no KMP-only triggers match but Android/KMP signals are clearly present, keep the baseline review output and state that no extra KMP-only specialist was needed for this scope.
+
+### Subagent Spawn Runtime Notes
+
+Specialist spawn instructions in this orchestrator are runtime-neutral. Each phrase such as "spawn the `bill-kmp-code-review-ui` subagent" maps to the native subagent surface of the host runtime (parent skill: `bill-kmp-code-review`). The per-runtime paragraphs below are imperative: the orchestrator MUST follow the paragraph that matches the runtime it is running in, including how it collects the subagent's `RESULT:` JSON. Picking a different mechanism (for example, emitting a natural-language "please spawn" message instead of calling the listed tool) causes the workflow to stall because no subagent actually runs and no `RESULT:` is ever returned.
+
+**On Claude (Claude Code, Anthropic SDK agents).** The orchestrator MUST invoke the built-in `Agent` tool with `subagent_type` set to the matching specialist name (for example, `subagent_type: "bill-kmp-code-review-ui"` for that role in `bill-kmp-code-review`) and pass the per-phase briefing as the tool's `prompt`. Call the tool in the **foreground** (the default — do NOT pass `run_in_background: true`). The `Agent` tool blocks until the subagent finishes and returns the subagent's final text message as the tool result; the orchestrator parses the `RESULT:` JSON directly from that returned message in the same turn. Do NOT sleep, poll, ping, re-call, or otherwise check on the subagent — Claude's `Agent` tool surfaces completion synchronously and any polling loop is both unnecessary and explicitly discouraged by the tool contract. If the tool returns and the message is missing a `RESULT:` block or contains malformed JSON, fall through to the `RESULT:` block parsing tolerance rules (best-effort recovery, then exactly one corrective re-spawn via another foreground `Agent` call) instead of waiting.
+
+**On Codex.** The spawn is a natural-language directive in the orchestrator's turn. Codex resolves the subagent by `name` against the installed TOML files in the Codex user agents directory (with the legacy Agents agents fallback), respecting `agents.max_threads` and `agents.max_depth`. Because Codex runs subagents asynchronously, the orchestrator MUST poll for completion between turns before consuming the subagent's `RESULT:` block — do not proceed to the next phase until the subagent has visibly finished and its `RESULT:` JSON is available in the conversation.
+
+**On OpenCode.** The spawn resolves by filename-derived `name` against markdown agents installed in the OpenCode user agents directory; operators can also invoke the same specialists manually with `@bill-kmp-code-review-ui`, `@bill-kmp-code-review-ux-accessibility`. Like Codex, OpenCode runs the spawn asynchronously, so the orchestrator MUST wait for the subagent to finish (checking between turns) and only then read its `RESULT:` JSON before advancing.
+
+OpenCode does not document a different native concurrency cap; keep the conservative limit of 6 or fewer specialists per wave.
+
+## Ceremony
+
+Follow the shell ceremony in [shell-ceremony.md](shell-ceremony.md).
+
+Determine the review scope using [review-scope.md](review-scope.md).
+
+When stack routing applies, follow [stack-routing.md](stack-routing.md).
+
+When delegated specialist review applies, use [specialist-contract.md](specialist-contract.md).
+
+When delegated review execution applies, follow [review-delegation.md](review-delegation.md).
+
+When review reporting applies, follow [review-orchestrator.md](review-orchestrator.md).
+
+When telemetry applies, follow [telemetry-contract.md](telemetry-contract.md).
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/review-orchestrator.md =====
+../../../../orchestration/review-orchestrator/PLAYBOOK.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/review-delegation.md =====
+../../../../orchestration/review-delegation/PLAYBOOK.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/review-scope.md =====
+../../../../orchestration/review-scope/PLAYBOOK.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/shell-ceremony.md =====
+../../../../orchestration/shell-content-contract/shell-ceremony.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/specialist-contract.md =====
+../../../../orchestration/review-orchestrator/specialist-contract.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/stack-routing.md =====
+../../../../orchestration/stack-routing/PLAYBOOK.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/telemetry-contract.md =====
+../../../../orchestration/telemetry-contract/PLAYBOOK.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/android-compose-adaptive-layouts.md =====
+../../addons/android-compose-adaptive-layouts.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/android-compose-edge-to-edge.md =====
+../../addons/android-compose-edge-to-edge.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/android-compose-review.md =====
+../../addons/android-compose-review.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/android-design-system-review.md =====
+../../addons/android-design-system-review.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/android-interop-review.md =====
+../../addons/android-interop-review.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/android-navigation-review.md =====
+../../addons/android-navigation-review.md
+
+===== pointer: platform-packs/kmp/code-review/bill-kmp-code-review/android-r8-review.md =====
+../../addons/android-r8-review.md

--- a/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kotlin-code-review.render.txt
+++ b/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kotlin-code-review.render.txt
@@ -37,7 +37,8 @@ Classify the review as one of:
 
 #### Decision Rules
 
-- If this skill is invoked from `bill-kmp-code-review`, accept Android/KMP scope and classify it as `kmp-baseline`. In that mode, review only shared Kotlin concerns and let `bill-kmp-code-review` add mobile-specific specialists.
+- If this skill is invoked as a manifest-declared composition baseline with mode `kmp-baseline`, accept Android/KMP scope and classify it as `kmp-baseline`. In that mode, review only shared Kotlin concerns and let the platform-specific review add mobile-specific specialists.
+- Do not infer `kmp-baseline` from caller name alone; require the manifest-declared baseline mode from the generated Review Composition instructions.
 - If strong Android/KMP markers are present and this skill is invoked standalone, clearly say that `bill-kmp-code-review` is required for full Android/KMP coverage. Continue only if the caller explicitly wants the baseline Kotlin layer.
 - Backend/server markers stay on the `kotlin` route. Select backend-focused Kotlin specialists for API contracts, persistence, and reliability when backend/server signals are present.
 - Otherwise use the `kotlin` route.

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmRuntimeScaffoldGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmRuntimeScaffoldGateway.kt
@@ -3,6 +3,11 @@ package skillbill.desktop.core.data.service
 import kotlinx.coroutines.CancellationException
 import me.tatarka.inject.annotations.Inject
 import skillbill.desktop.core.common.di.UserScope
+import skillbill.desktop.core.domain.model.BaselineReviewCompositionEdge
+import skillbill.desktop.core.domain.model.BaselineReviewLayerSuggestion
+import skillbill.desktop.core.domain.model.BaselineReviewPackOption
+import skillbill.desktop.core.domain.model.BaselineReviewSkillOption
+import skillbill.desktop.core.domain.model.ManifestEditPreview
 import skillbill.desktop.core.domain.model.PilotedPlatformPackEntry
 import skillbill.desktop.core.domain.model.PlatformPackPresetEntry
 import skillbill.desktop.core.domain.model.RepoSession
@@ -51,6 +56,7 @@ class JvmRuntimeScaffoldGateway : RuntimeScaffoldGateway {
 
   override suspend fun catalogSnapshot(session: RepoSession?): ScaffoldCatalogSnapshot {
     val piloted = pilotedPlatformPacks(session)
+    val baselineCatalog = baselineReviewCatalog(session)
     return ScaffoldCatalogSnapshot(
       approvedCodeReviewAreas = ScaffoldCatalog.approvedCodeReviewAreas.sorted(),
       preShellFamilies = ScaffoldCatalog.preShellFamilies.sorted(),
@@ -59,20 +65,21 @@ class JvmRuntimeScaffoldGateway : RuntimeScaffoldGateway {
         .map { (slug, display) -> PlatformPackPresetEntry(platform = slug, displayName = display) }
         .sortedBy { it.platform },
       pilotedPlatformPacks = piloted,
+      baselineReviewPacks = baselineCatalog.packs,
+      baselineReviewCompositionEdges = baselineCatalog.edges,
+      baselineReviewLayerSuggestions = baselineCatalog.suggestions,
       scaffoldPayloadVersion = ScaffoldCatalog.scaffoldPayloadVersion,
     )
   }
 
+  private data class DesktopBaselineCatalog(
+    val packs: List<BaselineReviewPackOption> = emptyList(),
+    val edges: List<BaselineReviewCompositionEdge> = emptyList(),
+    val suggestions: List<BaselineReviewLayerSuggestion> = emptyList(),
+  )
+
   private fun pilotedPlatformPacks(session: RepoSession?): List<PilotedPlatformPackEntry> {
-    val repoPath = session?.takeIf { it.isRecognizedSkillBillRepo }?.repoPath?.trim().orEmpty()
-    if (repoPath.isEmpty()) {
-      return emptyList()
-    }
-    val packsRoot = try {
-      Path.of(repoPath).toAbsolutePath().normalize().resolve("platform-packs")
-    } catch (_: InvalidPathException) {
-      return emptyList()
-    }
+    val packsRoot = platformPacksRoot(session) ?: return emptyList()
     return try {
       ScaffoldCatalog.discoverPilotedPlatformPacks(packsRoot)
         .map { pack ->
@@ -84,6 +91,61 @@ class JvmRuntimeScaffoldGateway : RuntimeScaffoldGateway {
         .sortedBy { it.platform }
     } catch (_: SkillBillRuntimeException) {
       emptyList()
+    }
+  }
+
+  private fun baselineReviewCatalog(session: RepoSession?): DesktopBaselineCatalog {
+    val packsRoot = platformPacksRoot(session) ?: return DesktopBaselineCatalog()
+    return try {
+      val catalog = ScaffoldCatalog.discoverBaselineReviewCatalog(packsRoot)
+      DesktopBaselineCatalog(
+        packs = catalog.packs.map { pack ->
+          BaselineReviewPackOption(
+            platform = pack.platform,
+            displayName = pack.displayName,
+            strongRoutingSignals = pack.strongRoutingSignals,
+            skills = pack.skills.map { skill ->
+              BaselineReviewSkillOption(
+                name = skill.name,
+                supportedModes = skill.supportedModes,
+                supportedScopes = skill.supportedScopes,
+              )
+            },
+          )
+        },
+        edges = catalog.compositionEdges.map { edge ->
+          BaselineReviewCompositionEdge(
+            sourcePlatform = edge.sourcePlatform,
+            targetPlatform = edge.targetPlatform,
+            targetSkill = edge.targetSkill,
+          )
+        },
+        suggestions = catalog.layerSuggestions.map { suggestion ->
+          BaselineReviewLayerSuggestion(
+            label = suggestion.label,
+            triggerSignals = suggestion.triggerSignals,
+            platform = suggestion.platform,
+            skill = suggestion.skill,
+            scope = suggestion.scope,
+            required = suggestion.required,
+            mode = suggestion.mode,
+          )
+        },
+      )
+    } catch (_: SkillBillRuntimeException) {
+      DesktopBaselineCatalog()
+    }
+  }
+
+  private fun platformPacksRoot(session: RepoSession?): Path? {
+    val repoPath = session?.takeIf { it.isRecognizedSkillBillRepo }?.repoPath?.trim().orEmpty()
+    if (repoPath.isEmpty()) {
+      return null
+    }
+    return try {
+      Path.of(repoPath).toAbsolutePath().normalize().resolve("platform-packs")
+    } catch (_: InvalidPathException) {
+      null
     }
   }
 
@@ -134,6 +196,9 @@ private fun ScaffoldResult.toPlan(): ScaffoldPlan = ScaffoldPlan(
   skillPath = skillPath.toPortableString(),
   createdFiles = createdFiles.map(Path::toPortableString),
   manifestEdits = manifestEdits.map(Path::toPortableString),
+  manifestPreviews = manifestPreviews.entries
+    .sortedBy { (path, _) -> path.toPortableString() }
+    .map { (path, preview) -> ManifestEditPreview(path = path.toPortableString(), content = preview) },
   symlinks = symlinks.map(Path::toPortableString),
   installTargets = installTargets.map(Path::toPortableString),
   notes = notes,

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmRuntimeScaffoldGatewayTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmRuntimeScaffoldGatewayTest.kt
@@ -11,6 +11,7 @@ import skillbill.error.InvalidScaffoldPayloadError
 import skillbill.error.MissingRequiredSectionError
 import skillbill.error.ScaffoldRollbackError
 import skillbill.scaffold.model.ScaffoldResult
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -203,6 +204,7 @@ class JvmRuntimeScaffoldGatewayTest {
     assertTrue(snapshot.shelledFamilies.contains("code-review"))
     assertTrue(snapshot.platformPackPresets.any { it.platform == "java" })
     assertTrue(snapshot.pilotedPlatformPacks.isEmpty())
+    assertTrue(snapshot.baselineReviewPacks.isEmpty())
   }
 
   @Test
@@ -216,7 +218,83 @@ class JvmRuntimeScaffoldGatewayTest {
 
     val snapshot = gateway.catalogSnapshot(session)
     assertTrue(snapshot.pilotedPlatformPacks.isEmpty())
+    assertTrue(snapshot.baselineReviewPacks.isEmpty())
     assertTrue(snapshot.approvedCodeReviewAreas.isNotEmpty())
+  }
+
+  @Test
+  fun `catalog snapshot maps baseline review catalog from manifests`() = runBlocking {
+    val repoRoot = Files.createTempDirectory("skillbill-baseline-catalog")
+    val packsRoot = repoRoot.resolve("platform-packs")
+    Files.createDirectories(packsRoot.resolve("kotlin"))
+    Files.createDirectories(packsRoot.resolve("docs"))
+    Files.writeString(
+      packsRoot.resolve("kotlin/platform.yaml"),
+      """
+      platform: kotlin
+      contract_version: "1.1"
+      display_name: Kotlin
+      routing_signals:
+        strong:
+          - ".kt"
+        tie_breakers: []
+      declared_code_review_areas: []
+      declared_files:
+        baseline: code-review/bill-kotlin-code-review/content.md
+        areas: {}
+      area_metadata: {}
+      """.trimIndent(),
+    )
+    Files.writeString(
+      packsRoot.resolve("docs/platform.yaml"),
+      """
+      platform: docs
+      contract_version: "1.1"
+      display_name: Docs
+      routing_signals:
+        strong:
+          - "docs/"
+        tie_breakers: []
+      declared_code_review_areas: []
+      area_metadata: {}
+      """.trimIndent(),
+    )
+    val gateway = JvmRuntimeScaffoldGateway()
+    val session = RepoSession(
+      repoPath = repoRoot.toString(),
+      isRecognizedSkillBillRepo = true,
+      loadStatus = RepoLoadStatus(state = RepoLoadState.LOADED, message = "Loaded"),
+    )
+
+    val snapshot = gateway.catalogSnapshot(session)
+
+    assertEquals(listOf("docs", "kotlin"), snapshot.pilotedPlatformPacks.map { it.platform })
+    assertEquals(listOf("kotlin"), snapshot.baselineReviewPacks.map { it.platform })
+    val kotlinSkill = snapshot.baselineReviewPacks.single().skills.single { it.name == "bill-kotlin-code-review" }
+    assertEquals(listOf("kmp-baseline"), kotlinSkill.supportedModes)
+    assertEquals(listOf("same-review-scope"), kotlinSkill.supportedScopes)
+  }
+
+  @Test
+  fun `dryRun maps manifest previews into scaffold plan`() = runBlocking {
+    val gateway = JvmRuntimeScaffoldGateway().apply {
+      scaffolder = { _, _ ->
+        ScaffoldResult(
+          kind = "platform-pack",
+          skillName = "bill-kmp-code-review",
+          skillPath = Path.of("/repo/platform-packs/kmp"),
+          manifestPreviews = mapOf(
+            Path.of("/repo/platform-packs/kmp/platform.yaml") to "code_review_composition:\n  baseline_layers: []\n",
+          ),
+        )
+      }
+    }
+
+    val result = gateway.dryRun(ScaffoldPayload.PlatformPack(platform = "kmp"))
+
+    val preview = result as ScaffoldRunResult.Preview
+    assertEquals(1, preview.planned.manifestPreviews.size)
+    assertTrue(preview.planned.manifestPreviews.single().content.contains("code_review_composition"))
   }
 
   @Test

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/ScaffoldModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/ScaffoldModels.kt
@@ -84,6 +84,7 @@ sealed class ScaffoldPayload {
     val specialistAreas: List<String> = emptyList(),
     val strongRoutingSignals: List<String> = emptyList(),
     val tieBreakers: List<String> = emptyList(),
+    val baselineLayers: List<ScaffoldBaselineLayerPayload> = emptyList(),
     val subagentSpecialists: List<String> = emptyList(),
     val suppressSubagents: Boolean = false,
     val contentBody: String? = null,
@@ -108,6 +109,17 @@ sealed class ScaffoldPayload {
         if (strongRoutingSignals.isNotEmpty()) routing["strong"] = strongRoutingSignals
         if (tieBreakers.isNotEmpty()) routing["tie_breakers"] = tieBreakers
         target["routing_signals"] = routing
+      }
+      if (baselineLayers.isNotEmpty()) {
+        target["baseline_layers"] = baselineLayers.map { layer ->
+          linkedMapOf<String, Any?>(
+            "platform" to layer.platform,
+            "skill" to layer.skill,
+            "scope" to layer.scope,
+            "required" to layer.required,
+            "mode" to layer.mode,
+          )
+        }
       }
       if (subagentSpecialists.isNotEmpty()) target["subagent_specialists"] = subagentSpecialists
       if (suppressSubagents) target["no_subagents"] = true
@@ -171,6 +183,14 @@ sealed class ScaffoldPayload {
   }
 }
 
+data class ScaffoldBaselineLayerPayload(
+  val platform: String,
+  val skill: String,
+  val scope: String,
+  val required: Boolean,
+  val mode: String,
+)
+
 /**
  * Snapshot of [ScaffoldCatalog] entries exposed to the wizard UI. Common-main does not have
  * access to runtime-core, so the JVM gateway projects the snapshot at composition time.
@@ -181,6 +201,9 @@ data class ScaffoldCatalogSnapshot(
   val shelledFamilies: List<String>,
   val platformPackPresets: List<PlatformPackPresetEntry>,
   val pilotedPlatformPacks: List<PilotedPlatformPackEntry>,
+  val baselineReviewPacks: List<BaselineReviewPackOption>,
+  val baselineReviewCompositionEdges: List<BaselineReviewCompositionEdge>,
+  val baselineReviewLayerSuggestions: List<BaselineReviewLayerSuggestion>,
   val scaffoldPayloadVersion: String,
 ) {
   companion object {
@@ -190,6 +213,9 @@ data class ScaffoldCatalogSnapshot(
       shelledFamilies = emptyList(),
       platformPackPresets = emptyList(),
       pilotedPlatformPacks = emptyList(),
+      baselineReviewPacks = emptyList(),
+      baselineReviewCompositionEdges = emptyList(),
+      baselineReviewLayerSuggestions = emptyList(),
       scaffoldPayloadVersion = ScaffoldPayload.SCAFFOLD_PAYLOAD_VERSION,
     )
   }
@@ -205,6 +231,35 @@ data class PilotedPlatformPackEntry(
   val displayName: String,
 )
 
+data class BaselineReviewPackOption(
+  val platform: String,
+  val displayName: String,
+  val strongRoutingSignals: List<String>,
+  val skills: List<BaselineReviewSkillOption>,
+)
+
+data class BaselineReviewSkillOption(
+  val name: String,
+  val supportedModes: List<String>,
+  val supportedScopes: List<String>,
+)
+
+data class BaselineReviewCompositionEdge(
+  val sourcePlatform: String,
+  val targetPlatform: String,
+  val targetSkill: String,
+)
+
+data class BaselineReviewLayerSuggestion(
+  val label: String,
+  val triggerSignals: List<String>,
+  val platform: String,
+  val skill: String,
+  val scope: String,
+  val required: Boolean,
+  val mode: String,
+)
+
 /**
  * Mirror of the runtime's `ScaffoldResult` fields, lifted into a common-main-safe DTO so the
  * scaffold preview and success surfaces don't import `java.nio.file.Path` from JVM-only code.
@@ -215,9 +270,15 @@ data class ScaffoldPlan(
   val skillPath: String,
   val createdFiles: List<String> = emptyList(),
   val manifestEdits: List<String> = emptyList(),
+  val manifestPreviews: List<ManifestEditPreview> = emptyList(),
   val symlinks: List<String> = emptyList(),
   val installTargets: List<String> = emptyList(),
   val notes: List<String> = emptyList(),
+)
+
+data class ManifestEditPreview(
+  val path: String,
+  val content: String,
 )
 
 /** Mirror DTO for the `ScaffoldResult` produced by execute mode. Same shape as [ScaffoldPlan]. */

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/ScaffoldWizardState.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/ScaffoldWizardState.kt
@@ -28,6 +28,9 @@ data class ScaffoldWizardState(
   val optionCatalog: ScaffoldCatalogSnapshot = ScaffoldCatalogSnapshot.empty,
   val dryRunPreview: ScaffoldPlan? = null,
   val executionResult: ScaffoldRunResult? = null,
+  val validationErrors: List<String> = emptyList(),
+  val baselineLayerSuggestion: ScaffoldBaselineLayerForm? = null,
+  val baselineLayerSuggestionLabel: String? = null,
   val dirtyRepoWarning: Boolean = false,
   val overrideDirtyRepo: Boolean = false,
   val busy: Boolean = false,
@@ -59,8 +62,22 @@ data class ScaffoldWizardFormFields(
   val specialistAreas: List<String> = emptyList(),
   val strongRoutingSignals: List<String> = emptyList(),
   val tieBreakers: List<String> = emptyList(),
+  val baselineLayers: List<ScaffoldBaselineLayerForm> = emptyList(),
   val subagentSpecialists: List<String> = emptyList(),
   val suppressSubagents: Boolean = false,
   val contentBody: String = "",
   val addonBody: String = "",
 )
+
+data class ScaffoldBaselineLayerForm(
+  val rowId: Long = 0L,
+  val platform: String = "",
+  val skill: String = "",
+  val scope: String = DEFAULT_SCOPE,
+  val required: Boolean = true,
+  val mode: String = "",
+) {
+  companion object {
+    const val DEFAULT_SCOPE: String = "same-review-scope"
+  }
+}

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/agent/history.md
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/agent/history.md
@@ -1,5 +1,15 @@
 # SkillBill desktop feature — history
 
+## [2026-05-22] SKILL-50 desktop-wizard-baseline-layer-authoring
+Areas: runtime-desktop/feature/skillbill, runtime-desktop/core/domain, runtime-desktop/core/data, runtime-core/scaffold, runtime-domain/scaffold
+- Platform-pack scaffold wizard can author baseline review layers through catalog-backed controls, add/edit/remove state, default `same-review-scope`, default `required=true`, and form validation before Plan/Run.
+- Runtime-core owns the baseline review catalog projection: eligible baseline packs, declared review skills, supported modes/scopes, composition edges, and Kotlin baseline suggestions flow through `RuntimeScaffoldGateway`; desktop does not duplicate manifest semantics or write `platform.yaml`.
+- Dry-run plans now carry `manifest_edit_previews`; wizard UI keeps YAML collapsed behind a detail control while showing governed manifest-edit summaries first.
+- Reusable: validation errors live on `ScaffoldWizardState.validationErrors` instead of `ScaffoldRunResult.Failed`, preserving the runtime-failure/rollback contract for actual scaffold calls only.
+- Reusable tests cover real manifest composition-edge projection, gateway catalog mapping, payload parity, validation failures/cycles, Kotlin suggestion eligibility, and Compose callback wiring for baseline controls.
+Feature flag: N/A
+Acceptance criteria: 12/12 implemented
+
 ## [2026-05-21] hide-runtime-contracts-from-desktop-tree
 Areas: runtime-desktop/feature/skillbill, runtime-desktop/core/domain, runtime-desktop/core/data
 - Runtime contract YAMLs under `orchestration/contracts/` are internal implementation details and are no longer surfaced as desktop tree rows; `TreeItemKind.CONTRACT`, contract rendering, and the single-target contract render no-op were removed.

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
@@ -41,6 +41,8 @@ import skillbill.desktop.core.domain.model.RenderSummary
 import skillbill.desktop.core.domain.model.RepoLoadState
 import skillbill.desktop.core.domain.model.RepoLoadStatus
 import skillbill.desktop.core.domain.model.RepoSession
+import skillbill.desktop.core.domain.model.ScaffoldBaselineLayerForm
+import skillbill.desktop.core.domain.model.ScaffoldBaselineLayerPayload
 import skillbill.desktop.core.domain.model.ScaffoldCatalogSnapshot
 import skillbill.desktop.core.domain.model.ScaffoldKind
 import skillbill.desktop.core.domain.model.ScaffoldOutcome
@@ -150,6 +152,7 @@ class SkillBillViewModel(
   private var commandPaletteSelectedResultIndex: Int = 0
   private var scaffoldWizard: ScaffoldWizardState? = null
   private var activeScaffoldToken: Long = 0L
+  private var nextScaffoldBaselineLayerRowId: Long = 1L
 
   // SKILL-46: dialog state for the tree-context-menu Delete affordance and accompanying
   // validate-agent-configs output slice. Tokens follow the same monotonic-increment pattern as
@@ -637,8 +640,11 @@ class SkillBillViewModel(
       selectedResultIndex = commandPaletteSelectedResultIndex,
     )
     commandPaletteSelectedResultIndex = paletteState.selectedResultIndex
+    val suggestedBaselineLayer = scaffoldWizard?.let(::suggestedBaselineLayer)
     val wizardState = scaffoldWizard?.copy(
       dirtyRepoWarning = computeDirtyRepoWarning(capturedSnapshot),
+      baselineLayerSuggestion = suggestedBaselineLayer?.form,
+      baselineLayerSuggestionLabel = suggestedBaselineLayer?.label,
     )
     return state.copy(
       commandPalette = paletteState,
@@ -2160,6 +2166,7 @@ class SkillBillViewModel(
       optionCatalog = snapshot,
       dryRunPreview = null,
       executionResult = null,
+      validationErrors = emptyList(),
       dirtyRepoWarning = computeDirtyRepoWarning(changesSnapshot),
       overrideDirtyRepo = false,
       busy = false,
@@ -2250,6 +2257,7 @@ class SkillBillViewModel(
       formFields = ScaffoldWizardFormFields(),
       dryRunPreview = null,
       executionResult = null,
+      validationErrors = emptyList(),
       overrideDirtyRepo = false,
       busy = false,
     )
@@ -2273,6 +2281,7 @@ class SkillBillViewModel(
     scaffoldWizard = current.copy(
       formFields = updatedFields,
       dryRunPreview = null,
+      validationErrors = emptyList(),
       // Editing the form after a Failed result keeps the banner so the user can read it; clear it
       // only when the success banner is displayed (we never accept further edits in that mode).
       executionResult = current.executionResult.takeIf { it is ScaffoldRunResult.Failed },
@@ -2280,6 +2289,119 @@ class SkillBillViewModel(
     currentState = createState()
     return currentState
   }
+
+  fun addScaffoldBaselineLayer(layer: ScaffoldBaselineLayerForm? = null): SkillBillState {
+    val current = scaffoldWizard ?: return currentState
+    if (current.busy || current.kind != ScaffoldKind.PLATFORM_PACK) {
+      return currentState
+    }
+    val nextLayer = ensureBaselineLayerRowId(layer ?: defaultBaselineLayer(current.optionCatalog))
+    return updateScaffoldForm { fields ->
+      fields.copy(baselineLayers = fields.baselineLayers + nextLayer)
+    }
+  }
+
+  fun editScaffoldBaselineLayer(
+    index: Int,
+    transform: (ScaffoldBaselineLayerForm) -> ScaffoldBaselineLayerForm,
+  ): SkillBillState {
+    val current = scaffoldWizard ?: return currentState
+    if (
+      current.busy ||
+      current.kind != ScaffoldKind.PLATFORM_PACK ||
+      index !in current.formFields.baselineLayers.indices
+    ) {
+      return currentState
+    }
+    return updateScaffoldForm { fields ->
+      fields.copy(
+        baselineLayers = fields.baselineLayers.mapIndexed { layerIndex, layer ->
+          if (layerIndex == index) transform(layer) else layer
+        },
+      )
+    }
+  }
+
+  fun removeScaffoldBaselineLayer(index: Int): SkillBillState {
+    val current = scaffoldWizard ?: return currentState
+    if (
+      current.busy ||
+      current.kind != ScaffoldKind.PLATFORM_PACK ||
+      index !in current.formFields.baselineLayers.indices
+    ) {
+      return currentState
+    }
+    return updateScaffoldForm { fields ->
+      fields.copy(baselineLayers = fields.baselineLayers.filterIndexed { layerIndex, _ -> layerIndex != index })
+    }
+  }
+
+  fun addSuggestedScaffoldBaselineLayer(): SkillBillState {
+    val current = scaffoldWizard ?: return currentState
+    if (current.busy || current.kind != ScaffoldKind.PLATFORM_PACK) {
+      return currentState
+    }
+    val suggestion = suggestedBaselineLayer(current)?.form ?: return currentState
+    return addScaffoldBaselineLayer(suggestion)
+  }
+
+  private fun defaultBaselineLayer(catalog: ScaffoldCatalogSnapshot): ScaffoldBaselineLayerForm {
+    val pack = catalog.baselineReviewPacks.firstOrNull()
+    val skill = pack?.skills?.firstOrNull()
+    return ScaffoldBaselineLayerForm(
+      platform = pack?.platform.orEmpty(),
+      skill = skill?.name.orEmpty(),
+      mode = skill?.supportedModes?.firstOrNull().orEmpty(),
+      scope = skill?.supportedScopes?.firstOrNull() ?: ScaffoldBaselineLayerForm.DEFAULT_SCOPE,
+      required = true,
+    )
+  }
+
+  private data class SuggestedBaselineLayer(
+    val label: String,
+    val form: ScaffoldBaselineLayerForm,
+  )
+
+  private fun suggestedBaselineLayer(wizard: ScaffoldWizardState): SuggestedBaselineLayer? {
+    if (wizard.kind != ScaffoldKind.PLATFORM_PACK) return null
+    return wizard.optionCatalog.baselineReviewLayerSuggestions.firstOrNull { suggestion ->
+      suggestion.matches(wizard.formFields) &&
+        wizard.formFields.baselineLayers.none { layer ->
+          layer.platform == suggestion.platform && layer.skill == suggestion.skill
+        }
+    }?.let { suggestion ->
+      SuggestedBaselineLayer(
+        label = suggestion.label,
+        form = ScaffoldBaselineLayerForm(
+          platform = suggestion.platform,
+          skill = suggestion.skill,
+          scope = suggestion.scope,
+          required = suggestion.required,
+          mode = suggestion.mode,
+        ),
+      )
+    }
+  }
+
+  private fun skillbill.desktop.core.domain.model.BaselineReviewLayerSuggestion.matches(
+    fields: ScaffoldWizardFormFields,
+  ): Boolean {
+    val haystack = (
+      listOf(fields.platform, fields.displayName, fields.description) +
+        fields.strongRoutingSignals +
+        fields.tieBreakers
+      )
+      .joinToString(separator = " ")
+      .lowercase()
+    return triggerSignals.any { signal -> signal.lowercase() in haystack }
+  }
+
+  private fun ensureBaselineLayerRowId(layer: ScaffoldBaselineLayerForm): ScaffoldBaselineLayerForm =
+    if (layer.rowId != 0L) {
+      layer
+    } else {
+      layer.copy(rowId = nextScaffoldBaselineLayerRowId++)
+    }
 
   fun setScaffoldDirtyOverride(override: Boolean): SkillBillState {
     val current = scaffoldWizard ?: return currentState
@@ -2570,6 +2692,11 @@ class SkillBillViewModel(
     if (!isScaffoldPlanAllowed(current)) {
       return null
     }
+    val validationErrors = validateScaffoldWizard(current)
+    if (validationErrors.isNotEmpty()) {
+      failScaffoldFormValidation(current, validationErrors)
+      return null
+    }
     val payload = buildScaffoldPayload(current) ?: return null
     activeScaffoldToken += 1
     scaffoldWizard = current.copy(busy = true, dryRunPreview = null, executionResult = null)
@@ -2629,6 +2756,11 @@ class SkillBillViewModel(
   fun beginScaffoldExecute(): ScaffoldRunRequest? {
     val current = scaffoldWizard ?: return null
     if (!current.runEnabled || !canStartScaffoldAction()) {
+      return null
+    }
+    val validationErrors = validateScaffoldWizard(current)
+    if (validationErrors.isNotEmpty()) {
+      failScaffoldFormValidation(current, validationErrors)
       return null
     }
     val payload = buildScaffoldPayload(current) ?: return null
@@ -2739,6 +2871,97 @@ class SkillBillViewModel(
     !pushBusy &&
     !changesBusy
 
+  private fun failScaffoldFormValidation(current: ScaffoldWizardState, errors: List<String>) {
+    scaffoldWizard = current.copy(
+      dryRunPreview = null,
+      validationErrors = errors,
+      executionResult = null,
+    )
+    currentState = createState()
+  }
+
+  private fun validateScaffoldWizard(wizard: ScaffoldWizardState): List<String> = buildList {
+    val fields = wizard.formFields
+    when (wizard.kind) {
+      ScaffoldKind.HORIZONTAL_SKILL -> if (fields.name.isBlank()) add("Skill name is required.")
+      ScaffoldKind.PLATFORM_PACK -> {
+        if (fields.platform.isBlank()) add("Platform slug is required.")
+        addAll(validateBaselineLayers(wizard))
+      }
+      ScaffoldKind.PLATFORM_OVERRIDE_PILOTED -> {
+        if (fields.platform.isBlank()) add("Platform is required.")
+        if (fields.family.isBlank()) add("Family is required.")
+      }
+      ScaffoldKind.CODE_REVIEW_AREA -> {
+        if (fields.platform.isBlank()) add("Platform is required.")
+        if (fields.area.isBlank()) add("Code-review area is required.")
+      }
+      ScaffoldKind.ADD_ON -> {
+        if (fields.name.isBlank()) add("Add-on name is required.")
+        if (fields.platform.isBlank()) add("Owning platform pack is required.")
+      }
+    }
+  }
+
+  private fun validateBaselineLayers(wizard: ScaffoldWizardState): List<String> = buildList {
+    val newPlatform = wizard.formFields.platform.trim()
+    val catalog = wizard.optionCatalog
+    val packsBySlug = catalog.baselineReviewPacks.associateBy { it.platform }
+    val seen = mutableSetOf<Pair<String, String>>()
+
+    wizard.formFields.baselineLayers.forEachIndexed { index, layer ->
+      val label = "Baseline layer ${index + 1}"
+      val platform = layer.platform.trim()
+      val skillName = layer.skill.trim()
+      if (platform.isBlank()) {
+        add("$label: baseline pack is required.")
+        return@forEachIndexed
+      }
+      val pack = packsBySlug[platform]
+      if (pack == null) {
+        add("$label: baseline pack '$platform' is not available or has no declared code-review baseline.")
+        return@forEachIndexed
+      }
+      if (skillName.isBlank()) {
+        add("$label: baseline skill is required.")
+        return@forEachIndexed
+      }
+      val skill = pack.skills.firstOrNull { it.name == skillName }
+      if (skill == null) {
+        add("$label: baseline skill '$skillName' is not declared by pack '$platform'.")
+        return@forEachIndexed
+      }
+      if (layer.mode !in skill.supportedModes) {
+        add("$label: mode '${layer.mode}' is not supported by '$platform/$skillName'.")
+      }
+      if (layer.scope !in skill.supportedScopes) {
+        add("$label: scope '${layer.scope}' is not supported by '$platform/$skillName'.")
+      }
+      if (!seen.add(platform to skillName)) {
+        add("$label: duplicate baseline layer '$platform/$skillName'.")
+      }
+      if (newPlatform.isNotBlank() && platform == newPlatform) {
+        add("$label: baseline layer self-references the new platform pack '$newPlatform'.")
+      } else if (newPlatform.isNotBlank() && compositionPathExists(catalog, from = platform, to = newPlatform)) {
+        add("$label: adding '$newPlatform -> $platform' would create a code-review composition cycle.")
+      }
+    }
+  }
+
+  private fun compositionPathExists(catalog: ScaffoldCatalogSnapshot, from: String, to: String): Boolean {
+    val graph = catalog.baselineReviewCompositionEdges.groupBy(
+      keySelector = { edge -> edge.sourcePlatform },
+      valueTransform = { edge -> edge.targetPlatform },
+    )
+    val visited = mutableSetOf<String>()
+    fun visit(platform: String): Boolean {
+      if (!visited.add(platform)) return false
+      if (platform == to) return true
+      return graph[platform].orEmpty().any(::visit)
+    }
+    return visit(from)
+  }
+
   private fun buildScaffoldPayload(wizard: ScaffoldWizardState): ScaffoldPayload? {
     val fields = wizard.formFields
     val repoRoot = currentSession?.repoPath?.takeIf { it.isNotBlank() } ?: return null
@@ -2771,6 +2994,15 @@ class SkillBillViewModel(
           specialistAreas = fields.specialistAreas.filter(String::isNotBlank),
           strongRoutingSignals = fields.strongRoutingSignals.filter(String::isNotBlank),
           tieBreakers = fields.tieBreakers.filter(String::isNotBlank),
+          baselineLayers = fields.baselineLayers.map { layer ->
+            ScaffoldBaselineLayerPayload(
+              platform = layer.platform.trim(),
+              skill = layer.skill.trim(),
+              scope = layer.scope.trim(),
+              required = layer.required,
+              mode = layer.mode.trim(),
+            )
+          },
           subagentSpecialists = fields.subagentSpecialists.filter(String::isNotBlank),
           suppressSubagents = fields.suppressSubagents,
           contentBody = fields.contentBody.takeIf { it.isNotBlank() },

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/ScaffoldWizardDialog.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/ScaffoldWizardDialog.kt
@@ -23,11 +23,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,10 +46,35 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import skillbill.desktop.core.designsystem.SkillBillTheme
+import skillbill.desktop.core.domain.model.BaselineReviewSkillOption
+import skillbill.desktop.core.domain.model.ScaffoldBaselineLayerForm
 import skillbill.desktop.core.domain.model.ScaffoldKind
 import skillbill.desktop.core.domain.model.ScaffoldRunResult
 import skillbill.desktop.core.domain.model.ScaffoldWizardFormFields
 import skillbill.desktop.core.domain.model.ScaffoldWizardState
+
+/**
+ * Centralized wizard copy. This module does not currently expose stringResource, so local string
+ * objects are the existing desktop style for keeping user-facing labels in one place.
+ */
+private object ScaffoldWizardStrings {
+  const val BASELINE_SECTION = "Baseline review layers"
+  const val NO_BASELINE_LAYERS = "(none)"
+  const val NO_BASELINE_PACKS = "No baseline review packs available"
+  const val ADD_LAYER = "Add layer"
+  const val ADD_SUGGESTED_BASELINE_PREFIX = "Add"
+  const val REMOVE_LAYER = "Remove"
+  const val BASELINE_PACK = "Baseline pack"
+  const val BASELINE_SKILL = "Baseline skill"
+  const val MODE = "Mode"
+  const val SCOPE = "Scope"
+  const val REQUIRED = "Required"
+  const val REQUIRED_CONTENT_DESCRIPTION = "Required baseline layer"
+  const val VALIDATION_TITLE = "Fix form validation"
+  const val MANIFEST_EDIT_PREVIEWS = "Manifest edit previews"
+  const val SHOW_MANIFEST_YAML = "Show manifest YAML"
+  const val HIDE_MANIFEST_YAML = "Hide manifest YAML"
+}
 
 /**
  * Public callbacks the dialog needs to drive the view model. Hoisting the callbacks here keeps
@@ -55,6 +84,10 @@ import skillbill.desktop.core.domain.model.ScaffoldWizardState
 data class ScaffoldWizardCallbacks(
   val onSelectKind: (ScaffoldKind) -> Unit,
   val onFormChanged: ((ScaffoldWizardFormFields) -> ScaffoldWizardFormFields) -> Unit,
+  val onAddBaselineLayer: () -> Unit,
+  val onAddSuggestedBaselineLayer: () -> Unit,
+  val onEditBaselineLayer: (Int, (ScaffoldBaselineLayerForm) -> ScaffoldBaselineLayerForm) -> Unit,
+  val onRemoveBaselineLayer: (Int) -> Unit,
   val onDirtyOverrideChanged: (Boolean) -> Unit,
   val onPlan: () -> Unit,
   val onRun: () -> Unit,
@@ -106,6 +139,9 @@ fun ScaffoldWizardDialog(
           )
         }
         WizardForm(state = state, callbacks = callbacks)
+        if (state.validationErrors.isNotEmpty()) {
+          ValidationBanner(state.validationErrors)
+        }
         // F-102: a Failed result supersedes the (now-stale) plan; render the failure console only
         // so the user is not led to believe Run is ready to fire. Preview/Success continue to
         // show the plan alongside the banner when relevant.
@@ -291,6 +327,7 @@ private fun WizardForm(state: ScaffoldWizardState, callbacks: ScaffoldWizardCall
           callbacks.onFormChanged { it.copy(skeletonMode = value) }
         },
       )
+      BaselineLayerControls(state = state, callbacks = callbacks)
     }
     ScaffoldKind.PLATFORM_OVERRIDE_PILOTED -> {
       PresetPicker(
@@ -380,6 +417,185 @@ private fun WizardForm(state: ScaffoldWizardState, callbacks: ScaffoldWizardCall
 }
 
 @Composable
+private fun BaselineLayerControls(state: ScaffoldWizardState, callbacks: ScaffoldWizardCallbacks) {
+  val fields = state.formFields
+  val hasBaselinePacks = state.optionCatalog.baselineReviewPacks.isNotEmpty()
+  Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    SectionLabel(ScaffoldWizardStrings.BASELINE_SECTION)
+    if (fields.baselineLayers.isEmpty()) {
+      Text(
+        text = ScaffoldWizardStrings.NO_BASELINE_LAYERS,
+        color = SkillBillTheme.colors.onSurfaceVariant,
+        fontSize = 11.sp,
+      )
+    }
+    fields.baselineLayers.forEachIndexed { index, layer ->
+      key(layer.rowId) {
+        BaselineLayerEditor(
+          index = index,
+          layer = layer,
+          state = state,
+          callbacks = callbacks,
+        )
+      }
+    }
+    if (!hasBaselinePacks) {
+      Text(
+        text = ScaffoldWizardStrings.NO_BASELINE_PACKS,
+        color = SkillBillTheme.colors.onSurfaceVariant,
+        fontSize = 11.sp,
+      )
+    }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      InlineButton(
+        label = ScaffoldWizardStrings.ADD_LAYER,
+        enabled = !state.busy && hasBaselinePacks,
+        onClick = callbacks.onAddBaselineLayer,
+      )
+      if (state.baselineLayerSuggestion != null) {
+        InlineButton(
+          label = "${ScaffoldWizardStrings.ADD_SUGGESTED_BASELINE_PREFIX} " +
+            state.baselineLayerSuggestionLabel.orEmpty(),
+          enabled = !state.busy,
+          onClick = callbacks.onAddSuggestedBaselineLayer,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun BaselineLayerEditor(
+  index: Int,
+  layer: ScaffoldBaselineLayerForm,
+  state: ScaffoldWizardState,
+  callbacks: ScaffoldWizardCallbacks,
+) {
+  val pack = state.optionCatalog.baselineReviewPacks.firstOrNull { it.platform == layer.platform }
+  val skill = pack?.skills?.firstOrNull { it.name == layer.skill }
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .border(1.dp, SkillBillTheme.semanticTones.dialog.border, RoundedCornerShape(6.dp))
+      .padding(horizontal = 10.dp, vertical = 8.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text(
+        text = "Layer ${index + 1}",
+        color = SkillBillTheme.semanticTones.dialog.content,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Medium,
+        modifier = Modifier.weight(1f),
+      )
+      InlineButton(
+        label = ScaffoldWizardStrings.REMOVE_LAYER,
+        enabled = !state.busy,
+        onClick = { callbacks.onRemoveBaselineLayer(index) },
+      )
+    }
+    PresetPicker(
+      label = ScaffoldWizardStrings.BASELINE_PACK,
+      options = state.optionCatalog.baselineReviewPacks.map { option -> option.platform to option.displayName },
+      selected = layer.platform,
+      enabled = !state.busy,
+      onSelected = { platform ->
+        val nextPack = state.optionCatalog.baselineReviewPacks.firstOrNull { it.platform == platform }
+        val nextSkill = nextPack?.skills?.firstOrNull()
+        callbacks.onEditBaselineLayer(index) {
+          it.copy(
+            platform = platform,
+            skill = nextSkill?.name.orEmpty(),
+            mode = nextSkill?.supportedModes?.firstOrNull().orEmpty(),
+            scope = nextSkill?.supportedScopes?.firstOrNull() ?: ScaffoldBaselineLayerForm.DEFAULT_SCOPE,
+          )
+        }
+      },
+    )
+    PresetPicker(
+      label = ScaffoldWizardStrings.BASELINE_SKILL,
+      options = pack?.skills.orEmpty().map { option -> option.name to option.name },
+      selected = layer.skill,
+      enabled = !state.busy && pack != null,
+      onSelected = { skillName ->
+        val nextSkill = pack?.skills?.firstOrNull { it.name == skillName }
+        callbacks.onEditBaselineLayer(index) {
+          it.copy(
+            skill = skillName,
+            mode = nextSkill?.supportedModes?.firstOrNull().orEmpty(),
+            scope = nextSkill?.supportedScopes?.firstOrNull() ?: ScaffoldBaselineLayerForm.DEFAULT_SCOPE,
+          )
+        }
+      },
+    )
+    ModeAndScopeRow(
+      index = index,
+      layer = layer,
+      skill = skill,
+      enabled = !state.busy && skill != null,
+      callbacks = callbacks,
+    )
+  }
+}
+
+@Composable
+private fun ModeAndScopeRow(
+  index: Int,
+  layer: ScaffoldBaselineLayerForm,
+  skill: BaselineReviewSkillOption?,
+  enabled: Boolean,
+  callbacks: ScaffoldWizardCallbacks,
+) {
+  Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.Top) {
+    Box(modifier = Modifier.weight(1f)) {
+      PresetPicker(
+        label = ScaffoldWizardStrings.MODE,
+        options = skill?.supportedModes.orEmpty().map { mode -> mode to mode },
+        selected = layer.mode,
+        enabled = enabled,
+        onSelected = { mode ->
+          callbacks.onEditBaselineLayer(index) { it.copy(mode = mode) }
+        },
+      )
+    }
+    Box(modifier = Modifier.weight(1f)) {
+      PresetPicker(
+        label = ScaffoldWizardStrings.SCOPE,
+        options = skill?.supportedScopes.orEmpty().map { scope -> scope to scope },
+        selected = layer.scope,
+        enabled = enabled,
+        onSelected = { scope ->
+          callbacks.onEditBaselineLayer(index) { it.copy(scope = scope) }
+        },
+      )
+    }
+    RequiredToggle(
+      required = layer.required,
+      enabled = enabled,
+      onToggle = {
+        callbacks.onEditBaselineLayer(index) { it.copy(required = !it.required) }
+      },
+    )
+  }
+}
+
+@Composable
+private fun RequiredToggle(required: Boolean, enabled: Boolean, onToggle: () -> Unit) {
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+    SectionLabel(ScaffoldWizardStrings.REQUIRED)
+    Checkbox(
+      checked = required,
+      enabled = enabled,
+      onCheckedChange = { onToggle() },
+      modifier = Modifier.semantics {
+        contentDescription = ScaffoldWizardStrings.REQUIRED_CONTENT_DESCRIPTION
+      },
+    )
+  }
+}
+
+@Composable
 private fun SectionLabel(text: String) {
   Text(
     text = text,
@@ -450,7 +666,10 @@ private fun PresetPicker(
         fontSize = 11.sp,
       )
     } else {
-      Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+      ) {
         options.forEach { (value, display) ->
           val isSelected = value == selected
           val backgroundColor = if (isSelected) colors.primary else colors.surfaceVariant
@@ -497,9 +716,62 @@ private fun PlanPreview(plan: skillbill.desktop.core.domain.model.ScaffoldPlan) 
     )
     PreviewSection(label = "Planned files", lines = plan.createdFiles)
     PreviewSection(label = "Manifest edits", lines = plan.manifestEdits)
+    ManifestPreviewSection(plan.manifestPreviews)
     PreviewSection(label = "Symlinks", lines = plan.symlinks)
     PreviewSection(label = "Install targets", lines = plan.installTargets)
     PreviewSection(label = "Notes", lines = plan.notes)
+  }
+}
+
+@Composable
+private fun ManifestPreviewSection(previews: List<skillbill.desktop.core.domain.model.ManifestEditPreview>) {
+  if (previews.isEmpty()) return
+  val colors = SkillBillTheme.colors
+  val dialogTone = SkillBillTheme.semanticTones.dialog
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Text(
+      text = ScaffoldWizardStrings.MANIFEST_EDIT_PREVIEWS,
+      color = colors.onSurfaceVariant,
+      fontSize = 10.5.sp,
+      fontFamily = FontFamily.Monospace,
+    )
+    previews.forEach { preview ->
+      var expanded by remember(preview.path) { mutableStateOf(false) }
+      Text(
+        text = preview.path,
+        color = dialogTone.content,
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+      InlineButton(
+        label = if (expanded) {
+          ScaffoldWizardStrings.HIDE_MANIFEST_YAML
+        } else {
+          ScaffoldWizardStrings.SHOW_MANIFEST_YAML
+        },
+        enabled = true,
+        onClick = { expanded = !expanded },
+      )
+      if (expanded) {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(4.dp))
+            .background(SkillBillTheme.colors.background)
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        ) {
+          Text(
+            text = preview.content,
+            color = SkillBillTheme.colors.onBackground,
+            fontSize = 10.5.sp,
+            fontFamily = FontFamily.Monospace,
+          )
+        }
+      }
+    }
   }
 }
 
@@ -523,6 +795,34 @@ private fun PreviewSection(label: String, lines: List<String>) {
         fontFamily = FontFamily.Monospace,
         maxLines = 2,
         overflow = TextOverflow.Ellipsis,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ValidationBanner(errors: List<String>) {
+  val tone = SkillBillTheme.semanticTones.warningBanner
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(6.dp))
+      .border(1.dp, tone.border, RoundedCornerShape(6.dp))
+      .background(tone.container)
+      .padding(horizontal = 12.dp, vertical = 10.dp),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    Text(
+      text = ScaffoldWizardStrings.VALIDATION_TITLE,
+      color = tone.content,
+      fontSize = 12.sp,
+      fontWeight = FontWeight.Medium,
+    )
+    errors.forEach { error ->
+      Text(
+        text = error,
+        color = tone.content,
+        fontSize = 11.sp,
       )
     }
   }
@@ -693,6 +993,24 @@ private fun WizardFooter(
       onClick = onRun,
     )
   }
+}
+
+@Composable
+private fun InlineButton(label: String, enabled: Boolean, onClick: () -> Unit) {
+  val colors = SkillBillTheme.colors
+  val dialogTone = SkillBillTheme.semanticTones.dialog
+  Text(
+    text = label,
+    color = if (enabled) dialogTone.content else colors.onSurfaceVariant,
+    fontSize = 11.sp,
+    modifier = Modifier
+      .clip(RoundedCornerShape(6.dp))
+      .border(1.dp, dialogTone.border, RoundedCornerShape(6.dp))
+      .background(colors.surfaceVariant)
+      .semantics { contentDescription = label }
+      .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
+      .padding(horizontal = 10.dp, vertical = 6.dp),
+  )
 }
 
 @Composable

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillRoute.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillRoute.kt
@@ -861,6 +861,18 @@ fun SkillBillRoute(
       onFormChanged = { transform ->
         state = viewModel.updateScaffoldForm(transform)
       },
+      onAddBaselineLayer = {
+        state = viewModel.addScaffoldBaselineLayer()
+      },
+      onAddSuggestedBaselineLayer = {
+        state = viewModel.addSuggestedScaffoldBaselineLayer()
+      },
+      onEditBaselineLayer = { index, transform ->
+        state = viewModel.editScaffoldBaselineLayer(index, transform)
+      },
+      onRemoveBaselineLayer = { index ->
+        state = viewModel.removeScaffoldBaselineLayer(index)
+      },
       onDirtyOverrideChanged = { override ->
         state = viewModel.setScaffoldDirtyOverride(override)
       },

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelScaffoldTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelScaffoldTest.kt
@@ -1,12 +1,18 @@
 package skillbill.desktop.feature.skillbill.state
 
 import kotlinx.coroutines.runBlocking
+import skillbill.desktop.core.domain.model.BaselineReviewCompositionEdge
+import skillbill.desktop.core.domain.model.BaselineReviewLayerSuggestion
+import skillbill.desktop.core.domain.model.BaselineReviewPackOption
+import skillbill.desktop.core.domain.model.BaselineReviewSkillOption
 import skillbill.desktop.core.domain.model.ChangedFile
 import skillbill.desktop.core.domain.model.ChangedFileGroup
 import skillbill.desktop.core.domain.model.ChangesSnapshot
+import skillbill.desktop.core.domain.model.ManifestEditPreview
 import skillbill.desktop.core.domain.model.RepoLoadState
 import skillbill.desktop.core.domain.model.RepoLoadStatus
 import skillbill.desktop.core.domain.model.RepoSession
+import skillbill.desktop.core.domain.model.ScaffoldBaselineLayerForm
 import skillbill.desktop.core.domain.model.ScaffoldCatalogSnapshot
 import skillbill.desktop.core.domain.model.ScaffoldKind
 import skillbill.desktop.core.domain.model.ScaffoldOutcome
@@ -49,6 +55,9 @@ class SkillBillViewModelScaffoldTest {
         shelledFamilies = listOf("code-review"),
         platformPackPresets = emptyList(),
         pilotedPlatformPacks = emptyList(),
+        baselineReviewPacks = emptyList(),
+        baselineReviewCompositionEdges = emptyList(),
+        baselineReviewLayerSuggestions = emptyList(),
         scaffoldPayloadVersion = "1.0",
       )
     }
@@ -617,6 +626,257 @@ class SkillBillViewModelScaffoldTest {
     assertNull(edited.scaffoldWizard?.dryRunPreview)
   }
 
+  @Test
+  fun `baseline layer add edit and remove mutate platform-pack form before dry-run`() = runBlocking {
+    val gateway = FakeScaffoldGateway().apply { scriptedCatalog = baselineCatalog() }
+    val viewModel = newViewModel(scaffoldGateway = gateway)
+    viewModel.selectRepoPath("/repo")
+    openWizard(viewModel, ScaffoldKind.PLATFORM_PACK)
+
+    val added = viewModel.addScaffoldBaselineLayer()
+    val addedLayer = assertNotNull(added.scaffoldWizard).formFields.baselineLayers.single()
+    assertEquals("kotlin", addedLayer.platform)
+    assertEquals("bill-kotlin-code-review", addedLayer.skill)
+    assertEquals("same-review-scope", addedLayer.scope)
+    assertTrue(addedLayer.required)
+    assertEquals("kmp-baseline", addedLayer.mode)
+
+    val edited = viewModel.editScaffoldBaselineLayer(0) { it.copy(required = false) }
+    assertFalse(assertNotNull(edited.scaffoldWizard).formFields.baselineLayers.single().required)
+
+    val removed = viewModel.removeScaffoldBaselineLayer(0)
+    assertTrue(assertNotNull(removed.scaffoldWizard).formFields.baselineLayers.isEmpty())
+  }
+
+  @Test
+  fun `platform-pack baseline layers map into payload and preserve dry-run execute parity`() = runBlocking {
+    val gateway = FakeScaffoldGateway().apply {
+      scriptedCatalog = baselineCatalog()
+      scriptDryRun(
+        ScaffoldKind.PLATFORM_PACK,
+        ScaffoldRunResult.Preview(
+          planned = ScaffoldPlan(kind = "platform-pack", skillName = "bill-kmp-code-review", skillPath = "/x"),
+        ),
+      )
+      scriptExecute(
+        ScaffoldKind.PLATFORM_PACK,
+        ScaffoldRunResult.Success(
+          result = ScaffoldOutcome(kind = "platform-pack", skillName = "bill-kmp-code-review", skillPath = "/x"),
+        ),
+      )
+    }
+    val viewModel = newViewModel(scaffoldGateway = gateway)
+    viewModel.selectRepoPath("/repo")
+    openWizard(viewModel, ScaffoldKind.PLATFORM_PACK)
+    viewModel.updateScaffoldForm { it.copy(platform = "kmp", displayName = "KMP") }
+    viewModel.addScaffoldBaselineLayer()
+
+    val planRequest = assertNotNull(viewModel.beginScaffoldDryRun())
+    viewModel.finishScaffoldDryRun(planRequest, viewModel.runScaffoldDryRun(planRequest))
+    val executeRequest = assertNotNull(viewModel.beginScaffoldExecute())
+    viewModel.runScaffoldExecute(executeRequest)
+
+    val dryRunPayload = planRequest.payload.toContractMap()
+    val executePayload = executeRequest.payload.toContractMap()
+    assertEquals(dryRunPayload, executePayload)
+    val layers = dryRunPayload["baseline_layers"] as List<*>
+    val layer = layers.single() as Map<*, *>
+    assertEquals("kotlin", layer["platform"])
+    assertEquals("bill-kotlin-code-review", layer["skill"])
+    assertEquals("same-review-scope", layer["scope"])
+    assertEquals(true, layer["required"])
+    assertEquals("kmp-baseline", layer["mode"])
+  }
+
+  @Test
+  fun `baseline validation blocks invalid layers before dry-run`() = runBlocking {
+    val cases = listOf(
+      ScaffoldBaselineLayerForm(platform = "", skill = "bill-kotlin-code-review", mode = "kmp-baseline") to
+        "baseline pack is required",
+      ScaffoldBaselineLayerForm(platform = "missing", skill = "bill-kotlin-code-review", mode = "kmp-baseline") to
+        "is not available or has no declared code-review baseline",
+      ScaffoldBaselineLayerForm(platform = "kotlin", skill = "", mode = "kmp-baseline") to
+        "baseline skill is required",
+      ScaffoldBaselineLayerForm(platform = "kotlin", skill = "missing", mode = "kmp-baseline") to
+        "baseline skill 'missing' is not declared",
+      ScaffoldBaselineLayerForm(platform = "kotlin", skill = "bill-kotlin-code-review", mode = "unsupported") to
+        "mode 'unsupported' is not supported",
+      ScaffoldBaselineLayerForm(
+        platform = "kotlin",
+        skill = "bill-kotlin-code-review",
+        scope = "unsupported",
+        mode = "kmp-baseline",
+      ) to "scope 'unsupported' is not supported",
+    )
+
+    cases.forEach { (layer, expectedMessage) ->
+      val gateway = FakeScaffoldGateway().apply { scriptedCatalog = baselineCatalog() }
+      val viewModel = newViewModel(scaffoldGateway = gateway)
+      viewModel.selectRepoPath("/repo")
+      openWizard(viewModel, ScaffoldKind.PLATFORM_PACK)
+      viewModel.updateScaffoldForm { it.copy(platform = "kmp", baselineLayers = listOf(layer)) }
+
+      assertNull(viewModel.beginScaffoldDryRun(), expectedMessage)
+      val wizard = assertNotNull(viewModel.state().scaffoldWizard)
+      assertNull(wizard.executionResult)
+      assertTrue(wizard.validationErrors.any { it.contains(expectedMessage) }, wizard.validationErrors.toString())
+      assertEquals(0, gateway.dryRunCallCount)
+    }
+  }
+
+  @Test
+  fun `baseline validation blocks duplicate layers and local cycles`() = runBlocking {
+    val duplicateGateway = FakeScaffoldGateway().apply { scriptedCatalog = baselineCatalog() }
+    val duplicateViewModel = newViewModel(scaffoldGateway = duplicateGateway)
+    duplicateViewModel.selectRepoPath("/repo")
+    openWizard(duplicateViewModel, ScaffoldKind.PLATFORM_PACK)
+    val layer = ScaffoldBaselineLayerForm(platform = "kotlin", skill = "bill-kotlin-code-review", mode = "kmp-baseline")
+    duplicateViewModel.updateScaffoldForm { it.copy(platform = "kmp", baselineLayers = listOf(layer, layer)) }
+
+    assertNull(duplicateViewModel.beginScaffoldDryRun())
+    val duplicateWizard = assertNotNull(duplicateViewModel.state().scaffoldWizard)
+    assertNull(duplicateWizard.executionResult)
+    assertTrue(duplicateWizard.validationErrors.any { it.contains("duplicate baseline layer") })
+
+    val cycleGateway = FakeScaffoldGateway().apply {
+      scriptedCatalog = baselineCatalog(
+        edges = listOf(
+          BaselineReviewCompositionEdge(
+            sourcePlatform = "kotlin",
+            targetPlatform = "android",
+            targetSkill = "bill-android-code-review",
+          ),
+        ),
+      )
+    }
+    val cycleViewModel = newViewModel(scaffoldGateway = cycleGateway)
+    cycleViewModel.selectRepoPath("/repo")
+    openWizard(cycleViewModel, ScaffoldKind.PLATFORM_PACK)
+    cycleViewModel.updateScaffoldForm { it.copy(platform = "android", baselineLayers = listOf(layer)) }
+
+    assertNull(cycleViewModel.beginScaffoldDryRun())
+    val cycleWizard = assertNotNull(cycleViewModel.state().scaffoldWizard)
+    assertNull(cycleWizard.executionResult)
+    assertTrue(
+      cycleWizard.validationErrors.any {
+        it.contains("composition cycle")
+      },
+      cycleWizard.validationErrors.toString(),
+    )
+  }
+
+  @Test
+  fun `KMP-like platform suggests Kotlin baseline only when eligible Kotlin pack is cataloged`() = runBlocking {
+    val gateway = FakeScaffoldGateway().apply { scriptedCatalog = baselineCatalog() }
+    val viewModel = newViewModel(scaffoldGateway = gateway)
+    viewModel.selectRepoPath("/repo")
+    openWizard(viewModel, ScaffoldKind.PLATFORM_PACK)
+
+    val suggested = viewModel.updateScaffoldForm { it.copy(platform = "android") }
+    val suggestedWizard = assertNotNull(suggested.scaffoldWizard)
+    val suggestion = assertNotNull(suggestedWizard.baselineLayerSuggestion)
+    assertEquals("Kotlin baseline", suggestedWizard.baselineLayerSuggestionLabel)
+    assertEquals("kotlin", suggestion.platform)
+    assertEquals("bill-kotlin-code-review", suggestion.skill)
+
+    val afterAdd = viewModel.addSuggestedScaffoldBaselineLayer()
+    val added = assertNotNull(afterAdd.scaffoldWizard).formFields.baselineLayers.single()
+    assertEquals("kotlin", added.platform)
+    assertEquals("bill-kotlin-code-review", added.skill)
+    assertEquals("same-review-scope", added.scope)
+    assertTrue(added.required)
+    assertEquals("kmp-baseline", added.mode)
+    assertTrue(added.rowId > 0)
+    assertNull(afterAdd.scaffoldWizard?.baselineLayerSuggestion)
+
+    val noKotlinGateway = FakeScaffoldGateway().apply { scriptedCatalog = ScaffoldCatalogSnapshot.empty }
+    val noKotlinViewModel = newViewModel(scaffoldGateway = noKotlinGateway)
+    noKotlinViewModel.selectRepoPath("/repo")
+    openWizard(noKotlinViewModel, ScaffoldKind.PLATFORM_PACK)
+    val noSuggestion = noKotlinViewModel.updateScaffoldForm { it.copy(platform = "android") }
+    assertNull(noSuggestion.scaffoldWizard?.baselineLayerSuggestion)
+  }
+
+  @Test
+  fun `baseline suggestion is absent when catalog does not publish an eligible recommendation`() = runBlocking {
+    val cases = listOf(
+      baselineCatalog(includeSuggestion = false),
+      baselineCatalog(
+        skills = listOf(
+          BaselineReviewSkillOption(
+            name = "bill-kotlin-code-review",
+            supportedModes = emptyList(),
+            supportedScopes = listOf("same-review-scope"),
+          ),
+        ),
+        includeSuggestion = false,
+      ),
+      baselineCatalog(
+        skills = listOf(
+          BaselineReviewSkillOption(
+            name = "bill-kotlin-code-review",
+            supportedModes = listOf("kmp-baseline"),
+            supportedScopes = emptyList(),
+          ),
+        ),
+        includeSuggestion = false,
+      ),
+      baselineCatalog(
+        skills = listOf(
+          BaselineReviewSkillOption(
+            name = "bill-not-kotlin-code-review",
+            supportedModes = listOf("kmp-baseline"),
+            supportedScopes = listOf("same-review-scope"),
+          ),
+        ),
+        includeSuggestion = false,
+      ),
+    )
+
+    cases.forEach { catalog ->
+      val gateway = FakeScaffoldGateway().apply { scriptedCatalog = catalog }
+      val viewModel = newViewModel(scaffoldGateway = gateway)
+      viewModel.selectRepoPath("/repo")
+      openWizard(viewModel, ScaffoldKind.PLATFORM_PACK)
+
+      val state = viewModel.updateScaffoldForm { it.copy(platform = "android") }
+
+      assertNull(state.scaffoldWizard?.baselineLayerSuggestion)
+    }
+  }
+
+  @Test
+  fun `dry-run manifest preview display data is retained in wizard state`() = runBlocking {
+    val gateway = FakeScaffoldGateway().apply {
+      scriptDryRun(
+        ScaffoldKind.PLATFORM_PACK,
+        ScaffoldRunResult.Preview(
+          planned = ScaffoldPlan(
+            kind = "platform-pack",
+            skillName = "bill-kmp-code-review",
+            skillPath = "/repo/platform-packs/kmp",
+            manifestPreviews = listOf(
+              ManifestEditPreview(
+                path = "/repo/platform-packs/kmp/platform.yaml",
+                content = "code_review_composition:\n  baseline_layers:\n",
+              ),
+            ),
+          ),
+        ),
+      )
+    }
+    val viewModel = newViewModel(scaffoldGateway = gateway)
+    viewModel.selectRepoPath("/repo")
+    openWizard(viewModel, ScaffoldKind.PLATFORM_PACK)
+    viewModel.updateScaffoldForm { it.copy(platform = "kmp") }
+
+    val request = assertNotNull(viewModel.beginScaffoldDryRun())
+    val finalState = viewModel.finishScaffoldDryRun(request, viewModel.runScaffoldDryRun(request))
+
+    val preview = assertNotNull(finalState.scaffoldWizard?.dryRunPreview)
+    assertTrue(preview.manifestPreviews.single().content.contains("code_review_composition"))
+  }
+
   // ----- helpers -----
 
   /**
@@ -645,6 +905,43 @@ class SkillBillViewModelScaffoldTest {
     ScaffoldKind.CODE_REVIEW_AREA -> fields.copy(platform = "java", area = "security", description = "d")
     ScaffoldKind.ADD_ON -> fields.copy(name = "bill-addon", platform = "java", description = "d")
   }
+
+  private fun baselineCatalog(
+    edges: List<BaselineReviewCompositionEdge> = emptyList(),
+    skills: List<BaselineReviewSkillOption> = listOf(
+      BaselineReviewSkillOption(
+        name = "bill-kotlin-code-review",
+        supportedModes = listOf("kmp-baseline"),
+        supportedScopes = listOf("same-review-scope"),
+      ),
+    ),
+    includeSuggestion: Boolean = true,
+  ): ScaffoldCatalogSnapshot = ScaffoldCatalogSnapshot.empty.copy(
+    baselineReviewPacks = listOf(
+      BaselineReviewPackOption(
+        platform = "kotlin",
+        displayName = "Kotlin",
+        strongRoutingSignals = listOf(".kt"),
+        skills = skills,
+      ),
+    ),
+    baselineReviewCompositionEdges = edges,
+    baselineReviewLayerSuggestions = if (includeSuggestion) {
+      listOf(
+        BaselineReviewLayerSuggestion(
+          label = "Kotlin baseline",
+          triggerSignals = listOf("android", "kmp"),
+          platform = "kotlin",
+          skill = "bill-kotlin-code-review",
+          scope = "same-review-scope",
+          required = true,
+          mode = "kmp-baseline",
+        ),
+      )
+    } else {
+      emptyList()
+    },
+  )
 
   private fun newViewModel(
     repoSessionService: RepoSessionService = FakeRepoSessionService(),

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillFrameScaffoldWizardTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillFrameScaffoldWizardTest.kt
@@ -1,5 +1,21 @@
 package skillbill.desktop.feature.skillbill.ui
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import skillbill.desktop.core.domain.model.BaselineReviewLayerSuggestion
+import skillbill.desktop.core.domain.model.BaselineReviewPackOption
+import skillbill.desktop.core.domain.model.BaselineReviewSkillOption
+import skillbill.desktop.core.domain.model.ManifestEditPreview
+import skillbill.desktop.core.domain.model.ScaffoldBaselineLayerForm
 import skillbill.desktop.core.domain.model.ScaffoldCatalogSnapshot
 import skillbill.desktop.core.domain.model.ScaffoldKind
 import skillbill.desktop.core.domain.model.ScaffoldOutcome
@@ -115,6 +131,12 @@ class SkillBillFrameScaffoldWizardTest {
       skillPath = "/repo/platform-packs/java",
       createdFiles = listOf("/repo/platform-packs/java/platform.yaml"),
       manifestEdits = listOf("/repo/platform-packs/java/platform.yaml"),
+      manifestPreviews = listOf(
+        ManifestEditPreview(
+          path = "/repo/platform-packs/java/platform.yaml",
+          content = "code_review_composition:\n  baseline_layers:\n",
+        ),
+      ),
       symlinks = emptyList(),
       installTargets = listOf("/repo/platform-packs/java/code-review/bill-java-code-review"),
       notes = listOf("Dry run - no filesystem changes applied."),
@@ -123,6 +145,7 @@ class SkillBillFrameScaffoldWizardTest {
     val preview = assertNotNull(state.dryRunPreview)
     assertEquals(1, preview.createdFiles.size)
     assertEquals(1, preview.manifestEdits.size)
+    assertTrue(preview.manifestPreviews.single().content.contains("code_review_composition"))
     assertEquals(1, preview.installTargets.size)
     assertEquals(1, preview.notes.size)
   }
@@ -134,7 +157,150 @@ class SkillBillFrameScaffoldWizardTest {
     assertEquals("", fields.platform)
     assertEquals("full", fields.skeletonMode)
     assertTrue(fields.specialistAreas.isEmpty())
+    assertTrue(fields.baselineLayers.isEmpty())
     assertFalse(fields.suppressSubagents)
+  }
+
+  @Test
+  fun `baseline layer form defaults match scaffold payload contract defaults`() {
+    val layer = ScaffoldBaselineLayerForm()
+    assertEquals("same-review-scope", layer.scope)
+    assertTrue(layer.required)
+    assertEquals("", layer.platform)
+    assertEquals("", layer.skill)
+    assertEquals("", layer.mode)
+  }
+
+  @Test
+  fun `baseline catalog state carries constrained mode and scope options`() {
+    val state = ScaffoldWizardState(
+      kind = ScaffoldKind.PLATFORM_PACK,
+      optionCatalog = ScaffoldCatalogSnapshot.empty.copy(
+        baselineReviewPacks = listOf(
+          BaselineReviewPackOption(
+            platform = "kotlin",
+            displayName = "Kotlin",
+            strongRoutingSignals = listOf(".kt"),
+            skills = listOf(
+              BaselineReviewSkillOption(
+                name = "bill-kotlin-code-review",
+                supportedModes = listOf("kmp-baseline"),
+                supportedScopes = listOf("same-review-scope"),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+    val skill = state.optionCatalog.baselineReviewPacks.single().skills.single()
+    assertEquals(listOf("kmp-baseline"), skill.supportedModes)
+    assertEquals(listOf("same-review-scope"), skill.supportedScopes)
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun `baseline layer controls wire add suggested remove required mode and scope callbacks`() = runComposeUiTest {
+    var addLayerCalls = 0
+    var addSuggestedCalls = 0
+    var editCalls = 0
+    var removeCalls = 0
+    val catalog = baselineCatalog()
+
+    setContent {
+      var dialogState by remember {
+        mutableStateOf(
+          ScaffoldWizardState(
+            kind = ScaffoldKind.PLATFORM_PACK,
+            optionCatalog = catalog,
+            baselineLayerSuggestion = ScaffoldBaselineLayerForm(
+              platform = "kotlin",
+              skill = "bill-kotlin-code-review",
+              mode = "kmp-baseline",
+            ),
+            baselineLayerSuggestionLabel = "Kotlin baseline",
+          ),
+        )
+      }
+      ScaffoldWizardDialog(
+        state = dialogState,
+        canStartScaffoldAction = true,
+        callbacks = ScaffoldWizardCallbacks(
+          onSelectKind = {},
+          onFormChanged = { transform ->
+            dialogState = dialogState.copy(
+              formFields = transform(dialogState.formFields),
+            )
+          },
+          onAddBaselineLayer = {
+            addLayerCalls += 1
+            dialogState = dialogState.copy(
+              formFields = dialogState.formFields.copy(
+                baselineLayers = dialogState.formFields.baselineLayers + ScaffoldBaselineLayerForm(
+                  rowId = 1L,
+                  platform = "kotlin",
+                  skill = "bill-kotlin-code-review",
+                  mode = "kmp-baseline",
+                ),
+              ),
+            )
+          },
+          onAddSuggestedBaselineLayer = { addSuggestedCalls += 1 },
+          onEditBaselineLayer = { index, transform ->
+            editCalls += 1
+            dialogState = dialogState.copy(
+              formFields = dialogState.formFields.copy(
+                baselineLayers = dialogState.formFields.baselineLayers.mapIndexed { layerIndex, layer ->
+                  if (layerIndex == index) transform(layer) else layer
+                },
+              ),
+            )
+          },
+          onRemoveBaselineLayer = { index ->
+            removeCalls += 1
+            dialogState = dialogState.copy(
+              formFields = dialogState.formFields.copy(
+                baselineLayers = dialogState.formFields.baselineLayers.filterIndexed { layerIndex, _ ->
+                  layerIndex != index
+                },
+              ),
+            )
+          },
+          onDirtyOverrideChanged = {},
+          onPlan = {},
+          onRun = {},
+          onAcknowledgeFailure = {},
+          onDismiss = {},
+        ),
+      )
+    }
+
+    onNodeWithText("Add layer").performClick()
+    onNodeWithText("Layer 1").assertIsDisplayed()
+    onNodeWithContentDescription("Mode option kmp-baseline").performClick()
+    onNodeWithContentDescription("Scope option same-review-scope").performClick()
+    onNodeWithContentDescription("Required baseline layer").performClick()
+    onNodeWithText("Remove").performClick()
+    onNodeWithText("Add Kotlin baseline").performClick()
+
+    assertEquals(1, addLayerCalls)
+    assertEquals(1, addSuggestedCalls)
+    assertEquals(3, editCalls)
+    assertEquals(1, removeCalls)
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun `baseline add layer control is disabled when no baseline packs are available`() = runComposeUiTest {
+    setContent {
+      ScaffoldWizardDialog(
+        state = ScaffoldWizardState(kind = ScaffoldKind.PLATFORM_PACK, optionCatalog = ScaffoldCatalogSnapshot.empty),
+        canStartScaffoldAction = true,
+        callbacks = noOpScaffoldCallbacks(),
+      )
+    }
+
+    onNodeWithText("No baseline review packs available").assertIsDisplayed()
+    onNodeWithText("Add layer").assertIsNotEnabled()
   }
 
   @Test
@@ -176,4 +342,46 @@ class SkillBillFrameScaffoldWizardTest {
     assertNull(viewModelState)
     assertNotNull(state)
   }
+
+  private fun baselineCatalog(): ScaffoldCatalogSnapshot = ScaffoldCatalogSnapshot.empty.copy(
+    baselineReviewPacks = listOf(
+      BaselineReviewPackOption(
+        platform = "kotlin",
+        displayName = "Kotlin",
+        strongRoutingSignals = listOf(".kt"),
+        skills = listOf(
+          BaselineReviewSkillOption(
+            name = "bill-kotlin-code-review",
+            supportedModes = listOf("kmp-baseline"),
+            supportedScopes = listOf("same-review-scope"),
+          ),
+        ),
+      ),
+    ),
+    baselineReviewLayerSuggestions = listOf(
+      BaselineReviewLayerSuggestion(
+        label = "Kotlin baseline",
+        triggerSignals = listOf("android", "kmp"),
+        platform = "kotlin",
+        skill = "bill-kotlin-code-review",
+        scope = "same-review-scope",
+        required = true,
+        mode = "kmp-baseline",
+      ),
+    ),
+  )
+
+  private fun noOpScaffoldCallbacks(): ScaffoldWizardCallbacks = ScaffoldWizardCallbacks(
+    onSelectKind = {},
+    onFormChanged = { _ -> },
+    onAddBaselineLayer = {},
+    onAddSuggestedBaselineLayer = {},
+    onEditBaselineLayer = { _, _ -> },
+    onRemoveBaselineLayer = {},
+    onDirtyOverrideChanged = {},
+    onPlan = {},
+    onRun = {},
+    onAcknowledgeFailure = {},
+    onDismiss = {},
+  )
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
@@ -88,6 +88,41 @@ data class PlatformManifest(
   val routedSkillName: String? = declaredFiles.baseline?.let { "bill-$slug-code-review" }
 }
 
+data class BaselineReviewCatalog(
+  val packs: List<BaselineReviewPackEntry>,
+  val compositionEdges: List<BaselineReviewCompositionEdge>,
+  val layerSuggestions: List<BaselineReviewLayerSuggestion> = emptyList(),
+)
+
+data class BaselineReviewPackEntry(
+  val platform: String,
+  val displayName: String,
+  val strongRoutingSignals: List<String>,
+  val skills: List<BaselineReviewSkillEntry>,
+)
+
+data class BaselineReviewSkillEntry(
+  val name: String,
+  val supportedModes: List<String>,
+  val supportedScopes: List<String>,
+)
+
+data class BaselineReviewCompositionEdge(
+  val sourcePlatform: String,
+  val targetPlatform: String,
+  val targetSkill: String,
+)
+
+data class BaselineReviewLayerSuggestion(
+  val label: String,
+  val triggerSignals: List<String>,
+  val platform: String,
+  val skill: String,
+  val scope: String,
+  val required: Boolean,
+  val mode: String,
+)
+
 data class GovernedAddonFile(
   val packSlug: String,
   val addonPath: Path,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
@@ -101,6 +101,7 @@ data class ScaffoldResult(
   val skillPath: Path,
   val createdFiles: List<Path> = emptyList(),
   val manifestEdits: List<Path> = emptyList(),
+  val manifestPreviews: Map<Path, String> = emptyMap(),
   val symlinks: List<Path> = emptyList(),
   val installTargets: List<Path> = emptyList(),
   val notes: List<String> = emptyList(),

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
@@ -26,6 +26,36 @@ data class PointerSpec(
   val target: String,
 )
 
+enum class CodeReviewCompositionScope(val wireValue: String) {
+  SameReviewScope("same-review-scope"),
+  ;
+
+  companion object {
+    fun fromWireValue(value: String): CodeReviewCompositionScope? = entries.firstOrNull { it.wireValue == value }
+  }
+}
+
+enum class CodeReviewCompositionMode(val wireValue: String) {
+  KmpBaseline("kmp-baseline"),
+  ;
+
+  companion object {
+    fun fromWireValue(value: String): CodeReviewCompositionMode? = entries.firstOrNull { it.wireValue == value }
+  }
+}
+
+data class CodeReviewBaselineLayer(
+  val platform: String,
+  val skill: String,
+  val scope: CodeReviewCompositionScope,
+  val required: Boolean,
+  val mode: CodeReviewCompositionMode,
+)
+
+data class CodeReviewComposition(
+  val baselineLayers: List<CodeReviewBaselineLayer>,
+)
+
 data class PlatformManifest(
   val slug: String,
   val packRoot: Path,
@@ -37,6 +67,7 @@ data class PlatformManifest(
   val displayName: String? = null,
   val notes: String? = null,
   val declaredQualityCheckFile: Path? = null,
+  val codeReviewComposition: CodeReviewComposition? = null,
   val pointers: List<PointerSpec> = emptyList(),
   /**
    * SKILL-48 Subtask 3: carries every non-anchored top-level field from `platform.yaml`


### PR DESCRIPTION
# Summary

Adds the SKILL-50 platform-pack review composition path end to end: manifests can declare baseline review layers, rendered review skills get governed composition instructions, scaffold payloads can write composition, and the desktop platform-pack wizard can author baseline layers without exposing raw manifest editing as the primary path.

- Extends the platform-pack schema and Kotlin manifest loader with strict `code_review_composition.baseline_layers` support, including coherence checks for missing targets, duplicates, self-reference, cycles, and unsupported modes.
- Renders manifest-derived Review Composition guidance before authored review content, preserving required baseline execution while keeping packs without composition free of generated composition sections.
- Extends platform-pack scaffold payloads with optional `baseline_layers`, shared dry-run/execute planning, manifest edit previews, rollback-safe invalid payload validation, and CLI/docs/tests for the new payload shape.
- Adds desktop wizard authoring for baseline review layers with manifest-discovered pack/skill/mode options, Kotlin baseline suggestions, form validation, collapsed manifest preview details, and state/UI coverage.

## Feature Flags

N/A

# How Has This Been Tested?

Latest validation for the desktop wizard authoring slice passed after fixing Detekt/Spotless findings during `bill-quality-check`.

1. Run `(cd runtime-kotlin && ./gradlew :runtime-core:test :runtime-desktop:core:data:jvmTest :runtime-desktop:feature:skillbill:jvmTest)`.
2. Run `(cd runtime-kotlin && ./gradlew check)`.
3. Run `git diff --check` before commit.
4. Review/audit status: KMP/Kotlin review approved after one fix loop; completeness audit passed 12/12 acceptance criteria.
