### PR TITLE
SKILL-51 auto reinstall after publish

### DIFF
--- a/.feature-specs/SKILL-51-auto-reinstall-after-publish/spec.md
+++ b/.feature-specs/SKILL-51-auto-reinstall-after-publish/spec.md
@@ -1,0 +1,29 @@
+# SKILL-51 — Auto reinstall after publish
+
+Status: Complete
+Issue key: SKILL-51
+
+## Context
+
+Desktop users can edit or delete governed `content.md` sources and pack-owned add-ons, then publish those changes. Published source changes do not affect the locally installed agent skills until Skill Bill is reinstalled. The current desktop path requires the user to reopen setup and make the same installation selections again.
+
+## Acceptance Criteria
+
+1. After a successful desktop publish that pushes changes, the app asks whether to reinstall Skill Bill so changed governed skills/add-ons take effect.
+2. Confirming the prompt reuses the latest completed install selections instead of reopening the full setup wizard.
+3. Latest install preferences are persisted whenever the first-run/setup install flow succeeds, including agents, platform packs, telemetry, MCP registration behavior, and desktop defaults already owned by the installer.
+4. The reinstall path runs through the existing typed install gateway plan/apply contract and reports success, warning, or failure in UI state.
+5. Declining or dismissing the prompt leaves the publish result intact and does not mutate install state.
+6. Tests cover preference reuse, reinstall gateway behavior, ViewModel prompt/state transitions, and publish-to-reinstall success/failure paths.
+
+## Non-goals
+
+- Change CLI `install.sh` behavior outside the desktop runtime.
+- Reinstall automatically without explicit user confirmation.
+- Rework PR publishing provider behavior.
+
+## Validation Strategy
+
+- Add focused ViewModel tests for post-publish reinstall prompt, decline, success, and failure.
+- Add datastore/gateway tests where needed for persisted install preference replay.
+- Run the relevant desktop JVM tests, then a broader Gradle check if feasible.

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
@@ -194,7 +194,7 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
       ),
       telemetryLevel = request.telemetryLevel.toInstallTelemetryLevel(),
       mcpRegistrationChoice = McpRegistrationChoice(
-        register = true,
+        register = request.registerMcp,
         runtimeMcpBin = runtimeAssets.runtimeMcpBin() ?: defaultRuntimeMcpBin(home),
       ),
       runtimeDistributionInputs = RuntimeDistributionInputs(

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
@@ -70,7 +70,7 @@ class JvmDesktopFirstRunGatewayTest {
   }
 
   @Test
-  fun `plan maps desktop request into shared install plan request with MCP registration`() = runBlocking {
+  fun `plan maps desktop request into shared install plan request with MCP preference`() = runBlocking {
     val root = Files.createTempDirectory("skillbill-first-run-root")
     var capturedRequest: InstallPlanRequest? = null
     val gateway = JvmDesktopFirstRunGateway().apply {
@@ -98,7 +98,7 @@ class JvmDesktopFirstRunGatewayTest {
     assertEquals(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX), request.agentSelection.manualAgents)
     assertEquals(setOf("kotlin"), request.platformPackSelection.selectedSlugs)
     assertEquals("full", request.telemetryLevel.id)
-    assertTrue(request.mcpRegistrationChoice.register)
+    assertFalse(request.mcpRegistrationChoice.register)
     assertEquals(
       root.resolve("runtime-mcp/bin/runtime-mcp").toAbsolutePath().normalize(),
       request.mcpRegistrationChoice.runtimeMcpBin,

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
@@ -71,7 +71,7 @@ class LocalDesktopPreferenceStore : DesktopPreferenceStore {
     selectedAgentIds = properties.getProperty(KEY_FIRST_RUN_AGENTS).toSetProperty(),
     selectedPlatformSlugs = properties.getProperty(KEY_FIRST_RUN_PLATFORMS).toSetProperty(),
     telemetryLevelId = properties.getProperty(KEY_FIRST_RUN_TELEMETRY, "anonymous"),
-    registerMcp = true,
+    registerMcp = properties.getProperty(KEY_FIRST_RUN_MCP)?.toBooleanStrictOrNull() ?: true,
   )
 
   private fun persistFirstRunPreferences(preferences: DesktopFirstRunPreferences) {
@@ -79,8 +79,8 @@ class LocalDesktopPreferenceStore : DesktopPreferenceStore {
     properties.setProperty(KEY_FIRST_RUN_AGENTS, preferences.selectedAgentIds.toPropertyValue())
     properties.setProperty(KEY_FIRST_RUN_PLATFORMS, preferences.selectedPlatformSlugs.toPropertyValue())
     properties.setProperty(KEY_FIRST_RUN_TELEMETRY, preferences.telemetryLevelId)
-    properties.remove(KEY_FIRST_RUN_MCP)
-    firstRunState.value = preferences.copy(registerMcp = true)
+    properties.setProperty(KEY_FIRST_RUN_MCP, preferences.registerMcp.toString())
+    firstRunState.value = preferences
     saveProperties()
   }
 

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -74,7 +75,7 @@ class LocalDesktopPreferenceStoreTest {
       assertEquals(setOf("claude", "codex"), reloaded.selectedAgentIds)
       assertEquals(setOf("kotlin"), reloaded.selectedPlatformSlugs)
       assertEquals("full", reloaded.telemetryLevelId)
-      assertTrue(reloaded.registerMcp)
+      assertFalse(reloaded.registerMcp)
     }
   }
 

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
@@ -162,6 +162,18 @@ data class FirstRunSetupState(
     selectedAgentIds = selectedAgentIds,
     selectedPlatformSlugs = selectedPlatformSlugs,
     telemetryLevel = telemetryLevel,
-    registerMcp = true,
+    registerMcp = registerMcp,
   )
+}
+
+data class PostPublishReinstallState(
+  val selectedAgentIds: Set<String>,
+  val selectedPlatformSlugs: Set<String>,
+  val telemetryLevel: FirstRunTelemetryLevel,
+  val registerMcp: Boolean,
+  val busy: Boolean = false,
+  val outcome: FirstRunInstallOutcome? = null,
+) {
+  val hasFinished: Boolean
+    get() = outcome != null
 }

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillBillModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillBillModels.kt
@@ -69,6 +69,7 @@ data class SkillBillState(
   val commandPalette: CommandPaletteState = CommandPaletteState(),
   val scaffoldWizard: ScaffoldWizardState? = null,
   val firstRunSetup: FirstRunSetupState? = null,
+  val postPublishReinstall: PostPublishReinstallState? = null,
   /** SKILL-46: non-null while the tree-context-menu Delete dialog is on screen. */
   val confirmDeletion: ConfirmDeletionState? = null,
   /** SKILL-46 AC8: post-delete output of scripts/validate_agent_configs piped into the dock console. */
@@ -204,6 +205,12 @@ enum class SkillBillBusyOperation {
    * surface a different running label.
    */
   VALIDATE_AGENT_CONFIGS,
+
+  /**
+   * Replays the latest completed desktop setup selection after publishing governed source changes,
+   * so refreshed installed skills take effect without reopening the full setup wizard.
+   */
+  REINSTALL,
 }
 
 data class CommandPaletteState(

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/agent/history.md
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/agent/history.md
@@ -1,5 +1,14 @@
 # SkillBill desktop feature — history
 
+## [2026-05-23] SKILL-51 auto-reinstall-after-publish
+Areas: runtime-desktop/feature/skillbill, runtime-desktop/core/domain, runtime-desktop/core/data, runtime-desktop/core/datastore
+- Successful desktop publish/push now opens a post-publish reinstall prompt when completed setup preferences include reusable agent selections; declining leaves the publish result intact.
+- Reinstall reuses the latest saved setup request, runs the existing typed first-run plan/apply gateway, and reports success/warning/failure in dialog state without reopening the wizard.
+- Reusable: setup preferences now preserve MCP registration choice end-to-end, so future install replay paths can use `DesktopFirstRunPreferences` as the source of truth.
+- Tests cover prompt gating, saved preference replay, gateway MCP mapping, success persistence, and failure retaining the publish link.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-05-23] SKILL-48 desktop repo-browser path normalization
 Areas: runtime-desktop/feature/skillbill, runtime-desktop/core/data
 - RuntimeRepoBrowserService now derives displayed/tree paths against the selected repo root first, then falls back to real-path containment, so discovery results returned via resolved paths still render as repo-relative IDs and authored paths. reusable

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/CommandPaletteBuilder.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/CommandPaletteBuilder.kt
@@ -470,6 +470,7 @@ private fun SkillBillBusyOperation.label(): String = when (this) {
   SkillBillBusyOperation.FIRST_RUN_SETUP -> "setup"
   SkillBillBusyOperation.DELETE -> "delete"
   SkillBillBusyOperation.VALIDATE_AGENT_CONFIGS -> "validate agent configs"
+  SkillBillBusyOperation.REINSTALL -> "reinstall"
 }
 
 private fun List<SkillBillTreeItem>.flattenPaletteTree(): List<SkillBillTreeItem> =

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
@@ -31,6 +31,7 @@ import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
 import skillbill.desktop.core.domain.model.GitOperationResult
 import skillbill.desktop.core.domain.model.GitPublishingStatus
 import skillbill.desktop.core.domain.model.GitPushTarget
+import skillbill.desktop.core.domain.model.PostPublishReinstallState
 import skillbill.desktop.core.domain.model.PrPublishingRequest
 import skillbill.desktop.core.domain.model.PrPublishingResult
 import skillbill.desktop.core.domain.model.PublishLink
@@ -174,6 +175,8 @@ class SkillBillViewModel(
       desktopPreferenceStore.firstRunPreferences.value.toFirstRunSetupState()
     }
   private var activeFirstRunToken: Long = 0L
+  private var postPublishReinstall: PostPublishReinstallState? = null
+  private var activePostPublishReinstallToken: Long = 0L
   private var currentState = createState()
 
   init {
@@ -650,6 +653,7 @@ class SkillBillViewModel(
       commandPalette = paletteState,
       scaffoldWizard = wizardState,
       firstRunSetup = firstRunSetup,
+      postPublishReinstall = postPublishReinstall,
       confirmDeletion = confirmDeletion,
       validateAgentConfigs = validateAgentConfigsSummary,
       partialMutationPostMortem = partialMutationPostMortem,
@@ -671,7 +675,7 @@ class SkillBillViewModel(
   }
 
   fun openFirstRunSetup(): SkillBillState {
-    if (busyOperation != null || scaffoldWizard != null || firstRunSetup != null) {
+    if (busyOperation != null || scaffoldWizard != null || firstRunSetup != null || postPublishReinstall != null) {
       return currentState
     }
     firstRunSetup = desktopPreferenceStore.firstRunPreferences.value.toFirstRunSetupState()
@@ -1632,6 +1636,82 @@ class SkillBillViewModel(
     return currentState
   }
 
+  fun dismissPostPublishReinstall(): SkillBillState {
+    val prompt = postPublishReinstall ?: return currentState
+    if (prompt.busy) {
+      return currentState
+    }
+    postPublishReinstall = null
+    currentState = createState()
+    return currentState
+  }
+
+  fun beginPostPublishReinstall(): PostPublishReinstallRequest? {
+    val prompt = postPublishReinstall ?: return null
+    if (prompt.busy) {
+      return null
+    }
+    val setupRequest = latestInstallSetupRequest() ?: return null
+    activePostPublishReinstallToken += 1
+    busyOperation = SkillBillBusyOperation.REINSTALL
+    postPublishReinstall = prompt.copy(busy = true, outcome = null)
+    currentState = createState()
+    return PostPublishReinstallRequest(
+      token = activePostPublishReinstallToken,
+      setupRequest = setupRequest,
+    )
+  }
+
+  suspend fun runPostPublishReinstall(request: PostPublishReinstallRequest): PostPublishReinstallResponse {
+    val planResult = firstRunGateway.planSetup(request.setupRequest)
+    val applyResult = when (planResult) {
+      is FirstRunPlanResult.Planned -> firstRunGateway.applySetup(planResult.plan)
+      is FirstRunPlanResult.Failed -> null
+    }
+    return PostPublishReinstallResponse(
+      request = request,
+      planResult = planResult,
+      applyResult = applyResult,
+    )
+  }
+
+  fun finishPostPublishReinstall(response: PostPublishReinstallResponse): SkillBillState {
+    if (response.request.token != activePostPublishReinstallToken) {
+      return currentState
+    }
+    if (busyOperation == SkillBillBusyOperation.REINSTALL) {
+      busyOperation = null
+    }
+    val prompt = postPublishReinstall ?: return currentState
+    val outcome = when (val planResult = response.planResult) {
+      is FirstRunPlanResult.Failed -> FirstRunInstallOutcome(
+        status = FirstRunInstallStatus.FAILURE,
+        title = "Reinstall planning failed.",
+        details = listOf(
+          skillbill.desktop.core.domain.model.FirstRunInstallDetail(
+            label = "Install",
+            message = planResult.message,
+            severity = skillbill.desktop.core.domain.model.FirstRunInstallDetailSeverity.ERROR,
+          ),
+        ),
+      )
+      is FirstRunPlanResult.Planned -> when (val applyResult = response.applyResult) {
+        is FirstRunApplyResult.Applied -> applyResult.outcome
+        is FirstRunApplyResult.Failed -> applyResult.outcome
+        null -> FirstRunInstallOutcome(
+          status = FirstRunInstallStatus.FAILURE,
+          title = "Reinstall did not run.",
+        )
+      }
+    }
+    postPublishReinstall = prompt.copy(busy = false, outcome = outcome)
+    if (outcome.status != FirstRunInstallStatus.FAILURE) {
+      desktopPreferenceStore.markFirstRunCompleted(response.request.setupRequest.toPreferences())
+    }
+    currentState = createState()
+    return currentState
+  }
+
   // --- Publish ---
 
   fun beginPublish(allowFailedValidation: Boolean = false, allowCanonicalRemote: Boolean = false): PublishRunRequest? {
@@ -1861,6 +1941,9 @@ class SkillBillViewModel(
     commitValidationFailed = false
     failedValidationStagedAuthoredPaths = null
     applyPublishRefreshes(result)
+    if (pushResult?.success == true) {
+      showPostPublishReinstallPrompt()
+    }
     currentState = createState()
     return currentState
   }
@@ -2096,6 +2179,9 @@ class SkillBillViewModel(
     if (busyOperation != null || changesBusy || publishBusy || commitBusy || commitValidationRunning || pushBusy) {
       return "Repository operation is already running."
     }
+    if (postPublishReinstall != null) {
+      return "Finish or dismiss the reinstall prompt before publishing again."
+    }
     if (changesSnapshot.nonSkillContentFiles.isNotEmpty()) {
       return "Repository has non-content.md changes. Resolve or stash those files before publishing from Skill Bill."
     }
@@ -2156,6 +2242,29 @@ class SkillBillViewModel(
       canonicalPushConfirmationTarget = null
     }
     publishingStatus = status
+  }
+
+  private fun showPostPublishReinstallPrompt() {
+    val request = latestInstallSetupRequest() ?: return
+    postPublishReinstall = PostPublishReinstallState(
+      selectedAgentIds = request.selectedAgentIds,
+      selectedPlatformSlugs = request.selectedPlatformSlugs,
+      telemetryLevel = request.telemetryLevel,
+      registerMcp = request.registerMcp,
+    )
+  }
+
+  private fun latestInstallSetupRequest(): FirstRunSetupRequest? {
+    val preferences = desktopPreferenceStore.firstRunPreferences.value
+    if (!preferences.completed || preferences.selectedAgentIds.isEmpty()) {
+      return null
+    }
+    return FirstRunSetupRequest(
+      selectedAgentIds = preferences.selectedAgentIds,
+      selectedPlatformSlugs = preferences.selectedPlatformSlugs,
+      telemetryLevel = FirstRunTelemetryLevel.fromId(preferences.telemetryLevelId),
+      registerMcp = preferences.registerMcp,
+    )
   }
 
   private fun containsTreeItem(itemId: String): Boolean = treeItems.flatten().any { item -> item.id == itemId }
@@ -3298,11 +3407,22 @@ data class FirstRunApplyResponse(
   val applyResult: FirstRunApplyResult?,
 )
 
+data class PostPublishReinstallRequest(
+  val token: Long,
+  val setupRequest: FirstRunSetupRequest,
+)
+
+data class PostPublishReinstallResponse(
+  val request: PostPublishReinstallRequest,
+  val planResult: FirstRunPlanResult,
+  val applyResult: FirstRunApplyResult?,
+)
+
 private fun DesktopFirstRunPreferences.toFirstRunSetupState(): FirstRunSetupState = FirstRunSetupState(
   selectedAgentIds = selectedAgentIds,
   selectedPlatformSlugs = selectedPlatformSlugs,
   telemetryLevel = FirstRunTelemetryLevel.fromId(telemetryLevelId),
-  registerMcp = true,
+  registerMcp = registerMcp,
 )
 
 private fun FirstRunSetupState.applyDiscovery(
@@ -3327,7 +3447,7 @@ private fun FirstRunSetupState.applyDiscovery(
     selectedAgentIds = selectedAgents,
     selectedPlatformSlugs = selectedPlatforms,
     telemetryLevel = FirstRunTelemetryLevel.fromId(preferences.telemetryLevelId),
-    registerMcp = true,
+    registerMcp = preferences.registerMcp,
   )
 }
 
@@ -3336,7 +3456,15 @@ private fun FirstRunSetupState.toPreferences(): DesktopFirstRunPreferences = Des
   selectedAgentIds = selectedAgentIds,
   selectedPlatformSlugs = selectedPlatformSlugs,
   telemetryLevelId = telemetryLevel.id,
-  registerMcp = true,
+  registerMcp = registerMcp,
+)
+
+private fun FirstRunSetupRequest.toPreferences(): DesktopFirstRunPreferences = DesktopFirstRunPreferences(
+  completed = false,
+  selectedAgentIds = selectedAgentIds,
+  selectedPlatformSlugs = selectedPlatformSlugs,
+  telemetryLevelId = telemetryLevel.id,
+  registerMcp = registerMcp,
 )
 
 private fun FirstRunSetupStep.next(): FirstRunSetupStep = when (this) {

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialog.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialog.kt
@@ -40,6 +40,7 @@ import skillbill.desktop.core.domain.model.FirstRunInstallStatus
 import skillbill.desktop.core.domain.model.FirstRunSetupState
 import skillbill.desktop.core.domain.model.FirstRunSetupStep
 import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
+import skillbill.desktop.core.domain.model.PostPublishReinstallState
 
 data class FirstRunSetupCallbacks(
   val onAgentSelectionChanged: (String, Boolean) -> Unit,
@@ -50,6 +51,11 @@ data class FirstRunSetupCallbacks(
   val onApply: () -> Unit,
   val onRetry: () -> Unit,
   val onFinish: () -> Unit,
+  val onDismiss: () -> Unit,
+)
+
+data class PostPublishReinstallCallbacks(
+  val onReinstall: () -> Unit,
   val onDismiss: () -> Unit,
 )
 
@@ -97,6 +103,122 @@ fun FirstRunSetupDialog(state: FirstRunSetupState, callbacks: FirstRunSetupCallb
       }
       HorizontalDivider(color = semanticTones.dialog.border)
       SetupFooter(state, callbacks)
+    }
+  }
+}
+
+@Composable
+fun PostPublishReinstallDialog(state: PostPublishReinstallState, callbacks: PostPublishReinstallCallbacks) {
+  val semanticTones = SkillBillTheme.semanticTones
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(semanticTones.scrim)
+      .semantics { contentDescription = "Reinstall Skill Bill after publishing" }
+      .clickable(enabled = !state.busy, role = Role.Button, onClick = callbacks.onDismiss),
+  ) {
+    Column(
+      modifier = Modifier
+        .align(Alignment.Center)
+        .widthIn(min = 520.dp, max = 720.dp)
+        .heightIn(max = 620.dp)
+        .clip(RoundedCornerShape(8.dp))
+        .border(1.dp, semanticTones.dialog.border, RoundedCornerShape(8.dp))
+        .background(semanticTones.dialog.container)
+        .clickable(enabled = false, onClick = {}),
+    ) {
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 18.dp, vertical = 14.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+      ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+          Text(
+            text = "Reinstall Skill Bill",
+            color = semanticTones.dialog.content,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+          )
+          Text(
+            text = "Published source changes need a reinstall before installed agents use them.",
+            color = SkillBillTheme.colors.onSurfaceVariant,
+            fontSize = 12.sp,
+          )
+        }
+        Text(
+          text = "x",
+          color = SkillBillTheme.colors.onSurfaceVariant,
+          fontSize = 14.sp,
+          modifier = Modifier
+            .semantics { contentDescription = "Dismiss reinstall prompt" }
+            .clickable(enabled = !state.busy, role = Role.Button, onClick = callbacks.onDismiss)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+      }
+      HorizontalDivider(color = semanticTones.dialog.border)
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .weight(1f, fill = false)
+          .verticalScroll(rememberScrollState())
+          .padding(horizontal = 18.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        if (state.busy) {
+          SetupBanner(
+            title = "Reinstalling",
+            message = "Reusing the latest saved install selections.",
+            tone = semanticTones.warningBanner,
+          )
+        } else if (state.outcome == null) {
+          SetupBanner(
+            title = "Apply published changes locally",
+            message = "Reinstall now using the latest saved selections.",
+            tone = semanticTones.successBanner,
+          )
+        }
+        SummaryLine(label = "Agents", value = state.selectedAgentIds.sorted().joinToString(", "))
+        SummaryLine(
+          label = "Platform packs",
+          value = state.selectedPlatformSlugs.sorted().joinToString(", ").ifBlank { "none" },
+        )
+        SummaryLine(label = "Telemetry", value = state.telemetryLevel.id)
+        SummaryLine(label = "MCP", value = if (state.registerMcp) "register" else "skip")
+        state.outcome?.let { outcome ->
+          val tone = when (outcome.status) {
+            FirstRunInstallStatus.SUCCESS -> semanticTones.successBanner
+            FirstRunInstallStatus.WARNING -> semanticTones.warningBanner
+            FirstRunInstallStatus.FAILURE -> semanticTones.errorBanner
+          }
+          SetupBanner(title = outcome.title, message = outcome.status.name.lowercase(), tone = tone)
+          outcome.details.forEach { detail -> DetailRow(detail) }
+        }
+      }
+      HorizontalDivider(color = semanticTones.dialog.border)
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 18.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        if (!state.busy && state.outcome?.status == FirstRunInstallStatus.FAILURE) {
+          SetupButton(label = "Retry", enabled = true, primary = true, onClick = callbacks.onReinstall)
+          SetupButton(label = "Done", enabled = true, onClick = callbacks.onDismiss)
+        } else if (state.hasFinished) {
+          SetupButton(label = "Done", enabled = !state.busy, primary = true, onClick = callbacks.onDismiss)
+        } else {
+          SetupButton(label = "Later", enabled = !state.busy, onClick = callbacks.onDismiss)
+          SetupButton(
+            label = if (state.busy) "Reinstalling..." else "Reinstall",
+            enabled = !state.busy,
+            primary = true,
+            onClick = callbacks.onReinstall,
+          )
+        }
+      }
     }
   }
 }
@@ -205,7 +327,11 @@ private fun PreferencesStep(state: FirstRunSetupState, callbacks: FirstRunSetupC
   Spacer(modifier = Modifier.height(4.dp))
   SectionTitle("MCP")
   Text(
-    text = "Skill Bill MCP server will be registered for selected agents.",
+    text = if (state.registerMcp) {
+      "Skill Bill MCP server will be registered for selected agents."
+    } else {
+      "Skill Bill MCP server registration is skipped."
+    },
     color = colors.onSurfaceVariant,
     fontSize = 12.sp,
   )
@@ -222,7 +348,7 @@ private fun ApplyStep(state: FirstRunSetupState) {
     },
   )
   SummaryLine(label = "Telemetry", value = state.telemetryLevel.id)
-  SummaryLine(label = "MCP", value = "register")
+  SummaryLine(label = "MCP", value = if (state.registerMcp) "register" else "skip")
 }
 
 @Composable

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillFrame.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillFrame.kt
@@ -265,6 +265,7 @@ fun SkillBillFrame(
   onOpenScaffoldWizard: (ScaffoldKind) -> Unit,
   scaffoldWizardCallbacks: ScaffoldWizardCallbacks,
   firstRunSetupCallbacks: FirstRunSetupCallbacks,
+  postPublishReinstallCallbacks: PostPublishReinstallCallbacks,
   // SKILL-46: right-click → Delete… dialog. The route owns target resolution from the node id so
   // the frame stays free of repo/skill semantics.
   onShowDeleteContextMenu: (SkillBillTreeItem) -> Unit = {},
@@ -571,6 +572,9 @@ fun SkillBillFrame(
     }
     state.firstRunSetup?.let { setup ->
       FirstRunSetupDialog(state = setup, callbacks = firstRunSetupCallbacks)
+    }
+    state.postPublishReinstall?.let { reinstall ->
+      PostPublishReinstallDialog(state = reinstall, callbacks = postPublishReinstallCallbacks)
     }
     state.confirmDeletion?.let { confirmation ->
       ConfirmDeletionDialog(
@@ -1012,6 +1016,7 @@ private fun BusyIndicator(busyOperation: SkillBillBusyOperation) {
     SkillBillBusyOperation.FIRST_RUN_SETUP -> "Setting up..."
     SkillBillBusyOperation.DELETE -> "Deleting..."
     SkillBillBusyOperation.VALIDATE_AGENT_CONFIGS -> "Validating agent configs..."
+    SkillBillBusyOperation.REINSTALL -> "Reinstalling..."
   }
   Row(
     modifier = Modifier.padding(start = 4.dp),

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillRoute.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillRoute.kt
@@ -23,6 +23,7 @@ import skillbill.desktop.core.domain.model.CommandPaletteResult
 import skillbill.desktop.core.domain.model.DesktopSkillRemovalTarget
 import skillbill.desktop.core.domain.model.DirtyEditorPromptReason
 import skillbill.desktop.core.domain.model.DockTab
+import skillbill.desktop.core.domain.model.FirstRunPlanResult
 import skillbill.desktop.core.domain.model.GitOperationResult
 import skillbill.desktop.core.domain.model.RepoLoadState
 import skillbill.desktop.core.domain.model.ScaffoldKind
@@ -30,6 +31,7 @@ import skillbill.desktop.core.domain.model.SkillBillBusyOperation
 import skillbill.desktop.core.domain.model.SkillBillState
 import skillbill.desktop.core.ui.di.rememberScreenComponent
 import skillbill.desktop.feature.skillbill.di.SkillBillComponent
+import skillbill.desktop.feature.skillbill.state.PostPublishReinstallResponse
 import skillbill.desktop.feature.skillbill.state.PublishRunResult
 
 @Suppress("DEPRECATION")
@@ -138,6 +140,33 @@ fun SkillBillRoute(
                   request = request,
                   validationSummary = request.previousValidationSummary,
                   pushResult = GitOperationResult.failed("Publish was cancelled."),
+                ),
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+
+  fun runPostPublishReinstall() {
+    val request = viewModel.beginPostPublishReinstall()
+    state = viewModel.state()
+    if (request != null) {
+      coroutineScope.launch {
+        var finished = false
+        try {
+          val response = withContext(Dispatchers.Default) { viewModel.runPostPublishReinstall(request) }
+          state = viewModel.finishPostPublishReinstall(response)
+          finished = true
+        } finally {
+          if (!finished) {
+            withContext(NonCancellable) {
+              state = viewModel.finishPostPublishReinstall(
+                PostPublishReinstallResponse(
+                  request = request,
+                  planResult = FirstRunPlanResult.Failed("Reinstall was cancelled."),
+                  applyResult = null,
                 ),
               )
             }
@@ -257,6 +286,7 @@ fun SkillBillRoute(
 
   fun canStartRepoScopedAction(): Boolean = state.busyOperation == null &&
     state.firstRunSetup == null &&
+    state.postPublishReinstall == null &&
     !state.publishBusy &&
     !state.commitBusy &&
     !state.commitValidationRunning &&
@@ -947,6 +977,12 @@ fun SkillBillRoute(
         state = viewModel.dismissFirstRunSetup()
       },
     ),
+    postPublishReinstallCallbacks = PostPublishReinstallCallbacks(
+      onReinstall = ::runPostPublishReinstall,
+      onDismiss = {
+        state = viewModel.dismissPostPublishReinstall()
+      },
+    ),
     recentlyCopiedKey = recentlyCopiedKey,
     recentlyOpenedCompareUrlKey = recentlyOpenedCompareUrlKey,
   )
@@ -960,6 +996,7 @@ private const val REPO_CHANGE_REFRESH_DEBOUNCE_MILLIS: Long = 500L
 internal fun canAutoRefreshGitStatus(state: SkillBillState): Boolean = state.selectedRepoPath != null &&
   state.repoStatus.state == RepoLoadState.LOADED &&
   state.busyOperation == null &&
+  state.postPublishReinstall == null &&
   !state.changesBusy &&
   !state.publishBusy &&
   !state.commitBusy &&

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
@@ -176,7 +176,7 @@ class SkillBillViewModelFirstRunTest {
     assertEquals(setOf("claude"), reopened.selectedAgentIds)
     assertEquals(setOf("kotlin"), reopened.selectedPlatformSlugs)
     assertEquals(FirstRunTelemetryLevel.FULL, reopened.telemetryLevel)
-    assertTrue(reopened.registerMcp)
+    assertFalse(reopened.registerMcp)
 
     val discoveryRequest = assertNotNull(viewModel.beginFirstRunDiscovery())
     val discovered = viewModel.finishFirstRunDiscovery(viewModel.runFirstRunDiscovery(discoveryRequest))
@@ -184,7 +184,7 @@ class SkillBillViewModelFirstRunTest {
     assertEquals(setOf("claude"), discovered.firstRunSetup?.selectedAgentIds)
     assertEquals(setOf("kotlin"), discovered.firstRunSetup?.selectedPlatformSlugs)
     assertEquals(FirstRunTelemetryLevel.FULL, discovered.firstRunSetup?.telemetryLevel)
-    assertTrue(discovered.firstRunSetup?.registerMcp ?: false)
+    assertFalse(discovered.firstRunSetup?.registerMcp ?: true)
   }
 
   @Test

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt
@@ -1,9 +1,21 @@
 package skillbill.desktop.feature.skillbill.state
 
+import kotlinx.coroutines.runBlocking
+import skillbill.desktop.core.datastore.DesktopFirstRunPreferences
 import skillbill.desktop.core.domain.model.ChangedFile
 import skillbill.desktop.core.domain.model.ChangedFileGroup
 import skillbill.desktop.core.domain.model.ChangesSnapshot
 import skillbill.desktop.core.domain.model.CommitEntry
+import skillbill.desktop.core.domain.model.FirstRunApplyResult
+import skillbill.desktop.core.domain.model.FirstRunDiscoveryResult
+import skillbill.desktop.core.domain.model.FirstRunInstallOutcome
+import skillbill.desktop.core.domain.model.FirstRunInstallPlan
+import skillbill.desktop.core.domain.model.FirstRunInstallPlanHandle
+import skillbill.desktop.core.domain.model.FirstRunInstallStatus
+import skillbill.desktop.core.domain.model.FirstRunPlanResult
+import skillbill.desktop.core.domain.model.FirstRunPlatformPackOption
+import skillbill.desktop.core.domain.model.FirstRunSetupDiscovery
+import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
 import skillbill.desktop.core.domain.model.GitAheadBehind
 import skillbill.desktop.core.domain.model.GitOperationResult
 import skillbill.desktop.core.domain.model.GitPublishingStatus
@@ -30,12 +42,14 @@ import skillbill.desktop.core.domain.service.RepoSessionService
 import skillbill.desktop.core.domain.service.SkillTreeService
 import skillbill.desktop.core.domain.service.ValidationGateway
 import skillbill.desktop.core.testing.FakeAuthoringGateway
+import skillbill.desktop.core.testing.FakeDesktopPreferenceStore
 import skillbill.desktop.core.testing.FakeGitGateway
 import skillbill.desktop.core.testing.FakePrPublishingGateway
 import skillbill.desktop.core.testing.FakeRecentRepoRepository
 import skillbill.desktop.core.testing.FakeRenderGateway
 import skillbill.desktop.core.testing.FakeSkillTreeService
 import skillbill.desktop.core.testing.FakeValidationGateway
+import skillbill.desktop.core.testing.install.FakeDesktopFirstRunGateway
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -1356,6 +1370,197 @@ class SkillBillViewModelGitTest {
   }
 
   @Test
+  fun `successful publish prompts reinstall when completed install preferences exist`() {
+    val gitGateway = FakeGitGateway(
+      scriptedPublishingStatus = GitPublishingStatus(
+        pushTarget = GitPushTarget(remoteName = "origin", branchName = "feature"),
+        aheadBehind = GitAheadBehind(ahead = 1, behind = 0),
+      ),
+    )
+    val preferenceStore = FakeDesktopPreferenceStore(
+      initialFirstRunPreferences = DesktopFirstRunPreferences(
+        completed = true,
+        selectedAgentIds = setOf("codex"),
+        selectedPlatformSlugs = setOf("kotlin"),
+        telemetryLevelId = FirstRunTelemetryLevel.FULL.id,
+      ),
+    )
+    val viewModel = newViewModel(gitGateway = gitGateway, desktopPreferenceStore = preferenceStore)
+    viewModel.selectRepoPath("/repo")
+    viewModel.refreshGit()
+
+    val request = viewModel.beginPublish()
+    assertNotNull(request)
+    val state = viewModel.finishPublish(viewModel.runPublish(request))
+
+    val reinstall = assertNotNull(state.postPublishReinstall)
+    assertEquals(setOf("codex"), reinstall.selectedAgentIds)
+    assertEquals(setOf("kotlin"), reinstall.selectedPlatformSlugs)
+    assertEquals(FirstRunTelemetryLevel.FULL, reinstall.telemetryLevel)
+    assertEquals(1, gitGateway.pushCallCount)
+  }
+
+  @Test
+  fun `successful publish does not prompt reinstall without reusable install preferences`() {
+    val gitGateway = FakeGitGateway(
+      scriptedPublishingStatus = GitPublishingStatus(
+        pushTarget = GitPushTarget(remoteName = "origin", branchName = "feature"),
+        aheadBehind = GitAheadBehind(ahead = 1, behind = 0),
+      ),
+    )
+    val viewModel = newViewModel(
+      gitGateway = gitGateway,
+      desktopPreferenceStore = FakeDesktopPreferenceStore(
+        initialFirstRunPreferences = DesktopFirstRunPreferences(completed = true),
+      ),
+    )
+    viewModel.selectRepoPath("/repo")
+    viewModel.refreshGit()
+
+    val request = viewModel.beginPublish()
+    assertNotNull(request)
+    val state = viewModel.finishPublish(viewModel.runPublish(request))
+
+    assertNull(state.postPublishReinstall)
+  }
+
+  @Test
+  fun `dismissing post publish reinstall leaves publish result and install preferences intact`() {
+    val initialPreferences = DesktopFirstRunPreferences(
+      completed = true,
+      selectedAgentIds = setOf("codex"),
+      selectedPlatformSlugs = setOf("kotlin"),
+      telemetryLevelId = FirstRunTelemetryLevel.FULL.id,
+      registerMcp = false,
+    )
+    val preferenceStore = FakeDesktopPreferenceStore(initialFirstRunPreferences = initialPreferences)
+    val gitGateway = FakeGitGateway(
+      scriptedPublishingStatus = GitPublishingStatus(
+        pushTarget = GitPushTarget(remoteName = "origin", branchName = "feature"),
+        aheadBehind = GitAheadBehind(ahead = 1, behind = 0),
+      ),
+    )
+    val viewModel = newViewModel(
+      gitGateway = gitGateway,
+      prPublishingGateway = FakePrPublishingGateway(
+        scriptedResult = PrPublishingResult.CreatedDraftPullRequest("https://github.com/acme/repo/pull/51"),
+      ),
+      desktopPreferenceStore = preferenceStore,
+    )
+    viewModel.selectRepoPath("/repo")
+    viewModel.refreshGit()
+    val publishRequest = viewModel.beginPublish()
+    assertNotNull(publishRequest)
+    val published = viewModel.finishPublish(viewModel.runPublish(publishRequest))
+    assertNotNull(published.postPublishReinstall)
+    assertEquals(PublishLinkKind.DRAFT_PR, published.publishLink?.kind)
+
+    val setupBlocked = viewModel.openFirstRunSetup()
+    assertNull(setupBlocked.firstRunSetup)
+    assertNotNull(setupBlocked.postPublishReinstall)
+
+    val dismissed = viewModel.dismissPostPublishReinstall()
+
+    assertNull(dismissed.postPublishReinstall)
+    assertEquals(PublishLinkKind.DRAFT_PR, dismissed.publishLink?.kind)
+    assertEquals(initialPreferences, preferenceStore.firstRunPreferences.value)
+  }
+
+  @Test
+  fun `post publish reinstall reuses saved setup request and reports success`() = runBlocking {
+    val plan = reinstallPlan()
+    val gateway = FakeDesktopFirstRunGateway(
+      discoveryResult = FirstRunDiscoveryResult.Success(
+        FirstRunSetupDiscovery(agents = emptyList(), platformPacks = emptyList()),
+      ),
+      planResult = FirstRunPlanResult.Planned(plan),
+      applyResult = FirstRunApplyResult.Applied(
+        FirstRunInstallOutcome(status = FirstRunInstallStatus.SUCCESS, title = "Setup completed."),
+      ),
+    )
+    val gitGateway = FakeGitGateway(
+      scriptedPublishingStatus = GitPublishingStatus(
+        pushTarget = GitPushTarget(remoteName = "origin", branchName = "feature"),
+        aheadBehind = GitAheadBehind(ahead = 1, behind = 0),
+      ),
+    )
+    val preferenceStore = FakeDesktopPreferenceStore(
+      initialFirstRunPreferences = DesktopFirstRunPreferences(
+        completed = true,
+        selectedAgentIds = setOf("codex", "claude"),
+        selectedPlatformSlugs = setOf("kotlin"),
+        telemetryLevelId = FirstRunTelemetryLevel.OFF.id,
+      ),
+    )
+    val viewModel = newViewModel(
+      gitGateway = gitGateway,
+      firstRunGateway = gateway,
+      desktopPreferenceStore = preferenceStore,
+    )
+    viewModel.selectRepoPath("/repo")
+    viewModel.refreshGit()
+    val publishRequest = viewModel.beginPublish()
+    assertNotNull(publishRequest)
+    viewModel.finishPublish(viewModel.runPublish(publishRequest))
+
+    val reinstallRequest = viewModel.beginPostPublishReinstall()
+    assertNotNull(reinstallRequest)
+    val state = viewModel.finishPostPublishReinstall(viewModel.runPostPublishReinstall(reinstallRequest))
+
+    assertEquals(setOf("claude", "codex"), gateway.planRequests.single().selectedAgentIds)
+    assertEquals(setOf("kotlin"), gateway.planRequests.single().selectedPlatformSlugs)
+    assertEquals(FirstRunTelemetryLevel.OFF, gateway.planRequests.single().telemetryLevel)
+    assertEquals(1, gateway.applyCallCount)
+    assertEquals(FirstRunInstallStatus.SUCCESS, state.postPublishReinstall?.outcome?.status)
+    assertTrue(preferenceStore.firstRunPreferences.value.completed)
+  }
+
+  @Test
+  fun `post publish reinstall failure stays in prompt and does not clear publish link`() = runBlocking {
+    val gateway = FakeDesktopFirstRunGateway(
+      discoveryResult = FirstRunDiscoveryResult.Success(
+        FirstRunSetupDiscovery(agents = emptyList(), platformPacks = emptyList()),
+      ),
+      planResult = FirstRunPlanResult.Failed("plan failed"),
+      applyResult = FirstRunApplyResult.Failed(
+        FirstRunInstallOutcome(status = FirstRunInstallStatus.FAILURE, title = "not used"),
+      ),
+    )
+    val gitGateway = FakeGitGateway(
+      scriptedPublishingStatus = GitPublishingStatus(
+        pushTarget = GitPushTarget(remoteName = "origin", branchName = "feature"),
+        aheadBehind = GitAheadBehind(ahead = 1, behind = 0),
+      ),
+    )
+    val viewModel = newViewModel(
+      gitGateway = gitGateway,
+      firstRunGateway = gateway,
+      prPublishingGateway = FakePrPublishingGateway(
+        scriptedResult = PrPublishingResult.CreatedDraftPullRequest("https://github.com/acme/repo/pull/51"),
+      ),
+      desktopPreferenceStore = FakeDesktopPreferenceStore(
+        initialFirstRunPreferences = DesktopFirstRunPreferences(
+          completed = true,
+          selectedAgentIds = setOf("codex"),
+        ),
+      ),
+    )
+    viewModel.selectRepoPath("/repo")
+    viewModel.refreshGit()
+    val publishRequest = viewModel.beginPublish()
+    assertNotNull(publishRequest)
+    viewModel.finishPublish(viewModel.runPublish(publishRequest))
+
+    val reinstallRequest = viewModel.beginPostPublishReinstall()
+    assertNotNull(reinstallRequest)
+    val state = viewModel.finishPostPublishReinstall(viewModel.runPostPublishReinstall(reinstallRequest))
+
+    assertEquals(FirstRunInstallStatus.FAILURE, state.postPublishReinstall?.outcome?.status)
+    assertEquals(PublishLinkKind.DRAFT_PR, state.publishLink?.kind)
+    assertEquals(0, gateway.applyCallCount)
+  }
+
+  @Test
   fun `publish to likely canonical remote is blocked by default`() {
     val target = GitPushTarget(
       remoteName = "origin",
@@ -1503,12 +1708,24 @@ class SkillBillViewModelGitTest {
     ),
   )
 
+  private fun reinstallPlan(): FirstRunInstallPlan = FirstRunInstallPlan(
+    handle = GitTestPlanHandle,
+    selectedAgentIds = setOf("codex"),
+    selectedPlatformSlugs = setOf("kotlin"),
+    platformPacks = listOf(FirstRunPlatformPackOption(slug = "kotlin", packRoot = "/repo/platform-packs/kotlin")),
+    baseSkillCount = 4,
+    platformSkillCount = 2,
+    stagingRoot = "/home/user/.skill-bill/installed-skills",
+  )
+
   // Confirm the unused parameters don't trigger warnings.
   @Suppress("unused")
   private fun referenceUnused(): Pair<ValidationSummary, RenderSummary> =
     ValidationSummary(state = ValidationRunState.UNAVAILABLE) to
       RenderSummary(state = RenderRunState.UNAVAILABLE)
 }
+
+private object GitTestPlanHandle : FirstRunInstallPlanHandle
 
 private fun defaultTree(): List<SkillBillTreeItem> = listOf(
   SkillBillTreeItem(


### PR DESCRIPTION
## Summary

Adds a post-publish reinstall prompt in the desktop app so published governed skill/add-on source changes can be applied locally without rerunning the full setup wizard.

## Changes

- Prompt after successful desktop publish/push when reusable completed install preferences exist.
- Reuse saved agent, platform pack, telemetry, and MCP selections through the existing typed first-run install plan/apply gateway.
- Preserve MCP opt-out in desktop preferences and honor it in the JVM install gateway.
- Block setup/publish races while the post-publish reinstall prompt is open.
- Add regression coverage for prompt gating, dismiss behavior, successful replay, failed reinstall, datastore persistence, and gateway MCP mapping.

## Validation

- `(cd runtime-kotlin && ./gradlew :runtime-desktop:feature:skillbill:spotlessApply :runtime-desktop:feature:skillbill:jvmTest)`
- `(cd runtime-kotlin && ./gradlew check)`
- `skill-bill validate`
- `scripts/validate_agent_configs`
- `npx --yes agnix --strict .`
- `git diff --check`

## Follow-up

A separate feature spec will define shared runtime install-selection persistence so installs from `./install.sh` can seed the same reusable choices.