### PR TITLE
[codex] Stabilize desktop repo browser path handling

### DIFF
--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserService.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserService.kt
@@ -45,7 +45,6 @@ import java.nio.file.InvalidPathException
 import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.security.MessageDigest
-import kotlin.io.path.isDirectory
 import kotlin.io.path.relativeTo
 
 @Inject
@@ -345,7 +344,7 @@ class RuntimeRepoBrowserService :
   }
 
   private fun validateRoot(root: Path): RepoLoadStatus {
-    if (!Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS)) {
+    if (!Files.isDirectory(root)) {
       return RepoLoadStatus(
         state = RepoLoadState.INVALID,
         message = "Selected path is not a directory: $root",
@@ -498,7 +497,7 @@ class RuntimeRepoBrowserService :
     discoverGovernedAddonFiles(root)
       .forEach { addonFile ->
         val addon = addonFile.addonPath
-        val relative = addon.relativeTo(root).portablePath()
+        val relative = relativePath(root, addon)
         val id = selectionId(repoToken, "addon:$relative")
         selections[id] =
           SelectionDetail(
@@ -543,7 +542,7 @@ class RuntimeRepoBrowserService :
       skillsRoot = root.resolve("skills"),
     )
       .flatMap { sourceFile ->
-        val relative = sourceFile.relativeTo(root).portablePath()
+        val relative = relativePath(root, sourceFile)
         runCatching { parseNativeAgentSourceFile(sourceFile) }
           .fold(
             onSuccess = { agents ->
@@ -709,7 +708,7 @@ class RuntimeRepoBrowserService :
   ): List<SkillBillTreeItem> {
     return discoverGeneratedArtifactFiles(root).map { generated ->
       val artifact = generated.path
-      val relative = artifact.relativeTo(root).portablePath()
+      val relative = relativePath(root, artifact)
       val id = selectionId(repoToken, "generated:$relative")
       selections[id] =
         SelectionDetail(
@@ -744,7 +743,7 @@ class RuntimeRepoBrowserService :
       .filter { artifact -> artifact.path.toAbsolutePath().normalize().parent == normalizedSkillDir }
       .map { artifact ->
         GeneratedArtifactDetail(
-          path = artifact.path.relativeTo(root).portablePath(),
+          path = relativePath(root, artifact.path),
           reason = artifact.reason,
         )
       }
@@ -903,7 +902,7 @@ private fun invalidSession(repoPath: String, message: String): RepoSession = Rep
 )
 
 private fun looksLikeSkillBillRepo(root: Path): Boolean =
-  root.resolve("skills").isDirectory() || root.resolve("platform-packs").isDirectory()
+  Files.isDirectory(root.resolve("skills")) || Files.isDirectory(root.resolve("platform-packs"))
 
 private fun isAuthoredContentFile(contentFile: Path?): Boolean = contentFile?.fileName?.toString() == "content.md"
 
@@ -920,9 +919,31 @@ private fun group(id: String, label: String, children: List<SkillBillTreeItem>):
 
 private fun Map<*, *>.string(key: String): String? = this[key] as? String
 
-private fun relativePath(root: Path, path: String): String =
-  runCatching { Path.of(path).toAbsolutePath().normalize().relativeTo(root).portablePath() }
-    .getOrDefault(path.replace('\\', '/'))
+private fun relativePath(root: Path, path: String): String = relativePath(root, Path.of(path))
+
+private fun relativePath(root: Path, path: Path): String {
+  val absoluteRoot = root.toAbsolutePath().normalize()
+  val absolutePath = path.toAbsolutePath().normalize()
+  relativeToRootOrNull(absoluteRoot, absolutePath)?.let { relative ->
+    return relative.portablePath()
+  }
+
+  val realRelative = runCatching {
+    val realRoot = root.toRealPath()
+    val realPath =
+      if (Files.exists(absolutePath, LinkOption.NOFOLLOW_LINKS)) {
+        absolutePath.toRealPath()
+      } else {
+        absolutePath
+      }
+    relativeToRootOrNull(realRoot, realPath)?.portablePath()
+  }.getOrNull()
+
+  return realRelative ?: path.portablePath()
+}
+
+private fun relativeToRootOrNull(root: Path, path: Path): Path? =
+  if (path.startsWith(root)) path.relativeTo(root) else null
 
 private fun Path.portablePath(): String = toString().replace('\\', '/')
 

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserServiceTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserServiceTest.kt
@@ -6,6 +6,7 @@ import skillbill.desktop.core.domain.model.RepoSession
 import skillbill.desktop.core.domain.model.TreeItemKind
 import skillbill.desktop.core.domain.model.ValidationRunState
 import skillbill.error.SkillBillRuntimeException
+import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
@@ -69,6 +70,58 @@ class RuntimeRepoBrowserServiceTest {
     assertFalse(generated.editable)
     assertEquals("RO", generated.readOnlyLabel)
     assertEquals("read-only", generated.status)
+  }
+
+  @Test
+  fun `native agent source rows stay repo relative when selected repo path is a symlink`() {
+    val repo = seedRepo("runtime-tree-symlink-target")
+    val linkParent = Files.createTempDirectory("skillbill-desktop-runtime-tree-link")
+    val repoLink = linkParent.resolve("repo-link")
+    val symlinkCreated = try {
+      Files.createSymbolicLink(repoLink, repo)
+      true
+    } catch (_: UnsupportedOperationException) {
+      false
+    } catch (_: FileSystemException) {
+      false
+    } catch (_: SecurityException) {
+      false
+    }
+    if (!symlinkCreated) {
+      return
+    }
+    val service = RuntimeRepoBrowserService()
+
+    val session = service.open(repoLink.toString())
+    assertEquals(RepoLoadState.LOADED, session.loadStatus.state, session.loadStatus.message)
+    val flattened = service.treeFor(session).flatten()
+    val treeSummary = flattened.joinToString("\n") { item ->
+      "${item.kind} ${item.label} ${item.authoredPath.orEmpty()} ${item.id}"
+    }
+
+    val sourceAgent = assertNotNull(
+      flattened.singleOrNull {
+        it.id.hasLocalId("native-agent:skills/bill-alpha/native-agents/alpha-agent.md:alpha-agent")
+      },
+      treeSummary,
+    )
+    val platformAgent = assertNotNull(
+      flattened.singleOrNull {
+        it.id.hasLocalId(
+          "native-agent:" +
+            "platform-packs/kotlin/code-review/bill-kotlin-code-review/native-agents/bill-kotlin-code-review-ui.md:" +
+            "bill-kotlin-code-review-ui",
+        )
+      },
+      treeSummary,
+    )
+    assertEquals("agent", sourceAgent.label)
+    assertEquals("skills/bill-alpha/native-agents/alpha-agent.md", sourceAgent.authoredPath)
+    assertEquals("ui", platformAgent.label)
+    assertEquals(
+      "platform-packs/kotlin/code-review/bill-kotlin-code-review/native-agents/bill-kotlin-code-review-ui.md",
+      platformAgent.authoredPath,
+    )
   }
 
   @Test

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/agent/history.md
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/agent/history.md
@@ -1,5 +1,12 @@
 # SkillBill desktop feature — history
 
+## [2026-05-23] SKILL-48 desktop repo-browser path normalization
+Areas: runtime-desktop/feature/skillbill, runtime-desktop/core/data
+- RuntimeRepoBrowserService now derives displayed/tree paths against the selected repo root first, then falls back to real-path containment, so discovery results returned via resolved paths still render as repo-relative IDs and authored paths. reusable
+- Repo open intentionally accepts a symlinked checkout directory, while source/editing rules remain unchanged: native-agent sources and generated artifacts stay read-only, and governed content/add-ons remain the editable surfaces.
+Feature flag: N/A
+Acceptance criteria: 4/4 implemented
+
 ## [2026-05-22] SKILL-50 desktop-wizard-baseline-layer-authoring
 Areas: runtime-desktop/feature/skillbill, runtime-desktop/core/domain, runtime-desktop/core/data, runtime-core/scaffold, runtime-domain/scaffold
 - Platform-pack scaffold wizard can author baseline review layers through catalog-backed controls, add/edit/remove state, default `same-review-scope`, default `required=true`, and form validation before Plan/Run.


### PR DESCRIPTION
## Summary

Stabilizes desktop repo browser path handling when a selected Skill Bill repo path is a symlink.

## Changes

- Resolves repo-relative authored and generated paths through a helper that first preserves lexical repo-relative paths and then falls back to real-path resolution when needed.
- Keeps selected symlink repo roots loadable as directories.
- Adds JVM regression coverage for native-agent rows discovered through a symlinked repo path.
- Records the feature history entry for the Skill Bill desktop surface.

## Why

The desktop repo browser could produce non-repo-relative paths when the selected repo root was a symlink, which broke stable selection IDs and authored path display for discovered native-agent sources.

## Validation

- `./gradlew :runtime-desktop:core:data:jvmTest --tests skillbill.desktop.core.data.service.RuntimeRepoBrowserServiceTest`
