### PR TITLE
feat: [SKILL-51] Add decomposition workflow state

### DIFF
--- a/.feature-specs/SKILL-51-decomposition-workflow-state/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/decomposition-manifest.yaml
@@ -1,0 +1,101 @@
+---
+contract_version: "0.1"
+issue_key: "SKILL-51"
+feature_name: "decomposition-workflow-state"
+parent_spec_path: ".feature-specs/SKILL-51-decomposition-workflow-state/spec.md"
+status: "complete"
+execution_model: "same_branch_commit_per_subtask"
+base_branch: "main"
+feature_branch: "feat/SKILL-51-decomposition-workflow-state"
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: "none"
+subtasks:
+- id: 1
+  name: "foundation"
+  spec_path: ".feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_1_foundation.md"
+  status: "complete"
+  branch: "feat/SKILL-51-decomposition-workflow-state"
+  commit_sha: "1f9ed5c"
+  workflow_id: null
+  review_result: null
+  audit_result: null
+  validation_result: null
+  blocked_reason: null
+  last_resumable_step: "finish"
+  dependencies: []
+- id: 2
+  name: "runtime-state"
+  spec_path: ".feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_2_runtime-state.md"
+  status: "complete"
+  branch: "feat/SKILL-51-decomposition-workflow-state"
+  commit_sha: "872bd18"
+  workflow_id: null
+  review_result: null
+  audit_result: null
+  validation_result: null
+  blocked_reason: null
+  last_resumable_step: "finish"
+  dependencies:
+  - subtask_id: 1
+    optional: false
+    skipped: false
+- id: 3
+  name: "continuation-branching"
+  spec_path: ".feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_3_continuation-branching.md"
+  status: "complete"
+  branch: "feat/SKILL-51-decomposition-workflow-state"
+  commit_sha: "1e90a51"
+  workflow_id: null
+  review_result: null
+  audit_result: null
+  validation_result: null
+  blocked_reason: null
+  last_resumable_step: "finish"
+  dependencies:
+  - subtask_id: 2
+    optional: false
+    skipped: false
+- id: 4
+  name: "validation-projection"
+  spec_path: ".feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_4_validation-projection.md"
+  status: "complete"
+  branch: "feat/SKILL-51-decomposition-workflow-state"
+  commit_sha: null
+  workflow_id: "wfl-20260523-145801-5om5"
+  review_result:
+    routed_skill: "bill-kotlin-code-review"
+    review_run_id: "rvw-20260523-145806-0001"
+    review_session_id: "rvs-ad4768ad-db57-4f93-a00a-eac5ae65b944"
+    verdict: "approve"
+    finding_count: 0
+    telemetry_fallback: "not_needed"
+  audit_result:
+    pass: true
+    per_criterion:
+    - criteria: "AC1-AC16"
+      status: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt"
+      - ".feature-specs/SKILL-51-decomposition-workflow-state/decomposition-manifest.yaml"
+      - "skills/bill-feature-implement/native-agents/agents.yaml"
+    gaps: []
+  validation_result:
+    validation_result: "pass"
+    routed_skill: "bill-kotlin-quality-check"
+    detected_stack: "kotlin"
+    initial_failure_count: 0
+    final_failure_count: 0
+    commands:
+    - "(cd runtime-kotlin && ./gradlew check)"
+    - "skill-bill validate"
+    - "npx --yes agnix --strict ."
+    - "scripts/validate_agent_configs"
+    - "./install.sh --no-desktop-app (Codex, all platforms)"
+  blocked_reason: null
+  last_resumable_step: "finish"
+  dependencies:
+  - subtask_id: 3
+    optional: false
+    skipped: false

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec.md
@@ -1,7 +1,7 @@
 ---
 issue_key: SKILL-51
 feature_name: decomposition-workflow-state
-status: In Progress
+status: Complete
 feature_size: LARGE
 rollout_needed: false
 sources:
@@ -12,7 +12,7 @@ sources:
 
 ## Status
 
-In Progress
+Complete
 
 ## Consolidated Spec
 

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec.md
@@ -1,0 +1,52 @@
+---
+issue_key: SKILL-51
+feature_name: decomposition-workflow-state
+status: In Progress
+feature_size: LARGE
+rollout_needed: false
+sources:
+  - user briefing in current pre-planning run
+---
+
+# SKILL-51: Decomposition Workflow State
+
+## Status
+
+In Progress
+
+## Consolidated Spec
+
+Implement durable decomposition workflow state for `bill-feature-implement` so decomposed parent features have a validator-backed parent manifest, resumable subtask execution details, and parent-level continuation behavior.
+
+Same-branch commit-per-subtask execution is the default for decomposed features. Stacked-branch execution is supported as an opt-in parent manifest setting.
+
+Existing single-spec `bill-feature-implement` workflows must continue to work without requiring a decomposition manifest.
+
+## Acceptance Criteria
+
+1. Decomposition creates or updates a validator-backed parent decomposition manifest for every decomposed feature.
+2. The manifest declares ordered subtasks, dependencies, spec paths, `execution_model`, base branch, feature branch or stack branches, and current subtask intent.
+3. Runtime workflow state tracks per-subtask execution details, including status, branch, commit SHA, workflow id, review result, audit result, validation result, blocked reason, and last resumable step.
+4. `continue SKILL-XX` can resolve a decomposed parent feature, determine the next eligible subtask, and resume or start that subtask without the user naming the subtask.
+5. If a subtask is in progress, `continue SKILL-XX` resumes that subtask at the last durable workflow step.
+6. If no subtask is in progress, `continue SKILL-XX` starts the first pending subtask whose dependencies are complete.
+7. If a subtask is blocked, `continue SKILL-XX` reports the blocked reason and does not skip to a later dependent subtask unless the manifest explicitly marks that dependency optional or skipped.
+8. Same-branch commit-per-subtask execution is the default for decomposed features.
+9. In same-branch mode, every completed subtask produces an individual commit before the runtime advances to the next subtask.
+10. Stacked-branch execution is supported as an opt-in parent manifest setting.
+11. In stacked-branch mode, the runtime creates or checks out the correct branch for each subtask, records branch base relationships, and does not advance dependent subtasks onto the wrong base.
+12. Changing `execution_model` is allowed before any subtask starts. Changing it after execution begins fails loudly with a typed/manual-migration message.
+13. Parent and subtask statuses update automatically after implementation, review, completeness audit, validation, commit, PR-description, blocked, and skipped outcomes.
+14. Markdown spec status/frontmatter is kept as a human-readable projection of runtime state where practical, but durable runtime state remains authoritative for resume decisions.
+15. Existing single-spec `bill-feature-implement` workflows continue to work without requiring a decomposition manifest.
+16. Tests cover manifest creation, manifest validation failures, same-branch subtask advancement, stacked-branch branch selection, blocked subtask behavior, resume of an in-progress subtask, and completion of all subtasks.
+
+## Non-goals
+
+- Implement SKILL-52 full hexagonal architecture.
+- Implement SKILL-53 shared install-selection persistence.
+- Replace the existing feature-implement workflow state contract wholesale.
+- Require every feature to be decomposed.
+- Force stacked branches as the default.
+- Automatically migrate already-started same-branch work into a stacked branch series.
+- Create or merge GitHub PRs differently unless the execution model requires branch base metadata for stacked PRs.

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_1_foundation.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_1_foundation.md
@@ -4,7 +4,7 @@ feature_name: decomposition-workflow-state
 subtask_id: 1
 subtask_name: foundation
 parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
-status: Pending
+status: Complete
 ---
 
 # SKILL-51 Subtask 1: Foundation

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_1_foundation.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_1_foundation.md
@@ -1,0 +1,51 @@
+---
+issue_key: SKILL-51
+feature_name: decomposition-workflow-state
+subtask_id: 1
+subtask_name: foundation
+parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
+status: Pending
+---
+
+# SKILL-51 Subtask 1: Foundation
+
+Parent overview: [spec.md](spec.md)
+
+## Scope
+
+Create the durable parent decomposition manifest contract and the runtime seams that create or update that manifest when `bill-feature-implement` planning chooses decomposition mode. The manifest should be validator-backed and should declare ordered subtasks, dependency metadata, subtask spec paths, `execution_model`, base branch, feature branch or stack branch metadata, and current subtask intent.
+
+This subtask owns the contract shape, schema validation, typed loud-fail behavior, classpath/resource wiring, Kotlin model mapping, and initial manifest creation/update from the existing decomposition planning artifact. Use the established runtime-contract pattern from workflow state and platform pack schemas: Draft 2020-12 YAML under `orchestration/contracts/`, a matching Kotlin contract version constant, parity/violation tests, typed `ShellContentContractException`, and read-seam validation.
+
+Same-branch execution must be the default when the manifest is created. Stacked-branch execution should be representable as an opt-in manifest setting, but branch checkout behavior is deferred to a later subtask.
+
+Existing single-spec workflows must continue without a decomposition manifest.
+
+## Acceptance Criteria
+
+- AC1: Decomposition creates or updates a validator-backed parent decomposition manifest for every decomposed feature.
+- AC2: The manifest declares ordered subtasks, dependencies, spec paths, `execution_model`, base branch, feature branch or stack branches, and current subtask intent.
+- AC8: Same-branch commit-per-subtask execution is the default for decomposed features.
+- AC10: Stacked-branch execution is supported as an opt-in parent manifest setting at the manifest/contract level.
+- AC15: Existing single-spec `bill-feature-implement` workflows continue to work without requiring a decomposition manifest.
+- AC16, foundation slice: Tests cover manifest creation and manifest validation failures.
+
+## Non-goals
+
+- Do not implement parent `continue SKILL-XX` resolution.
+- Do not implement per-subtask workflow state persistence beyond fields needed to write the manifest.
+- Do not implement branch checkout, commits, stacked branch advancement, or subtask status transitions.
+- Do not require every feature to be decomposed.
+- Do not replace the existing feature-implement workflow state contract wholesale.
+
+## Dependencies
+
+- No subtask dependency. This is the first subtask and establishes the contract consumed by later runtime work.
+
+## Validation Strategy
+
+Run `bill-quality-check`. At minimum, the implementation should add or update contract parity tests, schema violation tests, manifest creation tests, and a single-spec regression proving non-decomposed workflows do not require the new manifest.
+
+## Recommended Next Prompt
+
+Run bill-feature-implement on .feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_1_foundation.md.

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_2_runtime-state.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_2_runtime-state.md
@@ -4,7 +4,7 @@ feature_name: decomposition-workflow-state
 subtask_id: 2
 subtask_name: runtime-state
 parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
-status: Pending
+status: Complete
 ---
 
 # SKILL-51 Subtask 2: Runtime State

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_2_runtime-state.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_2_runtime-state.md
@@ -1,0 +1,50 @@
+---
+issue_key: SKILL-51
+feature_name: decomposition-workflow-state
+subtask_id: 2
+subtask_name: runtime-state
+parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
+status: Pending
+---
+
+# SKILL-51 Subtask 2: Runtime State
+
+Parent overview: [spec.md](spec.md)
+
+## Scope
+
+Extend durable workflow state so a decomposed parent feature can track subtask execution details authoritatively at runtime. Add per-subtask state fields for status, branch, commit SHA, workflow id, review result, audit result, validation result, blocked reason, and last resumable step, while preserving the existing single-spec feature-implement workflow behavior.
+
+This subtask owns domain/application/runtime-contract changes needed to persist, load, validate, and update per-subtask details. It should add automatic status updates for implementation, review, completeness audit, validation, blocked, skipped, and PR-description outcomes where those events already pass through the workflow engine/service. Commit-related status advancement may be represented in state here, but actual git commit creation is deferred to the branch orchestration subtask.
+
+Enforce `execution_model` immutability after execution begins. Changing `execution_model` before any subtask starts should be allowed. Changing it after any subtask has started must fail loudly with a typed/manual-migration message.
+
+Markdown status/frontmatter projection may be updated where the runtime already writes human-readable artifacts, but durable runtime state remains authoritative for resume decisions.
+
+## Acceptance Criteria
+
+- AC3: Runtime workflow state tracks per-subtask execution details, including status, branch, commit SHA, workflow id, review result, audit result, validation result, blocked reason, and last resumable step.
+- AC12: Changing `execution_model` is allowed before any subtask starts; changing it after execution begins fails loudly with a typed/manual-migration message.
+- AC13, state slice: Parent and subtask statuses update automatically after implementation, review, completeness audit, validation, PR-description, blocked, and skipped outcomes.
+- AC14, state slice: Markdown spec status/frontmatter is kept as a human-readable projection where practical, while durable runtime state remains authoritative.
+- AC15: Existing single-spec `bill-feature-implement` workflows continue to work without requiring a decomposition manifest.
+- AC16, state slice: Tests cover runtime state validation and status update behavior needed by later continuation.
+
+## Non-goals
+
+- Do not implement next-subtask selection for `continue SKILL-XX`.
+- Do not implement git branch checkout or commit creation.
+- Do not create or merge GitHub PRs differently.
+- Do not introduce SKILL-52 full hexagonal architecture or replace the existing workflow state contract wholesale.
+
+## Dependencies
+
+- Depends on subtask 1 because runtime state needs the parent decomposition manifest contract and typed validation seams.
+
+## Validation Strategy
+
+Run `bill-quality-check`. At minimum, add workflow-state mapping/persistence tests, schema/golden updates as needed, execution-model immutability tests, blocked/skipped status tests at the service or engine layer, and regressions for existing single-spec workflows.
+
+## Recommended Next Prompt
+
+Run bill-feature-implement on .feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_2_runtime-state.md.

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_3_continuation-branching.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_3_continuation-branching.md
@@ -4,7 +4,7 @@ feature_name: decomposition-workflow-state
 subtask_id: 3
 subtask_name: continuation-branching
 parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
-status: Pending
+status: Complete
 ---
 
 # SKILL-51 Subtask 3: Continuation And Branching

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_3_continuation-branching.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_3_continuation-branching.md
@@ -1,0 +1,55 @@
+---
+issue_key: SKILL-51
+feature_name: decomposition-workflow-state
+subtask_id: 3
+subtask_name: continuation-branching
+parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
+status: Pending
+---
+
+# SKILL-51 Subtask 3: Continuation And Branching
+
+Parent overview: [spec.md](spec.md)
+
+## Scope
+
+Wire parent-level continuation and execution-model branch behavior for decomposed features. `continue SKILL-XX` should resolve the decomposed parent by issue key, inspect the authoritative parent manifest and runtime state, and resume or start the correct subtask without requiring the user to name the subtask.
+
+Continuation must resume an in-progress subtask at its last durable workflow step. If no subtask is in progress, it must start the first pending subtask whose dependencies are complete. If a dependency is blocked, continuation must report the blocked reason and must not skip to a later dependent subtask unless the manifest explicitly marks that dependency optional or skipped.
+
+Implement same-branch commit-per-subtask behavior as the default: each completed subtask must produce an individual commit before the runtime advances to the next subtask. Implement stacked-branch behavior as an opt-in execution model: create or check out the correct branch for each subtask, record branch base relationships, and prevent dependent subtasks from advancing onto the wrong base.
+
+This subtask owns the CLI/MCP/runtime-application seams for parent issue-key continuation, subtask eligibility, branch selection, commit advancement, and branch metadata persistence.
+
+## Acceptance Criteria
+
+- AC4: `continue SKILL-XX` can resolve a decomposed parent feature, determine the next eligible subtask, and resume or start that subtask without the user naming the subtask.
+- AC5: If a subtask is in progress, `continue SKILL-XX` resumes that subtask at the last durable workflow step.
+- AC6: If no subtask is in progress, `continue SKILL-XX` starts the first pending subtask whose dependencies are complete.
+- AC7: If a subtask is blocked, `continue SKILL-XX` reports the blocked reason and does not skip to a later dependent subtask unless the manifest explicitly marks that dependency optional or skipped.
+- AC8: Same-branch commit-per-subtask execution is the default for decomposed features.
+- AC9: In same-branch mode, every completed subtask produces an individual commit before the runtime advances to the next subtask.
+- AC10: Stacked-branch execution is supported as an opt-in parent manifest setting.
+- AC11: In stacked-branch mode, the runtime creates or checks out the correct branch for each subtask, records branch base relationships, and does not advance dependent subtasks onto the wrong base.
+- AC13, branch slice: Parent and subtask statuses update automatically after commit and branch-related advancement outcomes.
+- AC16, continuation slice: Tests cover same-branch advancement, stacked-branch branch selection, blocked subtask behavior, and resume of an in-progress subtask.
+
+## Non-goals
+
+- Do not alter GitHub PR creation or merge behavior beyond recording branch base metadata required for stacked PRs.
+- Do not automatically migrate already-started same-branch work into a stacked branch series.
+- Do not replace the existing feature-implement workflow state contract wholesale.
+- Do not implement SKILL-53 shared install-selection persistence.
+
+## Dependencies
+
+- Depends on subtask 1 for the parent manifest contract and execution-model metadata.
+- Depends on subtask 2 for persisted subtask state, statuses, blocked reasons, workflow ids, and last resumable steps.
+
+## Validation Strategy
+
+Run `bill-quality-check`. At minimum, add CLI and MCP continuation tests for parent issue-key resolution, in-progress resume, pending dependency selection, blocked dependency reporting, same-branch commit advancement, stacked branch base selection, and wrong-base rejection.
+
+## Recommended Next Prompt
+
+Run bill-feature-implement on .feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_3_continuation-branching.md.

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_4_validation-projection.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_4_validation-projection.md
@@ -4,7 +4,7 @@ feature_name: decomposition-workflow-state
 subtask_id: 4
 subtask_name: validation-projection
 parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
-status: Pending
+status: Complete
 ---
 
 # SKILL-51 Subtask 4: Validation And Projection

--- a/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_4_validation-projection.md
+++ b/.feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_4_validation-projection.md
@@ -1,0 +1,63 @@
+---
+issue_key: SKILL-51
+feature_name: decomposition-workflow-state
+subtask_id: 4
+subtask_name: validation-projection
+parent_spec: .feature-specs/SKILL-51-decomposition-workflow-state/spec.md
+status: Pending
+---
+
+# SKILL-51 Subtask 4: Validation And Projection
+
+Parent overview: [spec.md](spec.md)
+
+## Scope
+
+Complete end-to-end validation, documentation/prose wiring, and human-readable projection for decomposed feature workflow state. Update the authored `bill-feature-implement` source guidance and native-agent source so future decomposition planning emits and respects the parent decomposition manifest, current subtask intent, execution model, same-branch default, stacked-branch opt-in, and parent-level continuation behavior.
+
+Keep edits in governed source files only, such as `skills/bill-feature-implement/content.md` and `skills/bill-feature-implement/native-agents/agents.yaml`; do not edit generated `SKILL.md`, generated support pointers, provider-specific native-agent outputs, or install staging artifacts.
+
+Finish any remaining Markdown spec status/frontmatter projection so parent and subtask specs show useful human-readable state after implementation, review, completeness audit, validation, commit, PR-description, blocked, skipped, and completion outcomes. Durable runtime state must remain authoritative for resume decisions.
+
+This subtask is also the final acceptance sweep for SKILL-51. It should ensure tests cover the full contract and that all new contract/resource files are included in repo validation.
+
+## Acceptance Criteria
+
+- AC1: Decomposition creates or updates a validator-backed parent decomposition manifest for every decomposed feature.
+- AC2: The manifest declares ordered subtasks, dependencies, spec paths, `execution_model`, base branch, feature branch or stack branches, and current subtask intent.
+- AC3: Runtime workflow state tracks per-subtask execution details, including status, branch, commit SHA, workflow id, review result, audit result, validation result, blocked reason, and last resumable step.
+- AC4: `continue SKILL-XX` can resolve a decomposed parent feature, determine the next eligible subtask, and resume or start that subtask without the user naming the subtask.
+- AC5: If a subtask is in progress, `continue SKILL-XX` resumes that subtask at the last durable workflow step.
+- AC6: If no subtask is in progress, `continue SKILL-XX` starts the first pending subtask whose dependencies are complete.
+- AC7: If a subtask is blocked, `continue SKILL-XX` reports the blocked reason and does not skip to a later dependent subtask unless the manifest explicitly marks that dependency optional or skipped.
+- AC8: Same-branch commit-per-subtask execution is the default for decomposed features.
+- AC9: In same-branch mode, every completed subtask produces an individual commit before the runtime advances to the next subtask.
+- AC10: Stacked-branch execution is supported as an opt-in parent manifest setting.
+- AC11: In stacked-branch mode, the runtime creates or checks out the correct branch for each subtask, records branch base relationships, and does not advance dependent subtasks onto the wrong base.
+- AC12: Changing `execution_model` is allowed before any subtask starts; changing it after execution begins fails loudly with a typed/manual-migration message.
+- AC13: Parent and subtask statuses update automatically after implementation, review, completeness audit, validation, commit, PR-description, blocked, and skipped outcomes.
+- AC14: Markdown spec status/frontmatter is kept as a human-readable projection of runtime state where practical, while durable runtime state remains authoritative for resume decisions.
+- AC15: Existing single-spec `bill-feature-implement` workflows continue to work without requiring a decomposition manifest.
+- AC16: Tests cover manifest creation, manifest validation failures, same-branch subtask advancement, stacked-branch branch selection, blocked subtask behavior, resume of an in-progress subtask, and completion of all subtasks.
+
+## Non-goals
+
+- Do not implement SKILL-52 full hexagonal architecture.
+- Do not implement SKILL-53 shared install-selection persistence.
+- Do not require every feature to be decomposed.
+- Do not force stacked branches as the default.
+- Do not create or merge GitHub PRs differently unless branch base metadata for stacked PRs already requires it.
+
+## Dependencies
+
+- Depends on subtask 1 for manifest creation and validation.
+- Depends on subtask 2 for durable per-subtask workflow state and status updates.
+- Depends on subtask 3 for continuation, same-branch commits, and stacked-branch behavior.
+
+## Validation Strategy
+
+Run `bill-quality-check`. For final maintainer confidence, also run or document results for `skill-bill validate`, `(cd runtime-kotlin && ./gradlew check)`, `npx --yes agnix --strict .`, and `scripts/validate_agent_configs` when available. The test suite should include end-to-end completion of all subtasks plus the specific AC16 cases.
+
+## Recommended Next Prompt
+
+Run bill-feature-implement on .feature-specs/SKILL-51-decomposition-workflow-state/spec_subtask_4_validation-projection.md.

--- a/.feature-specs/SKILL-52-full-hexagonal-runtime-architecture/spec.md
+++ b/.feature-specs/SKILL-52-full-hexagonal-runtime-architecture/spec.md
@@ -1,0 +1,258 @@
+# SKILL-52 - Full hexagonal runtime architecture
+
+Status: Draft
+Issue key: SKILL-52
+
+## Context
+
+`runtime-kotlin` currently presents itself as a pragmatic hexagonal JVM runtime:
+
+```text
+cli / mcp
+  -> application use cases
+    -> ports
+      -> domain models
+
+infrastructure/sqlite, infrastructure/http, infrastructure/fs
+  -> implement ports
+
+di
+  -> wires adapters, use cases, repositories, clients, clocks, and runtime
+     contexts
+```
+
+SKILL-28 established the first real module split and moved several runtime
+surfaces toward this shape. The current codebase, however, is still
+transitional rather than fully hexagonal:
+
+- `runtime-core` is documented as the integration/composition module, but it
+  still owns implementation packages such as `skillbill.install`,
+  `skillbill.scaffold`, `skillbill.nativeagent`, `skillbill.launcher`, and
+  workflow runtime wrappers.
+- `runtime-core` re-exports application, domain, port, contract, and
+  infrastructure modules through `api(...)`, making it an aggregator as well as
+  a composition root.
+- Some domain-layer code still owns schema-validator and file/path concerns
+  that are closer to contract or infrastructure seams than pure domain logic.
+- Architecture tests enforce useful boundary rules, but they do not yet enforce
+  the hard rule that `runtime-core` contains composition only and that all
+  implementation behavior lives in the correct hexagonal layer.
+
+This matters because future shared runtime features, including SKILL-53
+install-selection persistence, need an unambiguous place to land. Adding new
+`runtime-core:data` and `runtime-core:domain` modules would create a second
+architecture inside the existing one. Instead, the existing runtime architecture
+should become fully hexagonal.
+
+## Problem
+
+The runtime cannot be treated as fully hexagonal while `runtime-core` remains
+both a composition module and an implementation owner. "Mostly hexagonal" leaves
+too much discretion for new work:
+
+- new domain models may be placed in `runtime-core` because core already owns
+  nearby behavior;
+- new persistence or filesystem adapters may bypass ports because core already
+  sees infrastructure directly;
+- CLI/MCP/Desktop can keep depending on the `runtime-core` umbrella instead of
+  declaring their actual adapter/application/composition needs;
+- architecture tests can pass while the conceptual boundary continues to blur.
+
+SKILL-52 should turn the current architecture from an aspirational target into a
+hard, enforced module graph.
+
+## Goals
+
+1. Define the final runtime hexagonal module graph and dependency direction in
+   `runtime-kotlin/ARCHITECTURE.md`.
+2. Make `runtime-core` a composition/runtime-assembly module only.
+3. Move remaining implementation surfaces out of `runtime-core` into the proper
+   existing hexagonal modules, or create narrowly named top-level modules only
+   when an existing module would become semantically wrong.
+4. Remove broad `runtime-core` `api(...)` re-exports where downstream modules can
+   depend on their actual required modules.
+5. Keep CLI, MCP, and Desktop as adapter surfaces that do not depend on
+   infrastructure implementation details except through composition.
+6. Keep domain code pure: no Clikt, MCP, Desktop, JDBC, HTTP clients, concrete
+   filesystem reads/writes, process environment access, or infrastructure
+   imports.
+7. Keep ports as interfaces/contracts only, with port-owned DTOs in explicit
+   `model` packages.
+8. Keep infrastructure implementations behind ports and out of application,
+   domain, CLI, MCP, and Desktop business flows.
+9. Add architecture tests that fail loudly when new code violates the full
+   hexagonal structure.
+
+## Target Architecture
+
+The intended final shape is:
+
+```text
+runtime-cli          runtime-mcp          runtime-desktop
+     \                  |                     /
+      \                 |                    /
+       -> runtime-application use cases <-
+                    |
+                 runtime-ports
+                    |
+              runtime-domain
+
+runtime-infra-fs       runtime-infra-http       runtime-infra-sqlite
+       \                    |                         /
+        \                   |                        /
+         -------- implement runtime-ports ----------
+
+runtime-core
+  -> composition root / runtime assembly only
+  -> may depend on application, ports, domain, contracts, and infra modules
+  -> must not own business, persistence, filesystem, install, scaffold,
+     native-agent, workflow, telemetry, or launcher implementation behavior
+```
+
+Layer responsibilities:
+
+- `runtime-domain`: pure models, value rules, parsing/normalization rules, and
+  deterministic domain behavior. Public data types live in area-owned
+  `model` packages.
+- `runtime-ports`: interfaces that application/domain code uses to reach
+  persistence, filesystem, telemetry, process, clock, and other outside-world
+  capabilities. Port DTOs/results live under `skillbill.ports.*.model`.
+- `runtime-application`: use cases and orchestration shared by CLI, MCP, and
+  Desktop. It depends on domain and ports, not concrete infrastructure.
+- `runtime-infra-*`: concrete adapters implementing ports.
+- `runtime-contracts`: external DTOs, schema constants, contract serialization
+  helpers, and typed contract errors. Model-to-contract mapping belongs in
+  application or adapter packages, not in contracts.
+- `runtime-core`: Kotlin-Inject component(s), provider bindings, runtime module
+  metadata, and assembly-only helpers.
+- `runtime-cli`, `runtime-mcp`, `runtime-desktop`: entry adapters and UI/transport
+  concerns. They validate and translate inputs, then call application use cases.
+
+## Acceptance Criteria
+
+1. `runtime-kotlin/ARCHITECTURE.md` no longer describes the architecture as
+   transitional or "pragmatic" in a way that permits mixed ownership; it defines
+   the full hexagonal module graph, layer responsibilities, and forbidden
+   dependency directions.
+2. `runtime-core` contains only composition/runtime-assembly code:
+   Kotlin-Inject component/provider wiring, runtime module metadata, and
+   narrowly scoped assembly helpers. It no longer owns `skillbill.install`,
+   `skillbill.scaffold`, `skillbill.nativeagent`, `skillbill.launcher`,
+   workflow runtime wrappers, or other business/runtime implementation packages.
+3. Every package currently under `runtime-core` is either moved to an existing
+   correct layer or explicitly justified in a new top-level module with a
+   documented responsibility and dependency rule.
+4. CLI and MCP no longer rely on `runtime-core` as a broad API umbrella when a
+   direct dependency on `runtime-application`, `runtime-contracts`,
+   `runtime-domain`, `runtime-ports`, or a composition module is the honest
+   dependency.
+5. Domain modules contain no concrete filesystem reads/writes, JDBC, HTTP
+   clients, process environment access, Clikt, MCP, Desktop, or infrastructure
+   imports. Path value types are allowed only when they are pure values and do
+   not perform IO.
+6. Application use cases access outside-world behavior only through ports.
+   Existing exceptions must be removed or documented as temporary blockers with
+   failing or pending architecture coverage that names the exact follow-up.
+7. Infrastructure modules implement ports and may depend on domain/port/contract
+   types, but they do not depend on CLI, MCP, Desktop, or `runtime-core`.
+8. Runtime contract/schema validation ownership is clarified. Schema resources
+   and validators live in the layer that owns the parse seam, not in pure domain
+   code by convenience.
+9. `RuntimeModule.declaredGradleModules`, `RuntimeModule.declaredSubsystemPackages`,
+   and architecture tests reflect the final module/package graph.
+10. Architecture tests fail if:
+    - `runtime-core` gains non-composition packages;
+    - domain imports concrete IO, SQL, HTTP, entry adapters, or infrastructure;
+    - application imports concrete infrastructure or entry adapters;
+    - infrastructure imports entry adapters or `runtime-core`;
+    - CLI/MCP/Desktop call low-level runtime implementation packages instead of
+      application use cases;
+    - public application/domain/port models are declared outside `model`
+      packages.
+11. Existing runtime behavior is preserved. This task is architectural movement,
+    not a product-behavior rewrite.
+12. Validation passes with:
+    - `(cd runtime-kotlin && ./gradlew check)`
+    - `skill-bill validate`
+    - `scripts/validate_agent_configs`
+    - `npx --yes agnix --strict .`
+
+## Non-goals
+
+- Implement SKILL-53 shared install-selection persistence.
+- Add nested `runtime-core:data` or `runtime-core:domain` modules.
+- Redesign CLI prompts, MCP tools, desktop UI behavior, installer semantics, or
+  persisted data formats except where required to preserve behavior after moving
+  code.
+- Generate Kotlin types from schemas.
+- Rename public commands or break existing script entry points.
+- Rewrite all runtime APIs for style only; movement should serve the enforced
+  hexagonal boundary.
+
+## Open Questions
+
+1. Where should install/scaffold/native-agent implementation land?
+   - Preferred answer: use existing layers where possible:
+     domain models/rules in `runtime-domain`, use cases in
+     `runtime-application`, filesystem/process adapters in `runtime-infra-fs`,
+     contracts/schemas in `runtime-contracts`, and DI in `runtime-core`.
+   - If that creates an overly broad module, introduce a top-level module with a
+     precise role, for example `runtime-infra-process` or
+     `runtime-install-application`, but only after proving existing modules are
+     semantically wrong.
+2. Should launcher behavior be an adapter or composition concern?
+   - Preferred answer: keep script/entrypoint selection adapter code out of
+     domain/application. If it needs shared behavior, expose that behavior
+     through application use cases and ports.
+3. Should schema validators move out of `runtime-domain`?
+   - Preferred answer: pure schema constants and typed errors belong in
+     `runtime-contracts`; parse-seam validation belongs to the adapter or
+     application boundary that consumes the payload.
+4. Can `runtime-core` stop re-exporting infra immediately?
+   - Preferred answer: yes for most downstream code, but this may require a
+     staged dependency cleanup where CLI/MCP declare direct compile-time
+     dependencies before `runtime-core` switches from `api` to `implementation`.
+
+## Risks
+
+- The movement is mostly architectural but touches many files. A single PR may
+  become hard to review if all package moves land at once.
+- Gradle dependency changes can break downstream tests in non-obvious ways,
+  especially where CLI/MCP currently see dependencies through `runtime-core`.
+- Moving schema validation can accidentally weaken loud-fail behavior if parse
+  seams are not preserved.
+- Over-splitting into new modules can recreate the same ambiguity under new
+  names. New modules must be rare and justified by responsibility, not by
+  aesthetics.
+
+## Recommended Implementation Order
+
+This is likely too large for one reliable implementation run. When
+`bill-feature-implement` plans this spec, it should strongly consider
+decomposition.
+
+1. **Architecture contract and guardrails.**
+   Update architecture docs and tests to define the final graph. Add failing
+   guardrails for `runtime-core` composition-only ownership and strict layer
+   imports before moving large surfaces.
+2. **Dependency honesty.**
+   Make CLI/MCP/Desktop declare the direct modules they actually use, then
+   reduce `runtime-core` API re-exports where possible.
+3. **Move implementation packages out of `runtime-core`.**
+   Relocate install, scaffold, native-agent, launcher, and workflow runtime
+   wrapper code into the correct domain/application/contract/infra layers while
+   preserving public behavior.
+4. **Parse-seam and schema ownership cleanup.**
+   Move schema validation and resource ownership out of pure domain where it is
+   not domain behavior. Preserve typed errors and loud-fail semantics.
+5. **Final enforcement.**
+   Tighten tests so future code cannot reintroduce transitional shortcuts.
+   Update history/decision docs with the final architecture decision.
+
+## Relationship To SKILL-53
+
+SKILL-53 should remain the shared runtime install-selection persistence feature.
+It depends on the result of SKILL-52: once the runtime architecture is fully
+hexagonal, SKILL-53 can add install-selection domain models, ports, use cases,
+and persistence adapters in the correct layers without creating a parallel
+`runtime-core:data/domain` architecture.

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md
@@ -1,0 +1,73 @@
+# SKILL-53 — Shared runtime install architecture
+
+Status: Draft
+Issue key: SKILL-53
+
+## Context
+
+The desktop post-publish reinstall flow can reuse install selections only when those selections were persisted by the desktop setup wizard. Installs performed through `./install.sh` or `skill-bill install apply` go through the same typed install plan/apply runtime, but they do not persist reusable desktop-visible selections.
+
+This exposed a broader architecture issue: install-selection state is runtime state, not desktop-only state. Today the desktop owns `DesktopFirstRunPreferences` in `runtime-desktop:core:datastore`, while CLI and `install.sh` depend on top-level runtime modules and cannot write that desktop-owned contract without creating the wrong dependency direction.
+
+## Problem
+
+The runtime has top-level shared modules such as `runtime-domain`, `runtime-core`, and `runtime-application`, but install behavior is concentrated in `runtime-core` and does not have clear domain/data/application submodule boundaries. Desktop has its own `core:domain`, `core:data`, and `core:datastore` modules, but those are not shared with CLI.
+
+As a result:
+
+- `install.sh` can collect agent, platform, telemetry, MCP, and desktop app choices, but cannot persist them into the desktop preference contract cleanly.
+- Desktop has to own install-selection persistence even though the data describes the last runtime install.
+- Future shared install state risks duplication between shell, CLI, desktop, and runtime internals.
+
+## Goals
+
+1. Define a shared runtime-owned install-selection domain model that can represent the latest successful install choices.
+2. Define a shared persistence contract and implementation for that model outside desktop-only modules.
+3. Let desktop setup/reinstall flows and CLI/shell install flows write the same persisted install-selection record after successful apply.
+4. Let desktop read the shared install-selection record for post-publish reinstall without depending on shell-specific behavior.
+5. Preserve existing typed install plan/apply behavior and loud failure semantics.
+6. Avoid making `runtime-cli` depend on `runtime-desktop:*`.
+
+## Proposed Direction
+
+Introduce install-focused shared boundaries, either as new modules or as an incremental split from `runtime-core`:
+
+- `runtime-install-domain`
+  - install-selection model
+  - store interface
+  - path/key contract types where appropriate
+- `runtime-install-data`
+  - file-backed persistence implementation
+  - properties/serialization handling
+  - default `~/.skill-bill` path rules
+- `runtime-install-application`
+  - orchestration helpers around install apply and selection persistence
+  - optional compatibility wrappers for existing `InstallOperations`
+
+If introducing all three modules is too large for one cut, start with the smallest shared boundary that moves last-install-selection persistence out of desktop-only modules, then split additional install code afterward.
+
+## Acceptance Criteria
+
+1. A shared runtime install-selection model exists outside `runtime-desktop:*` and is usable by both CLI and desktop JVM code.
+2. A shared persistence implementation writes and reads the latest successful install choices, including selected agents, selected platform packs, telemetry level, and MCP registration choice.
+3. Desktop first-run setup and post-publish reinstall use the shared install-selection persistence instead of owning a separate install preference format.
+4. `skill-bill install apply` can persist the latest successful install choices without introducing a dependency on desktop modules.
+5. `install.sh` delegates persistence through the runtime CLI or shared runtime API after successful apply; it does not hand-write desktop preference internals.
+6. Detected-agent installs persist the actual resolved installed agents when that information is available from the typed apply result.
+7. Existing desktop-only preferences, such as recent repo path or UI-only state, remain desktop-owned.
+8. Tests cover CLI install persistence, desktop preference adapter behavior, detected/manual agent cases, MCP opt-out, and migration/backward compatibility for existing desktop preference files.
+
+## Non-goals
+
+- Rework the entire install runtime in one change if a smaller persistence-focused split is sufficient.
+- Change installer prompts or install selection semantics beyond persisting the successful result.
+- Make runtime modules depend on desktop modules.
+- Persist failed install attempts as reusable completed selections.
+
+## Validation Strategy
+
+- Add unit tests around the shared install-selection store.
+- Add CLI tests proving `install apply` persists choices only after successful apply.
+- Add desktop datastore/ViewModel tests proving existing first-run preferences migrate or adapt into the shared store.
+- Run `(cd runtime-kotlin && ./gradlew check)`.
+- Run `skill-bill validate`, `scripts/validate_agent_configs`, and `npx --yes agnix --strict .`.

--- a/orchestration/contracts/decomposition-manifest-schema.yaml
+++ b/orchestration/contracts/decomposition-manifest-schema.yaml
@@ -1,0 +1,201 @@
+# Decomposition manifest schema (canonical source of truth).
+#
+# This file describes the parent manifest written beside a decomposed
+# feature's parent spec under `.feature-specs/<issue>-<feature>/`. It is
+# authored in YAML for human readability and consumed as a JSON Schema
+# (Draft 2020-12) by the Kotlin runtime
+# (`DecompositionManifestSchemaValidator` in `runtime-domain`).
+#
+# What lives here vs. in Kotlin:
+#
+# - This file defines TYPES, ENUMS, REQUIRED-VS-OPTIONAL fields, and
+#   VALUE-LEVEL constraints (execution model enum, ordered subtask
+#   shape, non-empty paths, etc.) — anything expressible in pure JSON
+#   Schema.
+# - Cross-field "coherence" rules that JSON Schema cannot express
+#   cleanly stay in Kotlin (`DecompositionManifestValidator`). Every
+#   such rule is named below under `x-coherence-checks` so the schema
+#   document alone fully describes the contract.
+#
+# Versioning rule:
+#
+# - `contract_version` is pinned by `DECOMPOSITION_MANIFEST_CONTRACT_VERSION`
+#   in
+#   `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestSchemaPaths.kt`.
+# - The parity test `DecompositionManifestSchemaContractVersionTest`
+#   fails the build if they diverge. To bump the contract, edit BOTH
+#   constants in the same change.
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://skill-bill.dev/contracts/decomposition-manifest-schema.yaml"
+title: "Parent decomposition manifest"
+description: >
+  Schema for the parent manifest written when bill-feature-implement
+  decomposes an oversized feature into ordered subtask specs. The
+  manifest is optional for ordinary single-spec workflows, but required
+  at the decomposition write seam.
+type: object
+additionalProperties: false
+$defs:
+  executionModel:
+    type: string
+    enum:
+      - same_branch_commit_per_subtask
+      - stacked_branches
+    default: same_branch_commit_per_subtask
+  subtaskId:
+    type: integer
+    minimum: 1
+  subtaskStatus:
+    type: string
+    enum:
+      - pending
+      - in_progress
+      - blocked
+      - complete
+      - skipped
+  dependency:
+    type: object
+    additionalProperties: false
+    required:
+      - subtask_id
+      - optional
+      - skipped
+    properties:
+      subtask_id:
+        $ref: "#/$defs/subtaskId"
+      optional:
+        type: boolean
+      skipped:
+        type: boolean
+  subtask:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - name
+      - spec_path
+      - status
+      - dependencies
+    properties:
+      id:
+        $ref: "#/$defs/subtaskId"
+      name:
+        type: string
+        minLength: 1
+      spec_path:
+        type: string
+        minLength: 1
+      status:
+        $ref: "#/$defs/subtaskStatus"
+      dependencies:
+        type: array
+        items:
+          $ref: "#/$defs/dependency"
+  stackBranch:
+    type: object
+    additionalProperties: false
+    required:
+      - subtask_id
+      - branch
+      - base_branch
+    properties:
+      subtask_id:
+        $ref: "#/$defs/subtaskId"
+      branch:
+        type: string
+        minLength: 1
+      base_branch:
+        type: string
+        minLength: 1
+  currentSubtaskIntent:
+    type: object
+    additionalProperties: false
+    required:
+      - subtask_id
+      - action
+    properties:
+      subtask_id:
+        type: integer
+        minimum: 0
+      action:
+        type: string
+        enum:
+          - start
+          - resume
+          - blocked
+          - none
+required:
+  - contract_version
+  - issue_key
+  - feature_name
+  - parent_spec_path
+  - execution_model
+  - base_branch
+  - feature_branch
+  - stack_branches
+  - current_subtask_intent
+  - subtasks
+properties:
+  contract_version:
+    type: string
+    const: "0.1"
+  issue_key:
+    type: string
+    minLength: 1
+  feature_name:
+    type: string
+    minLength: 1
+  parent_spec_path:
+    type: string
+    minLength: 1
+  execution_model:
+    $ref: "#/$defs/executionModel"
+  base_branch:
+    type: string
+    minLength: 1
+  feature_branch:
+    type:
+      - string
+      - "null"
+    minLength: 1
+  stack_branches:
+    type: array
+    items:
+      $ref: "#/$defs/stackBranch"
+  current_subtask_intent:
+    $ref: "#/$defs/currentSubtaskIntent"
+  subtasks:
+    type: array
+    minItems: 1
+    items:
+      $ref: "#/$defs/subtask"
+x-coherence-checks:
+  execution-model-default:
+    description: >
+      Writers that omit an explicit execution model must persist
+      same_branch_commit_per_subtask. Schema default documents the
+      contract; Kotlin applies the runtime default before validation.
+  same-branch-feature-branch:
+    description: >
+      same_branch_commit_per_subtask manifests require feature_branch
+      to be a non-empty string and stack_branches to be empty.
+  stacked-branches-opt-in:
+    description: >
+      stacked_branches is accepted only when execution_model is
+      explicitly stacked_branches. Stacked manifests require
+      feature_branch to be null and stack_branches to declare one
+      branch per subtask, in subtask order.
+  dependency-order:
+    description: >
+      Every dependency id must reference an existing subtask that
+      appears earlier in the ordered subtasks array.
+  subtask-spec-paths:
+    description: >
+      Every subtask spec_path must be present and unique. Any current
+      subtask intent action other than none must reference an existing
+      subtask.
+  ordered-subtasks:
+    description: >
+      Subtask ids must be unique and the array order is the execution
+      order. Writers preserve the planning order instead of sorting by
+      title or path.

--- a/orchestration/contracts/decomposition-manifest-schema.yaml
+++ b/orchestration/contracts/decomposition-manifest-schema.yaml
@@ -53,6 +53,11 @@ $defs:
       - blocked
       - complete
       - skipped
+  runtimeResult:
+    type:
+      - object
+      - "null"
+    additionalProperties: true
   dependency:
     type: object
     additionalProperties: false
@@ -75,6 +80,14 @@ $defs:
       - name
       - spec_path
       - status
+      - branch
+      - commit_sha
+      - workflow_id
+      - review_result
+      - audit_result
+      - validation_result
+      - blocked_reason
+      - last_resumable_step
       - dependencies
     properties:
       id:
@@ -87,6 +100,37 @@ $defs:
         minLength: 1
       status:
         $ref: "#/$defs/subtaskStatus"
+      branch:
+        type:
+          - string
+          - "null"
+        minLength: 1
+      commit_sha:
+        type:
+          - string
+          - "null"
+        minLength: 1
+      workflow_id:
+        type:
+          - string
+          - "null"
+        minLength: 1
+      review_result:
+        $ref: "#/$defs/runtimeResult"
+      audit_result:
+        $ref: "#/$defs/runtimeResult"
+      validation_result:
+        $ref: "#/$defs/runtimeResult"
+      blocked_reason:
+        type:
+          - string
+          - "null"
+        minLength: 1
+      last_resumable_step:
+        type:
+          - string
+          - "null"
+        minLength: 1
       dependencies:
         type: array
         items:
@@ -148,6 +192,8 @@ properties:
   parent_spec_path:
     type: string
     minLength: 1
+  status:
+    $ref: "#/$defs/subtaskStatus"
   execution_model:
     $ref: "#/$defs/executionModel"
   base_branch:
@@ -199,3 +245,8 @@ x-coherence-checks:
       Subtask ids must be unique and the array order is the execution
       order. Writers preserve the planning order instead of sorting by
       title or path.
+  execution-model-immutability:
+    description: >
+      Writers may change execution_model before any subtask starts. Once
+      a subtask records runtime state, changing execution_model must fail
+      loudly with a typed error and a manual-migration message.

--- a/orchestration/contracts/telemetry-event-schema.yaml
+++ b/orchestration/contracts/telemetry-event-schema.yaml
@@ -519,13 +519,14 @@ $defs:
     required:
       - event_name
       - contract_version
-      - workflow_id
     properties:
       event_name:
         const: feature_implement_workflow_continue
       contract_version:
         const: "1.0.0"
       workflow_id:
+        type: string
+      issue_key:
         type: string
 
   featureImplementWorkflowGetEvent:

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,9 +1,9 @@
 ## [2026-05-23] SKILL-51 decomposition-workflow-state-runtime-state
 Areas: orchestration/contracts, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-core/application tests
 - `decomposition-manifest-schema.yaml` now carries parent/subtask runtime state: parent `status`, and per-subtask `branch`, `commit_sha`, `workflow_id`, `review_result`, `audit_result`, `validation_result`, `blocked_reason`, and `last_resumable_step`. The Kotlin model/codec/wire-map emit the same fields under the existing validator-backed manifest contract. reusable
-- `WorkflowService.update` projects feature-implement workflow updates into an existing sibling `decomposition-manifest.yaml` when the workflow assessment points at a decomposed subtask spec; ordinary single-spec workflows still no-op when no manifest exists.
+- `WorkflowService.update` persists `artifacts.decomposition_runtime` first, then writes `decomposition-manifest.yaml` / subtask frontmatter as a post-save human-readable projection; ordinary single-spec workflows still do not create decomposition runtime or manifests. reusable
 - Execution-model changes are allowed while every subtask is still pending. Once any subtask has recorded runtime state, `DecompositionManifestWriter` rejects an `execution_model` change with `InvalidDecompositionManifestSchemaError` and a manual-migration/reset message. reusable
-- Subtask status projection currently covers implementation/review/audit/validation/PR-description blocked/skipped/complete events and writes human-readable frontmatter `status` in the touched subtask spec. Parent manifest status is derived from subtask statuses; continuation selection and branch/commit advancement remain deferred to SKILL-51 subtasks 3/4.
+- Subtask status projection covers implementation/review/audit/validation/PR-description blocked/skipped/complete events, but explicit unmatched `assessment.spec_path` no-ops rather than falling back to current intent; continuation selection and branch/commit advancement remain deferred to SKILL-51 subtasks 3/4.
 Feature flag: N/A
 Acceptance criteria: 6/6 implemented
 

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,11 @@
+## [2026-05-23] SKILL-51 decomposition-workflow-state-validation-projection
+Areas: runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-core application tests, skills/bill-feature-implement
+- Parent decomposition projection now updates the parent spec status in addition to subtask frontmatter, and Markdown `## Status` sections are projected when present. reusable
+- Final all-subtasks completion coverage asserts parent/subtask manifest state, commit advancement, and human-readable spec projection in one application-level flow.
+- `bill-feature-implement` provider-neutral planning agents now carry the same decomposition manifest/execution-model guidance as governed `content.md`; source install was refreshed with `./install.sh`.
+Feature flag: N/A
+Acceptance criteria: 16/16 implemented
+
 ## [2026-05-23] SKILL-51 decomposition-workflow-state-continuation-branching
 Areas: runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-mcp, runtime-kotlin/runtime-infra-fs
 - Parent issue-key continuation now resolves decomposed feature parents from durable `artifacts.decomposition_runtime`, then resumes an in-progress subtask or starts the first dependency-complete pending subtask without requiring a subtask path. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-05-23] SKILL-51 decomposition-workflow-state-runtime-state
+Areas: orchestration/contracts, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-core/application tests
+- `decomposition-manifest-schema.yaml` now carries parent/subtask runtime state: parent `status`, and per-subtask `branch`, `commit_sha`, `workflow_id`, `review_result`, `audit_result`, `validation_result`, `blocked_reason`, and `last_resumable_step`. The Kotlin model/codec/wire-map emit the same fields under the existing validator-backed manifest contract. reusable
+- `WorkflowService.update` projects feature-implement workflow updates into an existing sibling `decomposition-manifest.yaml` when the workflow assessment points at a decomposed subtask spec; ordinary single-spec workflows still no-op when no manifest exists.
+- Execution-model changes are allowed while every subtask is still pending. Once any subtask has recorded runtime state, `DecompositionManifestWriter` rejects an `execution_model` change with `InvalidDecompositionManifestSchemaError` and a manual-migration/reset message. reusable
+- Subtask status projection currently covers implementation/review/audit/validation/PR-description blocked/skipped/complete events and writes human-readable frontmatter `status` in the touched subtask spec. Parent manifest status is derived from subtask statuses; continuation selection and branch/commit advancement remain deferred to SKILL-51 subtasks 3/4.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-05-23] SKILL-51 decomposition-workflow-state-foundation
 Areas: orchestration/contracts, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-contracts/error, skills/bill-feature-implement
 - New runtime contract `orchestration/contracts/decomposition-manifest-schema.yaml` defines the parent manifest for decomposed feature work; `DECOMPOSITION_MANIFEST_CONTRACT_VERSION` and classpath copy wiring mirror the workflow/install-plan schema pattern. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-05-23] SKILL-51 decomposition-workflow-state-foundation
+Areas: orchestration/contracts, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-contracts/error, skills/bill-feature-implement
+- New runtime contract `orchestration/contracts/decomposition-manifest-schema.yaml` defines the parent manifest for decomposed feature work; `DECOMPOSITION_MANIFEST_CONTRACT_VERSION` and classpath copy wiring mirror the workflow/install-plan schema pattern. reusable
+- `DecompositionManifestCodec`, `DecompositionManifestCoherenceValidator`, and `DecompositionManifestWireMap` provide schema-backed YAML load/write mapping plus Kotlin cross-field checks for dependency order, same-branch defaults, stacked branch opt-in, and current subtask intent. reusable
+- `WorkflowService` now writes a validated `decomposition-manifest.yaml` only for implement workflow updates whose plan artifact has `mode=decompose`; ordinary single-spec `mode=implement` updates remain manifest-free.
+- Authored `bill-feature-implement/content.md` now makes decomposition manifest creation part of the terminal planning-mode contract; generated skill installs were refreshed with `./install.sh`.
+- Known limitation: branch checkout/commits, parent continuation, stack advancement, and subtask status transitions remain deferred to later SKILL-51 subtasks.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-05-22] SKILL-50 render-runtime-composition-instructions
 Areas: runtime-kotlin/runtime-core/scaffold, runtime-kotlin/runtime-domain/scaffold/model, platform-packs/kmp, platform-packs/kotlin
 - Generated `SKILL.md` render output now carries manifest-declared code-review composition before authored execution guidance; `AuthoringTarget` receives `PlatformManifest.codeReviewComposition` only for pack baseline skills. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-05-23] SKILL-51 decomposition-workflow-state-continuation-branching
+Areas: runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-mcp, runtime-kotlin/runtime-infra-fs
+- Parent issue-key continuation now resolves decomposed feature parents from durable `artifacts.decomposition_runtime`, then resumes an in-progress subtask or starts the first dependency-complete pending subtask without requiring a subtask path. reusable
+- `DecompositionContinuationSelector` centralizes dependency/blocked/optional-skipped selection semantics; blocked dependencies stop continuation with the stored reason unless the dependency is explicitly optional+skipped. reusable
+- `WorkflowGitOperations` is the application port for branch checkout, commit creation, and stacked branch base validation; production DI uses `GitWorkflowGitOperations`, while CLI/MCP tests inject explicit fakes.
+- Same-branch mode records an individual subtask commit before advancing; branch/commit failures persist the subtask and parent as blocked with `blocked_reason` so resume decisions stay durable.
+- CLI and MCP continue paths accept either `workflow_id` or issue key for implement workflows, preserving existing single-workflow continuation behavior.
+Feature flag: N/A
+Acceptance criteria: 10/10 implemented
+
 ## [2026-05-23] SKILL-51 decomposition-workflow-state-runtime-state
 Areas: orchestration/contracts, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-core/application tests
 - `decomposition-manifest-schema.yaml` now carries parent/subtask runtime state: parent `status`, and per-subtask `branch`, `commit_sha`, `workflow_id`, `review_result`, `audit_result`, `validation_result`, `blocked_reason`, and `last_resumable_step`. The Kotlin model/codec/wire-map emit the same fields under the existing validator-backed manifest contract. reusable

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/ContinuationResult.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/ContinuationResult.kt
@@ -1,0 +1,110 @@
+package skillbill.application
+
+import skillbill.contracts.JsonSupport
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.workflow.model.DecompositionContinuationSelection
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.WorkflowStateSnapshot
+import skillbill.workflow.toWireMap
+
+internal data class ContinuationResult(
+  val payload: Map<String, Any?>,
+  val projectionArtifactsJson: String? = null,
+) {
+  fun withProjection(manifest: DecompositionManifest): ContinuationResult =
+    copy(projectionArtifactsJson = decompositionRuntimeArtifactsJson(manifest))
+
+  fun withProjectionArtifactsIfMissing(artifactsJson: String?): ContinuationResult =
+    if (projectionArtifactsJson == null && artifactsJson != null) {
+      copy(projectionArtifactsJson = artifactsJson)
+    } else {
+      this
+    }
+
+  fun withDecompositionFields(subtaskId: Int, specPath: String): ContinuationResult = copy(
+    payload = LinkedHashMap(payload).apply {
+      put("decomposition_subtask_id", subtaskId)
+      put("decomposition_subtask_spec_path", specPath)
+    },
+  )
+}
+
+internal fun missingSubtaskWorkflowPayload(
+  selection: DecompositionContinuationSelection.Resume,
+  unitOfWork: UnitOfWork,
+): ContinuationResult = ContinuationResult(
+  linkedMapOf(
+    "status" to "error",
+    "continue_status" to "blocked",
+    "subtask_id" to selection.subtask.id,
+    "blocked_reason" to "Subtask ${selection.subtask.id} is in progress but has no workflow_id.",
+    "db_path" to unitOfWork.dbPath.toString(),
+  ),
+)
+
+internal fun blockedSubtaskPayload(
+  parentRecord: WorkflowStateSnapshot,
+  manifest: DecompositionManifest,
+  selection: DecompositionContinuationSelection.Blocked,
+  dbPath: String,
+): Map<String, Any?> = linkedMapOf(
+  "status" to "error",
+  "continue_status" to "blocked",
+  "workflow_id" to parentRecord.workflowId,
+  "issue_key" to manifest.issueKey,
+  "decomposition_subtask_id" to selection.subtask.id,
+  "decomposition_subtask_spec_path" to selection.subtask.specPath,
+  "blocked_reason" to selection.reason,
+  "error" to selection.reason,
+  "db_path" to dbPath,
+)
+
+internal fun doneDecompositionPayload(
+  parentRecord: WorkflowStateSnapshot,
+  manifest: DecompositionManifest,
+  dbPath: String,
+): Map<String, Any?> = linkedMapOf(
+  "status" to "ok",
+  "continue_status" to "done",
+  "workflow_id" to parentRecord.workflowId,
+  "issue_key" to manifest.issueKey,
+  "decomposition_status" to manifest.status,
+  "db_path" to dbPath,
+)
+
+internal fun gitErrorPayload(
+  parentWorkflowId: String,
+  issueKey: String,
+  error: String,
+  unitOfWork: UnitOfWork,
+): Map<String, Any?> = linkedMapOf(
+  "status" to "error",
+  "continue_status" to "blocked",
+  "workflow_id" to parentWorkflowId,
+  "issue_key" to issueKey,
+  "error" to error.ifBlank { "Git operation failed." },
+  "db_path" to unitOfWork.dbPath.toString(),
+)
+
+internal fun blockedGitPayload(
+  parentWorkflowId: String,
+  issueKey: String,
+  dbPath: String,
+  reason: String,
+): Map<String, Any?> = linkedMapOf(
+  "status" to "error",
+  "continue_status" to "blocked",
+  "workflow_id" to parentWorkflowId,
+  "issue_key" to issueKey,
+  "blocked_reason" to reason.ifBlank { "Subtask advancement failed." },
+  "error" to reason.ifBlank { "Subtask advancement failed." },
+  "db_path" to dbPath,
+)
+
+internal fun decompositionRuntimeArtifactsJson(manifest: DecompositionManifest): String =
+  jsonString(mapOf(DECOMPOSITION_RUNTIME_ARTIFACT_KEY to manifest.toWireMap()))
+
+private fun jsonString(value: Any?): String = JsonSupport.json.encodeToString(
+  kotlinx.serialization.json.JsonElement.serializer(),
+  JsonSupport.valueToJsonElement(value),
+)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionBranchFailureSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionBranchFailureSupport.kt
@@ -1,0 +1,17 @@
+package skillbill.application
+
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.WorkflowStateSnapshot
+
+internal fun blockedBranchStartPayload(
+  parentRecord: WorkflowStateSnapshot,
+  manifest: DecompositionManifest,
+  subtaskId: Int,
+  reason: String,
+  unitOfWork: UnitOfWork,
+): Map<String, Any?> {
+  val blockedManifest = manifest.withBlockedSubtask(subtaskId, reason, "create_branch")
+  persistParentDecompositionRuntime(parentRecord, blockedManifest, unitOfWork)
+  return gitErrorPayload(parentRecord.workflowId, manifest.issueKey, reason, unitOfWork)
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeState.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeState.kt
@@ -90,6 +90,7 @@ internal fun DecompositionManifest.withRuntimeUpdate(
 }
 
 internal fun projectCurrentSubtaskStatus(repoRoot: Path, manifest: DecompositionManifest) {
+  projectDecompositionSpecStatus(resolvedParentSpecPath(repoRoot, Path.of(manifest.parentSpecPath)), manifest.status)
   manifest.subtasks.forEach { subtask ->
     if (subtask.status != "pending") {
       projectDecompositionSpecStatus(resolvedParentSpecPath(repoRoot, Path.of(subtask.specPath)), subtask.status)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeState.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeState.kt
@@ -1,0 +1,98 @@
+package skillbill.application
+
+import skillbill.application.model.DecompositionManifestRuntimeUpdate
+import skillbill.contracts.JsonSupport
+import skillbill.workflow.DecompositionManifestCodec
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionSubtask
+import skillbill.workflow.projectDecompositionSpecStatus
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+
+private const val DECOMPOSITION_MANIFEST_FILENAME: String = "decomposition-manifest.yaml"
+
+internal fun decodeArtifacts(existingArtifactsJson: String): Map<String, Any?> =
+  JsonSupport.parseObjectOrNull(existingArtifactsJson)
+    ?.let(JsonSupport::jsonElementToValue)
+    ?.let(JsonSupport::anyToStringAnyMap)
+    .orEmpty()
+
+internal fun loadManifestOrNull(path: Path): DecompositionManifest? = try {
+  DecompositionManifestCodec.load(path)
+} catch (_: NoSuchFileException) {
+  null
+}
+
+internal fun manifestPathFromArtifacts(
+  repoRoot: Path,
+  artifactsPatch: Map<String, Any?>?,
+  existingArtifacts: Map<String, Any?>,
+): Path? {
+  val merged = LinkedHashMap(existingArtifacts)
+  artifactsPatch?.let(merged::putAll)
+  val specPath = (merged["assessment"] as? Map<*, *>)?.get("spec_path")?.toString()?.takeIf(String::isNotBlank)
+    ?: (merged["plan"] as? Map<*, *>)?.get("parent_spec_path")?.toString()?.takeIf(String::isNotBlank)
+  return specPath?.let { resolvedParentSpecPath(repoRoot, Path.of(it)).parent.resolve(DECOMPOSITION_MANIFEST_FILENAME) }
+}
+
+internal fun DecompositionManifest.assertExecutionModelCanReplace(
+  existing: DecompositionManifest?,
+  manifestPath: Path,
+): DecompositionManifest {
+  if (existing != null && executionModel != existing.executionModel && existing.subtasks.any { it.hasStarted() }) {
+    invalidManifest(
+      manifestPath.toString(),
+      "execution_model cannot change after decomposition execution has begun; manually migrate or reset the " +
+        "decomposition manifest before changing execution_model.",
+    )
+  }
+  return this
+}
+
+internal fun DecompositionManifest.withPreservedRuntimeState(existing: DecompositionManifest?): DecompositionManifest {
+  if (existing == null) {
+    return this
+  }
+  val existingById = existing.subtasks.associateBy(DecompositionSubtask::id)
+  return copy(
+    status = existing.status,
+    subtasks = subtasks.map { planned ->
+      val previous = existingById[planned.id] ?: return@map planned
+      planned.copy(
+        status = previous.status,
+        branch = previous.branch,
+        commitSha = previous.commitSha,
+        workflowId = previous.workflowId,
+        reviewResult = previous.reviewResult,
+        auditResult = previous.auditResult,
+        validationResult = previous.validationResult,
+        blockedReason = previous.blockedReason,
+        lastResumableStep = previous.lastResumableStep,
+      )
+    },
+    currentSubtaskIntent = existing.currentSubtaskIntent,
+  )
+}
+
+internal fun DecompositionManifest.withRuntimeUpdate(
+  repoRoot: Path,
+  update: DecompositionManifestRuntimeUpdate,
+): DecompositionManifest {
+  val subtaskId = currentSubtaskIdForUpdate(repoRoot, update) ?: return this
+  val status = statusFromUpdate(update)
+  val updatedSubtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) subtask.withRuntimeFields(this, update, status) else subtask
+  }
+  return copy(
+    subtasks = updatedSubtasks,
+    currentSubtaskIntent = intentFor(subtaskId, status),
+  ).withParentStatus()
+}
+
+internal fun projectCurrentSubtaskStatus(repoRoot: Path, manifest: DecompositionManifest) {
+  manifest.subtasks.forEach { subtask ->
+    if (subtask.status != "pending") {
+      projectDecompositionSpecStatus(resolvedParentSpecPath(repoRoot, Path.of(subtask.specPath)), subtask.status)
+    }
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
@@ -9,6 +9,7 @@ import java.nio.file.Path
 
 private val statusTrackedSteps = setOf("implement", "review", "audit", "validate", "pr_description", "finish")
 private val completionSteps = setOf("pr_description", "finish")
+private val terminalSkippedSteps = setOf("pr_description", "finish")
 
 internal fun DecompositionSubtask.withRuntimeFields(
   manifest: DecompositionManifest,
@@ -37,14 +38,18 @@ internal fun DecompositionManifest.currentSubtaskIdForUpdate(
   val assessment = mergedArtifacts(update)["assessment"] as? Map<*, *>
   val specPath = assessment?.get("spec_path")?.toString()?.takeIf(String::isNotBlank)
   val matchedId = specPath?.let { matchingSubtaskId(repoRoot, it) }
-  return matchedId ?: currentSubtaskIntent.subtaskId.takeIf { it != 0 }
+  return if (specPath != null) {
+    matchedId
+  } else {
+    currentSubtaskIntent.subtaskId.takeIf { it != 0 }
+  }
 }
 
 internal fun statusFromUpdate(update: DecompositionManifestRuntimeUpdate): String? {
   val stepUpdates = update.stepUpdates.orEmpty()
   return when {
     update.workflowStatus == "blocked" || stepUpdates.any { it["status"] == "blocked" } -> "blocked"
-    stepUpdates.any { it["status"] == "skipped" && it["step_id"] in statusTrackedSteps } -> "skipped"
+    stepUpdates.any { it["status"] == "skipped" && it["step_id"] in terminalSkippedSteps } -> "skipped"
     update.workflowStatus == "completed" ||
       stepUpdates.any { it["status"] == "completed" && it["step_id"] in completionSteps } -> "complete"
     update.currentStepId in statusTrackedSteps || stepUpdates.any { it["step_id"] in statusTrackedSteps } ->

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
@@ -1,0 +1,99 @@
+package skillbill.application
+
+import skillbill.application.model.DecompositionManifestRuntimeUpdate
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionSubtask
+import java.nio.file.Path
+
+private val statusTrackedSteps = setOf("implement", "review", "audit", "validate", "pr_description", "finish")
+private val completionSteps = setOf("pr_description", "finish")
+
+internal fun DecompositionSubtask.withRuntimeFields(
+  manifest: DecompositionManifest,
+  update: DecompositionManifestRuntimeUpdate,
+  status: String?,
+): DecompositionSubtask {
+  val artifacts = mergedArtifacts(update)
+  val nextStatus = status ?: this.status
+  return copy(
+    status = nextStatus,
+    branch = branchName(artifacts["branch"]).ifBlank { manifest.branchFor(id) ?: branch },
+    commitSha = commitShaFrom(artifacts) ?: commitSha,
+    workflowId = update.workflowId.ifBlank { workflowId },
+    reviewResult = artifacts["review_result"].asStringAnyMapOrNull() ?: reviewResult,
+    auditResult = artifacts["audit_report"].asStringAnyMapOrNull() ?: auditResult,
+    validationResult = artifacts["validation_result"].asStringAnyMapOrNull() ?: validationResult,
+    blockedReason = blockedReasonFrom(update, nextStatus) ?: blockedReason.takeUnless { nextStatus != "blocked" },
+    lastResumableStep = update.currentStepId.takeIf(String::isNotBlank) ?: lastResumableStep,
+  )
+}
+
+internal fun DecompositionManifest.currentSubtaskIdForUpdate(
+  repoRoot: Path,
+  update: DecompositionManifestRuntimeUpdate,
+): Int? {
+  val assessment = mergedArtifacts(update)["assessment"] as? Map<*, *>
+  val specPath = assessment?.get("spec_path")?.toString()?.takeIf(String::isNotBlank)
+  val matchedId = specPath?.let { matchingSubtaskId(repoRoot, it) }
+  return matchedId ?: currentSubtaskIntent.subtaskId.takeIf { it != 0 }
+}
+
+internal fun statusFromUpdate(update: DecompositionManifestRuntimeUpdate): String? {
+  val stepUpdates = update.stepUpdates.orEmpty()
+  return when {
+    update.workflowStatus == "blocked" || stepUpdates.any { it["status"] == "blocked" } -> "blocked"
+    stepUpdates.any { it["status"] == "skipped" && it["step_id"] in statusTrackedSteps } -> "skipped"
+    update.workflowStatus == "completed" ||
+      stepUpdates.any { it["status"] == "completed" && it["step_id"] in completionSteps } -> "complete"
+    update.currentStepId in statusTrackedSteps || stepUpdates.any { it["step_id"] in statusTrackedSteps } ->
+      "in_progress"
+    else -> null
+  }
+}
+
+internal fun intentFor(subtaskId: Int, status: String?): CurrentSubtaskIntent = when (status) {
+  "blocked" -> CurrentSubtaskIntent(subtaskId = subtaskId, action = "blocked")
+  "complete", "skipped" -> CurrentSubtaskIntent(subtaskId = 0, action = "none")
+  "in_progress" -> CurrentSubtaskIntent(subtaskId = subtaskId, action = "resume")
+  else -> CurrentSubtaskIntent(subtaskId = subtaskId, action = "start")
+}
+
+internal fun DecompositionManifest.withParentStatus(): DecompositionManifest {
+  val parentStatus = when {
+    subtasks.all { it.status in setOf("complete", "skipped") } -> "complete"
+    subtasks.any { it.status == "blocked" } -> "blocked"
+    subtasks.any { it.status in setOf("in_progress", "complete", "skipped") || it.hasStarted() } -> "in_progress"
+    else -> "pending"
+  }
+  return copy(status = parentStatus)
+}
+
+private fun DecompositionManifest.matchingSubtaskId(repoRoot: Path, specPath: String): Int? {
+  val absoluteSpecPath = resolvedParentSpecPath(repoRoot, Path.of(specPath)).normalize()
+  return subtasks.firstOrNull { subtask ->
+    resolvedParentSpecPath(repoRoot, Path.of(subtask.specPath)).normalize() == absoluteSpecPath
+  }?.id
+}
+
+private fun DecompositionManifest.branchFor(subtaskId: Int): String? = when (executionModel) {
+  DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK -> featureBranch
+  DecompositionExecutionModel.STACKED_BRANCHES -> stackBranches.firstOrNull { it.subtaskId == subtaskId }?.branch
+}
+
+private fun mergedArtifacts(update: DecompositionManifestRuntimeUpdate): Map<String, Any?> =
+  LinkedHashMap(update.existingArtifacts).apply { update.artifactsPatch?.let(::putAll) }
+
+private fun blockedReasonFrom(update: DecompositionManifestRuntimeUpdate, status: String): String? =
+  if (status == "blocked") {
+    val artifacts = mergedArtifacts(update)
+    artifacts["blocked_reason"]?.toString()?.takeIf(String::isNotBlank)
+      ?: "Workflow step '${update.currentStepId.ifBlank { "unknown" }}' is blocked."
+  } else {
+    null
+  }
+
+private fun commitShaFrom(artifacts: Map<String, Any?>): String? =
+  artifacts["commit_sha"]?.toString()?.takeIf(String::isNotBlank)
+    ?: (artifacts["commit_push_result"] as? Map<*, *>)?.get("commit_sha")?.toString()?.takeIf(String::isNotBlank)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestTransitionSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestTransitionSupport.kt
@@ -1,0 +1,24 @@
+package skillbill.application
+
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionManifest
+
+internal fun DecompositionManifest.withBlockedSubtask(
+  subtaskId: Int,
+  reason: String,
+  lastResumableStep: String,
+): DecompositionManifest = copy(
+  status = "blocked",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = subtaskId, action = "resume"),
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) {
+      subtask.copy(
+        status = "blocked",
+        blockedReason = reason.ifBlank { "Subtask $subtaskId is blocked." },
+        lastResumableStep = lastResumableStep,
+      )
+    } else {
+      subtask
+    }
+  },
+)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LongParameterList")
+
 package skillbill.application
 
 import skillbill.application.model.DecompositionManifestRuntimeUpdate
@@ -8,28 +10,64 @@ import skillbill.workflow.model.CurrentSubtaskIntent
 import skillbill.workflow.model.DecompositionExecutionModel
 import skillbill.workflow.model.DecompositionManifest
 import skillbill.workflow.writeDecompositionManifestText
+import java.io.IOException
 import java.nio.file.Path
 
 private const val DECOMPOSITION_MODE: String = "decompose"
 private const val DECOMPOSITION_MANIFEST_FILENAME: String = "decomposition-manifest.yaml"
+internal const val DECOMPOSITION_RUNTIME_ARTIFACT_KEY: String = "decomposition_runtime"
 
 object DecompositionManifestWriter {
   fun writeFromWorkflowUpdate(
     repoRoot: Path,
     existingArtifactsJson: String,
     artifactsPatch: Map<String, Any?>?,
+    workflowId: String = "",
+    workflowStatus: String = "",
+    currentStepId: String = "",
+    stepUpdates: List<Map<String, Any?>>? = null,
     runtimeUpdate: DecompositionManifestRuntimeUpdate? = null,
   ): DecompositionManifestWriteResult? {
+    val manifest = manifestFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = existingArtifactsJson,
+      artifactsPatch = artifactsPatch,
+      workflowId = workflowId,
+      workflowStatus = workflowStatus,
+      currentStepId = currentStepId,
+      stepUpdates = stepUpdates,
+      runtimeUpdate = runtimeUpdate,
+    ) ?: return null
+    return writeProjection(repoRoot, manifest)
+  }
+
+  fun manifestFromWorkflowUpdate(
+    repoRoot: Path,
+    existingArtifactsJson: String,
+    artifactsPatch: Map<String, Any?>?,
+    workflowId: String = "",
+    workflowStatus: String = "",
+    currentStepId: String = "",
+    stepUpdates: List<Map<String, Any?>>? = null,
+    runtimeUpdate: DecompositionManifestRuntimeUpdate? = null,
+  ): DecompositionManifest? {
     val existingArtifacts = decodeArtifacts(existingArtifactsJson)
-    val update = (runtimeUpdate ?: DecompositionManifestRuntimeUpdate()).copy(
+    val update = (
+      runtimeUpdate ?: DecompositionManifestRuntimeUpdate(
+        workflowId = workflowId,
+        workflowStatus = workflowStatus,
+        currentStepId = currentStepId,
+        stepUpdates = stepUpdates,
+      )
+      ).copy(
       artifactsPatch = artifactsPatch,
       existingArtifacts = existingArtifacts,
     )
     val plan = artifactsPatch?.get("plan").asStringAnyMapOrNull()
     return if (plan != null && plan["mode"] == DECOMPOSITION_MODE) {
-      writeFromDecompositionPlan(repoRoot, plan, artifactsPatch, existingArtifacts)
+      manifestFromDecompositionPlan(repoRoot, plan, artifactsPatch, existingArtifacts)
     } else {
-      updateExistingManifest(repoRoot, update)
+      updatedExistingManifest(repoRoot, update)
     }
   }
 
@@ -38,6 +76,21 @@ object DecompositionManifestWriter {
     existingArtifactsJson: String,
     artifactsPatch: Map<String, Any?>?,
   ): Path? = writeFromWorkflowUpdate(repoRoot, existingArtifactsJson, artifactsPatch)?.manifestPath
+
+  fun writeProjectionFromWorkflowState(repoRoot: Path, artifactsJson: String): DecompositionManifestWriteResult? {
+    val artifacts = decodeArtifacts(artifactsJson)
+    val runtime = artifacts[DECOMPOSITION_RUNTIME_ARTIFACT_KEY].asStringAnyMapOrNull()
+      ?.let { DecompositionManifestCodec.decodeMap(it, DECOMPOSITION_RUNTIME_ARTIFACT_KEY) }
+      ?: return null
+    val manifestPath = resolvedParentSpecPath(repoRoot, Path.of(runtime.parentSpecPath))
+      .parent
+      .resolve(DECOMPOSITION_MANIFEST_FILENAME)
+    return try {
+      writeProjection(repoRoot, runtime, manifestPath)
+    } catch (_: IOException) {
+      null
+    }
+  }
 
   fun writeIfDecomposed(request: DecompositionManifestWriteRequest): DecompositionManifestWriteResult? {
     if (request.planningResult["mode"]?.toString().orEmpty() != DECOMPOSITION_MODE) {
@@ -67,52 +120,50 @@ object DecompositionManifestWriter {
     return DecompositionManifestWriteResult(manifestPath = manifestPath, manifest = loaded)
   }
 
-  private fun writeFromDecompositionPlan(
+  private fun manifestFromDecompositionPlan(
     repoRoot: Path,
     plan: Map<String, Any?>,
     artifactsPatch: Map<String, Any?>?,
     existingArtifacts: Map<String, Any?>,
-  ): DecompositionManifestWriteResult {
+  ): DecompositionManifest {
     val parentSpecPath = Path.of(parentSpecPath(plan))
     val branchName = branchName(artifactsPatch?.get("branch")).ifBlank { branchName(existingArtifacts["branch"]) }
     val executionModel = executionModel(plan)
-    return write(
-      DecompositionManifestWriteRequest(
-        repoRoot = repoRoot,
-        parentSpecPath = parentSpecPath,
-        planningResult = plan,
-        baseBranch = plan["base_branch"]?.toString()?.takeIf(String::isNotBlank) ?: "main",
-        featureBranch = when (executionModel) {
-          DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK ->
-            branchName.ifBlank { defaultFeatureBranch(parentSpecPath) }
-          DecompositionExecutionModel.STACKED_BRANCHES -> null
-        },
-        executionModel = executionModel,
-        stackBranches = parseStackBranches(plan),
-      ),
+    val request = DecompositionManifestWriteRequest(
+      repoRoot = repoRoot,
+      parentSpecPath = parentSpecPath,
+      planningResult = plan,
+      baseBranch = plan["base_branch"]?.toString()?.takeIf(String::isNotBlank) ?: "main",
+      featureBranch = when (executionModel) {
+        DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK ->
+          branchName.ifBlank { defaultFeatureBranch(parentSpecPath) }
+        DecompositionExecutionModel.STACKED_BRANCHES -> null
+      },
+      executionModel = executionModel,
+      stackBranches = parseStackBranches(plan),
     )
+    val manifestPath = request.manifestPath()
+    val existing = runtimeManifestFromArtifacts(existingArtifacts) ?: loadManifestOrNull(manifestPath)
+    return request.toManifest()
+      .assertExecutionModelCanReplace(existing, manifestPath)
+      .withPreservedRuntimeState(existing)
   }
 
-  private fun updateExistingManifest(
+  private fun updatedExistingManifest(
     repoRoot: Path,
     runtimeUpdate: DecompositionManifestRuntimeUpdate,
-  ): DecompositionManifestWriteResult? {
+  ): DecompositionManifest? {
+    val artifacts = LinkedHashMap(runtimeUpdate.existingArtifacts).apply {
+      runtimeUpdate.artifactsPatch?.let(::putAll)
+    }
+    val runtime = runtimeManifestFromArtifacts(artifacts)
     val manifestPath = manifestPathFromArtifacts(
       repoRoot = repoRoot,
       artifactsPatch = runtimeUpdate.artifactsPatch,
       existingArtifacts = runtimeUpdate.existingArtifacts,
-    )
-    val existing = manifestPath?.let(::loadManifestOrNull)
-    return if (manifestPath == null || existing == null) {
-      null
-    } else {
-      val updated = existing.withRuntimeUpdate(repoRoot, runtimeUpdate)
-      val yaml = DecompositionManifestCodec.encodeYaml(updated)
-      writeDecompositionManifestText(manifestPath, yaml)
-      val loaded = DecompositionManifestCodec.load(manifestPath)
-      projectCurrentSubtaskStatus(repoRoot, loaded)
-      DecompositionManifestWriteResult(manifestPath = manifestPath, manifest = loaded)
-    }
+    ) ?: runtime?.manifestPath(repoRoot)
+    val existing = runtime ?: manifestPath?.let(::loadManifestOrNull) ?: return null
+    return existing.withRuntimeUpdate(repoRoot, runtimeUpdate)
   }
 
   private fun DecompositionManifestWriteRequest.toManifest(): DecompositionManifest {
@@ -141,4 +192,28 @@ object DecompositionManifestWriter {
       subtasks = subtasks,
     )
   }
+}
+
+private fun DecompositionManifestWriteRequest.manifestPath(): Path =
+  resolvedParentSpecPath(repoRoot, parentSpecPath).parent.resolve(DECOMPOSITION_MANIFEST_FILENAME)
+
+private fun DecompositionManifest.manifestPath(repoRoot: Path): Path =
+  resolvedParentSpecPath(repoRoot, Path.of(parentSpecPath)).parent.resolve(DECOMPOSITION_MANIFEST_FILENAME)
+
+private fun runtimeManifestFromArtifacts(artifacts: Map<String, Any?>): DecompositionManifest? =
+  artifacts[DECOMPOSITION_RUNTIME_ARTIFACT_KEY].asStringAnyMapOrNull()
+    ?.let { DecompositionManifestCodec.decodeMap(it, DECOMPOSITION_RUNTIME_ARTIFACT_KEY) }
+
+private fun writeProjection(
+  repoRoot: Path,
+  manifest: DecompositionManifest,
+  manifestPath: Path = manifest.manifestPath(repoRoot),
+): DecompositionManifestWriteResult? = try {
+  val yaml = DecompositionManifestCodec.encodeYaml(manifest)
+  writeDecompositionManifestText(manifestPath, yaml)
+  val loaded = DecompositionManifestCodec.load(manifestPath)
+  projectCurrentSubtaskStatus(repoRoot, loaded)
+  DecompositionManifestWriteResult(manifestPath = manifestPath, manifest = loaded)
+} catch (_: IOException) {
+  null
 }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
@@ -1,8 +1,8 @@
 package skillbill.application
 
+import skillbill.application.model.DecompositionManifestRuntimeUpdate
 import skillbill.application.model.DecompositionManifestWriteRequest
 import skillbill.application.model.DecompositionManifestWriteResult
-import skillbill.contracts.JsonSupport
 import skillbill.workflow.DecompositionManifestCodec
 import skillbill.workflow.model.CurrentSubtaskIntent
 import skillbill.workflow.model.DecompositionExecutionModel
@@ -18,33 +18,18 @@ object DecompositionManifestWriter {
     repoRoot: Path,
     existingArtifactsJson: String,
     artifactsPatch: Map<String, Any?>?,
+    runtimeUpdate: DecompositionManifestRuntimeUpdate? = null,
   ): DecompositionManifestWriteResult? {
+    val existingArtifacts = decodeArtifacts(existingArtifactsJson)
+    val update = (runtimeUpdate ?: DecompositionManifestRuntimeUpdate()).copy(
+      artifactsPatch = artifactsPatch,
+      existingArtifacts = existingArtifacts,
+    )
     val plan = artifactsPatch?.get("plan").asStringAnyMapOrNull()
-    return if (plan == null || plan["mode"] != DECOMPOSITION_MODE) {
-      null
+    return if (plan != null && plan["mode"] == DECOMPOSITION_MODE) {
+      writeFromDecompositionPlan(repoRoot, plan, artifactsPatch, existingArtifacts)
     } else {
-      val existingArtifacts = JsonSupport.parseObjectOrNull(existingArtifactsJson)
-        ?.let(JsonSupport::jsonElementToValue)
-        ?.let(JsonSupport::anyToStringAnyMap)
-        .orEmpty()
-      val parentSpecPath = Path.of(parentSpecPath(plan))
-      val branchName = branchName(artifactsPatch?.get("branch")).ifBlank { branchName(existingArtifacts["branch"]) }
-      val executionModel = executionModel(plan)
-      writeIfDecomposed(
-        DecompositionManifestWriteRequest(
-          repoRoot = repoRoot,
-          parentSpecPath = parentSpecPath,
-          planningResult = plan,
-          baseBranch = plan["base_branch"]?.toString()?.takeIf(String::isNotBlank) ?: "main",
-          featureBranch = when (executionModel) {
-            DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK ->
-              branchName.ifBlank { defaultFeatureBranch(parentSpecPath) }
-            DecompositionExecutionModel.STACKED_BRANCHES -> null
-          },
-          executionModel = executionModel,
-          stackBranches = parseStackBranches(plan),
-        ),
-      )
+      updateExistingManifest(repoRoot, update)
     }
   }
 
@@ -61,15 +46,73 @@ object DecompositionManifestWriter {
     return write(request)
   }
 
-  fun write(request: DecompositionManifestWriteRequest): DecompositionManifestWriteResult {
+  fun write(
+    request: DecompositionManifestWriteRequest,
+    runtimeUpdate: DecompositionManifestRuntimeUpdate? = null,
+  ): DecompositionManifestWriteResult {
     val manifestPath = resolvedParentSpecPath(request.repoRoot, request.parentSpecPath)
       .parent
       .resolve(DECOMPOSITION_MANIFEST_FILENAME)
+    val existing = loadManifestOrNull(manifestPath)
     val manifest = request.toManifest()
+      .assertExecutionModelCanReplace(existing, manifestPath)
+      .withPreservedRuntimeState(existing)
+      .let { candidate ->
+        runtimeUpdate?.let { candidate.withRuntimeUpdate(request.repoRoot, it) } ?: candidate
+      }
     val yaml = DecompositionManifestCodec.encodeYaml(manifest)
     writeDecompositionManifestText(manifestPath, yaml)
     val loaded = DecompositionManifestCodec.load(manifestPath)
+    projectCurrentSubtaskStatus(request.repoRoot, loaded)
     return DecompositionManifestWriteResult(manifestPath = manifestPath, manifest = loaded)
+  }
+
+  private fun writeFromDecompositionPlan(
+    repoRoot: Path,
+    plan: Map<String, Any?>,
+    artifactsPatch: Map<String, Any?>?,
+    existingArtifacts: Map<String, Any?>,
+  ): DecompositionManifestWriteResult {
+    val parentSpecPath = Path.of(parentSpecPath(plan))
+    val branchName = branchName(artifactsPatch?.get("branch")).ifBlank { branchName(existingArtifacts["branch"]) }
+    val executionModel = executionModel(plan)
+    return write(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = plan,
+        baseBranch = plan["base_branch"]?.toString()?.takeIf(String::isNotBlank) ?: "main",
+        featureBranch = when (executionModel) {
+          DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK ->
+            branchName.ifBlank { defaultFeatureBranch(parentSpecPath) }
+          DecompositionExecutionModel.STACKED_BRANCHES -> null
+        },
+        executionModel = executionModel,
+        stackBranches = parseStackBranches(plan),
+      ),
+    )
+  }
+
+  private fun updateExistingManifest(
+    repoRoot: Path,
+    runtimeUpdate: DecompositionManifestRuntimeUpdate,
+  ): DecompositionManifestWriteResult? {
+    val manifestPath = manifestPathFromArtifacts(
+      repoRoot = repoRoot,
+      artifactsPatch = runtimeUpdate.artifactsPatch,
+      existingArtifacts = runtimeUpdate.existingArtifacts,
+    )
+    val existing = manifestPath?.let(::loadManifestOrNull)
+    return if (manifestPath == null || existing == null) {
+      null
+    } else {
+      val updated = existing.withRuntimeUpdate(repoRoot, runtimeUpdate)
+      val yaml = DecompositionManifestCodec.encodeYaml(updated)
+      writeDecompositionManifestText(manifestPath, yaml)
+      val loaded = DecompositionManifestCodec.load(manifestPath)
+      projectCurrentSubtaskStatus(repoRoot, loaded)
+      DecompositionManifestWriteResult(manifestPath = manifestPath, manifest = loaded)
+    }
   }
 
   private fun DecompositionManifestWriteRequest.toManifest(): DecompositionManifest {

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
@@ -1,0 +1,101 @@
+package skillbill.application
+
+import skillbill.application.model.DecompositionManifestWriteRequest
+import skillbill.application.model.DecompositionManifestWriteResult
+import skillbill.contracts.JsonSupport
+import skillbill.workflow.DecompositionManifestCodec
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.writeDecompositionManifestText
+import java.nio.file.Path
+
+private const val DECOMPOSITION_MODE: String = "decompose"
+private const val DECOMPOSITION_MANIFEST_FILENAME: String = "decomposition-manifest.yaml"
+
+object DecompositionManifestWriter {
+  fun writeFromWorkflowUpdate(
+    repoRoot: Path,
+    existingArtifactsJson: String,
+    artifactsPatch: Map<String, Any?>?,
+  ): DecompositionManifestWriteResult? {
+    val plan = artifactsPatch?.get("plan").asStringAnyMapOrNull()
+    return if (plan == null || plan["mode"] != DECOMPOSITION_MODE) {
+      null
+    } else {
+      val existingArtifacts = JsonSupport.parseObjectOrNull(existingArtifactsJson)
+        ?.let(JsonSupport::jsonElementToValue)
+        ?.let(JsonSupport::anyToStringAnyMap)
+        .orEmpty()
+      val parentSpecPath = Path.of(parentSpecPath(plan))
+      val branchName = branchName(artifactsPatch?.get("branch")).ifBlank { branchName(existingArtifacts["branch"]) }
+      val executionModel = executionModel(plan)
+      writeIfDecomposed(
+        DecompositionManifestWriteRequest(
+          repoRoot = repoRoot,
+          parentSpecPath = parentSpecPath,
+          planningResult = plan,
+          baseBranch = plan["base_branch"]?.toString()?.takeIf(String::isNotBlank) ?: "main",
+          featureBranch = when (executionModel) {
+            DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK ->
+              branchName.ifBlank { defaultFeatureBranch(parentSpecPath) }
+            DecompositionExecutionModel.STACKED_BRANCHES -> null
+          },
+          executionModel = executionModel,
+          stackBranches = parseStackBranches(plan),
+        ),
+      )
+    }
+  }
+
+  fun maybeWriteFromWorkflowUpdate(
+    repoRoot: Path,
+    existingArtifactsJson: String,
+    artifactsPatch: Map<String, Any?>?,
+  ): Path? = writeFromWorkflowUpdate(repoRoot, existingArtifactsJson, artifactsPatch)?.manifestPath
+
+  fun writeIfDecomposed(request: DecompositionManifestWriteRequest): DecompositionManifestWriteResult? {
+    if (request.planningResult["mode"]?.toString().orEmpty() != DECOMPOSITION_MODE) {
+      return null
+    }
+    return write(request)
+  }
+
+  fun write(request: DecompositionManifestWriteRequest): DecompositionManifestWriteResult {
+    val manifestPath = resolvedParentSpecPath(request.repoRoot, request.parentSpecPath)
+      .parent
+      .resolve(DECOMPOSITION_MANIFEST_FILENAME)
+    val manifest = request.toManifest()
+    val yaml = DecompositionManifestCodec.encodeYaml(manifest)
+    writeDecompositionManifestText(manifestPath, yaml)
+    val loaded = DecompositionManifestCodec.load(manifestPath)
+    return DecompositionManifestWriteResult(manifestPath = manifestPath, manifest = loaded)
+  }
+
+  private fun DecompositionManifestWriteRequest.toManifest(): DecompositionManifest {
+    val subtasks = parseSubtasks(planningResult, parentSpecPath.toString())
+    val currentId = currentSubtaskId
+      ?: planningResult.intValueOrNull("current_subtask_id")
+      ?: planningResult.intValueOrNull("recommended_first_subtask_id")
+      ?: subtasks.first().id
+    val currentSubtask = subtasks.firstOrNull { it.id == currentId }
+      ?: invalidManifest(
+        parentSpecPath.toString(),
+        "current subtask id '$currentId' does not reference a planned subtask.",
+      )
+    val (issueKey, featureName) = issueAndFeature(
+      resolvedParentSpecPath(repoRoot, parentSpecPath).parent.fileName.toString(),
+    )
+    return DecompositionManifest(
+      issueKey = issueKey,
+      featureName = featureName,
+      parentSpecPath = repoRelativePath(repoRoot, parentSpecPath),
+      executionModel = executionModel,
+      baseBranch = baseBranch,
+      featureBranch = featureBranch,
+      stackBranches = stackBranches,
+      currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = currentSubtask.id, action = "start"),
+      subtasks = subtasks,
+    )
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriterErrors.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriterErrors.kt
@@ -1,0 +1,6 @@
+package skillbill.application
+
+import skillbill.error.InvalidDecompositionManifestSchemaError
+
+internal fun invalidManifest(sourceLabel: String, reason: String): Nothing =
+  throw InvalidDecompositionManifestSchemaError(sourceLabel = sourceLabel, reason = reason)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriterPlan.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriterPlan.kt
@@ -1,0 +1,90 @@
+package skillbill.application
+
+import skillbill.workflow.model.DecompositionDependency
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionStackBranch
+import skillbill.workflow.model.DecompositionSubtask
+import java.nio.file.Path
+
+internal fun parseSubtasks(planningResult: Map<String, Any?>, sourceLabel: String): List<DecompositionSubtask> {
+  val rawSubtasks = planningResult["subtasks"] as? List<*>
+    ?: invalidManifest(sourceLabel, "decomposition planning result must contain subtasks.")
+  return rawSubtasks.mapIndexed { index, raw ->
+    val item = raw.asStringAnyMap(sourceLabel, "subtasks[$index]")
+    val name = item["title"]?.toString()?.ifBlank { null }
+      ?: item["name"]?.toString()?.ifBlank { null }
+      ?: "Subtask ${item.intValue("id", sourceLabel)}"
+    DecompositionSubtask(
+      id = item.intValue("id", sourceLabel),
+      name = name,
+      specPath = item["spec_path"]?.toString()?.ifBlank { null }
+        ?: invalidManifest(sourceLabel, "subtasks[$index].spec_path must be present."),
+      status = "pending",
+      dependencies = parseDependencies(item["dependencies"] ?: item["depends_on"], sourceLabel, index),
+    )
+  }
+}
+
+internal fun parseDependencies(raw: Any?, sourceLabel: String, subtaskIndex: Int): List<DecompositionDependency> {
+  if (raw == null) {
+    return emptyList()
+  }
+  val dependencies = raw as? List<*> ?: invalidManifest(
+    sourceLabel,
+    "subtasks[$subtaskIndex].dependencies must be a list.",
+  )
+  return dependencies.mapIndexed { depIndex, value ->
+    when (value) {
+      is Map<*, *> -> {
+        val dependency = value.asStringAnyMap(sourceLabel, "subtasks[$subtaskIndex].dependencies[$depIndex]")
+        DecompositionDependency(
+          subtaskId = dependency.intValue("subtask_id", sourceLabel),
+          optional = dependency.booleanValueOrDefault("optional", false, sourceLabel),
+          skipped = dependency.booleanValueOrDefault("skipped", false, sourceLabel),
+        )
+      }
+      else -> DecompositionDependency(
+        subtaskId = value.asInt(sourceLabel, "subtasks[$subtaskIndex].dependencies[$depIndex]"),
+      )
+    }
+  }
+}
+
+internal fun parentSpecPath(plan: Map<String, Any?>): String {
+  plan["parent_spec_path"]?.toString()?.takeIf(String::isNotBlank)?.let { return it }
+  val firstSubtask = (plan["subtasks"] as? List<*>).orEmpty().firstOrNull().asStringAnyMapOrNull()
+    ?: invalidManifest("<planning-result>", "decomposition planning result must contain subtasks.")
+  val firstSpecPath = firstSubtask["spec_path"]?.toString()?.takeIf(String::isNotBlank)
+    ?: invalidManifest("<planning-result>", "subtasks[0].spec_path must be present.")
+  return Path.of(firstSpecPath).parent.resolve("spec.md").toString()
+}
+
+internal fun executionModel(plan: Map<String, Any?>): DecompositionExecutionModel {
+  val raw = plan["execution_model"]?.toString()?.takeIf(String::isNotBlank)
+    ?: DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK.wireValue
+  return DecompositionExecutionModel.fromWireValue(raw)
+    ?: invalidManifest("<planning-result>", "execution_model '$raw' is not supported.")
+}
+
+internal fun parseStackBranches(plan: Map<String, Any?>): List<DecompositionStackBranch> =
+  (plan["stack_branches"] as? List<*>).orEmpty().mapIndexed { index, raw ->
+    val item = raw.asStringAnyMap("<planning-result>", "stack_branches[$index]")
+    DecompositionStackBranch(
+      subtaskId = item.intValue("subtask_id", "<planning-result>"),
+      branch = item["branch"]?.toString()?.takeIf(String::isNotBlank)
+        ?: invalidManifest("<planning-result>", "stack_branches[$index].branch must be present."),
+      baseBranch = item["base_branch"]?.toString()?.takeIf(String::isNotBlank) ?: "main",
+    )
+  }
+
+internal fun defaultFeatureBranch(parentSpecPath: Path): String {
+  val (issueKey, featureName) = issueAndFeature(parentSpecPath.parent.fileName.toString())
+  return "feat/$issueKey-$featureName"
+}
+
+internal fun branchName(branchArtifact: Any?): String = when (branchArtifact) {
+  is Map<*, *> -> branchArtifact["branch_name"]?.toString().orEmpty()
+    .ifBlank { branchArtifact["branch"]?.toString().orEmpty() }
+  is String -> branchArtifact
+  else -> ""
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriterSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriterSupport.kt
@@ -1,0 +1,58 @@
+package skillbill.application
+
+import java.nio.file.Path
+
+internal fun resolvedParentSpecPath(repoRoot: Path, parentSpecPath: Path): Path =
+  if (parentSpecPath.isAbsolute) parentSpecPath.normalize() else repoRoot.resolve(parentSpecPath).normalize()
+
+internal fun repoRelativePath(repoRoot: Path, path: Path): String {
+  val root = repoRoot.toAbsolutePath().normalize()
+  val absolute = resolvedParentSpecPath(root, path).toAbsolutePath().normalize()
+  if (!absolute.startsWith(root)) {
+    return absolute.toString()
+  }
+  return root.relativize(absolute).joinToString("/")
+}
+
+internal fun issueAndFeature(directoryName: String): Pair<String, String> {
+  val match = Regex("^([A-Z]+-\\d+)-(.+)$").matchEntire(directoryName)
+  if (match != null) {
+    return match.groupValues[1] to match.groupValues[2]
+  }
+  val parts = directoryName.split("-", limit = 2)
+  return parts.first() to parts.getOrElse(1) { "decomposition" }
+}
+
+internal fun Map<String, Any?>.intValueOrNull(key: String): Int? = this[key]?.asIntOrNull()
+
+internal fun Map<String, Any?>.intValue(key: String, sourceLabel: String): Int =
+  this[key].asIntOrNull() ?: invalidManifest(sourceLabel, "$key must be an integer.")
+
+internal fun Map<String, Any?>.booleanValueOrDefault(key: String, default: Boolean, sourceLabel: String): Boolean =
+  when (val value = this[key]) {
+    null -> default
+    is Boolean -> value
+    else -> invalidManifest(sourceLabel, "$key must be a boolean.")
+  }
+
+internal fun Any?.asInt(sourceLabel: String, fieldPath: String): Int =
+  asIntOrNull() ?: invalidManifest(sourceLabel, "$fieldPath must be an integer.")
+
+internal fun Any?.asIntOrNull(): Int? = when (this) {
+  is Int -> this
+  is Long -> this.toInt()
+  is Number -> this.toInt()
+  else -> null
+}
+
+internal fun Any?.asStringAnyMap(sourceLabel: String, fieldPath: String): Map<String, Any?> =
+  (this as? Map<*, *>)?.entries?.associateTo(LinkedHashMap<String, Any?>()) { (key, value) ->
+    val stringKey = key as? String ?: invalidManifest(sourceLabel, "$fieldPath contains a non-string key.")
+    stringKey to value
+  } ?: invalidManifest(sourceLabel, "$fieldPath must be an object.")
+
+internal fun Any?.asStringAnyMapOrNull(): Map<String, Any?>? =
+  (this as? Map<*, *>)?.entries?.associateTo(LinkedHashMap<String, Any?>()) { (key, value) ->
+    val stringKey = key as? String ?: return null
+    stringKey to value
+  }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuation.kt
@@ -1,0 +1,210 @@
+package skillbill.application
+
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.ports.workflow.WorkflowGitOperations
+import skillbill.workflow.DecompositionContinuationSelector
+import skillbill.workflow.WorkflowEngine
+import skillbill.workflow.model.DecompositionContinuationSelection
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.WorkflowStateSnapshot
+import skillbill.workflow.model.WorkflowUpdateInput
+import skillbill.workflow.toWireMap
+
+internal class DecompositionWorkflowContinuation(
+  private val gitOperations: WorkflowGitOperations,
+) {
+  fun continueDecomposedParentByIssueKey(issueKey: String, unitOfWork: UnitOfWork): ContinuationResult {
+    val parentRecord = unitOfWork.workflowStates
+      .findDecomposedParentWorkflow(issueKey)
+      ?.toSnapshot()
+    val manifest = parentRecord?.decompositionRuntime()
+    val result = if (parentRecord == null || manifest == null) {
+      ContinuationResult(unknownWorkflowPayload(issueKey, unitOfWork.dbPath.toString()))
+    } else {
+      continueManifest(parentRecord, manifest, unitOfWork)
+    }
+    return result
+  }
+
+  private fun continueManifest(
+    parentRecord: WorkflowStateSnapshot,
+    manifest: DecompositionManifest,
+    unitOfWork: UnitOfWork,
+  ): ContinuationResult {
+    val advancement = advanceCompletedSubtasks(parentRecord, manifest, unitOfWork)
+    if (advancement.error != null) {
+      return ContinuationResult(
+        blockedGitPayload(parentRecord.workflowId, manifest.issueKey, unitOfWork.dbPath.toString(), advancement.error),
+        advancement.projectionArtifactsJson,
+      )
+    }
+    val advancedManifest = advancement.manifest
+    val projectionArtifactsJson =
+      if (advancedManifest != manifest) decompositionRuntimeArtifactsJson(advancedManifest) else null
+    return selectedContinuation(parentRecord, advancedManifest, unitOfWork)
+      .withProjectionArtifactsIfMissing(projectionArtifactsJson)
+  }
+
+  private fun selectedContinuation(
+    parentRecord: WorkflowStateSnapshot,
+    manifest: DecompositionManifest,
+    unitOfWork: UnitOfWork,
+  ): ContinuationResult = when (val selection = DecompositionContinuationSelector.select(manifest)) {
+    is DecompositionContinuationSelection.Resume -> continueSelectedSubtask(selection, unitOfWork)
+    is DecompositionContinuationSelection.Start -> startSelectedSubtask(parentRecord, manifest, selection, unitOfWork)
+    is DecompositionContinuationSelection.Blocked ->
+      ContinuationResult(blockedSubtaskPayload(parentRecord, manifest, selection, unitOfWork.dbPath.toString()))
+    is DecompositionContinuationSelection.Done ->
+      ContinuationResult(doneDecompositionPayload(parentRecord, selection.manifest, unitOfWork.dbPath.toString()))
+  }
+
+  private fun continueSelectedSubtask(
+    selection: DecompositionContinuationSelection.Resume,
+    unitOfWork: UnitOfWork,
+  ): ContinuationResult {
+    val record = selection.workflowId
+      .takeIf(String::isNotBlank)
+      ?.let { WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, it) }
+    return if (record == null) {
+      missingSubtaskWorkflowPayload(selection, unitOfWork)
+    } else {
+      val alignedRecord = alignSubtaskResumeStep(record, selection.resumeStepId, unitOfWork)
+      continueExistingWorkflow(WorkflowFamily.IMPLEMENT, alignedRecord, selection.workflowId, unitOfWork)
+        .withDecompositionFields(selection.subtask.id, selection.subtask.specPath)
+    }
+  }
+
+  private fun startSelectedSubtask(
+    parentRecord: WorkflowStateSnapshot,
+    manifest: DecompositionManifest,
+    selection: DecompositionContinuationSelection.Start,
+    unitOfWork: UnitOfWork,
+  ): ContinuationResult {
+    val branchError = checkoutAndValidateBranch(parentRecord, manifest, selection, unitOfWork)
+    return if (branchError != null) {
+      ContinuationResult(branchError)
+    } else {
+      openSubtaskWorkflow(parentRecord, manifest, selection, unitOfWork)
+    }
+  }
+
+  private fun checkoutAndValidateBranch(
+    parentRecord: WorkflowStateSnapshot,
+    manifest: DecompositionManifest,
+    selection: DecompositionContinuationSelection.Start,
+    unitOfWork: UnitOfWork,
+  ): Map<String, Any?>? {
+    val branchPlan = selection.branchPlan
+    var errorPayload: Map<String, Any?>? = null
+    if (branchPlan.branch.isNotBlank()) {
+      val checkout = gitOperations.checkoutBranch(repoRoot(), branchPlan.branch, branchPlan.baseBranch)
+      errorPayload = checkout.takeUnless { it.ok }
+        ?.let { blockedBranchStartPayload(parentRecord, manifest, selection.subtask.id, it.error, unitOfWork) }
+      if (errorPayload == null && branchPlan.validateBase) {
+        errorPayload = gitOperations.validateBranchBase(repoRoot(), branchPlan.branch, branchPlan.baseBranch)
+          .takeUnless { it.ok }
+          ?.let { blockedBranchStartPayload(parentRecord, manifest, selection.subtask.id, it.error, unitOfWork) }
+      }
+    }
+    return errorPayload
+  }
+
+  private fun openSubtaskWorkflow(
+    parentRecord: WorkflowStateSnapshot,
+    manifest: DecompositionManifest,
+    selection: DecompositionContinuationSelection.Start,
+    unitOfWork: UnitOfWork,
+  ): ContinuationResult {
+    val workflowId = generateWorkflowId(WorkflowFamily.IMPLEMENT.definition.workflowIdPrefix)
+    val updatedManifest = manifest.withStartedSubtask(selection.subtask.id, workflowId, selection.branchPlan.branch)
+    val opened = WorkflowEngine.openRecord(
+      WorkflowFamily.IMPLEMENT.definition,
+      workflowId,
+      parentRecord.sessionId.orEmpty(),
+      WorkflowFamily.IMPLEMENT.definition.defaultInitialStepId,
+    )
+    val started = WorkflowEngine.updateRecord(
+      WorkflowFamily.IMPLEMENT.definition,
+      opened,
+      WorkflowUpdateInput(
+        workflowStatus = "running",
+        currentStepId = "assess",
+        stepUpdates = null,
+        artifactsPatch = subtaskStartArtifacts(selection, updatedManifest),
+        sessionId = parentRecord.sessionId.orEmpty(),
+      ),
+    )
+    WorkflowFamily.IMPLEMENT.save(unitOfWork.workflowStates, started)
+    persistParentDecompositionRuntime(parentRecord, updatedManifest, unitOfWork)
+    val saved = WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, workflowId) ?: started
+    return continueExistingWorkflow(WorkflowFamily.IMPLEMENT, saved, workflowId, unitOfWork)
+      .withProjection(updatedManifest)
+      .withDecompositionFields(selection.subtask.id, selection.subtask.specPath)
+  }
+
+  private fun subtaskStartArtifacts(
+    selection: DecompositionContinuationSelection.Start,
+    manifest: DecompositionManifest,
+  ): Map<String, Any?> = mapOf(
+    "assessment" to mapOf("spec_path" to selection.subtask.specPath),
+    "branch" to mapOf("branch_name" to selection.branchPlan.branch),
+    DECOMPOSITION_RUNTIME_ARTIFACT_KEY to manifest.toWireMap(),
+  )
+
+  private fun advanceCompletedSubtasks(
+    parentRecord: WorkflowStateSnapshot,
+    manifest: DecompositionManifest,
+    unitOfWork: UnitOfWork,
+  ): AdvancementResult {
+    var updated = manifest
+    manifest.subtasks
+      .filter { it.status == "complete" && it.commitSha.isNullOrBlank() }
+      .forEach { subtask ->
+        val advanced = commitCompletedSubtask(updated, subtask.id, subtask.name)
+        if (advanced.error != null) {
+          updated = updated.withBlockedSubtask(subtask.id, advanced.error, "commit_push")
+          persistParentDecompositionRuntime(parentRecord, updated, unitOfWork)
+          return AdvancementResult(updated, advanced.error, decompositionRuntimeArtifactsJson(updated))
+        }
+        updated = advanced.manifest
+      }
+    if (updated != manifest) {
+      persistParentDecompositionRuntime(parentRecord, updated, unitOfWork)
+    }
+    return AdvancementResult(updated)
+  }
+
+  private fun commitCompletedSubtask(
+    manifest: DecompositionManifest,
+    subtaskId: Int,
+    subtaskName: String,
+  ): CommitAdvanceResult {
+    val branch = manifest.branchForSubtask(subtaskId)
+    val checkout = if (branch.isNotBlank()) {
+      gitOperations.checkoutBranch(repoRoot(), branch, manifest.baseForSubtask(subtaskId))
+    } else {
+      null
+    }
+    return if (checkout?.ok == false) {
+      CommitAdvanceResult(manifest, checkout.error.ifBlank { "Git branch checkout failed." })
+    } else {
+      val commit = gitOperations.createCommit(repoRoot(), "${manifest.issueKey} subtask $subtaskId: $subtaskName")
+      if (commit.ok) {
+        CommitAdvanceResult(manifest.withCommittedSubtask(subtaskId, commit.value))
+      } else {
+        CommitAdvanceResult(manifest, commit.error.ifBlank { "Git commit failed." })
+      }
+    }
+  }
+}
+
+private data class AdvancementResult(
+  val manifest: DecompositionManifest,
+  val error: String? = null,
+  val projectionArtifactsJson: String? = null,
+)
+
+private data class CommitAdvanceResult(
+  val manifest: DecompositionManifest,
+  val error: String? = null,
+)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuationSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuationSupport.kt
@@ -1,0 +1,129 @@
+package skillbill.application
+
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.ports.persistence.model.WorkflowStateRecord
+import skillbill.workflow.DecompositionManifestCodec
+import skillbill.workflow.WorkflowEngine
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.WorkflowStateSnapshot
+import skillbill.workflow.model.WorkflowUpdateInput
+import skillbill.workflow.toWireMap
+import java.nio.file.Path
+
+internal fun continueExistingWorkflow(
+  family: WorkflowFamily,
+  initialRecord: WorkflowStateSnapshot,
+  workflowId: String,
+  unitOfWork: UnitOfWork,
+): ContinuationResult {
+  var record = initialRecord
+  val sessionSummary = family.sessionSummary(unitOfWork.workflowStates, record.sessionId.orEmpty())
+  var decision = WorkflowEngine.continueDecision(family.definition, record, sessionSummary)
+  var projectionArtifactsJson: String? = null
+  if (decision.shouldReopen) {
+    val continueStatus = decision.payload["continue_status"]
+    val runtimeInput = family.withDecompositionRuntime(record, decision.toReopenInput(record.sessionId), workflowId)
+    val reopened = WorkflowEngine.updateRecord(family.definition, record, runtimeInput.input)
+    family.save(unitOfWork.workflowStates, reopened)
+    record = family.get(unitOfWork.workflowStates, workflowId) ?: reopened
+    if (runtimeInput.updated) projectionArtifactsJson = record.artifactsJson
+    val refreshedPayload = LinkedHashMap(
+      WorkflowEngine.continueDecision(family.definition, record, sessionSummary).payload,
+    )
+    refreshedPayload["continue_status"] = continueStatus
+    decision = decision.copy(payload = refreshedPayload)
+  }
+  return ContinuationResult(continuePayload(decision.payload, unitOfWork), projectionArtifactsJson)
+}
+
+internal fun WorkflowStateSnapshot.decompositionRuntime(): DecompositionManifest? =
+  decodeArtifacts(artifactsJson)[DECOMPOSITION_RUNTIME_ARTIFACT_KEY].asStringAnyMapOrNull()
+    ?.let { DecompositionManifestCodec.decodeMap(it, DECOMPOSITION_RUNTIME_ARTIFACT_KEY) }
+
+internal fun alignSubtaskResumeStep(
+  record: WorkflowStateSnapshot,
+  resumeStepId: String,
+  unitOfWork: UnitOfWork,
+): WorkflowStateSnapshot {
+  if (resumeStepId.isBlank() || record.currentStepId == resumeStepId) return record
+  val updated = WorkflowEngine.updateRecord(
+    WorkflowFamily.IMPLEMENT.definition,
+    record,
+    WorkflowUpdateInput(
+      workflowStatus = record.workflowStatus,
+      currentStepId = resumeStepId,
+      stepUpdates = null,
+      artifactsPatch = null,
+      sessionId = record.sessionId.orEmpty(),
+    ),
+  )
+  WorkflowFamily.IMPLEMENT.save(unitOfWork.workflowStates, updated)
+  return WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, record.workflowId) ?: updated
+}
+
+internal fun persistParentDecompositionRuntime(
+  parentRecord: WorkflowStateSnapshot,
+  manifest: DecompositionManifest,
+  unitOfWork: UnitOfWork,
+) {
+  val updatedParent = WorkflowEngine.updateRecord(
+    WorkflowFamily.IMPLEMENT.definition,
+    parentRecord,
+    WorkflowUpdateInput(
+      workflowStatus = parentRecord.workflowStatus,
+      currentStepId = parentRecord.currentStepId,
+      stepUpdates = null,
+      artifactsPatch = mapOf(DECOMPOSITION_RUNTIME_ARTIFACT_KEY to manifest.toWireMap()),
+      sessionId = parentRecord.sessionId.orEmpty(),
+    ),
+  )
+  WorkflowFamily.IMPLEMENT.save(unitOfWork.workflowStates, updatedParent)
+}
+
+internal fun DecompositionManifest.withStartedSubtask(
+  subtaskId: Int,
+  workflowId: String,
+  branch: String,
+): DecompositionManifest = copy(
+  status = "in_progress",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = subtaskId, action = "resume"),
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) {
+      subtask.copy(
+        status = "in_progress",
+        workflowId = workflowId,
+        branch = branch.takeIf(String::isNotBlank) ?: subtask.branch,
+        lastResumableStep = "assess",
+      )
+    } else {
+      subtask
+    }
+  },
+)
+
+internal fun DecompositionManifest.withCommittedSubtask(subtaskId: Int, commitSha: String): DecompositionManifest =
+  copy(subtasks = subtasks.map { if (it.id == subtaskId) it.copy(commitSha = commitSha) else it })
+
+internal fun DecompositionManifest.branchForSubtask(subtaskId: Int): String = when (executionModel) {
+  DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK -> featureBranch.orEmpty()
+  DecompositionExecutionModel.STACKED_BRANCHES ->
+    stackBranches.firstOrNull { it.subtaskId == subtaskId }?.branch.orEmpty()
+}
+
+internal fun DecompositionManifest.baseForSubtask(subtaskId: Int): String? = when (executionModel) {
+  DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK -> baseBranch
+  DecompositionExecutionModel.STACKED_BRANCHES ->
+    stackBranches.firstOrNull { it.subtaskId == subtaskId }?.baseBranch ?: baseBranch
+}
+
+internal fun repoRoot(): Path = Path.of("").toAbsolutePath()
+
+internal fun WorkflowStateRepository.findDecomposedParentWorkflow(issueKey: String): WorkflowStateRecord? {
+  val normalizedIssueKey = issueKey.trim()
+  return listFeatureImplementWorkflows(Int.MAX_VALUE).firstOrNull { row ->
+    row.toSnapshot().decompositionRuntime()?.issueKey == normalizedIssueKey
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
@@ -13,6 +13,7 @@ import skillbill.workflow.implement.FeatureImplementWorkflowDefinition
 import skillbill.workflow.model.WorkflowDefinition
 import skillbill.workflow.model.WorkflowStateSnapshot
 import skillbill.workflow.model.WorkflowUpdateInput
+import skillbill.workflow.toWireMap
 import skillbill.workflow.verify.FeatureVerifyWorkflowDefinition
 import java.nio.file.Path
 import java.time.OffsetDateTime
@@ -49,26 +50,24 @@ class WorkflowService(
     WorkflowEngine.validateUpdate(family.definition, input)?.let { error ->
       return errorPayload(request.workflowId, error)
     }
-    return database.transaction(dbOverride) { unitOfWork ->
+    var projectionArtifactsJson: String? = null
+    val payload = database.transaction(dbOverride) { unitOfWork ->
       val existing = family.get(unitOfWork.workflowStates, request.workflowId)
         ?: return@transaction unknownWorkflowPayload(request.workflowId)
-      if (family == WorkflowFamily.IMPLEMENT) {
-        DecompositionManifestWriter.writeFromWorkflowUpdate(
-          repoRoot = Path.of("").toAbsolutePath(),
-          existingArtifactsJson = existing.artifactsJson,
-          artifactsPatch = input.artifactsPatch,
-          runtimeUpdate = DecompositionManifestRuntimeUpdate(
-            workflowId = request.workflowId,
-            workflowStatus = input.workflowStatus,
-            currentStepId = input.currentStepId,
-            stepUpdates = input.stepUpdates,
-          ),
-        )
+      val runtimeInput = family.withDecompositionRuntime(existing, input, request.workflowId)
+      val effectiveInput = runtimeInput.input
+      val updatedRecord = WorkflowEngine.updateRecord(family.definition, existing, effectiveInput)
+      family.save(unitOfWork.workflowStates, updatedRecord)
+      val updated = family.get(unitOfWork.workflowStates, request.workflowId) ?: updatedRecord
+      if (runtimeInput.updated) {
+        projectionArtifactsJson = updated.artifactsJson
       }
-      family.save(unitOfWork.workflowStates, WorkflowEngine.updateRecord(family.definition, existing, input))
-      val updated = family.get(unitOfWork.workflowStates, request.workflowId) ?: existing
       ok(WorkflowEngine.fullPayload(family.definition, updated), unitOfWork)
     }
+    projectionArtifactsJson?.let { artifactsJson ->
+      DecompositionManifestWriter.writeProjectionFromWorkflowState(Path.of("").toAbsolutePath(), artifactsJson)
+    }
+    return payload
   }
 
   fun get(kind: WorkflowFamilyKind, workflowId: String, dbOverride: String? = null): Map<String, Any?> =
@@ -111,8 +110,9 @@ class WorkflowService(
       ok(WorkflowEngine.resumePayload(family.definition, record), unitOfWork)
     }
 
-  fun continueWorkflow(kind: WorkflowFamilyKind, workflowId: String, dbOverride: String? = null): Map<String, Any?> =
-    database.transaction(dbOverride) { unitOfWork ->
+  fun continueWorkflow(kind: WorkflowFamilyKind, workflowId: String, dbOverride: String? = null): Map<String, Any?> {
+    var projectionArtifactsJson: String? = null
+    val payload = database.transaction(dbOverride) { unitOfWork ->
       val family = kind.workflowFamily()
       var record = family.get(unitOfWork.workflowStates, workflowId)
         ?: return@transaction unknownWorkflowPayload(workflowId, unitOfWork.dbPath.toString())
@@ -120,13 +120,18 @@ class WorkflowService(
       var decision = WorkflowEngine.continueDecision(family.definition, record, sessionSummary)
       if (decision.shouldReopen) {
         val continueStatus = decision.payload["continue_status"]
+        val reopenInput = decision.toReopenInput(record.sessionId)
+        val runtimeInput = family.withDecompositionRuntime(record, reopenInput, workflowId)
         val reopened = WorkflowEngine.updateRecord(
           family.definition,
           record,
-          decision.toReopenInput(record.sessionId),
+          runtimeInput.input,
         )
         family.save(unitOfWork.workflowStates, reopened)
         record = family.get(unitOfWork.workflowStates, workflowId) ?: reopened
+        if (runtimeInput.updated) {
+          projectionArtifactsJson = record.artifactsJson
+        }
         val refreshedPayload =
           LinkedHashMap(
             WorkflowEngine.continueDecision(family.definition, record, sessionSummary).payload,
@@ -136,6 +141,11 @@ class WorkflowService(
       }
       continuePayload(decision.payload, unitOfWork)
     }
+    projectionArtifactsJson?.let { artifactsJson ->
+      DecompositionManifestWriter.writeProjectionFromWorkflowState(Path.of("").toAbsolutePath(), artifactsJson)
+    }
+    return payload
+  }
 }
 
 private const val DEFAULT_LIST_LIMIT: Int = 20
@@ -165,6 +175,40 @@ private fun skillbill.workflow.model.WorkflowContinueDecision.toReopenInput(sess
     artifactsPatch = null,
     sessionId = sessionId,
   )
+
+private fun WorkflowFamily.withDecompositionRuntime(
+  existing: WorkflowStateSnapshot,
+  input: WorkflowUpdateInput,
+  workflowId: String,
+): DecompositionRuntimeInput = if (this != WorkflowFamily.IMPLEMENT) {
+  DecompositionRuntimeInput(input = input, updated = false)
+} else {
+  DecompositionManifestWriter.manifestFromWorkflowUpdate(
+    repoRoot = Path.of("").toAbsolutePath(),
+    existingArtifactsJson = existing.artifactsJson,
+    artifactsPatch = input.artifactsPatch,
+    runtimeUpdate = DecompositionManifestRuntimeUpdate(
+      workflowId = workflowId,
+      workflowStatus = input.workflowStatus,
+      currentStepId = input.currentStepId,
+      stepUpdates = input.stepUpdates,
+    ),
+  )?.let { manifest ->
+    DecompositionRuntimeInput(
+      input = input.copy(
+        artifactsPatch = LinkedHashMap(input.artifactsPatch.orEmpty()).apply {
+          put(DECOMPOSITION_RUNTIME_ARTIFACT_KEY, manifest.toWireMap())
+        },
+      ),
+      updated = true,
+    )
+  } ?: DecompositionRuntimeInput(input = input, updated = false)
+}
+
+private data class DecompositionRuntimeInput(
+  val input: WorkflowUpdateInput,
+  val updated: Boolean,
+)
 
 private fun ok(payload: Map<String, Any?>, unitOfWork: UnitOfWork): Map<String, Any?> = LinkedHashMap(payload).apply {
   put("status", "ok")

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
@@ -1,6 +1,7 @@
 package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.DecompositionManifestRuntimeUpdate
 import skillbill.application.model.WorkflowFamilyKind
 import skillbill.application.model.WorkflowUpdateRequest
 import skillbill.ports.persistence.DatabaseSessionFactory
@@ -56,6 +57,12 @@ class WorkflowService(
           repoRoot = Path.of("").toAbsolutePath(),
           existingArtifactsJson = existing.artifactsJson,
           artifactsPatch = input.artifactsPatch,
+          runtimeUpdate = DecompositionManifestRuntimeUpdate(
+            workflowId = request.workflowId,
+            workflowStatus = input.workflowStatus,
+            currentStepId = input.currentStepId,
+            stepUpdates = input.stepUpdates,
+          ),
         )
       }
       family.save(unitOfWork.workflowStates, WorkflowEngine.updateRecord(family.definition, existing, input))
@@ -113,7 +120,11 @@ class WorkflowService(
       var decision = WorkflowEngine.continueDecision(family.definition, record, sessionSummary)
       if (decision.shouldReopen) {
         val continueStatus = decision.payload["continue_status"]
-        val reopened = WorkflowEngine.updateRecord(family.definition, record, decision.toReopenInput(record.sessionId))
+        val reopened = WorkflowEngine.updateRecord(
+          family.definition,
+          record,
+          decision.toReopenInput(record.sessionId),
+        )
         family.save(unitOfWork.workflowStates, reopened)
         record = family.get(unitOfWork.workflowStates, workflowId) ?: reopened
         val refreshedPayload =

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
@@ -13,6 +13,7 @@ import skillbill.workflow.model.WorkflowDefinition
 import skillbill.workflow.model.WorkflowStateSnapshot
 import skillbill.workflow.model.WorkflowUpdateInput
 import skillbill.workflow.verify.FeatureVerifyWorkflowDefinition
+import java.nio.file.Path
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import kotlin.random.Random
@@ -50,6 +51,13 @@ class WorkflowService(
     return database.transaction(dbOverride) { unitOfWork ->
       val existing = family.get(unitOfWork.workflowStates, request.workflowId)
         ?: return@transaction unknownWorkflowPayload(request.workflowId)
+      if (family == WorkflowFamily.IMPLEMENT) {
+        DecompositionManifestWriter.writeFromWorkflowUpdate(
+          repoRoot = Path.of("").toAbsolutePath(),
+          existingArtifactsJson = existing.artifactsJson,
+          artifactsPatch = input.artifactsPatch,
+        )
+      }
       family.save(unitOfWork.workflowStates, WorkflowEngine.updateRecord(family.definition, existing, input))
       val updated = family.get(unitOfWork.workflowStates, request.workflowId) ?: existing
       ok(WorkflowEngine.fullPayload(family.definition, updated), unitOfWork)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
@@ -8,6 +8,8 @@ import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.persistence.WorkflowStateRepository
 import skillbill.ports.persistence.model.WorkflowStateRecord
+import skillbill.ports.workflow.NoopWorkflowGitOperations
+import skillbill.ports.workflow.WorkflowGitOperations
 import skillbill.workflow.WorkflowEngine
 import skillbill.workflow.implement.FeatureImplementWorkflowDefinition
 import skillbill.workflow.model.WorkflowDefinition
@@ -23,6 +25,7 @@ import kotlin.random.Random
 @Inject
 class WorkflowService(
   private val database: DatabaseSessionFactory,
+  private val gitOperations: WorkflowGitOperations = NoopWorkflowGitOperations,
 ) {
   fun open(
     kind: WorkflowFamilyKind,
@@ -115,31 +118,16 @@ class WorkflowService(
     val payload = database.transaction(dbOverride) { unitOfWork ->
       val family = kind.workflowFamily()
       var record = family.get(unitOfWork.workflowStates, workflowId)
-        ?: return@transaction unknownWorkflowPayload(workflowId, unitOfWork.dbPath.toString())
-      val sessionSummary = family.sessionSummary(unitOfWork.workflowStates, record.sessionId.orEmpty())
-      var decision = WorkflowEngine.continueDecision(family.definition, record, sessionSummary)
-      if (decision.shouldReopen) {
-        val continueStatus = decision.payload["continue_status"]
-        val reopenInput = decision.toReopenInput(record.sessionId)
-        val runtimeInput = family.withDecompositionRuntime(record, reopenInput, workflowId)
-        val reopened = WorkflowEngine.updateRecord(
-          family.definition,
-          record,
-          runtimeInput.input,
-        )
-        family.save(unitOfWork.workflowStates, reopened)
-        record = family.get(unitOfWork.workflowStates, workflowId) ?: reopened
-        if (runtimeInput.updated) {
-          projectionArtifactsJson = record.artifactsJson
-        }
-        val refreshedPayload =
-          LinkedHashMap(
-            WorkflowEngine.continueDecision(family.definition, record, sessionSummary).payload,
-          )
-        refreshedPayload["continue_status"] = continueStatus
-        decision = decision.copy(payload = refreshedPayload)
+      if (record == null && family == WorkflowFamily.IMPLEMENT) {
+        val resolved =
+          DecompositionWorkflowContinuation(gitOperations).continueDecomposedParentByIssueKey(workflowId, unitOfWork)
+        projectionArtifactsJson = resolved.projectionArtifactsJson ?: projectionArtifactsJson
+        return@transaction resolved.payload
       }
-      continuePayload(decision.payload, unitOfWork)
+      record ?: return@transaction unknownWorkflowPayload(workflowId, unitOfWork.dbPath.toString())
+      continueExistingWorkflow(family, record, workflowId, unitOfWork).also { result ->
+        projectionArtifactsJson = result.projectionArtifactsJson ?: projectionArtifactsJson
+      }.payload
     }
     projectionArtifactsJson?.let { artifactsJson ->
       DecompositionManifestWriter.writeProjectionFromWorkflowState(Path.of("").toAbsolutePath(), artifactsJson)
@@ -160,7 +148,7 @@ private fun WorkflowUpdateRequest.toWorkflowUpdateInput(): WorkflowUpdateInput =
   sessionId = sessionId,
 )
 
-private fun skillbill.workflow.model.WorkflowContinueDecision.toReopenInput(sessionId: String): WorkflowUpdateInput =
+internal fun skillbill.workflow.model.WorkflowContinueDecision.toReopenInput(sessionId: String): WorkflowUpdateInput =
   WorkflowUpdateInput(
     workflowStatus = "running",
     currentStepId = resumeStepId,
@@ -176,7 +164,7 @@ private fun skillbill.workflow.model.WorkflowContinueDecision.toReopenInput(sess
     sessionId = sessionId,
   )
 
-private fun WorkflowFamily.withDecompositionRuntime(
+internal fun WorkflowFamily.withDecompositionRuntime(
   existing: WorkflowStateSnapshot,
   input: WorkflowUpdateInput,
   workflowId: String,
@@ -205,17 +193,17 @@ private fun WorkflowFamily.withDecompositionRuntime(
   } ?: DecompositionRuntimeInput(input = input, updated = false)
 }
 
-private data class DecompositionRuntimeInput(
+internal data class DecompositionRuntimeInput(
   val input: WorkflowUpdateInput,
   val updated: Boolean,
 )
 
-private fun ok(payload: Map<String, Any?>, unitOfWork: UnitOfWork): Map<String, Any?> = LinkedHashMap(payload).apply {
+internal fun ok(payload: Map<String, Any?>, unitOfWork: UnitOfWork): Map<String, Any?> = LinkedHashMap(payload).apply {
   put("status", "ok")
   put("db_path", unitOfWork.dbPath.toString())
 }
 
-private fun unknownWorkflowPayload(workflowId: String, dbPath: String? = null): Map<String, Any?> =
+internal fun unknownWorkflowPayload(workflowId: String, dbPath: String? = null): Map<String, Any?> =
   LinkedHashMap<String, Any?>().apply {
     put("status", "error")
     put("workflow_id", workflowId)
@@ -226,7 +214,7 @@ private fun unknownWorkflowPayload(workflowId: String, dbPath: String? = null): 
 private fun errorPayload(workflowId: String, error: String): Map<String, Any?> =
   linkedMapOf("status" to "error", "workflow_id" to workflowId, "error" to error)
 
-private fun continuePayload(payload: Map<String, Any?>, unitOfWork: UnitOfWork): Map<String, Any?> =
+internal fun continuePayload(payload: Map<String, Any?>, unitOfWork: UnitOfWork): Map<String, Any?> =
   LinkedHashMap(payload).apply {
     put("db_path", unitOfWork.dbPath.toString())
     if (this["continue_status"] == "blocked") {
@@ -242,7 +230,7 @@ private fun continuePayload(payload: Map<String, Any?>, unitOfWork: UnitOfWork):
     }
   }
 
-private fun generateWorkflowId(prefix: String): String {
+internal fun generateWorkflowId(prefix: String): String {
   val now = OffsetDateTime.now(ZoneOffset.UTC)
   val suffix = (1..WORKFLOW_ID_SUFFIX_LENGTH).map { SUFFIX_CHARS[Random.nextInt(SUFFIX_CHARS.length)] }
     .joinToString("")
@@ -252,12 +240,12 @@ private fun generateWorkflowId(prefix: String): String {
 
 private fun Int.twoDigits(): String = toString().padStart(2, '0')
 
-private fun WorkflowFamilyKind.workflowFamily(): WorkflowFamily = when (this) {
+internal fun WorkflowFamilyKind.workflowFamily(): WorkflowFamily = when (this) {
   WorkflowFamilyKind.IMPLEMENT -> WorkflowFamily.IMPLEMENT
   WorkflowFamilyKind.VERIFY -> WorkflowFamily.VERIFY
 }
 
-private enum class WorkflowFamily(
+internal enum class WorkflowFamily(
   val definition: WorkflowDefinition,
   val humanName: String,
 ) {

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/DecompositionManifestWriteModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/DecompositionManifestWriteModels.kt
@@ -16,6 +16,15 @@ data class DecompositionManifestWriteRequest(
   val currentSubtaskId: Int? = null,
 )
 
+data class DecompositionManifestRuntimeUpdate(
+  val workflowId: String = "",
+  val workflowStatus: String = "",
+  val currentStepId: String = "",
+  val stepUpdates: List<Map<String, Any?>>? = null,
+  val artifactsPatch: Map<String, Any?>? = null,
+  val existingArtifacts: Map<String, Any?> = emptyMap(),
+)
+
 data class DecompositionManifestWriteResult(
   val manifestPath: Path,
   val manifest: DecompositionManifest,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/DecompositionManifestWriteModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/DecompositionManifestWriteModels.kt
@@ -1,0 +1,22 @@
+package skillbill.application.model
+
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionStackBranch
+import java.nio.file.Path
+
+data class DecompositionManifestWriteRequest(
+  val repoRoot: Path,
+  val parentSpecPath: Path,
+  val planningResult: Map<String, Any?>,
+  val baseBranch: String,
+  val featureBranch: String?,
+  val executionModel: DecompositionExecutionModel = DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK,
+  val stackBranches: List<DecompositionStackBranch> = emptyList(),
+  val currentSubtaskId: Int? = null,
+)
+
+data class DecompositionManifestWriteResult(
+  val manifestPath: Path,
+  val manifest: DecompositionManifest,
+)

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
@@ -2,12 +2,14 @@ package skillbill.application
 
 import skillbill.application.model.DecompositionManifestRuntimeUpdate
 import skillbill.application.model.DecompositionManifestWriteRequest
+import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidDecompositionManifestSchemaError
 import skillbill.workflow.DecompositionManifestCodec
 import skillbill.workflow.WorkflowEngine
 import skillbill.workflow.implement.FeatureImplementWorkflowDefinition
 import skillbill.workflow.model.DecompositionExecutionModel
 import skillbill.workflow.model.WorkflowUpdateInput
+import skillbill.workflow.toWireMap
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -118,6 +120,155 @@ class DecompositionManifestWriterTest {
     assertEquals(mapOf("finding_count" to 0), runtimeSubtask.reviewResult)
     assertEquals("audit", runtimeSubtask.lastResumableStep)
     assertContains(Files.readString(secondSubtaskSpec), "status: In Progress")
+  }
+
+  @Test
+  fun `runtime update with explicit unmatched spec path does not fall back to current subtask`() {
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-unmatched-spec")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+
+    val result = DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = runtimeArtifactsJson(parentSpecPath.parent.resolve("missing-subtask.md")),
+      artifactsPatch = mapOf("review_result" to mapOf("finding_count" to 0)),
+      runtimeUpdate = DecompositionManifestRuntimeUpdate(
+        workflowId = "wfl-wrong-subtask",
+        workflowStatus = "running",
+        currentStepId = "audit",
+        stepUpdates = listOf(mapOf("step_id" to "review", "status" to "completed", "attempt_count" to 1)),
+      ),
+    )
+
+    assertNotNull(result)
+    assertEquals(listOf("pending", "pending"), result.manifest.subtasks.map { it.status })
+    assertEquals(null, result.manifest.subtasks.first().workflowId)
+  }
+
+  @Test
+  fun `skipping an intermediate tracked step keeps subtask in progress when workflow advances`() {
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-intermediate-skip")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    val subtaskSpec = parentSpecPath.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+
+    val result = DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = runtimeArtifactsJson(subtaskSpec),
+      artifactsPatch = null,
+      runtimeUpdate = DecompositionManifestRuntimeUpdate(
+        workflowId = "wfl-subtask-1",
+        workflowStatus = "running",
+        currentStepId = "audit",
+        stepUpdates = listOf(mapOf("step_id" to "review", "status" to "skipped", "attempt_count" to 1)),
+      ),
+    )
+
+    assertNotNull(result)
+    assertEquals("in_progress", result.manifest.subtasks.first().status)
+    assertEquals("resume", result.manifest.currentSubtaskIntent.action)
+  }
+
+  @Test
+  fun `runtime projection is regenerated from durable decomposition runtime when manifest file is missing`() {
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-regenerate")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    val subtaskSpec = parentSpecPath.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    val initial = DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+    assertNotNull(initial)
+    Files.delete(initial.manifestPath)
+
+    val result = DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = durableRuntimeArtifactsJson(initial.manifest, subtaskSpec),
+      artifactsPatch = mapOf("validation_result" to mapOf("passed" to true)),
+      runtimeUpdate = DecompositionManifestRuntimeUpdate(
+        workflowId = "wfl-subtask-1",
+        workflowStatus = "running",
+        currentStepId = "validate",
+        stepUpdates = listOf(mapOf("step_id" to "validate", "status" to "completed", "attempt_count" to 1)),
+      ),
+    )
+
+    assertNotNull(result)
+    assertTrue(Files.isRegularFile(initial.manifestPath))
+    assertEquals(mapOf("passed" to true), result.manifest.subtasks.first().validationResult)
+  }
+
+  @Test
+  fun `runtime updates prefer durable decomposition runtime over stale filesystem projection`() {
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-durable-first")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    val subtaskSpec = parentSpecPath.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    val initial = DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+    assertNotNull(initial)
+    val durable = initial.manifest.copy(
+      subtasks = initial.manifest.subtasks.map { subtask ->
+        if (subtask.id == 1) {
+          subtask.copy(status = "in_progress", commitSha = "abc123", workflowId = "wfl-subtask-1")
+        } else {
+          subtask
+        }
+      },
+    )
+
+    val result = DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = durableRuntimeArtifactsJson(durable, subtaskSpec),
+      artifactsPatch = mapOf("review_result" to mapOf("finding_count" to 0)),
+      runtimeUpdate = DecompositionManifestRuntimeUpdate(
+        workflowId = "wfl-subtask-1",
+        workflowStatus = "running",
+        currentStepId = "audit",
+        stepUpdates = listOf(mapOf("step_id" to "review", "status" to "completed", "attempt_count" to 1)),
+      ),
+    )
+
+    assertNotNull(result)
+    val subtask = result.manifest.subtasks.first()
+    assertEquals("abc123", subtask.commitSha)
+    assertEquals("wfl-subtask-1", subtask.workflowId)
+    assertEquals(mapOf("finding_count" to 0), subtask.reviewResult)
   }
 
   @Test
@@ -301,4 +452,15 @@ class DecompositionManifestWriterTest {
   private fun runtimeArtifactsJson(subtaskSpec: java.nio.file.Path): String =
     """{"assessment":{"spec_path":"${subtaskSpec.toString().replace("\\", "\\\\")}"},""" +
       """"branch":{"branch":"feature/SKILL-51-decomposition"}}"""
+
+  private fun durableRuntimeArtifactsJson(
+    manifest: skillbill.workflow.model.DecompositionManifest,
+    subtaskSpec: java.nio.file.Path,
+  ): String = JsonSupport.mapToJsonString(
+    mapOf(
+      DECOMPOSITION_RUNTIME_ARTIFACT_KEY to manifest.toWireMap(),
+      "assessment" to mapOf("spec_path" to subtaskSpec.toString()),
+      "branch" to mapOf("branch" to "feature/SKILL-51-decomposition"),
+    ),
+  )
 }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
@@ -123,6 +123,62 @@ class DecompositionManifestWriterTest {
   }
 
   @Test
+  fun `runtime update projects completed subtask status and commit sha from durable runtime`() {
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-completed-projection")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    val subtaskSpec = parentSpecPath.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    Files.writeString(
+      subtaskSpec,
+      """
+      ---
+      status: In Progress
+      ---
+
+      # Foundation
+      """.trimIndent(),
+    )
+    val initial = DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+    assertNotNull(initial)
+    val completed = initial.manifest.copy(
+      subtasks = initial.manifest.subtasks.map { subtask ->
+        if (subtask.id == 1) {
+          subtask.copy(status = "complete", commitSha = "commit-subtask-1", workflowId = "wfl-subtask-1")
+        } else {
+          subtask
+        }
+      },
+    )
+
+    val result = DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = durableRuntimeArtifactsJson(completed, subtaskSpec),
+      artifactsPatch = null,
+      runtimeUpdate = DecompositionManifestRuntimeUpdate(
+        workflowId = "wfl-subtask-1",
+        workflowStatus = "completed",
+        currentStepId = "complete",
+        stepUpdates = listOf(mapOf("step_id" to "complete", "status" to "completed", "attempt_count" to 1)),
+      ),
+    )
+
+    assertNotNull(result)
+    val subtask = result.manifest.subtasks.single { it.id == 1 }
+    assertEquals("complete", subtask.status)
+    assertEquals("commit-subtask-1", subtask.commitSha)
+    assertContains(Files.readString(subtaskSpec), "status: Complete")
+  }
+
+  @Test
   fun `runtime update with explicit unmatched spec path does not fall back to current subtask`() {
     val repoRoot = Files.createTempDirectory("skillbill-runtime-unmatched-spec")
     val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
@@ -1,0 +1,163 @@
+package skillbill.application
+
+import skillbill.application.model.DecompositionManifestWriteRequest
+import skillbill.workflow.DecompositionManifestCodec
+import skillbill.workflow.WorkflowEngine
+import skillbill.workflow.implement.FeatureImplementWorkflowDefinition
+import skillbill.workflow.model.WorkflowUpdateInput
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DecompositionManifestWriterTest {
+  @Test
+  fun `decomposition planning result writes validated same branch manifest beside parent spec`() {
+    val repoRoot = Files.createTempDirectory("skillbill-decomposition-manifest")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+
+    val result = DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+
+    assertNotNull(result)
+    assertTrue(Files.isRegularFile(result.manifestPath))
+    assertEquals(parentSpecPath.parent.resolve("decomposition-manifest.yaml"), result.manifestPath)
+
+    val loaded = DecompositionManifestCodec.load(result.manifestPath)
+    assertEquals("same_branch_commit_per_subtask", loaded.executionModel.wireValue)
+    assertEquals("feature/SKILL-51-decomposition", loaded.featureBranch)
+    assertEquals(emptyList(), loaded.stackBranches)
+    assertEquals(1, loaded.currentSubtaskIntent.subtaskId)
+    assertEquals("start", loaded.currentSubtaskIntent.action)
+  }
+
+  @Test
+  fun `workflow update writes stacked branch manifest without same branch feature branch`() {
+    val repoRoot = Files.createTempDirectory("skillbill-stacked-decomposition")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+
+    val result = DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = "{}",
+      artifactsPatch = mapOf("plan" to stackedDecompositionPlan()),
+    )
+
+    assertNotNull(result)
+    assertEquals("stacked_branches", result.manifest.executionModel.wireValue)
+    assertEquals(null, result.manifest.featureBranch)
+    assertEquals(
+      listOf("feature/SKILL-51-01-foundation", "feature/SKILL-51-02-runtime"),
+      result.manifest.stackBranches.map { it.branch },
+    )
+  }
+
+  @Test
+  fun `single spec implement plan does not require or write decomposition manifest`() {
+    val repoRoot = Files.createTempDirectory("skillbill-single-spec")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-single/spec.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+
+    val result = DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = mapOf("mode" to "implement", "task_count" to 1),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-single",
+      ),
+    )
+
+    assertEquals(null, result)
+    assertFalse(Files.exists(parentSpecPath.parent.resolve("decomposition-manifest.yaml")))
+
+    val definition = FeatureImplementWorkflowDefinition.definition
+    val opened = WorkflowEngine.openRecord(definition, "fis-compat-001", "session-compat", "plan")
+    val updated = WorkflowEngine.updateRecord(
+      definition,
+      opened,
+      WorkflowUpdateInput(
+        workflowStatus = "running",
+        currentStepId = "implement",
+        stepUpdates =
+        listOf(
+          mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1),
+          mapOf("step_id" to "implement", "status" to "running", "attempt_count" to 1),
+        ),
+        artifactsPatch = mapOf("plan" to mapOf("mode" to "implement", "task_count" to 1)),
+        sessionId = "session-compat",
+      ),
+    )
+
+    val payload = WorkflowEngine.fullPayload(definition, updated)
+    val artifacts = payload["artifacts"] as Map<*, *>
+    assertEquals(mapOf("mode" to "implement", "task_count" to 1), artifacts["plan"])
+  }
+
+  private fun decompositionPlan(): Map<String, Any?> = linkedMapOf(
+    "mode" to "decompose",
+    "parent_spec_path" to ".feature-specs/SKILL-51-decomposition/spec.md",
+    "recommended_first_subtask_id" to 1,
+    "subtasks" to
+      listOf(
+        linkedMapOf(
+          "id" to 1,
+          "name" to "Foundation",
+          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_1_foundation.md",
+          "depends_on" to emptyList<Int>(),
+          "scope" to "Create contract foundation",
+        ),
+        linkedMapOf(
+          "id" to 2,
+          "name" to "Runtime",
+          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_2_runtime.md",
+          "depends_on" to listOf(1),
+          "scope" to "Wire runtime writer",
+        ),
+      ),
+  )
+
+  private fun stackedDecompositionPlan(): Map<String, Any?> = linkedMapOf(
+    "mode" to "decompose",
+    "parent_spec_path" to ".feature-specs/SKILL-51-decomposition/spec.md",
+    "execution_model" to "stacked_branches",
+    "recommended_first_subtask_id" to 1,
+    "stack_branches" to
+      listOf(
+        linkedMapOf("subtask_id" to 1, "branch" to "feature/SKILL-51-01-foundation", "base_branch" to "main"),
+        linkedMapOf(
+          "subtask_id" to 2,
+          "branch" to "feature/SKILL-51-02-runtime",
+          "base_branch" to "feature/SKILL-51-01-foundation",
+        ),
+      ),
+    "subtasks" to
+      listOf(
+        linkedMapOf(
+          "id" to 1,
+          "name" to "Foundation",
+          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_1_foundation.md",
+          "depends_on" to emptyList<Int>(),
+        ),
+        linkedMapOf(
+          "id" to 2,
+          "name" to "Runtime",
+          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_2_runtime.md",
+          "depends_on" to listOf(1),
+        ),
+      ),
+  )
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
@@ -1,13 +1,18 @@
 package skillbill.application
 
+import skillbill.application.model.DecompositionManifestRuntimeUpdate
 import skillbill.application.model.DecompositionManifestWriteRequest
+import skillbill.error.InvalidDecompositionManifestSchemaError
 import skillbill.workflow.DecompositionManifestCodec
 import skillbill.workflow.WorkflowEngine
 import skillbill.workflow.implement.FeatureImplementWorkflowDefinition
+import skillbill.workflow.model.DecompositionExecutionModel
 import skillbill.workflow.model.WorkflowUpdateInput
 import java.nio.file.Files
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -40,6 +45,8 @@ class DecompositionManifestWriterTest {
     assertEquals(emptyList(), loaded.stackBranches)
     assertEquals(1, loaded.currentSubtaskIntent.subtaskId)
     assertEquals("start", loaded.currentSubtaskIntent.action)
+    assertEquals(null, loaded.subtasks.first().workflowId)
+    assertEquals(null, loaded.subtasks.first().reviewResult)
   }
 
   @Test
@@ -62,6 +69,132 @@ class DecompositionManifestWriterTest {
       listOf("feature/SKILL-51-01-foundation", "feature/SKILL-51-02-runtime"),
       result.manifest.stackBranches.map { it.branch },
     )
+  }
+
+  @Test
+  fun `workflow update records runtime state on matching subtask and projects markdown status`() {
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-state")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    val secondSubtaskSpec = parentSpecPath.parent.resolve("spec_subtask_2_runtime.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    Files.writeString(
+      secondSubtaskSpec,
+      """
+      ---
+      status: Pending
+      ---
+
+      # Runtime
+      """.trimIndent(),
+    )
+    DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+
+    val result = DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = runtimeArtifactsJson(secondSubtaskSpec),
+      artifactsPatch = mapOf("review_result" to mapOf("finding_count" to 0)),
+      runtimeUpdate = DecompositionManifestRuntimeUpdate(
+        workflowId = "wfl-subtask-2",
+        workflowStatus = "running",
+        currentStepId = "audit",
+        stepUpdates = listOf(mapOf("step_id" to "review", "status" to "completed", "attempt_count" to 1)),
+      ),
+    )
+
+    assertNotNull(result)
+    val runtimeSubtask = result.manifest.subtasks.single { it.id == 2 }
+    assertEquals("in_progress", runtimeSubtask.status)
+    assertEquals("feature/SKILL-51-decomposition", runtimeSubtask.branch)
+    assertEquals("wfl-subtask-2", runtimeSubtask.workflowId)
+    assertEquals(mapOf("finding_count" to 0), runtimeSubtask.reviewResult)
+    assertEquals("audit", runtimeSubtask.lastResumableStep)
+    assertContains(Files.readString(secondSubtaskSpec), "status: In Progress")
+  }
+
+  @Test
+  fun `execution model can change before any subtask starts`() {
+    val repoRoot = Files.createTempDirectory("skillbill-model-change-before-start")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+
+    val changed = DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = stackedDecompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = null,
+        executionModel = DecompositionExecutionModel.STACKED_BRANCHES,
+        stackBranches = parseStackBranches(stackedDecompositionPlan(parentSpecPath)),
+      ),
+    )
+
+    assertNotNull(changed)
+    assertEquals("stacked_branches", changed.manifest.executionModel.wireValue)
+  }
+
+  @Test
+  fun `execution model change after subtask starts fails with manual migration message`() {
+    val repoRoot = Files.createTempDirectory("skillbill-model-change-after-start")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    DecompositionManifestWriter.writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+    DecompositionManifestWriter.writeFromWorkflowUpdate(
+      repoRoot = repoRoot,
+      existingArtifactsJson = runtimeArtifactsJson(parentSpecPath.parent.resolve("spec_subtask_1_foundation.md")),
+      artifactsPatch = null,
+      runtimeUpdate = DecompositionManifestRuntimeUpdate(
+        workflowId = "wfl-subtask-1",
+        workflowStatus = "running",
+        currentStepId = "implement",
+        stepUpdates = listOf(mapOf("step_id" to "implement", "status" to "running", "attempt_count" to 1)),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidDecompositionManifestSchemaError> {
+      DecompositionManifestWriter.writeIfDecomposed(
+        DecompositionManifestWriteRequest(
+          repoRoot = repoRoot,
+          parentSpecPath = parentSpecPath,
+          planningResult = stackedDecompositionPlan(parentSpecPath),
+          baseBranch = "main",
+          featureBranch = null,
+          executionModel = DecompositionExecutionModel.STACKED_BRANCHES,
+          stackBranches = parseStackBranches(stackedDecompositionPlan(parentSpecPath)),
+        ),
+      )
+    }
+
+    assertContains(error.reason, "execution_model cannot change after decomposition execution has begun")
+    assertContains(error.reason, "manually migrate")
   }
 
   @Test
@@ -107,32 +240,36 @@ class DecompositionManifestWriterTest {
     assertEquals(mapOf("mode" to "implement", "task_count" to 1), artifacts["plan"])
   }
 
-  private fun decompositionPlan(): Map<String, Any?> = linkedMapOf(
+  private fun decompositionPlan(
+    parentSpecPath: java.nio.file.Path = java.nio.file.Path.of(".feature-specs/SKILL-51-decomposition/spec.md"),
+  ): Map<String, Any?> = linkedMapOf(
     "mode" to "decompose",
-    "parent_spec_path" to ".feature-specs/SKILL-51-decomposition/spec.md",
+    "parent_spec_path" to parentSpecPath.toString(),
     "recommended_first_subtask_id" to 1,
     "subtasks" to
       listOf(
         linkedMapOf(
           "id" to 1,
           "name" to "Foundation",
-          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_1_foundation.md",
+          "spec_path" to parentSpecPath.parent.resolve("spec_subtask_1_foundation.md").toString(),
           "depends_on" to emptyList<Int>(),
           "scope" to "Create contract foundation",
         ),
         linkedMapOf(
           "id" to 2,
           "name" to "Runtime",
-          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_2_runtime.md",
+          "spec_path" to parentSpecPath.parent.resolve("spec_subtask_2_runtime.md").toString(),
           "depends_on" to listOf(1),
           "scope" to "Wire runtime writer",
         ),
       ),
   )
 
-  private fun stackedDecompositionPlan(): Map<String, Any?> = linkedMapOf(
+  private fun stackedDecompositionPlan(
+    parentSpecPath: java.nio.file.Path = java.nio.file.Path.of(".feature-specs/SKILL-51-decomposition/spec.md"),
+  ): Map<String, Any?> = linkedMapOf(
     "mode" to "decompose",
-    "parent_spec_path" to ".feature-specs/SKILL-51-decomposition/spec.md",
+    "parent_spec_path" to parentSpecPath.toString(),
     "execution_model" to "stacked_branches",
     "recommended_first_subtask_id" to 1,
     "stack_branches" to
@@ -149,15 +286,19 @@ class DecompositionManifestWriterTest {
         linkedMapOf(
           "id" to 1,
           "name" to "Foundation",
-          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_1_foundation.md",
+          "spec_path" to parentSpecPath.parent.resolve("spec_subtask_1_foundation.md").toString(),
           "depends_on" to emptyList<Int>(),
         ),
         linkedMapOf(
           "id" to 2,
           "name" to "Runtime",
-          "spec_path" to ".feature-specs/SKILL-51-decomposition/spec_subtask_2_runtime.md",
+          "spec_path" to parentSpecPath.parent.resolve("spec_subtask_2_runtime.md").toString(),
           "depends_on" to listOf(1),
         ),
       ),
   )
+
+  private fun runtimeArtifactsJson(subtaskSpec: java.nio.file.Path): String =
+    """{"assessment":{"spec_path":"${subtaskSpec.toString().replace("\\", "\\\\")}"},""" +
+      """"branch":{"branch":"feature/SKILL-51-decomposition"}}"""
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliCommands.kt
@@ -328,7 +328,9 @@ open class WorkflowContinueCommand(
   private val state: CliRunState,
   private val kind: WorkflowFamilyKind,
 ) : DocumentedCliCommand(name, "Activate a resumable workflow and emit a recovered continuation brief.") {
-  private val workflowId by argument(help = "Workflow id to continue.").optional()
+  private val workflowId by argument(
+    help = "Workflow id to continue, or an issue key for a decomposed feature parent.",
+  ).optional()
   private val latest by option("--latest", help = "Resolve the most recently updated workflow.").flag(default = false)
   private val format by formatOption()
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/models/CliRuntimeContext.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/models/CliRuntimeContext.kt
@@ -3,6 +3,8 @@ package skillbill.cli.models
 import skillbill.infrastructure.http.JdkHttpRequester
 import skillbill.model.RuntimeContext
 import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.workflow.NoopWorkflowGitOperations
+import skillbill.ports.workflow.WorkflowGitOperations
 import java.nio.file.Path
 
 data class CliRuntimeContext(
@@ -11,6 +13,7 @@ data class CliRuntimeContext(
   val environment: Map<String, String> = System.getenv(),
   val userHome: Path = Path.of(System.getProperty("user.home")),
   val requester: HttpRequester = JdkHttpRequester,
+  val workflowGitOperations: WorkflowGitOperations = NoopWorkflowGitOperations,
 ) {
   fun toRuntimeContext(): RuntimeContext = RuntimeContext(
     dbPathOverride = dbPathOverride,
@@ -18,5 +21,6 @@ data class CliRuntimeContext(
     environment = environment,
     userHome = userHome,
     requester = requester,
+    workflowGitOperations = workflowGitOperations,
   )
 }

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliWorkflowContinuationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliWorkflowContinuationRuntimeTest.kt
@@ -1,0 +1,122 @@
+package skillbill.cli
+
+import skillbill.contracts.JsonSupport
+import skillbill.ports.workflow.WorkflowGitOperations
+import skillbill.ports.workflow.model.WorkflowGitOperationResult
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CliWorkflowContinuationRuntimeTest {
+  @Test
+  fun `workflow continue accepts decomposed parent issue key`() {
+    val fixture = cliDecompositionFixture()
+    val opened = runJson(fixture.openCommand(), fixture.context)
+    val workflowId = opened["workflow_id"] as String
+
+    runJson(fixture.updateCommand(workflowId), fixture.context)
+    val continued = runJson(fixture.continueCommand(), fixture.context)
+
+    assertEquals("ok", continued["status"])
+    assertEquals(1, continued["decomposition_subtask_id"])
+    assertEquals(fixture.subtaskSpec.toString(), continued["decomposition_subtask_spec_path"])
+  }
+}
+
+private data class CliDecompositionFixture(
+  val dbPath: Path,
+  val context: CliRuntimeContext,
+  val parentSpec: Path,
+  val subtaskSpec: Path,
+) {
+  fun openCommand(): List<String> = listOf("--db", dbPath.toString(), "workflow", "open", "--format", "json")
+
+  fun updateCommand(workflowId: String): List<String> = listOf(
+    "--db",
+    dbPath.toString(),
+    "workflow",
+    "update",
+    workflowId,
+    "--workflow-status",
+    "running",
+    "--current-step-id",
+    "plan",
+    "--step-updates",
+    """[{"step_id":"plan","status":"completed","attempt_count":1}]""",
+    "--artifacts-patch",
+    artifactsPatch(),
+    "--format",
+    "json",
+  )
+
+  fun continueCommand(): List<String> =
+    listOf("--db", dbPath.toString(), "workflow", "continue", "SKILL-51", "--format", "json")
+
+  private fun artifactsPatch(): String = jsonString(
+    mapOf(
+      "branch" to mapOf("branch" to "feat/SKILL-51-demo"),
+      "plan" to mapOf(
+        "mode" to "decompose",
+        "parent_spec_path" to parentSpec.toString(),
+        "recommended_first_subtask_id" to 1,
+        "subtasks" to listOf(
+          mapOf(
+            "id" to 1,
+            "name" to "foundation",
+            "spec_path" to subtaskSpec.toString(),
+            "depends_on" to emptyList<Int>(),
+          ),
+        ),
+      ),
+    ),
+  )
+}
+
+private fun cliDecompositionFixture(): CliDecompositionFixture {
+  val tempDir = Files.createTempDirectory("skillbill-cli-decomposition-continue")
+  val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+  val subtaskSpec = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+  Files.createDirectories(parentSpec.parent)
+  Files.writeString(parentSpec, "# Parent")
+  Files.writeString(subtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
+  return CliDecompositionFixture(
+    dbPath = tempDir.resolve("metrics.db"),
+    context = CliRuntimeContext(userHome = tempDir, workflowGitOperations = TestWorkflowGitOperations),
+    parentSpec = parentSpec,
+    subtaskSpec = subtaskSpec,
+  )
+}
+
+private fun runJson(arguments: List<String>, context: CliRuntimeContext): Map<String, Any?> {
+  val result = CliRuntime.run(arguments, context)
+  assertEquals(0, result.exitCode, result.stdout)
+  return decodeJsonObject(result.stdout)
+}
+
+private fun decodeJsonObject(rawJson: String): Map<String, Any?> {
+  val parsed = requireNotNull(JsonSupport.parseObjectOrNull(rawJson))
+  return requireNotNull(JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(parsed)))
+}
+
+private fun jsonString(value: Any?): String = JsonSupport.json.encodeToString(
+  kotlinx.serialization.json.JsonElement.serializer(),
+  JsonSupport.valueToJsonElement(value),
+)
+
+private object TestWorkflowGitOperations : WorkflowGitOperations {
+  override fun checkoutBranch(repoRoot: Path, branch: String, baseBranch: String?): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = branch)
+
+  override fun currentBranch(repoRoot: Path): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = "")
+
+  override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = "test-commit")
+
+  override fun validateBranchBase(
+    repoRoot: Path,
+    branch: String,
+    expectedBaseBranch: String,
+  ): WorkflowGitOperationResult = WorkflowGitOperationResult(status = "ok", value = expectedBaseBranch)
+}

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
@@ -31,6 +31,23 @@ class InvalidWorkflowStateSchemaError(
 ) : ShellContentContractException(message, cause)
 
 /**
+ * SKILL-51: surfaced when a parent decomposition manifest fails the
+ * canonical `orchestration/contracts/decomposition-manifest-schema.yaml`
+ * Draft 2020-12 schema or its Kotlin-enforced coherence checks. The
+ * composed message carries the source label and the violation reason
+ * so decomposition write/read seams fail loudly without conflating this
+ * contract with durable workflow-state snapshots.
+ */
+class InvalidDecompositionManifestSchemaError(
+  val sourceLabel: String,
+  val reason: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(
+  "Decomposition manifest '${sourceLabel.ifBlank { "<unknown>" }}' fails schema validation: $reason",
+  cause,
+)
+
+/**
  * SKILL-48 Subtask 2b: surfaced when an `InstallPlan` wire payload fails
  * the canonical `orchestration/contracts/install-plan-schema.yaml` Draft
  * 2020-12 schema. The composed message carries the dotted field path of

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -9,6 +9,7 @@ import skillbill.application.SystemService
 import skillbill.application.TelemetryService
 import skillbill.application.WorkflowService
 import skillbill.infrastructure.fs.FileTelemetryConfigStore
+import skillbill.infrastructure.fs.GitWorkflowGitOperations
 import skillbill.infrastructure.http.HttpTelemetryClient
 import skillbill.infrastructure.sqlite.SQLiteDatabaseSessionFactory
 import skillbill.model.RuntimeContext
@@ -16,6 +17,8 @@ import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.telemetry.TelemetryClient
 import skillbill.ports.telemetry.TelemetryConfigStore
 import skillbill.ports.telemetry.TelemetrySettingsProvider
+import skillbill.ports.workflow.NoopWorkflowGitOperations
+import skillbill.ports.workflow.WorkflowGitOperations
 import skillbill.telemetry.DefaultTelemetrySettingsProvider
 
 @Component
@@ -33,6 +36,10 @@ abstract class RuntimeComponent(
 
   @Provides
   fun telemetryClient(client: HttpTelemetryClient): TelemetryClient = client
+
+  @Provides
+  fun workflowGitOperations(context: RuntimeContext, git: GitWorkflowGitOperations): WorkflowGitOperations =
+    if (context.workflowGitOperations === NoopWorkflowGitOperations) git else context.workflowGitOperations
 
   abstract val learningService: LearningService
   abstract val lifecycleTelemetryService: LifecycleTelemetryService

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -43,6 +43,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ApplicationPersistencePortTest {
@@ -295,6 +297,76 @@ class ApplicationPersistencePortTest {
   }
 
   @Test
+  fun `workflow service does not add decomposition runtime for single spec implement plan`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-single-spec")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-single/spec.md")
+    Files.createDirectories(parentSpec.parent)
+    Files.writeString(parentSpec, "# Parent")
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+    val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
+    val workflowId = opened["workflow_id"] as String
+
+    val updated = service.update(
+      WorkflowFamilyKind.IMPLEMENT,
+      WorkflowUpdateRequest(
+        workflowId = workflowId,
+        workflowStatus = "running",
+        currentStepId = "implement",
+        stepUpdates = listOf(mapOf("step_id" to "implement", "status" to "running", "attempt_count" to 1)),
+        artifactsPatch =
+        mapOf(
+          "plan" to
+            mapOf(
+              "mode" to "implement",
+              "task_count" to 1,
+              "parent_spec_path" to parentSpec.toString(),
+            ),
+        ),
+      ),
+      dbOverride = null,
+    )
+
+    val artifacts = updated["artifacts"] as Map<*, *>
+    assertEquals("ok", updated["status"])
+    assertEquals("implement", (artifacts["plan"] as Map<*, *>)["mode"])
+    assertFalse(artifacts.containsKey("decomposition_runtime"))
+    assertFalse(Files.exists(parentSpec.parent.resolve("decomposition-manifest.yaml")))
+  }
+
+  @Test
+  fun `workflow service does not write decomposition projection when durable save fails`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-save-fails")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskSpec = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpec.parent)
+    Files.writeString(parentSpec, "# Parent")
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+    val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
+    val workflowId = opened["workflow_id"] as String
+
+    workflowRepository.failNextImplementSave = true
+    assertFailsWith<IllegalStateException> {
+      service.update(
+        WorkflowFamilyKind.IMPLEMENT,
+        WorkflowUpdateRequest(
+          workflowId = workflowId,
+          workflowStatus = "running",
+          currentStepId = "plan",
+          stepUpdates = listOf(mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1)),
+          artifactsPatch = decompositionPlanPatch(parentSpec, subtaskSpec),
+        ),
+        dbOverride = null,
+      )
+    }
+
+    assertFalse(Files.exists(parentSpec.parent.resolve("decomposition-manifest.yaml")))
+  }
+
+  @Test
   fun `workflow service updates decomposition subtask runtime status for blocked and skipped outcomes`() {
     val tempDir = Files.createTempDirectory("skillbill-app-decomposition-state")
     val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
@@ -322,6 +394,48 @@ class ApplicationPersistencePortTest {
     assertEquals("skipped", skippedManifest.subtasks.single().status)
     assertEquals("none", skippedManifest.currentSubtaskIntent.action)
     assertEquals("Skipped", statusLine(subtaskSpec))
+  }
+
+  @Test
+  fun `workflow service reopens blocked decomposition subtask runtime state on continuation`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-reopen")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskSpec = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpec.parent)
+    Files.writeString(parentSpec, "# Parent")
+    Files.writeString(subtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+    val workflowId = createDecompositionWorkflow(service, parentSpec, subtaskSpec)
+
+    service.update(
+      WorkflowFamilyKind.IMPLEMENT,
+      WorkflowUpdateRequest(
+        workflowId = workflowId,
+        workflowStatus = "blocked",
+        currentStepId = "validate",
+        stepUpdates = listOf(mapOf("step_id" to "validate", "status" to "blocked", "attempt_count" to 1)),
+        artifactsPatch =
+        mapOf(
+          "assessment" to mapOf("spec_path" to subtaskSpec.toString()),
+          "audit_report" to mapOf("gap_count" to 0),
+          "blocked_reason" to "Validation paused.",
+        ),
+      ),
+      dbOverride = null,
+    )
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, workflowId, dbOverride = null)
+
+    val manifest = DecompositionManifestCodec.load(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    val subtask = manifest.subtasks.single()
+    assertEquals("ok", continued["status"])
+    assertEquals("reopened", continued["continue_status"])
+    assertEquals("in_progress", subtask.status)
+    assertEquals(null, subtask.blockedReason)
+    assertEquals("validate", subtask.lastResumableStep)
+    assertEquals("In Progress", statusLine(subtaskSpec))
   }
 
   @Test
@@ -734,8 +848,13 @@ private class InMemoryWorkflowStateRepository(
 ) : WorkflowStateRepository {
   private val implementRows = linkedMapOf<String, WorkflowStateRecord>()
   private val verifyRows = linkedMapOf<String, WorkflowStateRecord>()
+  var failNextImplementSave: Boolean = false
 
   override fun saveFeatureImplementWorkflow(row: WorkflowStateRecord) {
+    if (failNextImplementSave) {
+      failNextImplementSave = false
+      error("save failed")
+    }
     implementRows[row.workflowId] = row
   }
 

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -485,6 +485,37 @@ class ApplicationPersistencePortTest {
   }
 
   @Test
+  fun `workflow service completes all subtasks and projects parent spec status`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-complete")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val git = FakeWorkflowGitOperations(commitSha = "abc123")
+    val service = WorkflowService(FakeDatabaseSessionFactory(workflows = workflowRepository), git)
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    val first = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+    markDecompositionSubtaskComplete(service, first["workflow_id"] as String, subtaskOne)
+    val second = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+    markDecompositionSubtaskComplete(service, second["workflow_id"] as String, subtaskTwo)
+
+    val done = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+
+    val manifest = DecompositionManifestCodec.load(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    assertEquals("ok", done["status"])
+    assertEquals("done", done["continue_status"])
+    assertEquals("complete", manifest.status)
+    assertTrue(manifest.subtasks.all { it.status == "complete" })
+    assertTrue(manifest.subtasks.all { it.commitSha == "abc123" })
+    assertEquals(listOf("SKILL-51 subtask 1: foundation", "SKILL-51 subtask 2: runtime"), git.commits)
+    assertEquals("Complete", statusLine(parentSpec))
+    assertEquals("Complete", statusSection(parentSpec))
+    assertEquals("Complete", statusLine(subtaskOne))
+    assertEquals("Complete", statusLine(subtaskTwo))
+  }
+
+  @Test
   fun `workflow service records blocked status when same branch subtask commit fails`() {
     val tempDir = Files.createTempDirectory("skillbill-app-decomposition-commit-fails")
     val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
@@ -1050,7 +1081,7 @@ private fun decompositionPlanPatch(
 
 private fun writeSpecs(parentSpec: Path, vararg subtasks: Path) {
   Files.createDirectories(parentSpec.parent)
-  Files.writeString(parentSpec, "# Parent")
+  Files.writeString(parentSpec, "---\nstatus: Pending\n---\n\n# Parent\n\n## Status\n\nPending\n")
   subtasks.forEach { subtask ->
     Files.writeString(subtask, "---\nstatus: Pending\n---\n\n# Subtask")
   }
@@ -1058,6 +1089,12 @@ private fun writeSpecs(parentSpec: Path, vararg subtasks: Path) {
 
 private fun statusLine(path: Path): String =
   Files.readAllLines(path).first { it.startsWith("status: ") }.removePrefix("status: ")
+
+private fun statusSection(path: Path): String {
+  val lines = Files.readAllLines(path)
+  val statusHeading = lines.indexOf("## Status")
+  return lines.drop(statusHeading + 1).first(String::isNotBlank)
+}
 
 private class InMemoryWorkflowStateRepository(
   private val implementSessionSummary: FeatureImplementSessionSummary? = null,

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -42,6 +42,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ApplicationPersistencePortTest {
   @Test
@@ -243,6 +244,53 @@ class ApplicationPersistencePortTest {
     assertEquals(listOf("markdown_file"), sessionSummary["spec_input_types"])
     assertEquals("workflow-runtime", sessionSummary["feature_name"])
     assertEquals("Port workflow runtime", sessionSummary["spec_summary"])
+  }
+
+  @Test
+  fun `workflow service writes decomposition manifest when implement plan decomposes`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    Files.createDirectories(parentSpec.parent)
+    Files.writeString(parentSpec, "# Parent")
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+    val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
+    val workflowId = opened["workflow_id"] as String
+
+    service.update(
+      WorkflowFamilyKind.IMPLEMENT,
+      WorkflowUpdateRequest(
+        workflowId = workflowId,
+        workflowStatus = "running",
+        currentStepId = "plan",
+        stepUpdates = listOf(mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1)),
+        artifactsPatch =
+        mapOf(
+          "branch" to mapOf("branch" to "feat/SKILL-51-demo"),
+          "plan" to
+            mapOf(
+              "mode" to "decompose",
+              "parent_spec_path" to parentSpec.toString(),
+              "recommended_first_subtask_id" to 1,
+              "subtasks" to
+                listOf(
+                  mapOf(
+                    "id" to 1,
+                    "name" to "foundation",
+                    "spec_path" to parentSpec.parent.resolve("spec_subtask_1_foundation.md").toString(),
+                    "depends_on" to emptyList<Int>(),
+                  ),
+                ),
+            ),
+        ),
+      ),
+      dbOverride = null,
+    )
+
+    val manifest = parentSpec.parent.resolve("decomposition-manifest.yaml")
+    assertTrue(Files.isRegularFile(manifest), "Decomposition manifest should be written beside parent spec.")
+    assertTrue(Files.readString(manifest).contains("same_branch_commit_per_subtask"))
   }
 
   @Test

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -38,6 +38,7 @@ import skillbill.telemetry.model.QualityCheckFinishedRecord
 import skillbill.telemetry.model.QualityCheckStartedRecord
 import skillbill.telemetry.model.RemoteStatsRequest
 import skillbill.telemetry.model.TelemetrySettings
+import skillbill.workflow.DecompositionManifestCodec
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -291,6 +292,36 @@ class ApplicationPersistencePortTest {
     val manifest = parentSpec.parent.resolve("decomposition-manifest.yaml")
     assertTrue(Files.isRegularFile(manifest), "Decomposition manifest should be written beside parent spec.")
     assertTrue(Files.readString(manifest).contains("same_branch_commit_per_subtask"))
+  }
+
+  @Test
+  fun `workflow service updates decomposition subtask runtime status for blocked and skipped outcomes`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-state")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskSpec = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpec.parent)
+    Files.writeString(parentSpec, "# Parent")
+    Files.writeString(subtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
+    val service = WorkflowService(database)
+    val workflowId = createDecompositionWorkflow(service, parentSpec, subtaskSpec)
+
+    markDecompositionSubtaskBlocked(service, workflowId, subtaskSpec)
+
+    val blockedManifest = DecompositionManifestCodec.load(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    val blockedSubtask = blockedManifest.subtasks.single()
+    assertEquals("blocked", blockedSubtask.status)
+    assertEquals("Validation failed.", blockedSubtask.blockedReason)
+    assertEquals("validate", blockedSubtask.lastResumableStep)
+    assertEquals("Blocked", statusLine(subtaskSpec))
+
+    markDecompositionSubtaskSkipped(service, workflowId, subtaskSpec)
+
+    val skippedManifest = DecompositionManifestCodec.load(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    assertEquals("skipped", skippedManifest.subtasks.single().status)
+    assertEquals("none", skippedManifest.currentSubtaskIntent.action)
+    assertEquals("Skipped", statusLine(subtaskSpec))
   }
 
   @Test
@@ -624,6 +655,78 @@ private object NoopWorkflowStateRepository : WorkflowStateRepository {
 }
 
 private fun Map<String, Any?>.steps(): List<Map<*, *>> = (this["steps"] as List<*>).map { step -> step as Map<*, *> }
+
+private fun createDecompositionWorkflow(service: WorkflowService, parentSpec: Path, subtaskSpec: Path): String {
+  val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
+  val workflowId = opened["workflow_id"] as String
+  service.update(
+    WorkflowFamilyKind.IMPLEMENT,
+    WorkflowUpdateRequest(
+      workflowId = workflowId,
+      workflowStatus = "running",
+      currentStepId = "plan",
+      stepUpdates = listOf(mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1)),
+      artifactsPatch = decompositionPlanPatch(parentSpec, subtaskSpec),
+    ),
+    dbOverride = null,
+  )
+  return workflowId
+}
+
+private fun markDecompositionSubtaskBlocked(service: WorkflowService, workflowId: String, subtaskSpec: Path) {
+  service.update(
+    WorkflowFamilyKind.IMPLEMENT,
+    WorkflowUpdateRequest(
+      workflowId = workflowId,
+      workflowStatus = "blocked",
+      currentStepId = "validate",
+      stepUpdates = listOf(mapOf("step_id" to "validate", "status" to "blocked", "attempt_count" to 1)),
+      artifactsPatch =
+      mapOf(
+        "assessment" to mapOf("spec_path" to subtaskSpec.toString()),
+        "validation_result" to mapOf("passed" to false),
+        "blocked_reason" to "Validation failed.",
+      ),
+    ),
+    dbOverride = null,
+  )
+}
+
+private fun markDecompositionSubtaskSkipped(service: WorkflowService, workflowId: String, subtaskSpec: Path) {
+  service.update(
+    WorkflowFamilyKind.IMPLEMENT,
+    WorkflowUpdateRequest(
+      workflowId = workflowId,
+      workflowStatus = "running",
+      currentStepId = "pr_description",
+      stepUpdates = listOf(mapOf("step_id" to "pr_description", "status" to "skipped", "attempt_count" to 1)),
+      artifactsPatch = mapOf("assessment" to mapOf("spec_path" to subtaskSpec.toString())),
+    ),
+    dbOverride = null,
+  )
+}
+
+private fun decompositionPlanPatch(parentSpec: Path, subtaskSpec: Path): Map<String, Any?> = mapOf(
+  "branch" to mapOf("branch" to "feat/SKILL-51-demo"),
+  "plan" to
+    mapOf(
+      "mode" to "decompose",
+      "parent_spec_path" to parentSpec.toString(),
+      "recommended_first_subtask_id" to 1,
+      "subtasks" to
+        listOf(
+          mapOf(
+            "id" to 1,
+            "name" to "foundation",
+            "spec_path" to subtaskSpec.toString(),
+            "depends_on" to emptyList<Int>(),
+          ),
+        ),
+    ),
+)
+
+private fun statusLine(path: Path): String =
+  Files.readAllLines(path).first { it.startsWith("status: ") }.removePrefix("status: ")
 
 private class InMemoryWorkflowStateRepository(
   private val implementSessionSummary: FeatureImplementSessionSummary? = null,

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -25,6 +25,8 @@ import skillbill.ports.persistence.model.WorkflowStateRecord
 import skillbill.ports.telemetry.TelemetryClient
 import skillbill.ports.telemetry.TelemetryConfigStore
 import skillbill.ports.telemetry.TelemetrySettingsProvider
+import skillbill.ports.workflow.WorkflowGitOperations
+import skillbill.ports.workflow.model.WorkflowGitOperationResult
 import skillbill.review.model.FeedbackRequest
 import skillbill.review.model.FeedbackTelemetryOptions
 import skillbill.review.model.ImportedReview
@@ -439,6 +441,167 @@ class ApplicationPersistencePortTest {
   }
 
   @Test
+  fun `workflow service continues decomposed parent issue key by starting first dependency-complete subtask`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-start")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val git = FakeWorkflowGitOperations()
+    val service = WorkflowService(FakeDatabaseSessionFactory(workflows = workflowRepository), git)
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+
+    val manifest = DecompositionManifestCodec.load(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    assertEquals("ok", continued["status"])
+    assertEquals(1, continued["decomposition_subtask_id"])
+    assertEquals("in_progress", manifest.subtasks.first { it.id == 1 }.status)
+    assertEquals(listOf("feat/SKILL-51-demo@main"), git.checkouts)
+  }
+
+  @Test
+  fun `workflow service records same branch subtask commit before starting next subtask`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-commit")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val git = FakeWorkflowGitOperations(commitSha = "abc123")
+    val service = WorkflowService(FakeDatabaseSessionFactory(workflows = workflowRepository), git)
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    val first = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+    markDecompositionSubtaskComplete(service, first["workflow_id"] as String, subtaskOne)
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+
+    val manifest = DecompositionManifestCodec.load(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    assertEquals("ok", continued["status"])
+    assertEquals(2, continued["decomposition_subtask_id"])
+    assertEquals("abc123", manifest.subtasks.first { it.id == 1 }.commitSha)
+    assertEquals(listOf("SKILL-51 subtask 1: foundation"), git.commits)
+  }
+
+  @Test
+  fun `workflow service records blocked status when same branch subtask commit fails`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-commit-fails")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val service = WorkflowService(
+      FakeDatabaseSessionFactory(workflows = workflowRepository),
+      FakeWorkflowGitOperations(commitError = "missing git identity"),
+    )
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    val first = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+    markDecompositionSubtaskComplete(service, first["workflow_id"] as String, subtaskOne)
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+
+    val manifest = DecompositionManifestCodec.load(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    val blocked = manifest.subtasks.first { it.id == 1 }
+    assertEquals("error", continued["status"])
+    assertEquals("blocked", continued["continue_status"])
+    assertEquals("missing git identity", continued["blocked_reason"])
+    assertEquals("blocked", manifest.status)
+    assertEquals("blocked", blocked.status)
+    assertEquals("missing git identity", blocked.blockedReason)
+    assertEquals("commit_push", blocked.lastResumableStep)
+    assertEquals(null, blocked.commitSha)
+  }
+
+  @Test
+  fun `workflow service checks stacked subtask branch base before starting subtask`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-stacked")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val git = FakeWorkflowGitOperations()
+    val service = WorkflowService(FakeDatabaseSessionFactory(workflows = workflowRepository), git)
+    createDecompositionWorkflow(
+      service = service,
+      parentSpec = parentSpec,
+      subtaskOne = subtaskOne,
+      subtaskTwo = subtaskTwo,
+      executionModel = "stacked_branches",
+    )
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+
+    assertEquals("ok", continued["status"])
+    assertEquals(listOf("feat/SKILL-51-demo-1@main"), git.checkouts)
+    assertEquals(listOf("feat/SKILL-51-demo-1@main"), git.baseValidations)
+  }
+
+  @Test
+  fun `workflow service stops issue key continuation on blocked subtask reason`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-blocked")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val service = WorkflowService(
+      FakeDatabaseSessionFactory(workflows = workflowRepository),
+      FakeWorkflowGitOperations(),
+    )
+    val workflowId = createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    markDecompositionSubtaskBlocked(service, workflowId, subtaskOne)
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+
+    assertEquals("error", continued["status"])
+    assertEquals("blocked", continued["continue_status"])
+    assertEquals("Validation failed.", continued["blocked_reason"])
+    assertEquals(1, continued["decomposition_subtask_id"])
+  }
+
+  @Test
+  fun `workflow service resumes in-progress decomposed subtask by issue key`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-resume")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val service = WorkflowService(
+      FakeDatabaseSessionFactory(workflows = workflowRepository),
+      FakeWorkflowGitOperations(),
+    )
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    val first = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+    val subtaskWorkflowId = first["workflow_id"] as String
+    service.update(
+      WorkflowFamilyKind.IMPLEMENT,
+      WorkflowUpdateRequest(
+        workflowId = subtaskWorkflowId,
+        workflowStatus = "running",
+        currentStepId = "validate",
+        stepUpdates = listOf(mapOf("step_id" to "validate", "status" to "running", "attempt_count" to 1)),
+        artifactsPatch = mapOf(
+          "audit_report" to mapOf("gap_count" to 0),
+          "validation_result" to mapOf("passed" to false),
+        ),
+      ),
+      dbOverride = null,
+    )
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+
+    assertEquals("ok", continued["status"])
+    assertEquals("already_running", continued["continue_status"])
+    assertEquals(subtaskWorkflowId, continued["workflow_id"])
+    assertEquals("validate", continued["continue_step_id"])
+    assertEquals(1, continued["decomposition_subtask_id"])
+  }
+
+  @Test
   fun `workflow service owns verify prior steps done resume and reopened continuation`() {
     val workflowRepository = InMemoryWorkflowStateRepository()
     val database = FakeDatabaseSessionFactory(workflows = workflowRepository)
@@ -770,7 +933,16 @@ private object NoopWorkflowStateRepository : WorkflowStateRepository {
 
 private fun Map<String, Any?>.steps(): List<Map<*, *>> = (this["steps"] as List<*>).map { step -> step as Map<*, *> }
 
-private fun createDecompositionWorkflow(service: WorkflowService, parentSpec: Path, subtaskSpec: Path): String {
+private fun createDecompositionWorkflow(service: WorkflowService, parentSpec: Path, subtaskSpec: Path): String =
+  createDecompositionWorkflow(service, parentSpec, subtaskSpec, null)
+
+private fun createDecompositionWorkflow(
+  service: WorkflowService,
+  parentSpec: Path,
+  subtaskOne: Path,
+  subtaskTwo: Path?,
+  executionModel: String = "same_branch_commit_per_subtask",
+): String {
   val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
   val workflowId = opened["workflow_id"] as String
   service.update(
@@ -780,7 +952,7 @@ private fun createDecompositionWorkflow(service: WorkflowService, parentSpec: Pa
       workflowStatus = "running",
       currentStepId = "plan",
       stepUpdates = listOf(mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1)),
-      artifactsPatch = decompositionPlanPatch(parentSpec, subtaskSpec),
+      artifactsPatch = decompositionPlanPatch(parentSpec, subtaskOne, subtaskTwo, executionModel),
     ),
     dbOverride = null,
   )
@@ -820,24 +992,69 @@ private fun markDecompositionSubtaskSkipped(service: WorkflowService, workflowId
   )
 }
 
-private fun decompositionPlanPatch(parentSpec: Path, subtaskSpec: Path): Map<String, Any?> = mapOf(
-  "branch" to mapOf("branch" to "feat/SKILL-51-demo"),
-  "plan" to
-    mapOf(
-      "mode" to "decompose",
-      "parent_spec_path" to parentSpec.toString(),
-      "recommended_first_subtask_id" to 1,
-      "subtasks" to
-        listOf(
-          mapOf(
-            "id" to 1,
-            "name" to "foundation",
-            "spec_path" to subtaskSpec.toString(),
-            "depends_on" to emptyList<Int>(),
-          ),
-        ),
+private fun markDecompositionSubtaskComplete(service: WorkflowService, workflowId: String, subtaskSpec: Path) {
+  service.update(
+    WorkflowFamilyKind.IMPLEMENT,
+    WorkflowUpdateRequest(
+      workflowId = workflowId,
+      workflowStatus = "completed",
+      currentStepId = "pr_description",
+      stepUpdates = listOf(mapOf("step_id" to "pr_description", "status" to "completed", "attempt_count" to 1)),
+      artifactsPatch = mapOf("assessment" to mapOf("spec_path" to subtaskSpec.toString())),
     ),
-)
+    dbOverride = null,
+  )
+}
+
+private fun decompositionPlanPatch(
+  parentSpec: Path,
+  subtaskSpec: Path,
+  subtaskTwo: Path? = null,
+  executionModel: String = "same_branch_commit_per_subtask",
+): Map<String, Any?> {
+  val subtasks = mutableListOf(
+    mapOf(
+      "id" to 1,
+      "name" to "foundation",
+      "spec_path" to subtaskSpec.toString(),
+      "depends_on" to emptyList<Int>(),
+    ),
+  )
+  if (subtaskTwo != null) {
+    subtasks += mapOf(
+      "id" to 2,
+      "name" to "runtime",
+      "spec_path" to subtaskTwo.toString(),
+      "depends_on" to listOf(1),
+    )
+  }
+  val plan = linkedMapOf<String, Any?>(
+    "mode" to "decompose",
+    "parent_spec_path" to parentSpec.toString(),
+    "recommended_first_subtask_id" to 1,
+    "subtasks" to subtasks,
+  )
+  if (executionModel == "stacked_branches") {
+    plan["execution_model"] = "stacked_branches"
+    plan["base_branch"] = "main"
+    plan["stack_branches"] = listOf(
+      mapOf("subtask_id" to 1, "branch" to "feat/SKILL-51-demo-1", "base_branch" to "main"),
+      mapOf("subtask_id" to 2, "branch" to "feat/SKILL-51-demo-2", "base_branch" to "feat/SKILL-51-demo-1"),
+    ).take(subtasks.size)
+  }
+  return mapOf(
+    "branch" to mapOf("branch" to "feat/SKILL-51-demo"),
+    "plan" to plan,
+  )
+}
+
+private fun writeSpecs(parentSpec: Path, vararg subtasks: Path) {
+  Files.createDirectories(parentSpec.parent)
+  Files.writeString(parentSpec, "# Parent")
+  subtasks.forEach { subtask ->
+    Files.writeString(subtask, "---\nstatus: Pending\n---\n\n# Subtask")
+  }
+}
 
 private fun statusLine(path: Path): String =
   Files.readAllLines(path).first { it.startsWith("status: ") }.removePrefix("status: ")
@@ -881,6 +1098,40 @@ private class InMemoryWorkflowStateRepository(
 
   override fun getFeatureVerifySessionSummary(sessionId: String): FeatureVerifySessionSummary? =
     verifySessionSummary?.takeIf { it.sessionId == sessionId }
+}
+
+private class FakeWorkflowGitOperations(
+  private val commitSha: String = "commit-sha",
+  private val commitError: String = "",
+) : WorkflowGitOperations {
+  val checkouts = mutableListOf<String>()
+  val baseValidations = mutableListOf<String>()
+  val commits = mutableListOf<String>()
+
+  override fun checkoutBranch(repoRoot: Path, branch: String, baseBranch: String?): WorkflowGitOperationResult {
+    checkouts += "$branch@${baseBranch.orEmpty()}"
+    return WorkflowGitOperationResult(status = "ok", value = branch)
+  }
+
+  override fun currentBranch(repoRoot: Path): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = checkouts.lastOrNull()?.substringBefore("@").orEmpty())
+
+  override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult {
+    commits += message
+    if (commitError.isNotBlank()) {
+      return WorkflowGitOperationResult(status = "error", error = commitError)
+    }
+    return WorkflowGitOperationResult(status = "ok", value = commitSha)
+  }
+
+  override fun validateBranchBase(
+    repoRoot: Path,
+    branch: String,
+    expectedBaseBranch: String,
+  ): WorkflowGitOperationResult {
+    baseValidations += "$branch@$expectedBaseBranch"
+    return WorkflowGitOperationResult(status = "ok", value = expectedBaseBranch)
+  }
 }
 
 private fun learningRecord(id: Int, title: String = "Learning $id"): LearningRecord = LearningRecord(

--- a/runtime-kotlin/runtime-domain/build.gradle.kts
+++ b/runtime-kotlin/runtime-domain/build.gradle.kts
@@ -87,6 +87,30 @@ val copyInstallPlanSchema =
     }
   }
 
+// SKILL-51 Subtask 1: copy the canonical decomposition-manifest JSON
+// Schema into runtime-domain resources. This mirrors the workflow-state
+// and install-plan Copy tasks above: path strings must stay aligned
+// with `DecompositionManifestSchemaPaths`, and the existence guard runs
+// at task execution time so configuration-cache reads stay clean.
+val canonicalDecompositionManifestSchemaPath: String =
+  rootProject.projectDir.parentFile
+    .resolve("orchestration/contracts/decomposition-manifest-schema.yaml")
+    .absolutePath
+
+val copyDecompositionManifestSchema =
+  tasks.register<Copy>("copyDecompositionManifestSchema") {
+    val schemaPath = canonicalDecompositionManifestSchemaPath
+    from(schemaPath)
+    into(layout.buildDirectory.dir("generated/skillbill-contracts/skillbill/contracts"))
+    inputs.file(schemaPath)
+    doFirst {
+      require(File(schemaPath).exists()) {
+        "SKILL-51: canonical decomposition manifest schema is missing at $schemaPath. " +
+          "Run from the repo root and ensure the schema file exists."
+      }
+    }
+  }
+
 sourceSets.named("main") {
   resources.srcDir(layout.buildDirectory.dir("generated/skillbill-contracts"))
 }
@@ -94,11 +118,13 @@ sourceSets.named("main") {
 tasks.named("processResources") {
   dependsOn(copyWorkflowStateSchema)
   dependsOn(copyInstallPlanSchema)
+  dependsOn(copyDecompositionManifestSchema)
 }
 
 tasks.named("processTestResources") {
   dependsOn(copyWorkflowStateSchema)
   dependsOn(copyInstallPlanSchema)
+  dependsOn(copyDecompositionManifestSchema)
 }
 
 tasks.withType<Test>().configureEach {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionContinuationSelector.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionContinuationSelector.kt
@@ -1,0 +1,54 @@
+package skillbill.workflow
+
+import skillbill.workflow.model.DecompositionBranchPlan
+import skillbill.workflow.model.DecompositionContinuationSelection
+import skillbill.workflow.model.DecompositionDependency
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionSubtask
+
+object DecompositionContinuationSelector {
+  fun select(manifest: DecompositionManifest): DecompositionContinuationSelection {
+    val inProgress = manifest.subtasks.firstOrNull { it.status == "in_progress" }
+    val firstPending = manifest.subtasks.firstOrNull { it.status == "pending" && dependenciesComplete(manifest, it) }
+    val blocked = manifest.subtasks.firstOrNull { it.status == "blocked" }
+    return when {
+      inProgress != null -> DecompositionContinuationSelection.Resume(
+        subtask = inProgress,
+        workflowId = inProgress.workflowId.orEmpty(),
+        resumeStepId = inProgress.lastResumableStep.orEmpty(),
+      )
+      firstPending != null -> DecompositionContinuationSelection.Start(
+        subtask = firstPending,
+        branchPlan = manifest.branchPlanFor(firstPending.id),
+      )
+      blocked != null -> DecompositionContinuationSelection.Blocked(
+        subtask = blocked,
+        reason = blocked.blockedReason?.takeIf(String::isNotBlank)
+          ?: "Subtask ${blocked.id} is blocked.",
+      )
+      else -> DecompositionContinuationSelection.Done(manifest = manifest)
+    }
+  }
+
+  private fun dependenciesComplete(manifest: DecompositionManifest, subtask: DecompositionSubtask): Boolean {
+    val subtasksById = manifest.subtasks.associateBy(DecompositionSubtask::id)
+    return subtask.dependencies.all { dependency ->
+      val dependencySubtask = subtasksById[dependency.subtaskId] ?: return@all false
+      dependencySubtask.status == "complete" ||
+        dependencySubtask.status == "skipped" ||
+        dependency.isExplicitlySkipped()
+    }
+  }
+
+  private fun DecompositionDependency.isExplicitlySkipped(): Boolean = optional && skipped
+
+  private fun DecompositionManifest.branchPlanFor(subtaskId: Int): DecompositionBranchPlan = when (executionModel) {
+    DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK ->
+      DecompositionBranchPlan(branch = featureBranch.orEmpty(), baseBranch = baseBranch, validateBase = false)
+    DecompositionExecutionModel.STACKED_BRANCHES -> {
+      val stackBranch = stackBranches.first { it.subtaskId == subtaskId }
+      DecompositionBranchPlan(branch = stackBranch.branch, baseBranch = stackBranch.baseBranch, validateBase = true)
+    }
+  }
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestCodec.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestCodec.kt
@@ -1,0 +1,196 @@
+package skillbill.workflow
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import skillbill.error.InvalidDecompositionManifestSchemaError
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionDependency
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionStackBranch
+import skillbill.workflow.model.DecompositionSubtask
+import java.nio.file.Files
+import java.nio.file.Path
+
+object DecompositionManifestCodec {
+  private val yamlMapper: YAMLMapper by lazy { YAMLMapper() }
+
+  fun load(path: Path): DecompositionManifest = decodeYaml(Files.readString(path), path.toString())
+
+  fun validate(manifest: DecompositionManifest, sourceLabel: String = "<in-memory>") {
+    DecompositionManifestSchemaValidator.validate(manifest.toWireMap(), sourceLabel)
+    validateCoherence(manifest, sourceLabel)
+  }
+
+  fun encodeYaml(manifest: DecompositionManifest): String {
+    validate(manifest)
+    return yamlMapper.writeValueAsString(manifest.toWireMap())
+  }
+
+  fun decodeYaml(yamlText: String, sourceLabel: String = "<in-memory>"): DecompositionManifest {
+    val parsed = DecompositionManifestSchemaValidator.validateYamlText(yamlText, sourceLabel)
+    val manifest = parsed.toDecompositionManifest(sourceLabel)
+    validateCoherence(manifest, sourceLabel)
+    return manifest
+  }
+
+  private fun validateCoherence(manifest: DecompositionManifest, sourceLabel: String) {
+    if (manifest.contractVersion != DECOMPOSITION_MANIFEST_CONTRACT_VERSION) {
+      invalidDecompositionManifest(
+        sourceLabel,
+        "contract_version '${manifest.contractVersion}' must equal '$DECOMPOSITION_MANIFEST_CONTRACT_VERSION'.",
+      )
+    }
+    val seenIds = mutableSetOf<Int>()
+    val seenSpecPaths = mutableSetOf<String>()
+    manifest.subtasks.forEachIndexed { index, subtask ->
+      if (!seenIds.add(subtask.id)) {
+        invalidDecompositionManifest(sourceLabel, "subtasks[$index].id '${subtask.id}' is duplicated.")
+      }
+      if (!seenSpecPaths.add(subtask.specPath)) {
+        invalidDecompositionManifest(sourceLabel, "subtasks[$index].spec_path '${subtask.specPath}' is duplicated.")
+      }
+      subtask.dependencies.forEach { dependency ->
+        if (dependency.subtaskId !in seenIds) {
+          invalidDecompositionManifest(
+            sourceLabel,
+            "subtasks[$index].dependencies references '${dependency.subtaskId}', which is not a prior subtask id.",
+          )
+        }
+      }
+    }
+    validateExecutionModel(manifest, sourceLabel)
+    validateCurrentIntent(manifest, sourceLabel)
+  }
+
+  private fun validateExecutionModel(manifest: DecompositionManifest, sourceLabel: String) {
+    when (manifest.executionModel) {
+      DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK -> {
+        if (manifest.featureBranch.isNullOrBlank()) {
+          invalidDecompositionManifest(sourceLabel, "same_branch_commit_per_subtask requires feature_branch.")
+        }
+        if (manifest.stackBranches.isNotEmpty()) {
+          invalidDecompositionManifest(
+            sourceLabel,
+            "same_branch_commit_per_subtask requires stack_branches to be empty.",
+          )
+        }
+      }
+      DecompositionExecutionModel.STACKED_BRANCHES -> {
+        if (manifest.featureBranch != null) {
+          invalidDecompositionManifest(sourceLabel, "stacked_branches requires feature_branch to be null.")
+        }
+        val expectedIds = manifest.subtasks.map { it.id }
+        val branchIds = manifest.stackBranches.map { it.subtaskId }
+        if (branchIds != expectedIds) {
+          invalidDecompositionManifest(
+            sourceLabel,
+            "stacked_branches requires stack_branches to declare one branch per subtask in subtask order.",
+          )
+        }
+      }
+    }
+  }
+
+  private fun validateCurrentIntent(manifest: DecompositionManifest, sourceLabel: String) {
+    val current = manifest.currentSubtaskIntent
+    if (current.action == "none") {
+      if (current.subtaskId != 0) {
+        invalidDecompositionManifest(sourceLabel, "current_subtask_intent.subtask_id must be 0 when action is none.")
+      }
+      return
+    }
+    if (manifest.subtasks.none { it.id == current.subtaskId }) {
+      invalidDecompositionManifest(
+        sourceLabel,
+        "current_subtask_intent.subtask_id '${current.subtaskId}' does not reference an existing subtask.",
+      )
+    }
+  }
+}
+
+private fun Map<String, Any?>.toDecompositionManifest(sourceLabel: String): DecompositionManifest {
+  val executionModelValue = stringValue("execution_model", sourceLabel)
+  val executionModel =
+    DecompositionExecutionModel.fromWireValue(executionModelValue)
+      ?: invalidDecompositionManifest(sourceLabel, "execution_model '$executionModelValue' is not supported.")
+  val subtasks = listValue("subtasks").mapIndexed { index, raw ->
+    val item = raw.asMap(sourceLabel, "subtasks[$index]")
+    DecompositionSubtask(
+      id = item.intValue("id", sourceLabel),
+      name = item.stringValue("name", sourceLabel),
+      specPath = item.stringValue("spec_path", sourceLabel),
+      status = item.stringValue("status", sourceLabel),
+      dependencies = item.listValue("dependencies").mapIndexed { depIndex, dep ->
+        val dependency = dep.asMap(sourceLabel, "subtasks[$index].dependencies[$depIndex]")
+        DecompositionDependency(
+          subtaskId = dependency.intValue("subtask_id", sourceLabel),
+          optional = dependency.booleanValue("optional", sourceLabel),
+          skipped = dependency.booleanValue("skipped", sourceLabel),
+        )
+      },
+    )
+  }
+  val current = requiredMap("current_subtask_intent", sourceLabel)
+  return DecompositionManifest(
+    contractVersion = stringValue("contract_version", sourceLabel),
+    issueKey = stringValue("issue_key", sourceLabel),
+    featureName = stringValue("feature_name", sourceLabel),
+    parentSpecPath = stringValue("parent_spec_path", sourceLabel),
+    executionModel = executionModel,
+    baseBranch = stringValue("base_branch", sourceLabel),
+    featureBranch = nullableStringValue("feature_branch", sourceLabel),
+    stackBranches = listValue("stack_branches").mapIndexed { index, raw ->
+      val item = raw.asMap(sourceLabel, "stack_branches[$index]")
+      DecompositionStackBranch(
+        subtaskId = item.intValue("subtask_id", sourceLabel),
+        branch = item.stringValue("branch", sourceLabel),
+        baseBranch = item.stringValue("base_branch", sourceLabel),
+      )
+    },
+    currentSubtaskIntent = CurrentSubtaskIntent(
+      subtaskId = current.intValue("subtask_id", sourceLabel),
+      action = current.stringValue("action", sourceLabel),
+    ),
+    subtasks = subtasks,
+  )
+}
+
+private fun Map<String, Any?>.requiredMap(key: String, sourceLabel: String): Map<String, Any?> =
+  this[key].asMap(sourceLabel, key)
+
+private fun Map<String, Any?>.stringValue(key: String, sourceLabel: String): String = when (val value = this[key]) {
+  is String -> value
+  else -> invalidDecompositionManifest(sourceLabel, "$key must be a string.")
+}
+
+private fun Map<String, Any?>.nullableStringValue(key: String, sourceLabel: String): String? =
+  when (val value = this[key]) {
+    null -> null
+    is String -> value
+    else -> invalidDecompositionManifest(sourceLabel, "$key must be a string or null.")
+  }
+
+private fun Map<String, Any?>.intValue(key: String, sourceLabel: String): Int = this[key].asInt(sourceLabel, key)
+
+private fun Map<String, Any?>.booleanValue(key: String, sourceLabel: String): Boolean = when (val value = this[key]) {
+  is Boolean -> value
+  else -> invalidDecompositionManifest(sourceLabel, "$key must be a boolean.")
+}
+
+private fun Map<String, Any?>.listValue(key: String): List<Any?> = (this[key] as? List<*>).orEmpty()
+
+private fun Any?.asMap(sourceLabel: String, fieldPath: String): Map<String, Any?> =
+  (this as? Map<*, *>)?.entries?.associateTo(LinkedHashMap<String, Any?>()) { (key, value) ->
+    val stringKey = key as? String ?: invalidDecompositionManifest(sourceLabel, "$fieldPath contains a non-string key.")
+    stringKey to value
+  } ?: invalidDecompositionManifest(sourceLabel, "$fieldPath must be an object.")
+
+private fun Any?.asInt(sourceLabel: String, fieldPath: String): Int = when (this) {
+  is Int -> this
+  is Long -> this.toInt()
+  is Number -> this.toInt()
+  else -> invalidDecompositionManifest(sourceLabel, "$fieldPath must be an integer.")
+}
+
+private fun invalidDecompositionManifest(sourceLabel: String, reason: String): Nothing =
+  throw InvalidDecompositionManifestSchemaError(sourceLabel = sourceLabel, reason = reason)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestCodec.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestCodec.kt
@@ -16,6 +16,13 @@ object DecompositionManifestCodec {
 
   fun load(path: Path): DecompositionManifest = decodeYaml(Files.readString(path), path.toString())
 
+  fun decodeMap(wireMap: Map<String, Any?>, sourceLabel: String = "<in-memory>"): DecompositionManifest {
+    DecompositionManifestSchemaValidator.validate(wireMap, sourceLabel)
+    val manifest = wireMap.toDecompositionManifest(sourceLabel)
+    validateCoherence(manifest, sourceLabel)
+    return manifest
+  }
+
   fun validate(manifest: DecompositionManifest, sourceLabel: String = "<in-memory>") {
     DecompositionManifestSchemaValidator.validate(manifest.toWireMap(), sourceLabel)
     validateCoherence(manifest, sourceLabel)
@@ -120,6 +127,14 @@ private fun Map<String, Any?>.toDecompositionManifest(sourceLabel: String): Deco
       name = item.stringValue("name", sourceLabel),
       specPath = item.stringValue("spec_path", sourceLabel),
       status = item.stringValue("status", sourceLabel),
+      branch = item.nullableStringValue("branch", sourceLabel),
+      commitSha = item.nullableStringValue("commit_sha", sourceLabel),
+      workflowId = item.nullableStringValue("workflow_id", sourceLabel),
+      reviewResult = item.nullableMapValue("review_result", sourceLabel),
+      auditResult = item.nullableMapValue("audit_result", sourceLabel),
+      validationResult = item.nullableMapValue("validation_result", sourceLabel),
+      blockedReason = item.nullableStringValue("blocked_reason", sourceLabel),
+      lastResumableStep = item.nullableStringValue("last_resumable_step", sourceLabel),
       dependencies = item.listValue("dependencies").mapIndexed { depIndex, dep ->
         val dependency = dep.asMap(sourceLabel, "subtasks[$index].dependencies[$depIndex]")
         DecompositionDependency(
@@ -130,12 +145,13 @@ private fun Map<String, Any?>.toDecompositionManifest(sourceLabel: String): Deco
       },
     )
   }
-  val current = requiredMap("current_subtask_intent", sourceLabel)
+  val current = this["current_subtask_intent"].asMap(sourceLabel, "current_subtask_intent")
   return DecompositionManifest(
     contractVersion = stringValue("contract_version", sourceLabel),
     issueKey = stringValue("issue_key", sourceLabel),
     featureName = stringValue("feature_name", sourceLabel),
     parentSpecPath = stringValue("parent_spec_path", sourceLabel),
+    status = nullableStringValue("status", sourceLabel) ?: "pending",
     executionModel = executionModel,
     baseBranch = stringValue("base_branch", sourceLabel),
     featureBranch = nullableStringValue("feature_branch", sourceLabel),
@@ -155,9 +171,6 @@ private fun Map<String, Any?>.toDecompositionManifest(sourceLabel: String): Deco
   )
 }
 
-private fun Map<String, Any?>.requiredMap(key: String, sourceLabel: String): Map<String, Any?> =
-  this[key].asMap(sourceLabel, key)
-
 private fun Map<String, Any?>.stringValue(key: String, sourceLabel: String): String = when (val value = this[key]) {
   is String -> value
   else -> invalidDecompositionManifest(sourceLabel, "$key must be a string.")
@@ -168,6 +181,16 @@ private fun Map<String, Any?>.nullableStringValue(key: String, sourceLabel: Stri
     null -> null
     is String -> value
     else -> invalidDecompositionManifest(sourceLabel, "$key must be a string or null.")
+  }
+
+private fun Map<String, Any?>.nullableMapValue(key: String, sourceLabel: String): Map<String, Any?>? =
+  when (val value = this[key]) {
+    null -> null
+    is Map<*, *> -> value.entries.associateTo(LinkedHashMap<String, Any?>()) { (mapKey, mapValue) ->
+      val stringKey = mapKey as? String ?: invalidDecompositionManifest(sourceLabel, "$key contains a non-string key.")
+      stringKey to mapValue
+    }
+    else -> invalidDecompositionManifest(sourceLabel, "$key must be an object or null.")
   }
 
 private fun Map<String, Any?>.intValue(key: String, sourceLabel: String): Int = this[key].asInt(sourceLabel, key)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestCoherenceValidator.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestCoherenceValidator.kt
@@ -1,0 +1,126 @@
+package skillbill.workflow
+
+import skillbill.error.InvalidDecompositionManifestSchemaError
+
+internal object DecompositionManifestCoherenceValidator {
+  fun validate(manifest: Map<String, Any?>, sourceLabel: String) {
+    val stackBranches = (manifest["stack_branches"] as? List<*>).orEmpty().mapNotNull { it as? Map<*, *> }
+    val subtasks = (manifest["subtasks"] as? List<*>).orEmpty().mapNotNull { it as? Map<*, *> }
+    val subtaskIds = validateSubtasks(subtasks, sourceLabel)
+    validateExecutionModel(manifest, subtasks, subtaskIds, stackBranches, sourceLabel)
+    validateCurrentIntent(manifest, subtaskIds, sourceLabel)
+  }
+
+  private fun validateSubtasks(subtasks: List<Map<*, *>>, sourceLabel: String): Set<Int> {
+    val subtaskIds = mutableSetOf<Int>()
+    subtasks.forEachIndexed { index, subtask ->
+      val id = (subtask["id"] as? Number)?.toInt()
+        ?: throw coherenceError(sourceLabel, "subtasks[$index].id", "Subtask id must be an integer.")
+      if (!subtaskIds.add(id)) {
+        throw coherenceError(sourceLabel, "subtasks[$index].id", "Duplicate subtask id '$id'.")
+      }
+      validateDependencies(subtask, subtaskIds, id, index, sourceLabel)
+    }
+    return subtaskIds
+  }
+
+  private fun validateDependencies(
+    subtask: Map<*, *>,
+    subtaskIds: Set<Int>,
+    id: Int,
+    index: Int,
+    sourceLabel: String,
+  ) {
+    val dependencies = (subtask["dependencies"] as? List<*>).orEmpty().mapNotNull { it as? Map<*, *> }
+    dependencies.forEachIndexed { depIndex, dependency ->
+      val path = "subtasks[$index].dependencies[$depIndex].subtask_id"
+      val dependencyId = (dependency["subtask_id"] as? Number)?.toInt()
+        ?: throw coherenceError(sourceLabel, path, "Dependency subtask_id must be an integer.")
+      if (dependencyId !in subtaskIds || dependencyId == id) {
+        throw coherenceError(
+          sourceLabel,
+          path,
+          "Dependency '$dependencyId' must reference an earlier declared subtask.",
+        )
+      }
+    }
+  }
+
+  private fun validateExecutionModel(
+    manifest: Map<String, Any?>,
+    subtasks: List<Map<*, *>>,
+    subtaskIds: Set<Int>,
+    stackBranches: List<Map<*, *>>,
+    sourceLabel: String,
+  ) {
+    when (manifest["execution_model"]?.toString().orEmpty()) {
+      "same_branch_commit_per_subtask" -> validateSameBranch(manifest, stackBranches, sourceLabel)
+      "stacked_branches" -> validateStackedBranches(manifest, subtasks, subtaskIds, stackBranches, sourceLabel)
+    }
+  }
+
+  private fun validateSameBranch(manifest: Map<String, Any?>, stackBranches: List<Map<*, *>>, sourceLabel: String) {
+    if (manifest["feature_branch"]?.toString().orEmpty().isBlank()) {
+      throw coherenceError(
+        sourceLabel,
+        "feature_branch",
+        "same_branch_commit_per_subtask manifests must declare feature_branch.",
+      )
+    }
+    if (stackBranches.isNotEmpty()) {
+      throw coherenceError(
+        sourceLabel,
+        "stack_branches",
+        "same_branch_commit_per_subtask manifests must not declare stack branches.",
+      )
+    }
+  }
+
+  private fun validateStackedBranches(
+    manifest: Map<String, Any?>,
+    subtasks: List<Map<*, *>>,
+    subtaskIds: Set<Int>,
+    stackBranches: List<Map<*, *>>,
+    sourceLabel: String,
+  ) {
+    if (manifest["feature_branch"] != null) {
+      throw coherenceError(sourceLabel, "feature_branch", "stacked_branches manifests must set feature_branch to null.")
+    }
+    val expectedStackIds = subtasks.mapNotNull { (it["id"] as? Number)?.toInt() }
+    val actualStackIds = stackBranches.mapNotNull { (it["subtask_id"] as? Number)?.toInt() }
+    if (actualStackIds != expectedStackIds || actualStackIds.toSet() != subtaskIds) {
+      throw coherenceError(
+        sourceLabel,
+        "stack_branches",
+        "stacked_branches manifests must declare exactly one branch per subtask in subtask order.",
+      )
+    }
+  }
+
+  private fun validateCurrentIntent(manifest: Map<String, Any?>, subtaskIds: Set<Int>, sourceLabel: String) {
+    val intent = manifest["current_subtask_intent"] as? Map<*, *> ?: return
+    val intentId = (intent["subtask_id"] as? Number)?.toInt() ?: 0
+    val intentAction = intent["action"]?.toString().orEmpty()
+    if (intentAction == "none" && intentId != 0) {
+      throw coherenceError(
+        sourceLabel,
+        "current_subtask_intent.subtask_id",
+        "Intent action none must use subtask_id 0.",
+      )
+    }
+    if (intentAction != "none" && intentId !in subtaskIds) {
+      throw coherenceError(
+        sourceLabel,
+        "current_subtask_intent.subtask_id",
+        "Current subtask intent must reference a declared subtask.",
+      )
+    }
+  }
+
+  private fun coherenceError(
+    sourceLabel: String,
+    fieldPath: String,
+    reason: String,
+  ): InvalidDecompositionManifestSchemaError =
+    InvalidDecompositionManifestSchemaError(sourceLabel = sourceLabel, reason = "$fieldPath: $reason")
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestFileWrites.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestFileWrites.kt
@@ -39,7 +39,7 @@ private fun projectStatus(text: String, status: String): String {
     else -> status
   }
   val end = text.indexOf("\n---\n", startIndex = 4)
-  return if (!text.startsWith("---\n") || end == -1) {
+  val frontMatterProjected = if (!text.startsWith("---\n") || end == -1) {
     text
   } else {
     val frontMatter = text.substring(0, end + 1)
@@ -52,4 +52,11 @@ private fun projectStatus(text: String, status: String): String {
       }
     replaced + "---\n" + body
   }
+  return projectStatusSection(frontMatterProjected, humanStatus)
+}
+
+private fun projectStatusSection(text: String, humanStatus: String): String {
+  val statusSection = Regex("(?ms)(^## Status\\s*\\n\\n)(.*?)(?=\\n## |\\z)")
+  val match = statusSection.find(text) ?: return text
+  return text.replaceRange(match.range, match.groupValues[1] + humanStatus + "\n")
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestFileWrites.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestFileWrites.kt
@@ -7,6 +7,18 @@ import java.nio.file.StandardCopyOption.ATOMIC_MOVE
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 fun writeDecompositionManifestText(target: Path, content: String) {
+  writeTextAtomically(target, content)
+}
+
+fun projectDecompositionSpecStatus(target: Path, status: String) {
+  if (!Files.isRegularFile(target)) {
+    return
+  }
+  val projected = projectStatus(Files.readString(target), status)
+  writeTextAtomically(target, projected)
+}
+
+private fun writeTextAtomically(target: Path, content: String) {
   Files.createDirectories(target.parent)
   val temp = Files.createTempFile(target.parent, "${target.fileName}.", ".tmp")
   Files.writeString(temp, content)
@@ -14,5 +26,30 @@ fun writeDecompositionManifestText(target: Path, content: String) {
     Files.move(temp, target, REPLACE_EXISTING, ATOMIC_MOVE)
   } catch (_: AtomicMoveNotSupportedException) {
     Files.move(temp, target, REPLACE_EXISTING)
+  }
+}
+
+private fun projectStatus(text: String, status: String): String {
+  val humanStatus = when (status) {
+    "pending" -> "Pending"
+    "in_progress" -> "In Progress"
+    "blocked" -> "Blocked"
+    "complete" -> "Complete"
+    "skipped" -> "Skipped"
+    else -> status
+  }
+  val end = text.indexOf("\n---\n", startIndex = 4)
+  return if (!text.startsWith("---\n") || end == -1) {
+    text
+  } else {
+    val frontMatter = text.substring(0, end + 1)
+    val body = text.substring(end + "\n---\n".length)
+    val replaced =
+      if (Regex("(?m)^status: .*$").containsMatchIn(frontMatter)) {
+        frontMatter.replace(Regex("(?m)^status: .*$"), "status: $humanStatus")
+      } else {
+        frontMatter + "status: $humanStatus\n"
+      }
+    replaced + "---\n" + body
   }
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestFileWrites.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestFileWrites.kt
@@ -1,0 +1,18 @@
+package skillbill.workflow
+
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+fun writeDecompositionManifestText(target: Path, content: String) {
+  Files.createDirectories(target.parent)
+  val temp = Files.createTempFile(target.parent, "${target.fileName}.", ".tmp")
+  Files.writeString(temp, content)
+  try {
+    Files.move(temp, target, REPLACE_EXISTING, ATOMIC_MOVE)
+  } catch (_: AtomicMoveNotSupportedException) {
+    Files.move(temp, target, REPLACE_EXISTING)
+  }
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestSchemaPaths.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestSchemaPaths.kt
@@ -1,0 +1,33 @@
+package skillbill.workflow
+
+/**
+ * Pinned runtime-side mirror of the canonical decomposition manifest
+ * schema's `contract_version`. The parity test fails the build if this
+ * constant and the schema's `properties.contract_version.const`
+ * diverge. To bump the contract, edit BOTH sites in the same change.
+ */
+const val DECOMPOSITION_MANIFEST_CONTRACT_VERSION: String = "0.1"
+
+/**
+ * Single source of truth for where the canonical decomposition
+ * manifest schema lives. The Gradle copy task in
+ * `runtime-domain/build.gradle.kts` must mirror these values because
+ * Gradle's Kotlin DSL cannot import runtime constants directly.
+ */
+object DecompositionManifestSchemaPaths {
+  /** Repo-relative path to the canonical schema YAML on disk. */
+  const val REPO_RELATIVE_PATH: String =
+    "orchestration/contracts/decomposition-manifest-schema.yaml"
+
+  /** Classpath resource path where runtime-domain bundles the schema for runtime loads. */
+  const val CLASSPATH_RESOURCE: String =
+    "skillbill/contracts/decomposition-manifest-schema.yaml"
+
+  /**
+   * Expected value of the canonical schema's `$id`. The validator
+   * asserts this value on load so stale or shadowed resources fail
+   * loudly at the parse seam.
+   */
+  const val EXPECTED_SCHEMA_ID: String =
+    "https://skill-bill.dev/contracts/decomposition-manifest-schema.yaml"
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestSchemaValidator.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestSchemaValidator.kt
@@ -1,0 +1,209 @@
+@file:Suppress("TooGenericExceptionCaught")
+
+package skillbill.workflow
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.networknt.schema.JsonSchema
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+import com.networknt.schema.ValidationMessage
+import skillbill.error.InvalidDecompositionManifestSchemaError
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.logging.Level
+import java.util.logging.Logger
+
+private val decompositionManifestLog: Logger =
+  Logger.getLogger("skillbill.workflow.DecompositionManifestSchemaValidator")
+
+object DecompositionManifestSchemaValidator {
+  private val schema: JsonSchema by lazy { loadDecompositionManifestSchema() }
+  private val mapper: ObjectMapper by lazy { ObjectMapper() }
+  private val yamlMapper: YAMLMapper by lazy { YAMLMapper() }
+  private val mapType = object : TypeReference<Map<String, Any?>>() {}
+
+  fun validate(manifest: Map<String, Any?>, sourceLabel: String) {
+    val instance: JsonNode = mapper.valueToTree(manifest)
+    val errors: Set<ValidationMessage> = schema.validate(instance)
+    if (errors.isEmpty()) {
+      DecompositionManifestCoherenceValidator.validate(manifest, sourceLabel)
+      return
+    }
+    decompositionManifestLog.log(Level.WARNING, buildSchemaDriftLog(sourceLabel, errors, instance))
+    throw InvalidDecompositionManifestSchemaError(
+      sourceLabel = sourceLabel,
+      reason = formatValidationReason(errors.sortedWith(violationOrdering), instance),
+    )
+  }
+
+  fun validateYamlText(yamlText: String, sourceLabel: String): Map<String, Any?> {
+    val node = yamlMapper.readTree(yamlText)
+    val parsed = mapper.convertValue(node, mapType)
+    validate(parsed, sourceLabel)
+    return parsed
+  }
+
+  fun assertIdentity(yamlNode: JsonNode) {
+    val loadedId = yamlNode.path("\$id").asText("")
+    if (loadedId != DecompositionManifestSchemaPaths.EXPECTED_SCHEMA_ID) {
+      throw InvalidDecompositionManifestSchemaError(
+        sourceLabel = DecompositionManifestSchemaPaths.CLASSPATH_RESOURCE,
+        reason = "Canonical decomposition manifest schema identity mismatch: loaded '\$id' is '$loadedId' but " +
+          "expected '${DecompositionManifestSchemaPaths.EXPECTED_SCHEMA_ID}'. A stale or shadowed copy of the " +
+          "schema is on the classpath.",
+      )
+    }
+    val loadedConst = yamlNode.path("properties").path("contract_version").path("const").asText("")
+    if (loadedConst != DECOMPOSITION_MANIFEST_CONTRACT_VERSION) {
+      throw InvalidDecompositionManifestSchemaError(
+        sourceLabel = DecompositionManifestSchemaPaths.CLASSPATH_RESOURCE,
+        reason = "Canonical decomposition manifest schema contract_version.const mismatch: loaded '$loadedConst' " +
+          "but the runtime expects '$DECOMPOSITION_MANIFEST_CONTRACT_VERSION'. The schema on the classpath is " +
+          "out of date relative to the running runtime-domain.",
+      )
+    }
+  }
+
+  private fun buildSchemaDriftLog(sourceLabel: String, errors: Set<ValidationMessage>, instance: JsonNode): String {
+    val parts = errors.sortedWith(violationOrdering).take(2).map { error ->
+      val location = error.instanceLocation?.toString().orEmpty()
+      val fieldPath = decompositionManifestDottedFieldPath(location).ifBlank { "<root>" }
+      val offendingValue = extractDecompositionManifestOffendingValue(instance, location)
+      if (offendingValue.isNotBlank()) "$fieldPath=$offendingValue" else fieldPath
+    }
+    return "Decomposition manifest failed schema validation: source='$sourceLabel' " +
+      "violations=${parts.joinToString(", ")} totalViolations=${errors.size}"
+  }
+
+  private fun formatValidationReason(sorted: List<ValidationMessage>, instance: JsonNode): String {
+    val firstError = sorted.first()
+    val instanceLocation = firstError.instanceLocation?.toString().orEmpty()
+    val fieldPath = decompositionManifestDottedFieldPath(instanceLocation).ifBlank { "<root>" }
+    val offendingValue = extractDecompositionManifestOffendingValue(instance, instanceLocation)
+    return buildString {
+      append(fieldPath)
+      append(": ")
+      append(firstError.message)
+      if (offendingValue.isNotBlank()) {
+        append(" — offending value: ")
+        append(offendingValue)
+      }
+      sorted.drop(1).forEach { other ->
+        val otherLocation = other.instanceLocation?.toString().orEmpty()
+        val otherPath = decompositionManifestDottedFieldPath(otherLocation).ifBlank { "<root>" }
+        val otherValue = extractDecompositionManifestOffendingValue(instance, otherLocation)
+        append(" | ")
+        append(otherPath)
+        append(": ")
+        append(other.message)
+        if (otherValue.isNotBlank()) {
+          append(" — offending value: ")
+          append(otherValue)
+        }
+      }
+    }
+  }
+
+  private val violationOrdering: Comparator<ValidationMessage> = compareBy(
+    { it.instanceLocation?.toString().orEmpty().let { loc -> loc.isBlank() || loc == "$" || loc == "/" } },
+    { it.instanceLocation?.toString().orEmpty() },
+    { it.message.orEmpty() },
+  )
+}
+
+internal const val DECOMPOSITION_MANIFEST_SCHEMA_CLASSPATH_RESOURCE: String =
+  DecompositionManifestSchemaPaths.CLASSPATH_RESOURCE
+
+internal const val DECOMPOSITION_MANIFEST_SCHEMA_REPO_RELATIVE_PATH: String =
+  DecompositionManifestSchemaPaths.REPO_RELATIVE_PATH
+
+private fun loadDecompositionManifestSchema(): JsonSchema {
+  try {
+    val yamlText = readDecompositionManifestSchemaText()
+    val yamlNode = YAMLMapper().readTree(yamlText)
+    DecompositionManifestSchemaValidator.assertIdentity(yamlNode)
+    val jsonText = ObjectMapper().writeValueAsString(yamlNode)
+    val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+    return factory.getSchema(jsonText)
+  } catch (error: Throwable) {
+    decompositionManifestLog.log(
+      Level.SEVERE,
+      "Failed to load canonical decomposition manifest schema: " +
+        "classpath='$DECOMPOSITION_MANIFEST_SCHEMA_CLASSPATH_RESOURCE' " +
+        "repoRelativePath='$DECOMPOSITION_MANIFEST_SCHEMA_REPO_RELATIVE_PATH' " +
+        "errorType='${error::class.qualifiedName}' message='${error.message.orEmpty()}'",
+      error,
+    )
+    throw error
+  }
+}
+
+private fun readDecompositionManifestSchemaText(): String {
+  DecompositionManifestSchemaValidator::class.java.classLoader
+    .getResourceAsStream(DECOMPOSITION_MANIFEST_SCHEMA_CLASSPATH_RESOURCE)
+    ?.use { return it.readBytes().toString(Charsets.UTF_8) }
+
+  val walkAnchor: Path = Path.of("").toAbsolutePath()
+  val resolved = walkForDecompositionManifestSchemaFile(walkAnchor)
+  if (resolved != null) {
+    return Files.readString(resolved)
+  }
+  throw InvalidDecompositionManifestSchemaError(
+    sourceLabel = DECOMPOSITION_MANIFEST_SCHEMA_CLASSPATH_RESOURCE,
+    reason = "Canonical decomposition manifest schema is missing. Expected to find it on the JVM classpath at " +
+      "'$DECOMPOSITION_MANIFEST_SCHEMA_CLASSPATH_RESOURCE' or on disk under " +
+      "'$DECOMPOSITION_MANIFEST_SCHEMA_REPO_RELATIVE_PATH' walked up from: $walkAnchor.",
+  )
+}
+
+fun decompositionManifestDottedFieldPath(instanceLocation: String): String = when {
+  instanceLocation.isBlank() || instanceLocation == "/" || instanceLocation == "$" -> ""
+  instanceLocation.startsWith("$.") -> instanceLocation.removePrefix("$.")
+  instanceLocation.startsWith("$") -> instanceLocation.removePrefix("$").trimStart('.')
+  else -> instanceLocation.trimStart('/').replace('/', '.')
+}
+
+fun extractDecompositionManifestOffendingValue(instance: JsonNode, instanceLocation: String): String {
+  val dotted = decompositionManifestDottedFieldPath(instanceLocation)
+  if (dotted.isBlank()) return ""
+  var node: JsonNode = instance
+  dotted.split('.').forEach { rawSegment ->
+    if (rawSegment.isBlank()) return@forEach
+    val arrayMatch = Regex("^([^\\[]*)\\[(\\d+)]$").matchEntire(rawSegment)
+    when {
+      arrayMatch != null -> {
+        val (keyPart, indexPart) = arrayMatch.destructured
+        if (keyPart.isNotBlank()) {
+          node = node.path(keyPart)
+        }
+        node = node.path(indexPart.toInt())
+      }
+      node.isArray && rawSegment.toIntOrNull() != null -> {
+        node = node.path(rawSegment.toInt())
+      }
+      else -> {
+        node = node.path(rawSegment)
+      }
+    }
+  }
+  return when {
+    node.isMissingNode -> ""
+    node.isValueNode -> node.asText()
+    else -> ""
+  }
+}
+
+private fun walkForDecompositionManifestSchemaFile(hint: Path): Path? {
+  var current: Path? = hint.toAbsolutePath().normalize()
+  while (current != null) {
+    val candidate = current.resolve(DECOMPOSITION_MANIFEST_SCHEMA_REPO_RELATIVE_PATH)
+    if (Files.isRegularFile(candidate)) {
+      return candidate
+    }
+    current = current.parent
+  }
+  return null
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestWireMap.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestWireMap.kt
@@ -1,0 +1,39 @@
+package skillbill.workflow
+
+import skillbill.workflow.model.DecompositionManifest
+
+fun DecompositionManifest.toWireMap(): Map<String, Any?> = linkedMapOf(
+  "contract_version" to contractVersion,
+  "issue_key" to issueKey,
+  "feature_name" to featureName,
+  "parent_spec_path" to parentSpecPath,
+  "execution_model" to executionModel.wireValue,
+  "base_branch" to baseBranch,
+  "feature_branch" to featureBranch,
+  "stack_branches" to stackBranches.map { branch ->
+    linkedMapOf(
+      "subtask_id" to branch.subtaskId,
+      "branch" to branch.branch,
+      "base_branch" to branch.baseBranch,
+    )
+  },
+  "current_subtask_intent" to linkedMapOf(
+    "subtask_id" to currentSubtaskIntent.subtaskId,
+    "action" to currentSubtaskIntent.action,
+  ),
+  "subtasks" to subtasks.map { subtask ->
+    linkedMapOf(
+      "id" to subtask.id,
+      "name" to subtask.name,
+      "spec_path" to subtask.specPath,
+      "status" to subtask.status,
+      "dependencies" to subtask.dependencies.map { dependency ->
+        linkedMapOf(
+          "subtask_id" to dependency.subtaskId,
+          "optional" to dependency.optional,
+          "skipped" to dependency.skipped,
+        )
+      },
+    )
+  },
+)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestWireMap.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionManifestWireMap.kt
@@ -7,6 +7,7 @@ fun DecompositionManifest.toWireMap(): Map<String, Any?> = linkedMapOf(
   "issue_key" to issueKey,
   "feature_name" to featureName,
   "parent_spec_path" to parentSpecPath,
+  "status" to status,
   "execution_model" to executionModel.wireValue,
   "base_branch" to baseBranch,
   "feature_branch" to featureBranch,
@@ -27,6 +28,14 @@ fun DecompositionManifest.toWireMap(): Map<String, Any?> = linkedMapOf(
       "name" to subtask.name,
       "spec_path" to subtask.specPath,
       "status" to subtask.status,
+      "branch" to subtask.branch,
+      "commit_sha" to subtask.commitSha,
+      "workflow_id" to subtask.workflowId,
+      "review_result" to subtask.reviewResult,
+      "audit_result" to subtask.auditResult,
+      "validation_result" to subtask.validationResult,
+      "blocked_reason" to subtask.blockedReason,
+      "last_resumable_step" to subtask.lastResumableStep,
       "dependencies" to subtask.dependencies.map { dependency ->
         linkedMapOf(
           "subtask_id" to dependency.subtaskId,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionContinuationModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionContinuationModels.kt
@@ -1,0 +1,27 @@
+package skillbill.workflow.model
+
+sealed class DecompositionContinuationSelection {
+  data class Resume(
+    val subtask: DecompositionSubtask,
+    val workflowId: String,
+    val resumeStepId: String,
+  ) : DecompositionContinuationSelection()
+
+  data class Start(
+    val subtask: DecompositionSubtask,
+    val branchPlan: DecompositionBranchPlan,
+  ) : DecompositionContinuationSelection()
+
+  data class Blocked(
+    val subtask: DecompositionSubtask,
+    val reason: String,
+  ) : DecompositionContinuationSelection()
+
+  data class Done(val manifest: DecompositionManifest) : DecompositionContinuationSelection()
+}
+
+data class DecompositionBranchPlan(
+  val branch: String,
+  val baseBranch: String,
+  val validateBase: Boolean,
+)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionManifestModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionManifestModels.kt
@@ -17,8 +17,26 @@ data class DecompositionSubtask(
   val name: String,
   val specPath: String,
   val status: String = "pending",
+  val branch: String? = null,
+  val commitSha: String? = null,
+  val workflowId: String? = null,
+  val reviewResult: Map<String, Any?>? = null,
+  val auditResult: Map<String, Any?>? = null,
+  val validationResult: Map<String, Any?>? = null,
+  val blockedReason: String? = null,
+  val lastResumableStep: String? = null,
   val dependencies: List<DecompositionDependency> = emptyList(),
-)
+) {
+  fun hasStarted(): Boolean = status != "pending" ||
+    branch != null ||
+    commitSha != null ||
+    workflowId != null ||
+    reviewResult != null ||
+    auditResult != null ||
+    validationResult != null ||
+    blockedReason != null ||
+    lastResumableStep != null
+}
 
 data class DecompositionDependency(
   val subtaskId: Int,
@@ -42,6 +60,7 @@ data class DecompositionManifest(
   val issueKey: String,
   val featureName: String,
   val parentSpecPath: String,
+  val status: String = "pending",
   val executionModel: DecompositionExecutionModel = DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK,
   val baseBranch: String,
   val featureBranch: String?,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionManifestModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionManifestModels.kt
@@ -1,0 +1,51 @@
+package skillbill.workflow.model
+
+import skillbill.workflow.DECOMPOSITION_MANIFEST_CONTRACT_VERSION
+
+enum class DecompositionExecutionModel(val wireValue: String) {
+  SAME_BRANCH_COMMIT_PER_SUBTASK("same_branch_commit_per_subtask"),
+  STACKED_BRANCHES("stacked_branches"),
+  ;
+
+  companion object {
+    fun fromWireValue(value: String): DecompositionExecutionModel? = entries.firstOrNull { it.wireValue == value }
+  }
+}
+
+data class DecompositionSubtask(
+  val id: Int,
+  val name: String,
+  val specPath: String,
+  val status: String = "pending",
+  val dependencies: List<DecompositionDependency> = emptyList(),
+)
+
+data class DecompositionDependency(
+  val subtaskId: Int,
+  val optional: Boolean = false,
+  val skipped: Boolean = false,
+)
+
+data class DecompositionStackBranch(
+  val subtaskId: Int,
+  val branch: String,
+  val baseBranch: String,
+)
+
+data class CurrentSubtaskIntent(
+  val subtaskId: Int,
+  val action: String,
+)
+
+data class DecompositionManifest(
+  val contractVersion: String = DECOMPOSITION_MANIFEST_CONTRACT_VERSION,
+  val issueKey: String,
+  val featureName: String,
+  val parentSpecPath: String,
+  val executionModel: DecompositionExecutionModel = DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK,
+  val baseBranch: String,
+  val featureBranch: String?,
+  val stackBranches: List<DecompositionStackBranch> = emptyList(),
+  val currentSubtaskIntent: CurrentSubtaskIntent,
+  val subtasks: List<DecompositionSubtask>,
+)

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionContinuationSelectorTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionContinuationSelectorTest.kt
@@ -1,0 +1,125 @@
+package skillbill.workflow
+
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionContinuationSelection
+import skillbill.workflow.model.DecompositionDependency
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionStackBranch
+import skillbill.workflow.model.DecompositionSubtask
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DecompositionContinuationSelectorTest {
+  @Test
+  fun `select resumes in-progress subtask at last resumable step`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        resumableSubtask(1, workflowId = "wfl-1", lastResumableStep = "validate"),
+        subtask(2, dependencies = listOf(DecompositionDependency(1))),
+      ),
+    )
+
+    val resumed = assertIs<DecompositionContinuationSelection.Resume>(selection)
+    assertEquals(1, resumed.subtask.id)
+    assertEquals("wfl-1", resumed.workflowId)
+    assertEquals("validate", resumed.resumeStepId)
+  }
+
+  @Test
+  fun `select starts first pending subtask whose dependencies are complete`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        subtask(1, status = "complete"),
+        subtask(2, dependencies = listOf(DecompositionDependency(1))),
+      ),
+    )
+
+    val started = assertIs<DecompositionContinuationSelection.Start>(selection)
+    assertEquals(2, started.subtask.id)
+    assertEquals("feat/SKILL-51-demo", started.branchPlan.branch)
+  }
+
+  @Test
+  fun `select reports blocked subtask when dependent pending work is not explicitly skippable`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        blockedSubtask(1, "Needs API decision."),
+        subtask(2, dependencies = listOf(DecompositionDependency(1))),
+      ),
+    )
+
+    val blocked = assertIs<DecompositionContinuationSelection.Blocked>(selection)
+    assertEquals(1, blocked.subtask.id)
+    assertEquals("Needs API decision.", blocked.reason)
+  }
+
+  @Test
+  fun `select allows explicit optional skipped dependency`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        blockedSubtask(1, "Optional path paused."),
+        subtask(2, dependencies = listOf(DecompositionDependency(1, optional = true, skipped = true))),
+      ),
+    )
+
+    val started = assertIs<DecompositionContinuationSelection.Start>(selection)
+    assertEquals(2, started.subtask.id)
+  }
+
+  @Test
+  fun `select uses stacked branch plan when manifest opts in`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        subtask(1),
+        executionModel = DecompositionExecutionModel.STACKED_BRANCHES,
+        featureBranch = null,
+        stackBranches = listOf(DecompositionStackBranch(1, "feat/SKILL-51-demo-1", "main")),
+      ),
+    )
+
+    val started = assertIs<DecompositionContinuationSelection.Start>(selection)
+    assertEquals("feat/SKILL-51-demo-1", started.branchPlan.branch)
+    assertEquals("main", started.branchPlan.baseBranch)
+    assertEquals(true, started.branchPlan.validateBase)
+  }
+
+  private fun manifest(
+    vararg subtasks: DecompositionSubtask,
+    executionModel: DecompositionExecutionModel = DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK,
+    featureBranch: String? = "feat/SKILL-51-demo",
+    stackBranches: List<DecompositionStackBranch> = emptyList(),
+  ): DecompositionManifest = DecompositionManifest(
+    issueKey = "SKILL-51",
+    featureName = "demo",
+    parentSpecPath = ".feature-specs/SKILL-51-demo/spec.md",
+    executionModel = executionModel,
+    baseBranch = "main",
+    featureBranch = featureBranch,
+    stackBranches = stackBranches,
+    currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 1, action = "start"),
+    subtasks = subtasks.toList(),
+  )
+
+  private fun subtask(
+    id: Int,
+    status: String = "pending",
+    dependencies: List<DecompositionDependency> = emptyList(),
+  ): DecompositionSubtask = DecompositionSubtask(
+    id = id,
+    name = "subtask-$id",
+    specPath = ".feature-specs/SKILL-51-demo/spec_subtask_$id.md",
+    status = status,
+    dependencies = dependencies,
+  )
+
+  private fun resumableSubtask(id: Int, workflowId: String, lastResumableStep: String): DecompositionSubtask =
+    subtask(id, status = "in_progress").copy(
+      workflowId = workflowId,
+      lastResumableStep = lastResumableStep,
+    )
+
+  private fun blockedSubtask(id: Int, reason: String): DecompositionSubtask =
+    subtask(id, status = "blocked").copy(blockedReason = reason)
+}

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionManifestSchemaContractVersionTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionManifestSchemaContractVersionTest.kt
@@ -1,0 +1,53 @@
+package skillbill.workflow
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DecompositionManifestSchemaContractVersionTest {
+  @Test
+  fun `schema contract_version const matches DECOMPOSITION_MANIFEST_CONTRACT_VERSION`() {
+    val schema = classpathSchema()
+    val contractVersionNode = schema.path("properties").path("contract_version").path("const")
+
+    assertTrue(
+      !contractVersionNode.isMissingNode && contractVersionNode.isTextual,
+      "Schema must pin properties.contract_version.const as a string; found: $contractVersionNode",
+    )
+    assertEquals(
+      DECOMPOSITION_MANIFEST_CONTRACT_VERSION,
+      contractVersionNode.asText(),
+      "Schema contract_version.const must equal DECOMPOSITION_MANIFEST_CONTRACT_VERSION " +
+        "($DECOMPOSITION_MANIFEST_CONTRACT_VERSION).",
+    )
+  }
+
+  @Test
+  fun `schema id matches DecompositionManifestSchemaPaths EXPECTED_SCHEMA_ID`() {
+    val schema = classpathSchema()
+    val idNode = schema.path("\$id")
+
+    assertTrue(!idNode.isMissingNode && idNode.isTextual, "Schema must declare a textual `\$id`.")
+    assertEquals(
+      DecompositionManifestSchemaPaths.EXPECTED_SCHEMA_ID,
+      idNode.asText(),
+      "Schema `\$id` must equal DecompositionManifestSchemaPaths.EXPECTED_SCHEMA_ID.",
+    )
+  }
+
+  private fun classpathSchema(): JsonNode {
+    val resourceStream = DecompositionManifestSchemaValidator::class.java.classLoader
+      .getResourceAsStream(DecompositionManifestSchemaPaths.CLASSPATH_RESOURCE)
+    assertNotNull(
+      resourceStream,
+      "Canonical decomposition manifest schema is missing from the classpath at " +
+        "'${DecompositionManifestSchemaPaths.CLASSPATH_RESOURCE}'. " +
+        "Ensure `copyDecompositionManifestSchema` ran before this test.",
+    )
+    val yamlText = resourceStream.use { it.readBytes().toString(Charsets.UTF_8) }
+    return YAMLMapper().readTree(yamlText)
+  }
+}

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionManifestValidationTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionManifestValidationTest.kt
@@ -1,0 +1,137 @@
+package skillbill.workflow
+
+import skillbill.error.InvalidDecompositionManifestSchemaError
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionDependency
+import skillbill.workflow.model.DecompositionExecutionModel
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionStackBranch
+import skillbill.workflow.model.DecompositionSubtask
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DecompositionManifestValidationTest {
+  @Test
+  fun `valid same branch manifest passes with default execution model`() {
+    val manifest = validSameBranchManifest()
+
+    DecompositionManifestCodec.validate(manifest)
+
+    val wireMap = manifest.toWireMap()
+    assertEquals("same_branch_commit_per_subtask", wireMap["execution_model"])
+    assertEquals("feature/SKILL-51-decomposition", wireMap["feature_branch"])
+    assertEquals(emptyList<Any?>(), wireMap["stack_branches"])
+  }
+
+  @Test
+  fun `valid stacked branch opt-in passes validation`() {
+    val manifest = validSameBranchManifest().copy(
+      executionModel = DecompositionExecutionModel.STACKED_BRANCHES,
+      featureBranch = null,
+      stackBranches =
+      listOf(
+        DecompositionStackBranch(subtaskId = 1, branch = "feature/SKILL-51-01-foundation", baseBranch = "main"),
+        DecompositionStackBranch(
+          subtaskId = 2,
+          branch = "feature/SKILL-51-02-runtime",
+          baseBranch = "feature/SKILL-51-01-foundation",
+        ),
+      ),
+    )
+
+    DecompositionManifestCodec.validate(manifest)
+
+    assertEquals("stacked_branches", manifest.toWireMap()["execution_model"])
+  }
+
+  @Test
+  fun `malformed schema payload rejects missing required fields`() {
+    val wireMap = validSameBranchManifest().toWireMap().toMutableMap()
+    wireMap.remove("contract_version")
+
+    val error = assertFailsWith<InvalidDecompositionManifestSchemaError> {
+      DecompositionManifestSchemaValidator.validate(wireMap, "missing-contract")
+    }
+    assertContains(error.reason, "contract_version")
+  }
+
+  @Test
+  fun `same branch manifest rejects missing feature branch`() {
+    val manifest = validSameBranchManifest().copy(featureBranch = null)
+
+    val error = assertFailsWith<InvalidDecompositionManifestSchemaError> {
+      DecompositionManifestCodec.validate(manifest)
+    }
+    assertContains(error.reason, "feature_branch")
+  }
+
+  @Test
+  fun `stacked manifest rejects out of order branch declarations`() {
+    val manifest = validSameBranchManifest().copy(
+      executionModel = DecompositionExecutionModel.STACKED_BRANCHES,
+      featureBranch = null,
+      stackBranches =
+      listOf(
+        DecompositionStackBranch(subtaskId = 2, branch = "feature/SKILL-51-02-runtime", baseBranch = "main"),
+        DecompositionStackBranch(subtaskId = 1, branch = "feature/SKILL-51-01-foundation", baseBranch = "main"),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidDecompositionManifestSchemaError> {
+      DecompositionManifestCodec.validate(manifest)
+    }
+    assertContains(error.reason, "one branch per subtask in subtask order")
+  }
+
+  @Test
+  fun `dependency must reference prior subtask`() {
+    val manifest = validSameBranchManifest().copy(
+      subtasks =
+      listOf(
+        DecompositionSubtask(
+          id = 1,
+          name = "Foundation",
+          specPath = ".feature-specs/SKILL-51-decomposition/spec_subtask_1_foundation.md",
+          dependencies = listOf(DecompositionDependency(subtaskId = 2)),
+        ),
+        DecompositionSubtask(
+          id = 2,
+          name = "Runtime",
+          specPath = ".feature-specs/SKILL-51-decomposition/spec_subtask_2_runtime.md",
+          dependencies = emptyList(),
+        ),
+      ),
+    )
+
+    val error = assertFailsWith<InvalidDecompositionManifestSchemaError> {
+      DecompositionManifestCodec.validate(manifest)
+    }
+    assertContains(error.reason, "earlier declared subtask")
+  }
+
+  private fun validSameBranchManifest(): DecompositionManifest = DecompositionManifest(
+    issueKey = "SKILL-51",
+    featureName = "decomposition",
+    parentSpecPath = ".feature-specs/SKILL-51-decomposition/spec.md",
+    baseBranch = "main",
+    featureBranch = "feature/SKILL-51-decomposition",
+    currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 1, action = "start"),
+    subtasks =
+    listOf(
+      DecompositionSubtask(
+        id = 1,
+        name = "Foundation",
+        specPath = ".feature-specs/SKILL-51-decomposition/spec_subtask_1_foundation.md",
+        dependencies = emptyList(),
+      ),
+      DecompositionSubtask(
+        id = 2,
+        name = "Runtime",
+        specPath = ".feature-specs/SKILL-51-decomposition/spec_subtask_2_runtime.md",
+        dependencies = listOf(DecompositionDependency(subtaskId = 1)),
+      ),
+    ),
+  )
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperations.kt
@@ -1,0 +1,85 @@
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.ports.workflow.WorkflowGitOperations
+import skillbill.ports.workflow.model.WorkflowGitOperationResult
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+private const val GIT_TIMEOUT_SECONDS = 30L
+
+@Inject
+class GitWorkflowGitOperations : WorkflowGitOperations {
+  override fun checkoutBranch(repoRoot: Path, branch: String, baseBranch: String?): WorkflowGitOperationResult {
+    val normalizedBranch = branch.trim()
+    if (normalizedBranch.isBlank()) {
+      return WorkflowGitOperationResult(status = "error", error = "Branch name is required.")
+    }
+    val existing = runGit(repoRoot, "rev-parse", "--verify", "--quiet", normalizedBranch)
+    return if (existing.ok) {
+      runGit(repoRoot, "checkout", normalizedBranch).withValue(normalizedBranch)
+    } else {
+      val base = baseBranch?.trim().orEmpty()
+      if (base.isBlank()) {
+        runGit(repoRoot, "checkout", "-b", normalizedBranch).withValue(normalizedBranch)
+      } else {
+        runGit(repoRoot, "checkout", "-b", normalizedBranch, base).withValue(normalizedBranch)
+      }
+    }
+  }
+
+  override fun currentBranch(repoRoot: Path): WorkflowGitOperationResult = runGit(repoRoot, "branch", "--show-current")
+
+  override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult {
+    val commit = runGit(repoRoot, "commit", "-m", message)
+    if (!commit.ok) return commit
+    return runGit(repoRoot, "rev-parse", "HEAD")
+  }
+
+  override fun validateBranchBase(
+    repoRoot: Path,
+    branch: String,
+    expectedBaseBranch: String,
+  ): WorkflowGitOperationResult {
+    val normalizedBranch = branch.trim()
+    val normalizedBase = expectedBaseBranch.trim()
+    if (normalizedBranch.isBlank() || normalizedBase.isBlank()) {
+      return WorkflowGitOperationResult(status = "error", error = "Branch and expected base branch are required.")
+    }
+    val result = runGit(repoRoot, "merge-base", "--is-ancestor", normalizedBase, normalizedBranch)
+    return if (result.ok) {
+      WorkflowGitOperationResult(status = "ok", value = normalizedBase)
+    } else {
+      WorkflowGitOperationResult(
+        status = "error",
+        error = "Branch '$normalizedBranch' is not based on '$normalizedBase'. ${result.error}".trim(),
+      )
+    }
+  }
+
+  private fun runGit(repoRoot: Path, vararg args: String): WorkflowGitOperationResult {
+    val process = ProcessBuilder(listOf("git", "-C", repoRoot.toString()) + args)
+      .redirectErrorStream(true)
+      .start()
+    val finished = process.waitFor(GIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    val output = process.inputStream.bufferedReader().readText().trim()
+    if (!finished) {
+      process.destroyForcibly()
+      return WorkflowGitOperationResult(
+        status = "error",
+        error = "git ${args.joinToString(" ")} timed out after ${GIT_TIMEOUT_SECONDS}s.",
+      )
+    }
+    return if (process.exitValue() == 0) {
+      WorkflowGitOperationResult(status = "ok", value = output)
+    } else {
+      WorkflowGitOperationResult(
+        status = "error",
+        error = "git ${args.joinToString(" ")} failed with exit code ${process.exitValue()}: $output",
+      )
+    }
+  }
+
+  private fun WorkflowGitOperationResult.withValue(value: String): WorkflowGitOperationResult =
+    if (ok) copy(value = value) else this
+}

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpRuntime.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpRuntime.kt
@@ -20,6 +20,8 @@ import skillbill.di.create
 import skillbill.infrastructure.http.JdkHttpRequester
 import skillbill.model.RuntimeContext
 import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.workflow.NoopWorkflowGitOperations
+import skillbill.ports.workflow.WorkflowGitOperations
 import skillbill.telemetry.model.RemoteStatsRequest
 import java.nio.file.Path
 
@@ -27,12 +29,14 @@ data class McpRuntimeContext(
   val requester: HttpRequester = JdkHttpRequester,
   val environment: Map<String, String> = System.getenv(),
   val userHome: Path = Path.of(System.getProperty("user.home")),
+  val workflowGitOperations: WorkflowGitOperations = NoopWorkflowGitOperations,
 ) {
   fun toRuntimeContext(stdinText: String? = null): RuntimeContext = RuntimeContext(
     stdinText = stdinText,
     environment = environment,
     userHome = userHome,
     requester = requester,
+    workflowGitOperations = workflowGitOperations,
   )
 }
 

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolRegistry.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolRegistry.kt
@@ -191,7 +191,12 @@ object McpToolRegistry {
           "child_steps" to arraySchema(freeObjectSchema),
         ),
       ),
-      "feature_implement_workflow_continue" to workflowIdSchema(),
+      "feature_implement_workflow_continue" to objectSchema(
+        properties = mapOf(
+          "workflow_id" to stringSchema(),
+          "issue_key" to stringSchema(),
+        ),
+      ),
       "feature_implement_workflow_get" to workflowIdSchema(),
       "feature_implement_workflow_latest" to emptyObjectSchema,
       "feature_implement_workflow_list" to workflowListSchema(),

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpWorkflowToolHandlers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpWorkflowToolHandlers.kt
@@ -54,4 +54,9 @@ internal fun workflowContinue(
   kind: WorkflowFamilyKind,
   arguments: Map<String, Any?>,
   context: McpRuntimeContext,
-): Map<String, Any?> = McpWorkflowRuntime.continueWorkflow(kind, arguments.string("workflow_id"), context)
+): Map<String, Any?> {
+  val workflowIdOrIssueKey = arguments.optionalString("workflow_id")
+    ?: arguments.optionalString("issue_key")
+    ?: return mapOf("status" to "error", "error" to "Provide workflow_id or issue_key.")
+  return McpWorkflowRuntime.continueWorkflow(kind, workflowIdOrIssueKey, context)
+}

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
@@ -157,6 +157,10 @@ class McpStdioServerTest {
       listOf("pending", "running", "completed", "failed", "abandoned", "blocked"),
       tools.schemaFor("feature_implement_workflow_update").properties().enumFor("workflow_status"),
     )
+    assertEquals(
+      setOf("workflow_id", "issue_key"),
+      tools.schemaFor("feature_implement_workflow_continue").properties().keys,
+    )
     tools.schemaFor("telemetry_remote_stats").assertRequired("workflow")
     assertEquals(
       listOf("verify", "implement", "bill-feature-verify", "bill-feature-implement"),

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpWorkflowContinuationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpWorkflowContinuationRuntimeTest.kt
@@ -1,0 +1,100 @@
+package skillbill.mcp
+
+import skillbill.application.model.WorkflowFamilyKind
+import skillbill.application.model.WorkflowUpdateRequest
+import skillbill.ports.workflow.WorkflowGitOperations
+import skillbill.ports.workflow.model.WorkflowGitOperationResult
+import skillbill.telemetry.CONFIG_ENVIRONMENT_KEY
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class McpWorkflowContinuationRuntimeTest {
+  @Test
+  fun `mcp workflow continue accepts decomposed parent issue key`() {
+    val fixture = mcpDecompositionFixture()
+    val opened = McpWorkflowRuntime.open(
+      WorkflowFamilyKind.IMPLEMENT,
+      sessionId = "fis-mcp-decomp",
+      context = fixture.context,
+    )
+    val workflowId = opened["workflow_id"] as String
+
+    McpWorkflowRuntime.update(WorkflowFamilyKind.IMPLEMENT, fixture.updateRequest(workflowId), fixture.context)
+    val continued = McpWorkflowRuntime.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", fixture.context)
+
+    assertEquals("ok", continued["status"])
+    assertEquals(1, continued["decomposition_subtask_id"])
+    assertEquals(fixture.subtaskSpec.toString(), continued["decomposition_subtask_spec_path"])
+  }
+}
+
+private data class McpDecompositionFixture(
+  val context: McpRuntimeContext,
+  val parentSpec: Path,
+  val subtaskSpec: Path,
+) {
+  fun updateRequest(workflowId: String): WorkflowUpdateRequest = WorkflowUpdateRequest(
+    workflowId = workflowId,
+    workflowStatus = "running",
+    currentStepId = "plan",
+    stepUpdates = listOf(mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1)),
+    artifactsPatch = mapOf(
+      "branch" to mapOf("branch" to "feat/SKILL-51-demo"),
+      "plan" to mapOf(
+        "mode" to "decompose",
+        "parent_spec_path" to parentSpec.toString(),
+        "recommended_first_subtask_id" to 1,
+        "subtasks" to listOf(
+          mapOf(
+            "id" to 1,
+            "name" to "foundation",
+            "spec_path" to subtaskSpec.toString(),
+            "depends_on" to emptyList<Int>(),
+          ),
+        ),
+      ),
+    ),
+  )
+}
+
+private fun mcpDecompositionFixture(): McpDecompositionFixture {
+  val tempDir = Files.createTempDirectory("skillbill-mcp-decomposition-continue")
+  val configPath = tempDir.resolve("config.json")
+  Files.writeString(configPath, """{"install_id":"test","telemetry":{"level":"off"}}""")
+  val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+  val subtaskSpec = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+  Files.createDirectories(parentSpec.parent)
+  Files.writeString(parentSpec, "# Parent")
+  Files.writeString(subtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
+  return McpDecompositionFixture(
+    context = McpRuntimeContext(
+      environment = mapOf(
+        "SKILL_BILL_REVIEW_DB" to tempDir.resolve("metrics.db").toString(),
+        CONFIG_ENVIRONMENT_KEY to configPath.toString(),
+      ),
+      userHome = tempDir,
+      workflowGitOperations = TestWorkflowGitOperations,
+    ),
+    parentSpec = parentSpec,
+    subtaskSpec = subtaskSpec,
+  )
+}
+
+private object TestWorkflowGitOperations : WorkflowGitOperations {
+  override fun checkoutBranch(repoRoot: Path, branch: String, baseBranch: String?): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = branch)
+
+  override fun currentBranch(repoRoot: Path): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = "")
+
+  override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = "test-commit")
+
+  override fun validateBranchBase(
+    repoRoot: Path,
+    branch: String,
+    expectedBaseBranch: String,
+  ): WorkflowGitOperationResult = WorkflowGitOperationResult(status = "ok", value = expectedBaseBranch)
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/model/RuntimeContext.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/model/RuntimeContext.kt
@@ -2,6 +2,8 @@ package skillbill.model
 
 import skillbill.ports.telemetry.HttpRequester
 import skillbill.ports.telemetry.UnconfiguredHttpRequester
+import skillbill.ports.workflow.NoopWorkflowGitOperations
+import skillbill.ports.workflow.WorkflowGitOperations
 import java.nio.file.Path
 
 data class RuntimeContext(
@@ -10,4 +12,5 @@ data class RuntimeContext(
   val environment: Map<String, String> = System.getenv(),
   val userHome: Path = Path.of(System.getProperty("user.home")),
   val requester: HttpRequester = UnconfiguredHttpRequester,
+  val workflowGitOperations: WorkflowGitOperations = NoopWorkflowGitOperations,
 )

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/workflow/WorkflowGitOperations.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/workflow/WorkflowGitOperations.kt
@@ -1,0 +1,35 @@
+package skillbill.ports.workflow
+
+import skillbill.ports.workflow.model.WorkflowGitOperationResult
+import java.nio.file.Path
+
+private const val HASH_RADIX_HEX: Int = 16
+
+interface WorkflowGitOperations {
+  fun checkoutBranch(repoRoot: Path, branch: String, baseBranch: String? = null): WorkflowGitOperationResult
+
+  fun currentBranch(repoRoot: Path): WorkflowGitOperationResult
+
+  fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult
+
+  fun validateBranchBase(repoRoot: Path, branch: String, expectedBaseBranch: String): WorkflowGitOperationResult
+}
+
+object NoopWorkflowGitOperations : WorkflowGitOperations {
+  override fun checkoutBranch(repoRoot: Path, branch: String, baseBranch: String?): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = branch)
+
+  override fun currentBranch(repoRoot: Path): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = "")
+
+  override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult = WorkflowGitOperationResult(
+    status = "ok",
+    value = "recorded:${message.hashCode().toUInt().toString(HASH_RADIX_HEX)}",
+  )
+
+  override fun validateBranchBase(
+    repoRoot: Path,
+    branch: String,
+    expectedBaseBranch: String,
+  ): WorkflowGitOperationResult = WorkflowGitOperationResult(status = "ok", value = expectedBaseBranch)
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/workflow/model/WorkflowGitOperationResult.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/workflow/model/WorkflowGitOperationResult.kt
@@ -1,0 +1,9 @@
+package skillbill.ports.workflow.model
+
+data class WorkflowGitOperationResult(
+  val status: String,
+  val value: String = "",
+  val error: String = "",
+) {
+  val ok: Boolean get() = status == "ok"
+}

--- a/skills/bill-feature-implement/content.md
+++ b/skills/bill-feature-implement/content.md
@@ -310,7 +310,10 @@ The orchestrator must maintain:
 External callers may inspect and reactivate persisted runs through:
 
 - `feature_implement_workflow_resume` — dry-run recovery summary
-- `feature_implement_workflow_continue` — re-open a resumable run and emit a recovered continuation brief
+- `feature_implement_workflow_continue` — re-open a resumable run and emit a recovered continuation brief.
+  For decomposed parent features, callers may pass the parent issue key
+  (for example `SKILL-51`) instead of naming a subtask workflow id; the
+  runtime resolves the parent manifest and selects the current subtask.
 
 ### Canonical step ids
 
@@ -446,6 +449,18 @@ Re-entry rules:
   backwards.
 - After the resumed step completes, continue the standard `bill-feature-implement`
   sequence from that point onward.
+- For decomposed parent features, `continue <issue-key>` resumes the
+  in-progress subtask at its last durable workflow step. If none is in
+  progress, it starts the first pending subtask whose dependencies are complete.
+- If the selected decomposition path is blocked, report the blocked reason and
+  stop. Do not skip to a later dependent subtask unless the manifest explicitly
+  marks that dependency as optional and skipped.
+- Decomposed execution defaults to `same_branch_commit_per_subtask`: all
+  subtasks run on the parent feature branch, and each completed subtask must
+  produce its own commit before the runtime advances to the next subtask.
+- `stacked_branches` is an explicit parent manifest opt-in. In stacked mode the
+  runtime uses the declared subtask branch and base relationship, and must stop
+  instead of advancing when the current branch/base does not match the manifest.
 
 ## Pre-planning subagent briefing
 
@@ -559,6 +574,15 @@ Decomposition rules:
 - Order subtasks by dependency and identify the first subtask to run.
 - The decomposition manifest uses `execution_model: same_branch_commit_per_subtask` by default with one parent feature branch and no stack branches. Use `execution_model: stacked_branches` only as an explicit opt-in and then declare one stack branch per subtask in subtask order.
 - The manifest must declare `contract_version`, `parent_spec_path`, ordered `subtasks`, dependency ids, each subtask `spec_path`, `execution_model`, `base_branch`, either `feature_branch` or ordered `stack_branches`, and `current_subtask_intent` derived from the recommended first/current subtask.
+- Same-branch decompositions advance one subtask at a time on the parent feature
+  branch. Each completed subtask gets an individual commit before the next
+  pending dependency-complete subtask starts.
+- Stacked decompositions are opt-in only. Every subtask must declare its branch
+  and expected base in stack order so continuation can check out the right branch
+  and reject advancement onto the wrong base.
+- Blocked subtasks are sticky: continuation reports the blocked reason and stops
+  unless a later subtask's dependency marks the blocked dependency both optional
+  and skipped.
 
 Return exactly one RESULT: block as your final message, containing valid JSON with this shape:
 

--- a/skills/bill-feature-implement/content.md
+++ b/skills/bill-feature-implement/content.md
@@ -123,13 +123,13 @@ The subagent returns one of two planning return contracts:
 - `mode: "implement"` — an ordered task list, each task with description, files to create or modify, which acceptance criteria it satisfies, and test coverage (or `None` when deferred to the final test task). MEDIUM plans may use phases with checkpoints when helpful.
 - `mode: "decompose"` — a terminal decomposition package for work that is too large for one reliable feature-implement run.
 
-Decomposition is mandatory when a plan would exceed 15 atomic implementation tasks, touch more than 6 boundaries, contain multiple independently resumable milestones, or require sequencing where later work depends on foundation that should be verified separately. In decomposition mode, the planning subagent writes subtask specs under `.feature-specs/{ISSUE_KEY}-{feature-name}/` using names like `spec_subtask_1_foundation.md`, `spec_subtask_2_runtime-wiring.md`, and `spec_subtask_3_validation.md`. Each subtask spec must contain its own acceptance criteria, non-goals, dependency notes, validation strategy, and a clear instruction to run `bill-feature-implement` on that subtask spec in a later session.
+Decomposition is mandatory when a plan would exceed 15 atomic implementation tasks, touch more than 6 boundaries, contain multiple independently resumable milestones, or require sequencing where later work depends on foundation that should be verified separately. In decomposition mode, the planning subagent writes subtask specs under `.feature-specs/{ISSUE_KEY}-{feature-name}/` using names like `spec_subtask_1_foundation.md`, `spec_subtask_2_runtime-wiring.md`, and `spec_subtask_3_validation.md`. Each subtask spec must contain its own acceptance criteria, non-goals, dependency notes, validation strategy, and a clear instruction to run `bill-feature-implement` on that subtask spec in a later session. The orchestrator then creates or updates `.feature-specs/{ISSUE_KEY}-{feature-name}/decomposition-manifest.yaml` from the decomposition package and validates it against `orchestration/contracts/decomposition-manifest-schema.yaml`; ordinary `mode: "implement"` and single-spec workflows do not read or require this manifest.
 
 If an implementation plan includes testable logic, the final task must be a dedicated test task. The subagent is responsible for enforcing this rule when it returns `mode: "implement"`.
 
 The orchestrator presents the plan, then proceeds to implementation — the plan is not a second approval gate.
 
-If the planning subagent returns `mode: "decompose"`, the orchestrator must not proceed to implementation. Persist `plan`, present the decomposition summary with wording equivalent to: "I split this into N subtasks. Here are the acceptance criteria for each subtask. We should work on the first subtask first because of the dependency reason." Then close the workflow as an intentional planning-stage stop: mark `plan` completed, mark later steps skipped, set workflow status to `abandoned`, keep `current_step_id: "plan"`, call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`, and record `plan_deviation_notes` as `decomposed into N subtasks`. This is a successful scope-governance outcome, not an implementation failure.
+If the planning subagent returns `mode: "decompose"`, the orchestrator must not proceed to implementation. Persist `plan`, write or update `decomposition-manifest.yaml`, present the decomposition summary with wording equivalent to: "I split this into N subtasks. Here are the acceptance criteria for each subtask. We should work on the first subtask first because of the dependency reason." Then close the workflow as an intentional planning-stage stop: mark `plan` completed, mark later steps skipped, set workflow status to `abandoned`, keep `current_step_id: "plan"`, call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`, and record `plan_deviation_notes` as `decomposed into N subtasks`. This is a successful scope-governance outcome, not an implementation failure.
 
 Persist `plan` before advancing to `implement` or before closing on decomposition.
 
@@ -557,6 +557,8 @@ Decomposition rules:
 - Keep `spec.md` as the parent overview. Each subtask spec links back to `spec.md`, contains only the scope for that subtask, and includes acceptance criteria, non-goals, dependencies, validation strategy, and the recommended next `bill-feature-implement` prompt.
 - Prefer 2-4 subtasks. Each subtask should be small enough for one independent feature-implement run.
 - Order subtasks by dependency and identify the first subtask to run.
+- The decomposition manifest uses `execution_model: same_branch_commit_per_subtask` by default with one parent feature branch and no stack branches. Use `execution_model: stacked_branches` only as an explicit opt-in and then declare one stack branch per subtask in subtask order.
+- The manifest must declare `contract_version`, `parent_spec_path`, ordered `subtasks`, dependency ids, each subtask `spec_path`, `execution_model`, `base_branch`, either `feature_branch` or ordered `stack_branches`, and `current_subtask_intent` derived from the recommended first/current subtask.
 
 Return exactly one RESULT: block as your final message, containing valid JSON with this shape:
 
@@ -807,7 +809,7 @@ RESULT:
 
 SMALL and MEDIUM implementation runs: feature flag if required, code review (inline in orchestrator), quality check (subagent), boundary history (inline), commit/push (inline), PR description (subagent).
 
-LARGE decomposition runs stop after Step 3, persist the decomposition package as `plan`, write subtask specs, and close with `completion_status: "abandoned_at_planning"` plus `plan_deviation_notes: "decomposed into N subtasks"`. This is an intentional planning-stage terminal state. The next implementation run starts from the first generated subtask spec.
+LARGE decomposition runs stop after Step 3, persist the decomposition package as `plan`, write subtask specs, create or update the parent `decomposition-manifest.yaml`, and close with `completion_status: "abandoned_at_planning"` plus `plan_deviation_notes: "decomposed into N subtasks"`. This is an intentional planning-stage terminal state. The next implementation run starts from the first generated subtask spec.
 
 ## Error Recovery
 
@@ -815,7 +817,7 @@ For the parsing posture of subagent `RESULT:` blocks (best-effort recovery, sing
 
 - **Pre-planning subagent fails** — report the error and ask the user whether to retry, adjust scope, or abandon. If abandoned, call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`.
 - **Planning subagent returns an invalid plan** (missing fields, no dedicated test task when testable logic exists, etc.) — respawn it once with a corrective briefing that lists the violations. If it still fails, abandon at planning.
-- **Planning subagent returns `mode: "decompose"`** — treat this as a valid terminal planning result. Persist the `plan` artifact, present the subtask order and acceptance criteria, mark later workflow steps skipped, close workflow state as `abandoned` at `plan`, and call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`.
+- **Planning subagent returns `mode: "decompose"`** — treat this as a valid terminal planning result. Persist the `plan` artifact, validate and write the parent `decomposition-manifest.yaml`, present the subtask order and acceptance criteria, mark later workflow steps skipped, close workflow state as `abandoned` at `plan`, and call `feature_implement_finished` with `completion_status: "abandoned_at_planning"`.
 - **Implementation subagent stops early with `stopped_early: true`** — the orchestrator decides: if `plan_deviation_notes` imply a re-plan, respawn the planning subagent with the deviation notes and then a fresh implementation subagent; otherwise, hand to the user.
 - **Code-review fix loop exceeds 3 iterations** — stop, report remaining findings, hand to user. Call `feature_implement_finished` with `completion_status: "abandoned_at_review"`.
 - **Completeness audit loops exceed 2 iterations** — report remaining gaps, let user decide. Call `feature_implement_finished` accordingly.

--- a/skills/bill-feature-implement/native-agents/agents.yaml
+++ b/skills/bill-feature-implement/native-agents/agents.yaml
@@ -96,6 +96,11 @@ agents:
       - Keep `spec.md` as the parent overview. Each subtask spec links back to `spec.md`, contains only the scope for that subtask, and includes acceptance criteria, non-goals, dependencies, validation strategy, and the recommended next `bill-feature-implement` prompt.
       - Prefer 2-4 subtasks. Each subtask should be small enough for one independent feature-implement run.
       - Order subtasks by dependency and identify the first subtask to run.
+      - The decomposition manifest uses `execution_model: same_branch_commit_per_subtask` by default with one parent feature branch and no stack branches. Use `execution_model: stacked_branches` only as an explicit opt-in and then declare one stack branch per subtask in subtask order.
+      - The manifest must declare `contract_version`, `parent_spec_path`, ordered `subtasks`, dependency ids, each subtask `spec_path`, `execution_model`, `base_branch`, either `feature_branch` or ordered `stack_branches`, and `current_subtask_intent` derived from the recommended first/current subtask.
+      - Same-branch decompositions advance one subtask at a time on the parent feature branch. Each completed subtask gets an individual commit before the next pending dependency-complete subtask starts.
+      - Stacked decompositions are opt-in only. Every subtask must declare its branch and base branch; continuation must stop instead of advancing onto the wrong branch/base.
+      - Blocked subtasks are sticky: continuation reports the blocked reason and stops unless a later subtask's dependency marks the blocked dependency both optional and skipped.
       
       Return exactly one RESULT: block as your final message, containing valid JSON with this shape:
       


### PR DESCRIPTION
# Summary

Adds durable decomposition workflow state for `bill-feature-implement` so decomposed parent features can be validated, resumed, and advanced across subtasks.

- Creates the validator-backed parent decomposition manifest and keeps single-spec `mode=implement` workflows manifest-free.
- Persists per-subtask runtime state in `artifacts.decomposition_runtime`, with manifest/frontmatter as a human-readable projection.
- Resolves `continue SKILL-XX` by parent issue key, resumes in-progress subtasks at their last durable step, or starts the first dependency-complete pending subtask.
- Enforces blocked-subtask behavior, same-branch commit-per-subtask advancement, and opt-in stacked branch checkout/base validation through a workflow git port.
- Updates authored `bill-feature-implement` guidance and boundary history for the continuation/branching contract.

## Feature Flags

N/A

# How Has This Been Tested?

- `(cd runtime-kotlin && ./gradlew check)`
- `./install.sh`

Reviewer reproduction:
1. Run `(cd runtime-kotlin && ./gradlew check)`.
2. Run `./install.sh` from the repo root to refresh generated local skill installs after the authored skill-source update.
3. Inspect `ApplicationPersistencePortTest`, `DecompositionContinuationSelectorTest`, `CliWorkflowContinuationRuntimeTest`, and `McpWorkflowContinuationRuntimeTest` for parent issue-key continuation, in-progress resume, blocked dependency handling, same-branch advancement, stacked branch base validation, and MCP/CLI compatibility coverage.
