### PR TITLE
[codex] govern add-on usage manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ skill-bill is a governed system for authoring, routing, validating, installing, 
 - Skill Bill is platform-extensible: any team may author and ship a new conforming pack.
 - This repo may contain any maintained pack that follows the governed contract; routing and install flows must stay manifest-driven rather than relying on a hardcoded shortlist.
 - Each pack ships a manifest. **The canonical source of truth for `platform-packs/<slug>/platform.yaml` shape is `orchestration/contracts/platform-pack-schema.yaml`** — a JSON Schema (Draft 2020-12) authored as YAML. New fields, type changes, value constraints, and field-level enums land in that file first; the runtime parser (`ShellContentLoader.buildPack`) loads the schema at runtime and rejects malformed manifests via `InvalidManifestSchemaError`.
-- Cross-field coherence rules that JSON Schema cannot express live in Kotlin and are documented under `x-coherence-checks` in the schema file. The five named rules are `slug-parity`, `areas-require-baseline`, `areas-equal-declared`, `area-metadata-keys-subset-declared`, and `pointers-unique-name-per-dir`.
+- Cross-field coherence rules that JSON Schema cannot express live in Kotlin and are documented under `x-coherence-checks` in the schema file, including declared-area parity, pointer uniqueness, baseline composition, and governed add-on usage rules.
 - The current shell contract version is 1.1. `SHELL_CONTRACT_VERSION` (Kotlin) and the schema's `contract_version.const` are pinned in lockstep by `PlatformPackSchemaContractVersionTest`. Bumping the contract means bumping BOTH; the build breaks if they drift.
 - **Runtime contracts directory rule.** Every YAML under `orchestration/contracts/` is part of the runtime contract surface. Adding a new contract YAML requires the same five-part recipe used for the platform-pack schema:
   1. Author the file as a Draft 2020-12 JSON Schema in YAML (mirror the `$schema` / `$id` / `title` / `description` / `additionalProperties: false` / `contract_version` const / `x-coherence-checks` block used by `orchestration/contracts/platform-pack-schema.yaml`).
@@ -65,6 +65,7 @@ skill-bill is a governed system for authoring, routing, validating, installing, 
 - Add-ons are pack-owned files, not standalone skills.
 - Keep them flat in the owning pack's `addons/` directory, use lowercase kebab-case names, and resolve them only after dominant-stack routing.
 - Runtime skills consume add-ons through generated support pointer files in installed staging, report them as `Selected add-ons: ...`, and every add-on change needs validator plus routing-contract coverage.
+- Declare which skills may consume which add-ons through the owning pack's `platform.yaml` `addon_usage` block. Do not hand-author per-skill add-on selection tables in `content.md`; the renderer emits the governed add-on usage section from the manifest.
 
 ## Non-negotiable rules
 

--- a/docs/skill-source-generation.md
+++ b/docs/skill-source-generation.md
@@ -63,6 +63,14 @@ Platform packs use their own source layout:
 Platform pack pointer files declared by `platform.yaml` are generated output,
 not source files.
 
+Pack-owned add-ons are consumed through `platform.yaml` `addon_usage`, not
+hand-authored skill prose. The manifest maps a skill-relative directory to the
+add-on entry pointer and optional companion pointers the installed skill may
+open after stack routing. The renderer turns that contract into a generated
+`## Governed Add-Ons` wrapper section, and the loader rejects add-on usage that
+does not reference generated pointers targeting the same pack's `addons/`
+directory.
+
 ## `content.md`
 
 `content.md` is the only authored skill body for governed skills. It owns:
@@ -145,6 +153,11 @@ If a skill needs a new support file:
 2. Register the support pointer target or manifest pointer.
 3. Add validator and install-staging coverage.
 4. Do not add the pointer file under `skills/<skill>/`.
+
+If a platform-pack skill needs governed add-ons, declare their generated
+pointer filenames in the pack's `addon_usage` block. Keep add-on selection
+cues and topic indexes in the pack-owned add-on files, not duplicated in
+`content.md`.
 
 ## Install Staging
 

--- a/orchestration/contracts/platform-pack-schema.yaml
+++ b/orchestration/contracts/platform-pack-schema.yaml
@@ -60,6 +60,13 @@ $defs:
       - reliability
       - ui
       - ux-accessibility
+  pointerFileName:
+    type: string
+    minLength: 1
+    pattern: "^[^/\\\\]+\\.md$"
+    allOf:
+      - not:
+          pattern: "\\.\\."
 required:
   - platform
   - contract_version
@@ -250,14 +257,9 @@ properties:
           - target
         properties:
           name:
-            type: string
-            minLength: 1
             # Bare-filename rule: name must end in `.md`, must not contain
             # path separators or parent-dir segments.
-            pattern: "^[^/\\\\]+\\.md$"
-            allOf:
-              - not:
-                  pattern: "\\.\\."
+            $ref: "#/$defs/pointerFileName"
           target:
             type: string
             minLength: 1
@@ -270,6 +272,42 @@ properties:
       `quality-check/<skill-name>`) skill-relative directory to a list of
       pointer entries. Keys must be relative paths (no leading `/`, no
       `..`); the runtime enforces this in `requireSafePointerSubpath`.
+  addon_usage:
+    type: object
+    x-runtime-anchored: true
+    additionalProperties:
+      type: array
+      minItems: 1
+      items:
+        type: object
+        additionalProperties: false
+        required:
+          - slug
+          - entrypoint
+        properties:
+          slug:
+            type: string
+            minLength: 1
+            pattern: "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+            description: >
+              Stable add-on selector reported in `Selected add-ons: ...`.
+          entrypoint:
+            $ref: "#/$defs/pointerFileName"
+            description: >
+              Generated pointer filename to scan first when deciding whether this add-on applies.
+          companion_pointers:
+            type: array
+            uniqueItems: true
+            items:
+              $ref: "#/$defs/pointerFileName"
+            description: >
+              Optional generated pointer filenames that may be opened only after the entrypoint
+              selects them through its section index or activation guidance.
+    description: >
+      Optional mapping of skill-relative directory to governed add-on selections. Each entry
+      references generated pointer filenames declared under `pointers` for the same skill
+      directory; Kotlin coherence checks require those pointers to target
+      `platform-packs/<slug>/addons/*.md`.
 
 # ---------------------------------------------------------------------------
 # Coherence checks (enforced in Kotlin)
@@ -307,6 +345,26 @@ x-coherence-checks:
       Within a single skill-relative directory in `pointers`, every pointer
       `name` must be unique. Enforced in
       `ShellContentLoader.parsePointers`.
+  addon-usage-references-declared-pointers:
+    description: >
+      Every `addon_usage.<skill-dir>[]` entrypoint and companion pointer must
+      reference a `pointers.<skill-dir>[]` entry declared for the same skill
+      directory. Enforced in `ShellContentLoader.parseAddonUsage`.
+  addon-usage-keys-declared:
+    description: >
+      Every `addon_usage.<skill-dir>` key must match a skill directory declared
+      by `declared_files.baseline`, `declared_files.areas`, or
+      `declared_quality_check_file`. Enforced in
+      `ShellContentLoader.parseAddonUsage`.
+  addon-usage-targets-pack-owned-addons:
+    description: >
+      Every pointer referenced by `addon_usage` must target a markdown file
+      under the same pack's `platform-packs/<slug>/addons/` directory.
+      Enforced in `ShellContentLoader.parseAddonUsage`.
+  addon-usage-unique-slug-per-dir:
+    description: >
+      Within a single `addon_usage.<skill-dir>` list, every add-on `slug`
+      must be unique. Enforced in `ShellContentLoader.parseAddonUsage`.
   composition-references-resolve:
     description: >
       Every `code_review_composition.baseline_layers[]` entry must reference

--- a/orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md
+++ b/orchestration/shell-content-contract/SCAFFOLD_PAYLOAD.md
@@ -106,6 +106,13 @@ Every payload MUST include:
 - `body` — optional string for `add-on`. When provided, the scaffolder
   writes this markdown body verbatim to the target add-on file instead of
   rendering the default placeholder template.
+- `consumer_skill_dirs` — optional list for `add-on`. Each entry is a
+  declared platform-pack-relative skill directory such as
+  `code-review/bill-kmp-code-review-ui`. The scaffolder rejects directories
+  that are not declared by the pack manifest, then registers the new add-on in
+  `platform.yaml` by adding generated pointer entries and `addon_usage`
+  entries for these consumers. When omitted, the scaffolder defaults to the
+  owning pack's baseline code-review skill, if one exists.
 - `repo_root` — absolute path override used by tests. Defaults to the
   current working directory.
 - `subagent_specialists` — list of specialist subagent names to scaffold

--- a/platform-packs/kmp/code-review/bill-kmp-code-review-ui/content.md
+++ b/platform-packs/kmp/code-review/bill-kmp-code-review-ui/content.md
@@ -8,14 +8,6 @@ description: Use when reviewing or building KMP UI surfaces. Today this skill is
 
 The canonical KMP UI review command stays `bill-kmp-code-review-ui`. Governed add-ons apply only after the parent review has already routed to `kmp`.
 
-When the parent KMP review selects the `android-compose` add-on, scan [android-compose-review.md](android-compose-review.md) first. If the add-on is split into topic files, open only the linked topic files whose cues match the diff, such as [android-compose-edge-to-edge.md](android-compose-edge-to-edge.md) and [android-compose-adaptive-layouts.md](android-compose-adaptive-layouts.md).
-
-When the parent KMP review selects `android-navigation`, scan [android-navigation-review.md](android-navigation-review.md) first and apply any Android-specific UI risks from it alongside the base Compose review rubric.
-
-When the parent KMP review selects `android-interop`, scan [android-interop-review.md](android-interop-review.md) first and apply any Android-specific UI risks from it alongside the base Compose review rubric.
-
-When the parent KMP review selects `android-design-system`, scan [android-design-system-review.md](android-design-system-review.md) first and apply any Android-specific UI risks from it alongside the base Compose review rubric.
-
 When no governed add-on applies, use the base Compose review rubric by itself.
 
 For review enforcement, read [compose-guidelines.md](compose-guidelines.md) as the Compose review rubric covering:

--- a/platform-packs/kmp/code-review/bill-kmp-code-review/content.md
+++ b/platform-packs/kmp/code-review/bill-kmp-code-review/content.md
@@ -35,25 +35,6 @@ Classify the review as one of:
 - If backend/server files are also touched, keep the `kmp` route and rely on the manifest-declared baseline layer so shared Kotlin concerns are still reviewed before this skill adds mobile-specific specialists.
 - When uncertain, prefer the safer route that preserves Android/KMP review depth.
 
-## Governed Add-On Resolution
-
-After the stack is already classified as `kmp`, resolve governed add-ons before selecting KMP-specific specialists.
-
-- If no add-on cues match, continue with the base KMP review without a governed add-on.
-- Select `android-compose` when the scoped diff contains Compose UI signals such as `@Composable`, Compose UI state, `Modifier` chains, previews, `remember*`, or Compose side effects.
-- Select `android-navigation` when the scoped diff changes route models, `NavHost`/`NavDisplay`, deep links, multi-back-stack behavior, scene destinations, or Android navigation ownership.
-- Select `android-interop` when the scoped diff mixes Compose with legacy Views, Fragments, `ComposeView`, `AndroidView`, `AndroidViewBinding`, or other Android host-boundary glue.
-- Select `android-design-system` when the scoped diff changes Android theme layers, `MaterialTheme`, design tokens, styled components, or XML-theme-to-Compose translation.
-- Select `android-r8` when the scoped diff changes Android keep rules, shrinker config, `proguardFiles`, `isMinifyEnabled`, `isShrinkResources`, or release-only R8 settings.
-- Scan [android-compose-review.md](android-compose-review.md) first. If the add-on is split into topic files, open only the linked topic files whose cues match the scoped diff when `android-compose` is selected, such as [android-compose-edge-to-edge.md](android-compose-edge-to-edge.md) and [android-compose-adaptive-layouts.md](android-compose-adaptive-layouts.md).
-- Scan [android-navigation-review.md](android-navigation-review.md) when `android-navigation` is selected.
-- Scan [android-interop-review.md](android-interop-review.md) when `android-interop` is selected.
-- Scan [android-design-system-review.md](android-design-system-review.md) when `android-design-system` is selected.
-- Scan [android-r8-review.md](android-r8-review.md) when `android-r8` is selected.
-- Add-ons enrich the routed KMP review; they do not create standalone reviewer names or bypass the `kmp` route.
-
----
-
 ## Layered Review Plan
 
 ### Step 1: Scale review depth

--- a/platform-packs/kmp/platform.yaml
+++ b/platform-packs/kmp/platform.yaml
@@ -41,6 +41,40 @@ code_review_composition:
       required: true
       mode: kmp-baseline
 
+addon_usage:
+  code-review/bill-kmp-code-review:
+    - slug: android-compose
+      entrypoint: android-compose-review.md
+      companion_pointers:
+        - android-compose-edge-to-edge.md
+        - android-compose-adaptive-layouts.md
+        - android-navigation-review.md
+        - android-design-system-review.md
+        - android-interop-review.md
+    - slug: android-navigation
+      entrypoint: android-navigation-review.md
+    - slug: android-interop
+      entrypoint: android-interop-review.md
+    - slug: android-design-system
+      entrypoint: android-design-system-review.md
+    - slug: android-r8
+      entrypoint: android-r8-review.md
+  code-review/bill-kmp-code-review-ui:
+    - slug: android-compose
+      entrypoint: android-compose-review.md
+      companion_pointers:
+        - android-compose-edge-to-edge.md
+        - android-compose-adaptive-layouts.md
+        - android-navigation-review.md
+        - android-design-system-review.md
+        - android-interop-review.md
+    - slug: android-navigation
+      entrypoint: android-navigation-review.md
+    - slug: android-interop
+      entrypoint: android-interop-review.md
+    - slug: android-design-system
+      entrypoint: android-design-system-review.md
+
 # Pointer files (single-line markdown files containing only a relative path) are generated
 # from this block during render/install output. Targets are repo-rooted; the renderer computes
 # the correct ../-prefixed relative path. Never commit pointer files — add or modify entries here

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
@@ -418,6 +418,11 @@ class NewAddonCommand(
   )
   private val body by option("--body", help = "Complete markdown body to write to the add-on file.")
   private val bodyFile by option("--body-file", help = "Path to a markdown file to copy into the add-on (or '-').")
+  private val consumerSkillDirs by option(
+    "--consumer-skill-dir",
+    help = "Skill-relative directory to register as an add-on consumer. May be repeated. " +
+      "Defaults to the pack baseline code-review skill.",
+  ).multiple()
   private val interactive by option("--interactive", help = "Prompt for platform, add-on slug, and markdown content.")
     .flag(default = false)
   private val dryRun by option("--dry-run", help = "Plan the scaffold and report the operations without touching disk.")
@@ -437,7 +442,11 @@ class NewAddonCommand(
       } else if (body != null && bodyFile != null) {
         errorResult("--body and --body-file are mutually exclusive.", format)
       } else {
-        runNativeScaffoldPayload(newAddonPayload(platform, name, body, bodyFile, state), dryRun, format)
+        runNativeScaffoldPayload(
+          newAddonPayload(platform, name, body, bodyFile, consumerSkillDirs, state),
+          dryRun,
+          format,
+        )
       }
   }
 }
@@ -648,14 +657,18 @@ private fun newAddonPayload(
   name: String?,
   body: String?,
   bodyFile: String?,
+  consumerSkillDirs: List<String>,
   state: CliRunState,
-): Map<String, String> = mapOf(
-  "scaffold_payload_version" to "1.0",
-  "kind" to "add-on",
-  "platform" to platform.orEmpty(),
-  "name" to name.orEmpty(),
-  "body" to (body ?: bodyFile?.let { path -> readCliTextFile(path, state) }).orEmpty(),
-)
+): Map<String, Any> = buildMap {
+  put("scaffold_payload_version", "1.0")
+  put("kind", "add-on")
+  put("platform", platform.orEmpty())
+  put("name", name.orEmpty())
+  put("body", (body ?: bodyFile?.let { path -> readCliTextFile(path, state) }).orEmpty())
+  if (consumerSkillDirs.isNotEmpty()) {
+    put("consumer_skill_dirs", consumerSkillDirs)
+  }
+}
 
 private fun readCliTextFile(path: String, state: CliRunState): String =
   if (path == "-") state.stdinText.orEmpty() else Path.of(path).toFile().readText()

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliScaffoldRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliScaffoldRuntimeTest.kt
@@ -94,6 +94,8 @@ class CliScaffoldRuntimeTest {
           "kmp",
           "--name",
           "android-new-addon",
+          "--consumer-skill-dir",
+          "code-review/bill-kmp-code-review-ui",
           "--body",
           "Pack-owned guidance.",
           "--dry-run",
@@ -309,6 +311,7 @@ private fun assertAddonScaffoldPayload(payload: JsonObject) {
     Path.of(payload.stringValue("skill_path"))
       .endsWith(Path.of("platform-packs", "kmp", "addons")),
   )
+  assertContains(payload["manifest_edits"].toString(), "platform-packs/kmp/platform.yaml")
 }
 
 private fun assertNativeBodyConflictErrors(prefix: List<String>, context: CliRuntimeContext) {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringDiscovery.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringDiscovery.kt
@@ -90,6 +90,7 @@ private fun recordPackTargets(discovered: MutableMap<String, AuthoringTarget>, p
         baselineContent.resolveSibling("SKILL.md"),
         baselineContent,
         pack.codeReviewComposition,
+        pack.addonUsageFor(baselineContent),
       )
   }
   pack.declaredFiles.areas.forEach { (area, declaredFile) ->
@@ -104,6 +105,7 @@ private fun recordPackTargets(discovered: MutableMap<String, AuthoringTarget>, p
         area,
         contentFile.resolveSibling("SKILL.md"),
         contentFile,
+        addonUsage = pack.addonUsageFor(contentFile),
       )
   }
   pack.declaredQualityCheckFile?.let { declaredFile ->
@@ -118,6 +120,7 @@ private fun recordPackTargets(discovered: MutableMap<String, AuthoringTarget>, p
         "",
         contentFile.resolveSibling("SKILL.md"),
         contentFile,
+        addonUsage = pack.addonUsageFor(contentFile),
       )
   }
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringOperations.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringOperations.kt
@@ -3,6 +3,7 @@ package skillbill.scaffold
 import skillbill.error.SkillBillRuntimeException
 import skillbill.nativeagent.NativeAgentOperations
 import skillbill.scaffold.model.CodeReviewComposition
+import skillbill.scaffold.model.GovernedAddonSelection
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -22,6 +23,7 @@ data class AuthoringTarget(
   val skillFile: Path,
   val contentFile: Path,
   val codeReviewComposition: CodeReviewComposition? = null,
+  val addonUsage: List<GovernedAddonSelection> = emptyList(),
 )
 
 object AuthoringOperations {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringRender.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/AuthoringRender.kt
@@ -4,6 +4,7 @@ import skillbill.nativeagent.NATIVE_AGENT_BUNDLE_FILE
 import skillbill.nativeagent.NATIVE_AGENT_SOURCE_DIR
 import skillbill.nativeagent.parseNativeAgentSourceFile
 import skillbill.scaffold.model.CodeReviewBaselineLayer
+import skillbill.scaffold.model.GovernedAddonSelection
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
@@ -42,6 +43,12 @@ internal fun renderWrapper(target: AuthoringTarget): String {
       appendLine()
       appendLine()
     }
+    val governedAddons = renderGovernedAddonsSection(target)
+    if (governedAddons.isNotBlank()) {
+      append(governedAddons.trimEnd())
+      appendLine()
+      appendLine()
+    }
     appendLine("## Execution")
     if (executionBody.isNotBlank()) {
       appendLine()
@@ -58,6 +65,47 @@ internal fun renderWrapper(target: AuthoringTarget): String {
     append(renderCeremonySection(skillClass).trimEnd())
     appendLine()
   }
+}
+
+private fun renderGovernedAddonsSection(target: AuthoringTarget): String {
+  val addons = target.addonUsage
+  if (addons.isEmpty()) {
+    return ""
+  }
+  return buildString {
+    appendLine("## Governed Add-Ons")
+    appendLine()
+    appendLine(
+      "This platform pack declares add-on usage for this skill in `platform.yaml`. Runtime agents MUST resolve " +
+        "these add-ons only after stack routing has selected `${target.platform}`.",
+    )
+    appendLine()
+    appendLine(
+      "Start from `Selected add-ons: none`. Scan each declared entrypoint's `## Activation signals` and " +
+        "`## Section index` headings first, select only add-ons whose cues match the scoped work, then open " +
+        "only the selected entrypoint and companion pointers needed for that scope.",
+    )
+    appendLine(
+      "Report the final selection as `Selected add-ons: <slug, ...>` and pass the selected add-ons into any " +
+        "specialist passes. Add-ons enrich this routed skill; they do not create standalone skill names or " +
+        "bypass stack routing.",
+    )
+    appendLine()
+    appendLine("### Declared Add-Ons")
+    appendLine()
+    addons.forEach { addon ->
+      appendLine("- ${renderAddonSelection(addon)}")
+    }
+  }
+}
+
+private fun renderAddonSelection(addon: GovernedAddonSelection): String {
+  val companionText = if (addon.companionPointers.isEmpty()) {
+    "companions `none`"
+  } else {
+    "companions ${addon.companionPointers.joinToString(", ") { pointer -> "`$pointer`" }}"
+  }
+  return "`${addon.slug}`: entrypoint `${addon.entrypoint}`; $companionText."
 }
 
 private fun renderReviewCompositionSection(target: AuthoringTarget): String {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/PlatformManifestAddonUsage.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/PlatformManifestAddonUsage.kt
@@ -1,0 +1,31 @@
+package skillbill.scaffold
+
+import skillbill.scaffold.model.DeclaredFiles
+import skillbill.scaffold.model.PlatformManifest
+import java.nio.file.Path
+
+internal fun PlatformManifest.addonUsageFor(contentFile: Path) =
+  addonUsage.firstOrNull { usage -> usage.skillRelativeDir == packRelativeSkillDir(contentFile) }?.addons.orEmpty()
+
+internal fun PlatformManifest.declaredSkillRelativeDirs(): Set<String> =
+  declaredSkillRelativeDirs(packRoot, declaredFiles, declaredQualityCheckFile)
+
+internal fun declaredSkillRelativeDirs(
+  packRoot: Path,
+  declaredFiles: DeclaredFiles,
+  declaredQualityCheckFile: Path?,
+): Set<String> = buildSet {
+  declaredFiles.baseline?.let { add(packRelativeSkillDir(packRoot, it)) }
+  declaredFiles.areas.values.forEach { add(packRelativeSkillDir(packRoot, it)) }
+  declaredQualityCheckFile?.let { add(packRelativeSkillDir(packRoot, it)) }
+}
+
+private fun PlatformManifest.packRelativeSkillDir(contentFile: Path): String = packRoot.toAbsolutePath().normalize()
+  .relativize(contentFile.parent.toAbsolutePath().normalize())
+  .toString()
+  .replace('\\', '/')
+
+private fun packRelativeSkillDir(packRoot: Path, contentFile: Path): String = packRoot.toAbsolutePath().normalize()
+  .relativize(contentFile.parent.toAbsolutePath().normalize())
+  .toString()
+  .replace('\\', '/')

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldManifestEdits.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldManifestEdits.kt
@@ -22,6 +22,7 @@ private val QUALITY_CHECK_KEY_PATTERN =
   Regex("^declared_quality_check_file:\\s*(.+)$", RegexOption.MULTILINE)
 private val DECLARED_FILES_BLOCK_PATTERN =
   Regex("^(declared_files:\\n(?:(?:[ \\t]+[^\\n]*\\n)*))", RegexOption.MULTILINE)
+private val TOP_LEVEL_KEY_PATTERN = Regex("^[^\\s#][^:\\n]*:", RegexOption.MULTILINE)
 
 internal fun appendCodeReviewArea(manifestPath: Path, area: String, relativeContentPath: String, areaFocus: String) {
   val original = manifestPath.toFile().readText()
@@ -49,6 +50,33 @@ internal fun setDeclaredQualityCheckFile(manifestPath: Path, relativeContentPath
     }
   if (updated != original) {
     manifestPath.toFile().writeText(updated)
+  }
+}
+
+internal fun appendGovernedAddonManifestRegistration(
+  manifestPath: Path,
+  platform: String,
+  skillRelativeDirs: List<String>,
+  addonSlug: String,
+) {
+  val original = manifestPath.toFile().readText()
+  val updated = renderGovernedAddonManifestRegistration(original, platform, skillRelativeDirs, addonSlug)
+  if (updated != original) {
+    manifestPath.toFile().writeText(updated)
+  }
+}
+
+internal fun renderGovernedAddonManifestRegistration(
+  text: String,
+  platform: String,
+  skillRelativeDirs: List<String>,
+  addonSlug: String,
+): String {
+  val pointerName = "$addonSlug.md"
+  val target = "platform-packs/$platform/addons/$pointerName"
+  return skillRelativeDirs.fold(text) { current, skillRelativeDir ->
+    val withPointer = appendManifestPointer(current, skillRelativeDir, pointerName, target)
+    appendAddonUsage(withPointer, skillRelativeDir, addonSlug, pointerName)
   }
 }
 
@@ -161,6 +189,87 @@ private fun appendBaselineLayers(lines: MutableList<String>, baselineLayers: Lis
     lines += "      required: ${layer.required}"
     lines += "      mode: ${yamlScalar(layer.mode.wireValue)}"
   }
+}
+
+private fun appendManifestPointer(text: String, skillRelativeDir: String, pointerName: String, target: String): String =
+  appendPointerLikeEntry(
+    text = text,
+    blockName = "pointers",
+    skillRelativeDir = skillRelativeDir,
+    entryName = pointerName,
+    renderBlock = {
+      "  $skillRelativeDir:\n" +
+        "    - name: ${yamlScalar(pointerName)}\n" +
+        "      target: ${yamlScalar(target)}\n"
+    },
+    renderEntry = {
+      "    - name: ${yamlScalar(pointerName)}\n" +
+        "      target: ${yamlScalar(target)}\n"
+    },
+    existingEntryPattern = Regex(
+      "^    - name:\\s*['\"]?${Regex.escape(pointerName)}['\"]?\\s*$",
+      RegexOption.MULTILINE,
+    ),
+  )
+
+private fun appendAddonUsage(text: String, skillRelativeDir: String, addonSlug: String, pointerName: String): String =
+  appendPointerLikeEntry(
+    text = text,
+    blockName = "addon_usage",
+    skillRelativeDir = skillRelativeDir,
+    entryName = addonSlug,
+    renderBlock = {
+      "  $skillRelativeDir:\n" +
+        "    - slug: ${yamlScalar(addonSlug)}\n" +
+        "      entrypoint: ${yamlScalar(pointerName)}\n"
+    },
+    renderEntry = {
+      "    - slug: ${yamlScalar(addonSlug)}\n" +
+        "      entrypoint: ${yamlScalar(pointerName)}\n"
+    },
+    existingEntryPattern = Regex("^    - slug:\\s*['\"]?${Regex.escape(addonSlug)}['\"]?\\s*$", RegexOption.MULTILINE),
+  )
+
+private fun appendPointerLikeEntry(
+  text: String,
+  blockName: String,
+  skillRelativeDir: String,
+  @Suppress("UNUSED_PARAMETER") entryName: String,
+  renderBlock: () -> String,
+  renderEntry: () -> String,
+  existingEntryPattern: Regex,
+): String {
+  val blockRange = topLevelBlockRange(text, blockName)
+    ?: return text.trimEnd() + "\n\n$blockName:\n${renderBlock()}"
+  val skillRange = nestedSkillDirRange(text, blockRange, skillRelativeDir)
+  if (skillRange == null) {
+    return text.replaceRange(blockRange.last + 1, blockRange.last + 1, renderBlock())
+  }
+  val existingBlock = text.substring(skillRange)
+  if (existingEntryPattern.containsMatchIn(existingBlock)) {
+    return text
+  }
+  return text.replaceRange(skillRange.last + 1, skillRange.last + 1, renderEntry())
+}
+
+private fun topLevelBlockRange(text: String, blockName: String): IntRange? {
+  val header = Regex("^${Regex.escape(blockName)}:\\s*$", RegexOption.MULTILINE).find(text) ?: return null
+  val next = TOP_LEVEL_KEY_PATTERN.find(text, startIndex = header.range.last + 1)
+  val endExclusive = next?.range?.first ?: text.length
+  return header.range.first until endExclusive
+}
+
+private fun nestedSkillDirRange(text: String, blockRange: IntRange, skillRelativeDir: String): IntRange? {
+  val block = text.substring(blockRange)
+  val localHeader = Regex(
+    "^  ${Regex.escape(skillRelativeDir)}:\\s*$",
+    RegexOption.MULTILINE,
+  ).find(block) ?: return null
+  val start = blockRange.first + localHeader.range.first
+  val next = Regex("^  [^\\s].*:\\s*$", RegexOption.MULTILINE)
+    .find(text, startIndex = start + localHeader.value.length)
+  val endExclusive = next?.range?.first?.takeIf { it <= blockRange.last + 1 } ?: (blockRange.last + 1)
+  return start until endExclusive
 }
 
 private fun appendAreaToList(text: String, area: String): String {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldService.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ScaffoldService.kt
@@ -120,6 +120,7 @@ private data class ScaffoldPlan(
   val createdFiles: List<Path> = emptyList(),
   val contentBody: String? = null,
   val addonBody: String? = null,
+  val addonConsumerSkillDirs: List<String> = emptyList(),
   val baselineLayers: List<CodeReviewBaselineLayer> = emptyList(),
   val subagentSpecialists: List<String> = emptyList(),
   val subagentDescriptions: Map<String, String> = emptyMap(),
@@ -699,6 +700,7 @@ private fun planAddOn(payload: Map<String, Any?>, repoRoot: Path): ScaffoldPlan 
         "Create a conforming platform.yaml before adding a governed add-on into it.",
     )
   }
+  val pack = loadPlatformPack(packRoot)
   val skillFile = packRoot.resolve("addons").resolve("$name.md")
   return ScaffoldPlan(
     kind = SKILL_KIND_ADD_ON,
@@ -713,7 +715,67 @@ private fun planAddOn(payload: Map<String, Any?>, repoRoot: Path): ScaffoldPlan 
     notes = emptyList(),
     description = requireStringOrDefault(payload, "description", ""),
     addonBody = payload["body"] as? String,
+    addonConsumerSkillDirs = resolveAddonConsumerSkillDirs(payload, packRoot, pack),
   )
+}
+
+private fun resolveAddonConsumerSkillDirs(
+  payload: Map<String, Any?>,
+  packRoot: Path,
+  pack: skillbill.scaffold.model.PlatformManifest,
+): List<String> {
+  val raw = payload["consumer_skill_dirs"]
+  val requested = if (raw == null) {
+    listOfNotNull(pack.declaredFiles.baseline?.let { contentFile -> packRoot.relativize(contentFile.parent) })
+      .map { path -> path.toString().replace('\\', '/') }
+  } else {
+    requireStringList(raw, "consumer_skill_dirs")
+  }
+  val seen = mutableSetOf<String>()
+  return requested.map { dir ->
+    validateAddonConsumerSkillDir(pack, dir)
+  }.filter { dir -> seen.add(dir) }
+}
+
+private fun validateAddonConsumerSkillDir(
+  pack: skillbill.scaffold.model.PlatformManifest,
+  skillRelativeDir: String,
+): String {
+  val relative = try {
+    Path.of(skillRelativeDir)
+  } catch (error: java.nio.file.InvalidPathException) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'consumer_skill_dirs' contains invalid path '$skillRelativeDir': ${error.message}",
+      error,
+    )
+  }
+  if (relative.isAbsolute || skillRelativeDir.startsWith("/") || skillRelativeDir.startsWith("\\")) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'consumer_skill_dirs' entries must be relative skill directories.",
+    )
+  }
+  relative.iterator().forEachRemaining { segment ->
+    if (segment.toString() == "..") {
+      throw InvalidScaffoldPayloadError(
+        "Scaffold payload field 'consumer_skill_dirs' entries must not contain '..' segments.",
+      )
+    }
+  }
+  val normalized = relative.normalize()
+  val normalizedDir = normalized.toString().replace('\\', '/')
+  if (!Files.isDirectory(pack.packRoot.resolve(normalized))) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'consumer_skill_dirs' references missing skill directory '$skillRelativeDir'.",
+    )
+  }
+  if (normalizedDir !in pack.declaredSkillRelativeDirs()) {
+    throw InvalidScaffoldPayloadError(
+      "Scaffold payload field 'consumer_skill_dirs' references '$skillRelativeDir', but that directory is not " +
+        "declared as a skill in platform pack '${pack.slug}'. Declared skill directories: " +
+        "${pack.declaredSkillRelativeDirs().sorted()}.",
+    )
+  }
+  return normalizedDir
 }
 
 private data class PlatformPackDefaults(
@@ -901,6 +963,21 @@ private fun applyManifestEdits(txn: ScaffoldTransaction, plan: ScaffoldPlan, rep
         emptyList()
       }
     }
+    SKILL_KIND_ADD_ON -> {
+      if (plan.addonConsumerSkillDirs.isEmpty()) {
+        emptyList()
+      } else {
+        val manifestPath = repoRoot.resolve("platform-packs").resolve(plan.platform).resolve("platform.yaml")
+        snapshotManifest(txn, manifestPath)
+        appendGovernedAddonManifestRegistration(
+          manifestPath = manifestPath,
+          platform = plan.platform,
+          skillRelativeDirs = plan.addonConsumerSkillDirs,
+          addonSlug = plan.skillName,
+        )
+        listOf(manifestPath)
+      }
+    }
     else -> emptyList()
   }
 }
@@ -916,6 +993,11 @@ private fun previewCreatedFiles(plan: ScaffoldPlan): List<Path> = when (plan.kin
 
 private fun previewManifestEdits(plan: ScaffoldPlan, repoRoot: Path): List<Path> = when (plan.kind) {
   SKILL_KIND_PLATFORM_PACK -> listOf(plan.manifestPath ?: platformPackManifestPath(repoRoot, plan.platform))
+  SKILL_KIND_ADD_ON -> if (plan.addonConsumerSkillDirs.isEmpty()) {
+    emptyList()
+  } else {
+    listOf(platformPackManifestPath(repoRoot, plan.platform))
+  }
   SKILL_KIND_CODE_REVIEW_AREA, SKILL_KIND_PLATFORM_OVERRIDE_PILOTED ->
     listOf(platformPackManifestPath(repoRoot, plan.platform))
   else -> emptyList()
@@ -929,13 +1011,25 @@ private fun previewManifestPreviews(plan: ScaffoldPlan, repoRoot: Path): Map<Pat
       plan.qualityCheckSkillPath ?: error("Platform pack plan missing quality-check skill path.")
     mapOf(manifestPath to renderPlatformPackManifestContent(plan, repoRoot, baselineSkillPath, qualityCheckSkillPath))
   }
+  SKILL_KIND_ADD_ON -> {
+    if (plan.addonConsumerSkillDirs.isEmpty()) {
+      emptyMap()
+    } else {
+      val manifestPath = platformPackManifestPath(repoRoot, plan.platform)
+      mapOf(
+        manifestPath to renderGovernedAddonManifestRegistration(
+          text = Files.readString(manifestPath),
+          platform = plan.platform,
+          skillRelativeDirs = plan.addonConsumerSkillDirs,
+          addonSlug = plan.skillName,
+        ),
+      )
+    }
+  }
   else -> emptyMap()
 }
 
 private fun validateScaffold(plan: ScaffoldPlan, repoRoot: Path) {
-  if (plan.kind == SKILL_KIND_ADD_ON) {
-    return
-  }
   if (plan.kind == SKILL_KIND_HORIZONTAL) {
     val issues = validateTarget(plannedAuthoringTarget(plan), repoRoot)
     if (issues.isNotEmpty()) {

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/scaffold/ShellContentLoader.kt
@@ -14,6 +14,8 @@ import skillbill.scaffold.model.CodeReviewCompositionMode
 import skillbill.scaffold.model.CodeReviewCompositionScope
 import skillbill.scaffold.model.DeclaredFiles
 import skillbill.scaffold.model.GovernedAddonFile
+import skillbill.scaffold.model.GovernedAddonSelection
+import skillbill.scaffold.model.GovernedAddonUsage
 import skillbill.scaffold.model.PlatformManifest
 import skillbill.scaffold.model.PointerSpec
 import skillbill.scaffold.model.RoutingSignals
@@ -268,7 +270,7 @@ private fun buildPack(slug: String, packRoot: Path, manifestPath: Path, raw: Any
   // and for the named coherence checks documented in the schema's
   // `x-coherence-checks` block (slug-parity, areas-require-baseline,
   // areas-equal-declared, area-metadata-keys-subset-declared,
-  // pointers-unique-name-per-dir).
+  // pointers-unique-name-per-dir, addon-usage-*).
   val manifest = requireManifestMap(slug, manifestPath, raw)
   val typedManifest = validateAgainstCanonicalSchema(slug, manifest)
 
@@ -291,6 +293,12 @@ private fun buildPack(slug: String, packRoot: Path, manifestPath: Path, raw: Any
   val declaredQualityCheckFile = parseOptionalPath(manifest, slug, "declared_quality_check_file", packRoot)
   val codeReviewComposition = parseCodeReviewComposition(manifest, slug)
   val pointers = parsePointers(manifest, slug)
+  val addonUsage = parseAddonUsage(
+    manifest = manifest,
+    slug = slug,
+    pointers = pointers,
+    declaredSkillDirs = declaredSkillRelativeDirs(packRoot, declaredFiles, declaredQualityCheckFile),
+  )
 
   // SKILL-48 Subtask 3: anchored top-level keys (those the runtime consumes by name) are
   // already captured in the typed fields above. Every remaining top-level YAML key flows
@@ -323,6 +331,7 @@ private fun buildPack(slug: String, packRoot: Path, manifestPath: Path, raw: Any
     declaredQualityCheckFile = declaredQualityCheckFile,
     codeReviewComposition = codeReviewComposition,
     pointers = pointers,
+    addonUsage = addonUsage,
     customFields = customFields,
   )
 }
@@ -642,6 +651,115 @@ private fun parsePointers(manifest: Map<*, *>, slug: String): List<PointerSpec> 
     }
   }
   return collected
+}
+
+private fun parseAddonUsage(
+  manifest: Map<*, *>,
+  slug: String,
+  pointers: List<PointerSpec>,
+  declaredSkillDirs: Set<String>,
+): List<GovernedAddonUsage> {
+  val raw = manifest["addon_usage"] ?: return emptyList()
+  val usageMap = raw as? Map<*, *>
+    ?: throw InvalidManifestSchemaError(
+      "Platform pack '$slug': 'addon_usage' must be a mapping of skill-relative-dir to add-on entries.",
+    )
+  val pointersByDir = pointers.groupBy { spec -> spec.skillRelativeDir }
+  return usageMap.map { (dirKey, entriesRaw) ->
+    val skillRelativeDir = dirKey as? String
+      ?: throw InvalidManifestSchemaError(
+        "Platform pack '$slug': 'addon_usage' keys must be strings (skill-relative directory paths).",
+      )
+    if (skillRelativeDir.isBlank()) {
+      throw InvalidManifestSchemaError(
+        "Platform pack '$slug': 'addon_usage' skill-relative directory must be a non-empty string.",
+      )
+    }
+    requireSafePointerSubpath(slug, skillRelativeDir, "addon_usage skill-relative directory")
+    if (skillRelativeDir !in declaredSkillDirs) {
+      throw InvalidManifestSchemaError(
+        "Platform pack '$slug': 'addon_usage' key '$skillRelativeDir' must match a declared skill directory. " +
+          "Declared skill directories: ${declaredSkillDirs.sorted()}.",
+      )
+    }
+    val entriesList = entriesRaw as? List<*>
+      ?: throw InvalidManifestSchemaError(
+        "Platform pack '$slug': 'addon_usage[$skillRelativeDir]' must be a list of add-on entries.",
+      )
+    if (entriesList.isEmpty()) {
+      throw InvalidManifestSchemaError(
+        "Platform pack '$slug': 'addon_usage[$skillRelativeDir]' must declare at least one add-on entry.",
+      )
+    }
+    val context = AddonUsageParseContext(
+      slug = slug,
+      skillRelativeDir = skillRelativeDir,
+      seenSlugs = mutableSetOf(),
+      pointersForDir = pointersByDir[skillRelativeDir].orEmpty(),
+    )
+    val addons = entriesList.mapIndexed { index, entry ->
+      parseAddonUsageEntry(context, index, entry)
+    }
+    GovernedAddonUsage(skillRelativeDir = skillRelativeDir, addons = addons)
+  }
+}
+
+private data class AddonUsageParseContext(
+  val slug: String,
+  val skillRelativeDir: String,
+  val seenSlugs: MutableSet<String>,
+  val pointersForDir: List<PointerSpec>,
+)
+
+private fun parseAddonUsageEntry(context: AddonUsageParseContext, index: Int, raw: Any?): GovernedAddonSelection {
+  val entry = raw as? Map<*, *>
+    ?: throw InvalidManifestSchemaError(
+      "Platform pack '${context.slug}': 'addon_usage[${context.skillRelativeDir}][$index]' must be a mapping.",
+    )
+  val fieldPrefix = "addon_usage[${context.skillRelativeDir}][$index]"
+  val addonSlug = requireStringInMap(context.slug, entry, "$fieldPrefix.slug", "slug")
+  if (!context.seenSlugs.add(addonSlug)) {
+    throw InvalidManifestSchemaError(
+      "Platform pack '${context.slug}': duplicate add-on usage slug '$addonSlug' under " +
+        "'${context.skillRelativeDir}'.",
+    )
+  }
+  val entrypoint = requireStringInMap(context.slug, entry, "$fieldPrefix.entrypoint", "entrypoint")
+  val companionPointers = parseStringList(
+    context.slug,
+    entry["companion_pointers"],
+    "$fieldPrefix.companion_pointers",
+    required = false,
+  )
+  requirePackOwnedAddonPointer(context, addonSlug, "entrypoint", entrypoint)
+  companionPointers.forEach { pointerName ->
+    requirePackOwnedAddonPointer(context, addonSlug, "companion_pointers", pointerName)
+  }
+  return GovernedAddonSelection(
+    slug = addonSlug,
+    entrypoint = entrypoint,
+    companionPointers = companionPointers,
+  )
+}
+
+private fun requirePackOwnedAddonPointer(
+  context: AddonUsageParseContext,
+  addonSlug: String,
+  field: String,
+  pointerName: String,
+) {
+  val pointer = context.pointersForDir.firstOrNull { spec -> spec.name == pointerName }
+    ?: throw InvalidManifestSchemaError(
+      "Platform pack '${context.slug}': addon_usage[${context.skillRelativeDir}] entry '$addonSlug' references " +
+        "$field '$pointerName', but pointers[${context.skillRelativeDir}] does not declare that pointer.",
+    )
+  val expectedPrefix = "platform-packs/${context.slug}/addons/"
+  if (!pointer.target.startsWith(expectedPrefix) || !pointer.target.endsWith(".md")) {
+    throw InvalidManifestSchemaError(
+      "Platform pack '${context.slug}': addon_usage[${context.skillRelativeDir}] entry '$addonSlug' " +
+        "references pointer '$pointerName', but its target '${pointer.target}' is not under '$expectedPrefix'.",
+    )
+  }
 }
 
 private fun parsePointerEntry(slug: String, skillRelativeDir: String, entry: Map<*, *>): PointerSpec {

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/AuthoringRenderSnapshotTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/AuthoringRenderSnapshotTest.kt
@@ -66,6 +66,14 @@ class AuthoringRenderSnapshotTest {
         "and stack signals" in first,
       "generated review composition must forward required review context",
     )
+    assertTrue(
+      first.indexOf("## Governed Add-Ons") < first.indexOf("## Execution"),
+      "generated governed add-on usage must render before authored execution guidance",
+    )
+    assertTrue(
+      "`android-compose`: entrypoint `android-compose-review.md`" in first,
+      "generated governed add-on section must list manifest-declared entrypoints",
+    )
     assertEquals(first, second, "render output must be deterministic across repeated in-memory renders")
     SnapshotAssertions.assertMatchesSnapshot(
       "snapshots/scaffold/bill-kmp-code-review.render.txt",
@@ -83,6 +91,10 @@ class AuthoringRenderSnapshotTest {
     assertEquals(
       expectedHeadersFromManifest(repoRoot, packSlug = "kmp", skillRelativeDir = "code-review/bill-kmp-code-review-ui"),
       rendered.blocks.map { block -> block.header },
+    )
+    assertTrue(
+      "## Governed Add-Ons" in first,
+      "KMP UI specialist must receive generated add-on usage from platform.yaml",
     )
     assertEquals(first, second, "render output must be deterministic across repeated in-memory renders")
     SnapshotAssertions.assertMatchesSnapshot(

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaAnchoredBijectionTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaAnchoredBijectionTest.kt
@@ -44,6 +44,7 @@ class PlatformPackSchemaAnchoredBijectionTest {
     "declared_quality_check_file",
     "code_review_composition",
     "pointers",
+    "addon_usage",
   )
 
   @Test

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaViolationsTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/PlatformPackSchemaViolationsTest.kt
@@ -328,6 +328,121 @@ class PlatformPackSchemaViolationsTest {
   }
 
   @Test
+  fun `coherence rule addon_usage keys must match declared skill directories`() {
+    val manifest = """
+      platform: scenarioslug
+      contract_version: "1.1"
+      routing_signals:
+        strong: [".kt"]
+      declared_code_review_areas: []
+      declared_files:
+        baseline: code-review/bill-scenarioslug-code-review/content.md
+        areas: {}
+      pointers:
+        code-review/not-a-skill:
+          - name: android-compose-review.md
+            target: platform-packs/scenarioslug/addons/android-compose-review.md
+      addon_usage:
+        code-review/not-a-skill:
+          - slug: android-compose
+            entrypoint: android-compose-review.md
+    """.trimIndent()
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPackFromInMemory("scenarioslug", manifest)
+    }
+    val message = error.message.orEmpty()
+    assertContains(message, "addon_usage")
+    assertContains(message, "code-review/not-a-skill")
+    assertContains(message, "declared skill directory")
+  }
+
+  @Test
+  fun `coherence rule addon_usage must reference declared pointer under same skill dir`() {
+    val manifest = """
+      platform: scenarioslug
+      contract_version: "1.1"
+      routing_signals:
+        strong: [".kt"]
+      declared_code_review_areas: []
+      declared_files:
+        baseline: code-review/something/content.md
+        areas: {}
+      addon_usage:
+        code-review/something:
+          - slug: android-compose
+            entrypoint: android-compose-review.md
+    """.trimIndent()
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPackFromInMemory("scenarioslug", manifest)
+    }
+    val message = error.message.orEmpty()
+    assertContains(message, "addon_usage")
+    assertContains(message, "android-compose-review.md")
+    assertContains(message, "pointers[code-review/something]")
+  }
+
+  @Test
+  fun `coherence rule addon_usage must reference pack-owned addon pointer targets`() {
+    val manifest = """
+      platform: scenarioslug
+      contract_version: "1.1"
+      routing_signals:
+        strong: [".kt"]
+      declared_code_review_areas: []
+      declared_files:
+        baseline: code-review/something/content.md
+        areas: {}
+      pointers:
+        code-review/something:
+          - name: shell-ceremony.md
+            target: orchestration/shell-content-contract/shell-ceremony.md
+      addon_usage:
+        code-review/something:
+          - slug: shell-help
+            entrypoint: shell-ceremony.md
+    """.trimIndent()
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPackFromInMemory("scenarioslug", manifest)
+    }
+    val message = error.message.orEmpty()
+    assertContains(message, "addon_usage")
+    assertContains(message, "shell-ceremony.md")
+    assertContains(message, "platform-packs/scenarioslug/addons/")
+  }
+
+  @Test
+  fun `coherence rule addon_usage rejects duplicate slug per skill dir`() {
+    val manifest = """
+      platform: scenarioslug
+      contract_version: "1.1"
+      routing_signals:
+        strong: [".kt"]
+      declared_code_review_areas: []
+      declared_files:
+        baseline: code-review/something/content.md
+        areas: {}
+      pointers:
+        code-review/something:
+          - name: android-compose-review.md
+            target: platform-packs/scenarioslug/addons/android-compose-review.md
+          - name: android-compose-edge-to-edge.md
+            target: platform-packs/scenarioslug/addons/android-compose-edge-to-edge.md
+      addon_usage:
+        code-review/something:
+          - slug: android-compose
+            entrypoint: android-compose-review.md
+          - slug: android-compose
+            entrypoint: android-compose-edge-to-edge.md
+    """.trimIndent()
+    val error = assertFailsWith<InvalidManifestSchemaError> {
+      loadPackFromInMemory("scenarioslug", manifest)
+    }
+    val message = error.message.orEmpty()
+    assertContains(message, "android-compose")
+    assertContains(message, "duplicate")
+  }
+
+  @Test
   fun `SKILL-48 nested anchored block typo fails loudly`() {
     // Defense-in-depth: a typo *inside* a strict nested anchored block (e.g. mis-spelling
     // `baseline` as `baselin` under `declared_files`) MUST loud-fail with the field path

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldAddonGovernanceTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldAddonGovernanceTest.kt
@@ -1,0 +1,103 @@
+package skillbill.scaffold
+
+import skillbill.error.InvalidScaffoldPayloadError
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class ScaffoldAddonGovernanceTest {
+  @Test
+  fun `add-on scaffold rejects explicit consumer dirs that are not declared skills`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    Files.createDirectories(repo.resolve("platform-packs/kotlin/code-review/not-a-declared-skill"))
+
+    val error = assertFailsWith<InvalidScaffoldPayloadError> {
+      scaffold(
+        payload(
+          repo,
+          "add-on",
+          "platform" to "kotlin",
+          "name" to "orphan-helper",
+          "consumer_skill_dirs" to listOf("code-review/not-a-declared-skill"),
+        ),
+      )
+    }
+
+    assertContains(error.message.orEmpty(), "not declared as a skill")
+    assertFalse(Files.exists(repo.resolve("platform-packs/kotlin/addons/orphan-helper.md")))
+  }
+
+  @Test
+  fun `add-on manifest registration preserves hyphenated custom top-level fields`() {
+    val manifest = """
+      platform: kotlin
+      contract_version: "1.1"
+      routing_signals:
+        strong:
+          - ".kt"
+      declared_code_review_areas: []
+      declared_files:
+        baseline: code-review/bill-kotlin-code-review/content.md
+        areas: {}
+      pointers:
+        code-review/bill-kotlin-code-review:
+          - name: shell-ceremony.md
+            target: orchestration/shell-content-contract/shell-ceremony.md
+      fork-specific-field:
+        owner: local
+    """.trimIndent() + "\n"
+
+    val updated = renderGovernedAddonManifestRegistration(
+      text = manifest,
+      platform = "kotlin",
+      skillRelativeDirs = listOf("code-review/bill-kotlin-code-review"),
+      addonSlug = "review-helper",
+    )
+
+    assertContains(
+      updated,
+      "    - name: \"review-helper.md\"\n      target: \"platform-packs/kotlin/addons/review-helper.md\"",
+    )
+    assertContains(updated, "\nfork-specific-field:\n  owner: local\n")
+    assertFalse("fork-specific-field:\n    - name: \"review-helper.md\"" in updated)
+  }
+}
+
+private fun payload(repo: Path, kind: String, vararg pairs: Pair<String, Any?>): Map<String, Any?> =
+  mapOf("scaffold_payload_version" to "1.0", "kind" to kind, "repo_root" to repo.toString()) + pairs
+
+private fun seedRepo(): Path {
+  val repo = Files.createTempDirectory("skillbill-scaffold-addon-repo")
+  val packRoot = repo.resolve("platform-packs/kotlin")
+  val baseline = packRoot.resolve("code-review/bill-kotlin-code-review")
+  Files.createDirectories(baseline)
+  val context = TemplateContext("bill-kotlin-code-review", "code-review", "kotlin", "", "Kotlin")
+  Files.writeString(
+    packRoot.resolve("platform.yaml"),
+    renderPlatformPackManifest(
+      platform = "kotlin",
+      displayName = "Kotlin",
+      strongSignals = listOf(".kt"),
+      baselineContentPath = "code-review/bill-kotlin-code-review/content.md",
+    ),
+  )
+  Files.writeString(
+    baseline.resolve("content.md"),
+    renderContentBody(context, inferSkillDescription(context)),
+  )
+  return repo
+}
+
+private fun withIsolatedUserHome(block: () -> Unit) {
+  val previousHome = System.getProperty("user.home")
+  val tempHome = Files.createTempDirectory("skillbill-scaffold-addon-home").toString()
+  try {
+    System.setProperty("user.home", tempHome)
+    block()
+  } finally {
+    System.setProperty("user.home", previousHome)
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldServiceParityTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/scaffold/ScaffoldServiceParityTest.kt
@@ -324,6 +324,74 @@ class ScaffoldServiceParityTest {
   }
 
   @Test
+  fun `add-on scaffold registers generated pointer and addon usage in platform manifest`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val result = scaffold(
+      payload(
+        repo,
+        "add-on",
+        "platform" to "kotlin",
+        "name" to "review-helper",
+        "body" to "# Review Helper\n\nUse after routed Kotlin review.",
+      ),
+    )
+    val manifestPath = repo.resolve("platform-packs/kotlin/platform.yaml")
+    val manifest = Files.readString(manifestPath)
+
+    assertEquals(listOf(repo.resolve("platform-packs/kotlin/addons/review-helper.md")), result.createdFiles)
+    assertEquals(listOf(manifestPath), result.manifestEdits)
+    assertContains(manifest, "pointers:")
+    assertContains(manifest, "  code-review/bill-kotlin-code-review:")
+    assertContains(manifest, "    - name: \"review-helper.md\"")
+    assertContains(manifest, "      target: \"platform-packs/kotlin/addons/review-helper.md\"")
+    assertContains(manifest, "addon_usage:")
+    assertContains(manifest, "    - slug: \"review-helper\"")
+    assertContains(manifest, "      entrypoint: \"review-helper.md\"")
+
+    loadPlatformPack(repo.resolve("platform-packs/kotlin"))
+    val rendered = renderAuthoringTarget(repo, "bill-kotlin-code-review").stdout
+    assertContains(rendered, "## Governed Add-Ons")
+    assertContains(rendered, "`review-helper`: entrypoint `review-helper.md`")
+  }
+
+  @Test
+  fun `add-on scaffold accepts explicit consumer skill dirs`() = withIsolatedUserHome {
+    val repo = seedRepo()
+    val specialist = repo.resolve("platform-packs/kotlin/code-review/bill-kotlin-code-review-testing")
+    Files.createDirectories(specialist)
+    Files.writeString(
+      specialist.resolve("content.md"),
+      renderContentBody(
+        TemplateContext("bill-kotlin-code-review-testing", "code-review", "kotlin", "testing", "Kotlin"),
+        "Use when reviewing Kotlin test coverage quality.",
+      ),
+    )
+    val manifestPath = repo.resolve("platform-packs/kotlin/platform.yaml")
+    appendCodeReviewArea(
+      manifestPath,
+      "testing",
+      "code-review/bill-kotlin-code-review-testing/content.md",
+      defaultAreaFocus("testing"),
+    )
+
+    scaffold(
+      payload(
+        repo,
+        "add-on",
+        "platform" to "kotlin",
+        "name" to "testing-helper",
+        "consumer_skill_dirs" to listOf("code-review/bill-kotlin-code-review-testing"),
+      ),
+    )
+    val manifest = Files.readString(manifestPath)
+
+    assertContains(manifest, "  code-review/bill-kotlin-code-review-testing:")
+    assertContains(manifest, "    - name: \"testing-helper.md\"")
+    assertContains(manifest, "    - slug: \"testing-helper\"")
+    assertFalse("  code-review/bill-kotlin-code-review:\n    - slug: \"testing-helper\"" in manifest)
+  }
+
+  @Test
   fun `authoring render preserves platform display name and base shell ceremony references`() = withIsolatedUserHome {
     val repo = seedRepo()
     val packSkill = repo.resolve("platform-packs/kotlin/code-review/bill-kotlin-code-review/SKILL.md")

--- a/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kmp-code-review-ui.render.txt
+++ b/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kmp-code-review-ui.render.txt
@@ -12,19 +12,25 @@ Platform pack: `kmp` (KMP)
 Area: `ui`
 Description: Use when reviewing KMP changes for UI correctness and framework usage.
 
+## Governed Add-Ons
+
+This platform pack declares add-on usage for this skill in `platform.yaml`. Runtime agents MUST resolve these add-ons only after stack routing has selected `kmp`.
+
+Start from `Selected add-ons: none`. Scan each declared entrypoint's `## Activation signals` and `## Section index` headings first, select only add-ons whose cues match the scoped work, then open only the selected entrypoint and companion pointers needed for that scope.
+Report the final selection as `Selected add-ons: <slug, ...>` and pass the selected add-ons into any specialist passes. Add-ons enrich this routed skill; they do not create standalone skill names or bypass stack routing.
+
+### Declared Add-Ons
+
+- `android-compose`: entrypoint `android-compose-review.md`; companions `android-compose-edge-to-edge.md`, `android-compose-adaptive-layouts.md`, `android-navigation-review.md`, `android-design-system-review.md`, `android-interop-review.md`.
+- `android-navigation`: entrypoint `android-navigation-review.md`; companions `none`.
+- `android-interop`: entrypoint `android-interop-review.md`; companions `none`.
+- `android-design-system`: entrypoint `android-design-system-review.md`; companions `none`.
+
 ## Execution
 
 ### Compose Review Rubric
 
 The canonical KMP UI review command stays `bill-kmp-code-review-ui`. Governed add-ons apply only after the parent review has already routed to `kmp`.
-
-When the parent KMP review selects the `android-compose` add-on, scan [android-compose-review.md](android-compose-review.md) first. If the add-on is split into topic files, open only the linked topic files whose cues match the diff, such as [android-compose-edge-to-edge.md](android-compose-edge-to-edge.md) and [android-compose-adaptive-layouts.md](android-compose-adaptive-layouts.md).
-
-When the parent KMP review selects `android-navigation`, scan [android-navigation-review.md](android-navigation-review.md) first and apply any Android-specific UI risks from it alongside the base Compose review rubric.
-
-When the parent KMP review selects `android-interop`, scan [android-interop-review.md](android-interop-review.md) first and apply any Android-specific UI risks from it alongside the base Compose review rubric.
-
-When the parent KMP review selects `android-design-system`, scan [android-design-system-review.md](android-design-system-review.md) first and apply any Android-specific UI risks from it alongside the base Compose review rubric.
 
 When no governed add-on applies, use the base Compose review rubric by itself.
 

--- a/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kmp-code-review.render.txt
+++ b/runtime-kotlin/runtime-core/src/test/resources/snapshots/scaffold/bill-kmp-code-review.render.txt
@@ -22,6 +22,21 @@ Keep baseline-layer findings attributed to that layer before merging and dedupli
 
 - `kotlin/bill-kotlin-code-review` with scope `same-review-scope`, mode `kmp-baseline`, required `true`.
 
+## Governed Add-Ons
+
+This platform pack declares add-on usage for this skill in `platform.yaml`. Runtime agents MUST resolve these add-ons only after stack routing has selected `kmp`.
+
+Start from `Selected add-ons: none`. Scan each declared entrypoint's `## Activation signals` and `## Section index` headings first, select only add-ons whose cues match the scoped work, then open only the selected entrypoint and companion pointers needed for that scope.
+Report the final selection as `Selected add-ons: <slug, ...>` and pass the selected add-ons into any specialist passes. Add-ons enrich this routed skill; they do not create standalone skill names or bypass stack routing.
+
+### Declared Add-Ons
+
+- `android-compose`: entrypoint `android-compose-review.md`; companions `android-compose-edge-to-edge.md`, `android-compose-adaptive-layouts.md`, `android-navigation-review.md`, `android-design-system-review.md`, `android-interop-review.md`.
+- `android-navigation`: entrypoint `android-navigation-review.md`; companions `none`.
+- `android-interop`: entrypoint `android-interop-review.md`; companions `none`.
+- `android-design-system`: entrypoint `android-design-system-review.md`; companions `none`.
+- `android-r8`: entrypoint `android-r8-review.md`; companions `none`.
+
 ## Execution
 
 You are an experienced Android/KMP architect conducting a code review.
@@ -53,25 +68,6 @@ Classify the review as one of:
 - If Android/KMP signals are weak or absent, delegate to `bill-kotlin-code-review` and stop instead of pretending mobile-specific coverage exists.
 - If backend/server files are also touched, keep the `kmp` route and rely on the manifest-declared baseline layer so shared Kotlin concerns are still reviewed before this skill adds mobile-specific specialists.
 - When uncertain, prefer the safer route that preserves Android/KMP review depth.
-
-### Governed Add-On Resolution
-
-After the stack is already classified as `kmp`, resolve governed add-ons before selecting KMP-specific specialists.
-
-- If no add-on cues match, continue with the base KMP review without a governed add-on.
-- Select `android-compose` when the scoped diff contains Compose UI signals such as `@Composable`, Compose UI state, `Modifier` chains, previews, `remember*`, or Compose side effects.
-- Select `android-navigation` when the scoped diff changes route models, `NavHost`/`NavDisplay`, deep links, multi-back-stack behavior, scene destinations, or Android navigation ownership.
-- Select `android-interop` when the scoped diff mixes Compose with legacy Views, Fragments, `ComposeView`, `AndroidView`, `AndroidViewBinding`, or other Android host-boundary glue.
-- Select `android-design-system` when the scoped diff changes Android theme layers, `MaterialTheme`, design tokens, styled components, or XML-theme-to-Compose translation.
-- Select `android-r8` when the scoped diff changes Android keep rules, shrinker config, `proguardFiles`, `isMinifyEnabled`, `isShrinkResources`, or release-only R8 settings.
-- Scan [android-compose-review.md](android-compose-review.md) first. If the add-on is split into topic files, open only the linked topic files whose cues match the scoped diff when `android-compose` is selected, such as [android-compose-edge-to-edge.md](android-compose-edge-to-edge.md) and [android-compose-adaptive-layouts.md](android-compose-adaptive-layouts.md).
-- Scan [android-navigation-review.md](android-navigation-review.md) when `android-navigation` is selected.
-- Scan [android-interop-review.md](android-interop-review.md) when `android-interop` is selected.
-- Scan [android-design-system-review.md](android-design-system-review.md) when `android-design-system` is selected.
-- Scan [android-r8-review.md](android-r8-review.md) when `android-r8` is selected.
-- Add-ons enrich the routed KMP review; they do not create standalone reviewer names or bypass the `kmp` route.
-
----
 
 ### Layered Review Plan
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt
@@ -56,6 +56,17 @@ data class CodeReviewComposition(
   val baselineLayers: List<CodeReviewBaselineLayer>,
 )
 
+data class GovernedAddonUsage(
+  val skillRelativeDir: String,
+  val addons: List<GovernedAddonSelection>,
+)
+
+data class GovernedAddonSelection(
+  val slug: String,
+  val entrypoint: String,
+  val companionPointers: List<String> = emptyList(),
+)
+
 data class PlatformManifest(
   val slug: String,
   val packRoot: Path,
@@ -69,6 +80,7 @@ data class PlatformManifest(
   val declaredQualityCheckFile: Path? = null,
   val codeReviewComposition: CodeReviewComposition? = null,
   val pointers: List<PointerSpec> = emptyList(),
+  val addonUsage: List<GovernedAddonUsage> = emptyList(),
   /**
    * SKILL-48 Subtask 3: carries every non-anchored top-level field from `platform.yaml`
    * verbatim. Intentionally untyped (`Map<String, Any?>`) so repo authors can add


### PR DESCRIPTION
## Summary

- Add manifest-backed `addon_usage` for governed add-ons and render a generated `## Governed Add-Ons` section into routed skills.
- Teach add-on scaffolding to register generated pointers plus `addon_usage` in `platform.yaml`, defaulting to the pack baseline review skill and supporting explicit declared consumers.
- Move KMP add-on selection out of hand-authored skill prose and into the pack manifest, with loader/schema coherence checks and regression coverage.

## Validation

- `(cd runtime-kotlin && ./gradlew check)`
- `skill-bill validate`
- `scripts/validate_agent_configs`
- `npx --yes agnix --strict .` returned 0 errors and 4 existing AGENTS.md warnings
- `./install.sh --no-desktop-app`
