### PR TITLE
feat: [SKILL-53] Persist shared install selections

### DIFF
--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
@@ -1,5 +1,5 @@
 ---
-contract_version: "0.1"
+contract_version: "0.2"
 issue_key: "SKILL-53"
 feature_name: "shared-runtime-install-architecture"
 parent_spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md"
@@ -9,8 +9,8 @@ base_branch: "main"
 feature_branch: "feat/SKILL-53-shared-runtime-install-architecture"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 0
-  action: "none"
+  subtask_id: 3
+  action: "start"
 subtasks:
 - id: 1
   name: "shared-install-selection-foundation"
@@ -142,15 +142,77 @@ subtasks:
 - id: 2
   name: "cli-shell-persistence"
   spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_2_cli-shell-persistence.md"
-  status: "pending"
-  branch: null
+  status: "complete"
+  branch: "feat/SKILL-53-shared-runtime-install-architecture"
   commit_sha: null
   workflow_id: null
-  review_result: null
-  audit_result: null
-  validation_result: null
+  review_result:
+    review_iterations: 1
+    result: "passed_no_blocker_major_findings"
+    remaining_blocker_major_findings: 0
+    remaining_minor_findings: 0
+    initial_findings: []
+    fixes_applied: []
+    review_telemetry_note: "Workflow state was unavailable for SKILL-53 continuation in this local Codex run; review was performed inline against the working-tree diff without bill-code-review import telemetry."
+  audit_result:
+    pass: true
+    per_criterion:
+    - id: 1
+      criterion: "`skill-bill install apply` can persist latest successful install choices without introducing a dependency on desktop modules."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:70"
+      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:97"
+      - "runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt:172"
+    - id: 2
+      criterion: "`install.sh` delegates persistence through the runtime CLI or shared runtime API after successful apply and does not hand-write desktop preference internals."
+      verdict: "pass"
+      evidence:
+      - "install.sh:890"
+      - "install.sh:924"
+      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:97"
+    - id: 3
+      criterion: "Detected-agent installs persist the actual resolved installed agents when available from the typed apply result."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:101"
+      - "runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt:89"
+      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:259"
+    - id: 4
+      criterion: "Manual agent selections, selected platform packs, telemetry level, and MCP opt-out choices persist through the shared store."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:104"
+      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:112"
+      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:108"
+      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:259"
+    - id: 5
+      criterion: "Failed install attempts are not persisted as completed reusable selections."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:92"
+      - "runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt:133"
+      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:284"
+    gaps: []
+  validation_result:
+    validation_result: "pass"
+    routed_skill: "bill-kotlin-quality-check"
+    detected_stack: "kotlin"
+    initial_failure_count: 1
+    final_failure_count: 0
+    fixes_applied: "Applied :runtime-application:spotlessApply after focused tests exposed only formatting drift; focused application and CLI tests plus spotless checks pass."
+    telemetry_payload:
+      routed_skill: "bill-kotlin-quality-check"
+      detected_stack: "kotlin"
+      scope_type: "working_tree"
+      initial_failure_count: 1
+      final_failure_count: 0
+      iterations: 2
+      result: "pass"
+      duration_seconds: 9
+      skill: "bill-quality-check"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "finish"
   dependencies:
   - subtask_id: 1
     optional: false

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
@@ -1,0 +1,198 @@
+---
+contract_version: "0.1"
+issue_key: "SKILL-53"
+feature_name: "shared-runtime-install-architecture"
+parent_spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md"
+status: "in_progress"
+execution_model: "same_branch_commit_per_subtask"
+base_branch: "main"
+feature_branch: "feat/SKILL-53-shared-runtime-install-architecture"
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: "none"
+subtasks:
+- id: 1
+  name: "shared-install-selection-foundation"
+  spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_1_shared-install-selection-foundation.md"
+  status: "complete"
+  branch: "feat/SKILL-53-shared-runtime-install-architecture"
+  commit_sha: null
+  workflow_id: "wfl-20260524-180427-jhmn"
+  review_result:
+    review_iterations: 3
+    result: "passed_after_fixes"
+    remaining_blocker_major_findings: 0
+    remaining_minor_findings: 0
+    initial_findings:
+    - "Major: persistence request lacked explicit install home/scope"
+    - "Major: direct non-atomic write to latest install-selection record"
+    - "Major: no size guard before reading latest install-selection record"
+    - "Major: resolvedInstalledAgents could include partial failed apply data"
+    - "Major: platform_pack_selection invariants were not enforced"
+    - "Major: tests missed overwrite/MCP opt-out, resolved-agent edge cases, infra-fs\
+      \ boundary, and malformed record cases"
+    fixes_applied:
+    - "Read/write requests now carry explicit installHome and filesystem adapter resolves\
+      \ path per operation."
+    - "Latest record writes now use same-directory temp file plus ATOMIC_MOVE/REPLACE_EXISTING\
+      \ fallback."
+    - "Read path rejects records over 64 KiB before loading/parsing."
+    - "resolvedInstalledAgents is a computed property derived from status and skills,\
+      \ empty for FAILURE and CREATED/SKIPPED links only otherwise."
+    - "Parser rejects invalid platform_pack_selection cross-field states, blank selected\
+      \ slugs, and blank runtime_mcp_bin."
+    - "Tests cover canonical v1 JSON read/write shape, overwrite with MCP opt-out,\
+      \ alternate install home, malformed records, resolved-agent edge cases, and\
+      \ runtime-infra-fs desktop boundary."
+    review_telemetry_note: "Specialist review was orchestrated inline in Codex; no\
+      \ bill-code-review run id was emitted, so import_review was not called to avoid\
+      \ synthesizing a review-run id."
+  audit_result:
+    pass: true
+    per_criterion:
+    - id: 1
+      criterion: "A shared runtime install-selection model exists outside runtime-desktop:*\
+        \ and is usable by both CLI and desktop JVM code."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/SharedInstallSelection.kt:3"
+      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt:8"
+      - "runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt:172"
+      - "runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt:250"
+      - "runtime-kotlin/runtime-cli/build.gradle.kts:11"
+      - "runtime-kotlin/runtime-desktop/core/data/build.gradle.kts:14"
+      - "runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallSelectionRuntimeBoundaryTest.kt:38"
+    - id: 2
+      criterion: "A shared persistence implementation writes and reads latest successful\
+        \ install choices, including selected agents, selected platform packs, telemetry\
+        \ level, and MCP registration choice."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt:9"
+      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt:13"
+      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/model/InstallSelectionPersistenceModels.kt:6"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt:21"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt:11"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionParser.kt:20"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:25"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:50"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:132"
+    - id: 3
+      criterion: "The shared model does not include desktop-only preferences such\
+        \ as recent repo path or UI-only state."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/SharedInstallSelection.kt:3"
+      - "runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/SharedInstallSelectionModelTest.kt:9"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt:31"
+      - "runtime-kotlin/runtime-desktop/core/datastore/src/commonMain/kotlin/skillbill/desktop/core/datastore/DesktopPreferenceStore.kt:13"
+      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:87"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:180"
+    - id: 4
+      criterion: "The persistence implementation follows existing runtime loud-fail\
+        \ conventions for unreadable or malformed shared install-selection records."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt:114"
+      - "runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt:122"
+      - "runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt:130"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt:37"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt:63"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionParser.kt:12"
+      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionValidation.kt:7"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:168"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:180"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:195"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:208"
+      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:244"
+    - id: 5
+      criterion: "Any typed seam needed to prefer resolved installed agents from successful\
+        \ apply results is present without wiring CLI or desktop behavior yet."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:271"
+      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:277"
+      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:284"
+      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:361"
+      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:373"
+      - "runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/SharedInstallSelectionModelTest.kt:18"
+    gaps: []
+  validation_result:
+    validation_result: "pass"
+    routed_skill: "bill-kotlin-quality-check"
+    detected_stack: "kotlin"
+    initial_failure_count: 1
+    final_failure_count: 0
+    fixes_applied: "Applied :runtime-infra-fs:spotlessApply to fix Kotlin import ordering\
+      \ in FileSystemInstallSelectionPersistenceTest.kt."
+    telemetry_payload:
+      routed_skill: "bill-kotlin-quality-check"
+      detected_stack: "kotlin"
+      scope_type: "working_tree"
+      initial_failure_count: 1
+      final_failure_count: 0
+      iterations: 2
+      result: "pass"
+      duration_seconds: 38
+      skill: "bill-quality-check"
+  blocked_reason: null
+  last_resumable_step: "finish"
+  dependencies: []
+- id: 2
+  name: "cli-shell-persistence"
+  spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_2_cli-shell-persistence.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: null
+  review_result: null
+  audit_result: null
+  validation_result: null
+  blocked_reason: null
+  last_resumable_step: null
+  dependencies:
+  - subtask_id: 1
+    optional: false
+    skipped: false
+- id: 3
+  name: "desktop-adapter-migration"
+  spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_3_desktop-adapter-migration.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: null
+  review_result: null
+  audit_result: null
+  validation_result: null
+  blocked_reason: null
+  last_resumable_step: null
+  dependencies:
+  - subtask_id: 1
+    optional: false
+    skipped: false
+  - subtask_id: 2
+    optional: false
+    skipped: false
+- id: 4
+  name: "validation-contract-lock"
+  spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_4_validation-contract-lock.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: null
+  review_result: null
+  audit_result: null
+  validation_result: null
+  blocked_reason: null
+  last_resumable_step: null
+  dependencies:
+  - subtask_id: 1
+    optional: false
+    skipped: false
+  - subtask_id: 2
+    optional: false
+    skipped: false
+  - subtask_id: 3
+    optional: false
+    skipped: false

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
@@ -9,7 +9,7 @@ base_branch: "main"
 feature_branch: "feat/SKILL-53-shared-runtime-install-architecture"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 3
+  subtask_id: 4
   action: "start"
 subtasks:
 - id: 1
@@ -220,15 +220,77 @@ subtasks:
 - id: 3
   name: "desktop-adapter-migration"
   spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_3_desktop-adapter-migration.md"
-  status: "pending"
-  branch: null
+  status: "complete"
+  branch: "feat/SKILL-53-shared-runtime-install-architecture"
   commit_sha: null
   workflow_id: null
-  review_result: null
-  audit_result: null
-  validation_result: null
+  review_result:
+    review_iterations: 1
+    result: "passed_no_blocker_major_findings"
+    remaining_blocker_major_findings: 0
+    remaining_minor_findings: 0
+    initial_findings: []
+    fixes_applied: []
+    review_telemetry_note: "Workflow state was unavailable for SKILL-53 continuation in this local Codex run; review was performed inline against the working-tree diff without bill-code-review import telemetry."
+  audit_result:
+    pass: true
+    per_criterion:
+    - id: 1
+      criterion: "Desktop first-run setup uses shared install-selection persistence for reusable install choices."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt:2258"
+      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt:234"
+      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt:58"
+    - id: 2
+      criterion: "Desktop post-publish reinstall uses the shared install-selection persistence instead of owning or reading a separate desktop install preference format."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt:2248"
+      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt:1374"
+      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt:1492"
+    - id: 3
+      criterion: "Existing desktop-only preferences such as recent repo path and UI-only state remain desktop-owned."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:34"
+      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:77"
+      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt:60"
+    - id: 4
+      criterion: "Existing desktop preference files with legacy firstRun.* install keys migrate or adapt into the shared install-selection record."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:69"
+      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt:242"
+      - "runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt:112"
+      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt:83"
+    - id: 5
+      criterion: "Desktop JVM code depends only on shared runtime APIs for install selection, not CLI or shell behavior."
+      verdict: "pass"
+      evidence:
+      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt:15"
+      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt:44"
+      - "runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/service/DesktopFirstRunGateway.kt:12"
+    gaps: []
+  validation_result:
+    validation_result: "pass"
+    routed_skill: "bill-kotlin-quality-check"
+    detected_stack: "kotlin"
+    initial_failure_count: 2
+    final_failure_count: 0
+    fixes_applied: "Applied :runtime-desktop:core:data:spotlessApply and :runtime-desktop:feature:skillbill:spotlessApply after full check exposed only formatting drift; focused desktop JVM tests and full repo validation pass."
+    telemetry_payload:
+      routed_skill: "bill-kotlin-quality-check"
+      detected_stack: "kotlin"
+      scope_type: "working_tree"
+      initial_failure_count: 2
+      final_failure_count: 0
+      iterations: 3
+      result: "pass"
+      duration_seconds: 12
+      skill: "bill-quality-check"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "finish"
   dependencies:
   - subtask_id: 1
     optional: false

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/decomposition-manifest.yaml
@@ -3,14 +3,14 @@ contract_version: "0.2"
 issue_key: "SKILL-53"
 feature_name: "shared-runtime-install-architecture"
 parent_spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md"
-status: "in_progress"
+status: "complete"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-53-shared-runtime-install-architecture"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 4
-  action: "start"
+  subtask_id: 0
+  action: "none"
 subtasks:
 - id: 1
   name: "shared-install-selection-foundation"
@@ -19,123 +19,6 @@ subtasks:
   branch: "feat/SKILL-53-shared-runtime-install-architecture"
   commit_sha: null
   workflow_id: "wfl-20260524-180427-jhmn"
-  review_result:
-    review_iterations: 3
-    result: "passed_after_fixes"
-    remaining_blocker_major_findings: 0
-    remaining_minor_findings: 0
-    initial_findings:
-    - "Major: persistence request lacked explicit install home/scope"
-    - "Major: direct non-atomic write to latest install-selection record"
-    - "Major: no size guard before reading latest install-selection record"
-    - "Major: resolvedInstalledAgents could include partial failed apply data"
-    - "Major: platform_pack_selection invariants were not enforced"
-    - "Major: tests missed overwrite/MCP opt-out, resolved-agent edge cases, infra-fs\
-      \ boundary, and malformed record cases"
-    fixes_applied:
-    - "Read/write requests now carry explicit installHome and filesystem adapter resolves\
-      \ path per operation."
-    - "Latest record writes now use same-directory temp file plus ATOMIC_MOVE/REPLACE_EXISTING\
-      \ fallback."
-    - "Read path rejects records over 64 KiB before loading/parsing."
-    - "resolvedInstalledAgents is a computed property derived from status and skills,\
-      \ empty for FAILURE and CREATED/SKIPPED links only otherwise."
-    - "Parser rejects invalid platform_pack_selection cross-field states, blank selected\
-      \ slugs, and blank runtime_mcp_bin."
-    - "Tests cover canonical v1 JSON read/write shape, overwrite with MCP opt-out,\
-      \ alternate install home, malformed records, resolved-agent edge cases, and\
-      \ runtime-infra-fs desktop boundary."
-    review_telemetry_note: "Specialist review was orchestrated inline in Codex; no\
-      \ bill-code-review run id was emitted, so import_review was not called to avoid\
-      \ synthesizing a review-run id."
-  audit_result:
-    pass: true
-    per_criterion:
-    - id: 1
-      criterion: "A shared runtime install-selection model exists outside runtime-desktop:*\
-        \ and is usable by both CLI and desktop JVM code."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/SharedInstallSelection.kt:3"
-      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt:8"
-      - "runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt:172"
-      - "runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt:250"
-      - "runtime-kotlin/runtime-cli/build.gradle.kts:11"
-      - "runtime-kotlin/runtime-desktop/core/data/build.gradle.kts:14"
-      - "runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallSelectionRuntimeBoundaryTest.kt:38"
-    - id: 2
-      criterion: "A shared persistence implementation writes and reads latest successful\
-        \ install choices, including selected agents, selected platform packs, telemetry\
-        \ level, and MCP registration choice."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt:9"
-      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt:13"
-      - "runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/model/InstallSelectionPersistenceModels.kt:6"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt:21"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt:11"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionParser.kt:20"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:25"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:50"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:132"
-    - id: 3
-      criterion: "The shared model does not include desktop-only preferences such\
-        \ as recent repo path or UI-only state."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/SharedInstallSelection.kt:3"
-      - "runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/SharedInstallSelectionModelTest.kt:9"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt:31"
-      - "runtime-kotlin/runtime-desktop/core/datastore/src/commonMain/kotlin/skillbill/desktop/core/datastore/DesktopPreferenceStore.kt:13"
-      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:87"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:180"
-    - id: 4
-      criterion: "The persistence implementation follows existing runtime loud-fail\
-        \ conventions for unreadable or malformed shared install-selection records."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt:114"
-      - "runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt:122"
-      - "runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt:130"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt:37"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt:63"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionParser.kt:12"
-      - "runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionValidation.kt:7"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:168"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:180"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:195"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:208"
-      - "runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt:244"
-    - id: 5
-      criterion: "Any typed seam needed to prefer resolved installed agents from successful\
-        \ apply results is present without wiring CLI or desktop behavior yet."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:271"
-      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:277"
-      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:284"
-      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:361"
-      - "runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:373"
-      - "runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/SharedInstallSelectionModelTest.kt:18"
-    gaps: []
-  validation_result:
-    validation_result: "pass"
-    routed_skill: "bill-kotlin-quality-check"
-    detected_stack: "kotlin"
-    initial_failure_count: 1
-    final_failure_count: 0
-    fixes_applied: "Applied :runtime-infra-fs:spotlessApply to fix Kotlin import ordering\
-      \ in FileSystemInstallSelectionPersistenceTest.kt."
-    telemetry_payload:
-      routed_skill: "bill-kotlin-quality-check"
-      detected_stack: "kotlin"
-      scope_type: "working_tree"
-      initial_failure_count: 1
-      final_failure_count: 0
-      iterations: 2
-      result: "pass"
-      duration_seconds: 38
-      skill: "bill-quality-check"
   blocked_reason: null
   last_resumable_step: "finish"
   dependencies: []
@@ -146,71 +29,6 @@ subtasks:
   branch: "feat/SKILL-53-shared-runtime-install-architecture"
   commit_sha: null
   workflow_id: null
-  review_result:
-    review_iterations: 1
-    result: "passed_no_blocker_major_findings"
-    remaining_blocker_major_findings: 0
-    remaining_minor_findings: 0
-    initial_findings: []
-    fixes_applied: []
-    review_telemetry_note: "Workflow state was unavailable for SKILL-53 continuation in this local Codex run; review was performed inline against the working-tree diff without bill-code-review import telemetry."
-  audit_result:
-    pass: true
-    per_criterion:
-    - id: 1
-      criterion: "`skill-bill install apply` can persist latest successful install choices without introducing a dependency on desktop modules."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:70"
-      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:97"
-      - "runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt:172"
-    - id: 2
-      criterion: "`install.sh` delegates persistence through the runtime CLI or shared runtime API after successful apply and does not hand-write desktop preference internals."
-      verdict: "pass"
-      evidence:
-      - "install.sh:890"
-      - "install.sh:924"
-      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:97"
-    - id: 3
-      criterion: "Detected-agent installs persist the actual resolved installed agents when available from the typed apply result."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:101"
-      - "runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt:89"
-      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:259"
-    - id: 4
-      criterion: "Manual agent selections, selected platform packs, telemetry level, and MCP opt-out choices persist through the shared store."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:104"
-      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:112"
-      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:108"
-      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:259"
-    - id: 5
-      criterion: "Failed install attempts are not persisted as completed reusable selections."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt:92"
-      - "runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt:133"
-      - "runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt:284"
-    gaps: []
-  validation_result:
-    validation_result: "pass"
-    routed_skill: "bill-kotlin-quality-check"
-    detected_stack: "kotlin"
-    initial_failure_count: 1
-    final_failure_count: 0
-    fixes_applied: "Applied :runtime-application:spotlessApply after focused tests exposed only formatting drift; focused application and CLI tests plus spotless checks pass."
-    telemetry_payload:
-      routed_skill: "bill-kotlin-quality-check"
-      detected_stack: "kotlin"
-      scope_type: "working_tree"
-      initial_failure_count: 1
-      final_failure_count: 0
-      iterations: 2
-      result: "pass"
-      duration_seconds: 9
-      skill: "bill-quality-check"
   blocked_reason: null
   last_resumable_step: "finish"
   dependencies:
@@ -224,71 +42,6 @@ subtasks:
   branch: "feat/SKILL-53-shared-runtime-install-architecture"
   commit_sha: null
   workflow_id: null
-  review_result:
-    review_iterations: 1
-    result: "passed_no_blocker_major_findings"
-    remaining_blocker_major_findings: 0
-    remaining_minor_findings: 0
-    initial_findings: []
-    fixes_applied: []
-    review_telemetry_note: "Workflow state was unavailable for SKILL-53 continuation in this local Codex run; review was performed inline against the working-tree diff without bill-code-review import telemetry."
-  audit_result:
-    pass: true
-    per_criterion:
-    - id: 1
-      criterion: "Desktop first-run setup uses shared install-selection persistence for reusable install choices."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt:2258"
-      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt:234"
-      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt:58"
-    - id: 2
-      criterion: "Desktop post-publish reinstall uses the shared install-selection persistence instead of owning or reading a separate desktop install preference format."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt:2248"
-      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt:1374"
-      - "runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt:1492"
-    - id: 3
-      criterion: "Existing desktop-only preferences such as recent repo path and UI-only state remain desktop-owned."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:34"
-      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:77"
-      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt:60"
-    - id: 4
-      criterion: "Existing desktop preference files with legacy firstRun.* install keys migrate or adapt into the shared install-selection record."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt:69"
-      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt:242"
-      - "runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt:112"
-      - "runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt:83"
-    - id: 5
-      criterion: "Desktop JVM code depends only on shared runtime APIs for install selection, not CLI or shell behavior."
-      verdict: "pass"
-      evidence:
-      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt:15"
-      - "runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt:44"
-      - "runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/service/DesktopFirstRunGateway.kt:12"
-    gaps: []
-  validation_result:
-    validation_result: "pass"
-    routed_skill: "bill-kotlin-quality-check"
-    detected_stack: "kotlin"
-    initial_failure_count: 2
-    final_failure_count: 0
-    fixes_applied: "Applied :runtime-desktop:core:data:spotlessApply and :runtime-desktop:feature:skillbill:spotlessApply after full check exposed only formatting drift; focused desktop JVM tests and full repo validation pass."
-    telemetry_payload:
-      routed_skill: "bill-kotlin-quality-check"
-      detected_stack: "kotlin"
-      scope_type: "working_tree"
-      initial_failure_count: 2
-      final_failure_count: 0
-      iterations: 3
-      result: "pass"
-      duration_seconds: 12
-      skill: "bill-quality-check"
   blocked_reason: null
   last_resumable_step: "finish"
   dependencies:
@@ -301,15 +54,12 @@ subtasks:
 - id: 4
   name: "validation-contract-lock"
   spec_path: ".feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_4_validation-contract-lock.md"
-  status: "pending"
-  branch: null
+  status: "complete"
+  branch: "feat/SKILL-53-shared-runtime-install-architecture"
   commit_sha: null
-  workflow_id: null
-  review_result: null
-  audit_result: null
-  validation_result: null
+  workflow_id: "wfl-20260524-201006-cw93"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "finish"
   dependencies:
   - subtask_id: 1
     optional: false

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md
@@ -1,6 +1,6 @@
 # SKILL-53 — Shared runtime install architecture
 
-Status: In Progress
+Status: Complete
 Issue key: SKILL-53
 
 ## Sources

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec.md
@@ -1,7 +1,11 @@
 # SKILL-53 — Shared runtime install architecture
 
-Status: Draft
+Status: In Progress
 Issue key: SKILL-53
+
+## Sources
+
+- User-provided feature brief for SKILL-53 shared-runtime-install-architecture.
 
 ## Context
 

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_1_shared-install-selection-foundation.md
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_1_shared-install-selection-foundation.md
@@ -1,0 +1,52 @@
+# SKILL-53 Shared Runtime Install Architecture - Subtask 1: Shared Install Selection Foundation
+
+Parent overview: [spec.md](spec.md)  
+Issue key: SKILL-53  
+Branch model: same-branch (`feat/SKILL-53-shared-runtime-install-architecture`); commit on completion before subtask 2.
+
+## Scope
+
+Create the shared runtime-owned install-selection foundation outside `runtime-desktop:*`.
+
+This subtask owns the data/model layer only:
+
+- Introduce a shared install-selection model and store contract in runtime JVM modules usable by CLI and desktop code without any desktop dependency. Prefer the existing install boundary shape from `runtime-domain/install`, `runtime-ports/install`, and `runtime-infra-fs/install` instead of adding desktop-owned abstractions.
+- Represent the latest successful install choices: selected agents, selected platform packs, telemetry level, and MCP registration choice. Keep paths inert outside adapters/composition.
+- Add a file-backed persistence implementation under shared runtime infrastructure using repo-standard typed errors/loud-fail behavior for malformed persisted data.
+- Add mapping helpers only where they belong in shared runtime code. If deriving the exact installed agents from an apply result requires orchestration context, define the typed seam here and leave call-site wiring to subtask 2.
+- Keep desktop-only preferences such as recent repo path and UI state out of the shared model.
+
+## Acceptance Criteria
+
+1. A shared runtime install-selection model exists outside `runtime-desktop:*` and is usable by both CLI and desktop JVM code.
+2. A shared persistence implementation writes and reads latest successful install choices, including selected agents, selected platform packs, telemetry level, and MCP registration choice.
+3. The shared model does not include desktop-only preferences such as recent repo path or UI-only state.
+4. The persistence implementation follows existing runtime loud-fail conventions for unreadable or malformed shared install-selection records.
+5. Any typed seam needed to prefer resolved installed agents from successful apply results is present without wiring CLI or desktop behavior yet.
+
+## Non-Goals
+
+- Do not wire `skill-bill install apply`, `install.sh`, or desktop flows in this subtask.
+- Do not migrate existing desktop `firstRun.*` preferences yet.
+- Do not rework the full install runtime or move unrelated install apply mechanics.
+- Do not change installer prompts or install selection semantics.
+- Do not introduce dependencies from runtime modules to `runtime-desktop:*`.
+
+## Dependencies
+
+No subtask dependencies. This runs first because CLI and desktop need a shared model and store before either can persist or read the latest install selection.
+
+## Validation Strategy
+
+Primary: `bill-quality-check`.
+
+Recommended local focus before the full check:
+
+```bash
+(cd runtime-kotlin && ./gradlew :runtime-domain:test :runtime-ports:test :runtime-infra-fs:test)
+```
+
+## Recommended Next Prompt
+
+Run `bill-feature-implement` on `.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_1_shared-install-selection-foundation.md`.
+

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_2_cli-shell-persistence.md
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_2_cli-shell-persistence.md
@@ -1,0 +1,52 @@
+# SKILL-53 Shared Runtime Install Architecture - Subtask 2: CLI And Shell Persistence
+
+Parent overview: [spec.md](spec.md)  
+Issue key: SKILL-53  
+Branch model: same-branch (`feat/SKILL-53-shared-runtime-install-architecture`); commit on completion before subtask 3.
+
+## Scope
+
+Wire successful runtime install apply operations to the shared install-selection store from CLI and shell entry points.
+
+This subtask owns the non-desktop write path:
+
+- Update `skill-bill install apply` so it persists latest install choices only after a successful typed apply result.
+- Keep `runtime-cli` free of any dependency on `runtime-desktop:*`; use the shared runtime store/API introduced by subtask 1.
+- Persist selected agents, selected platform packs, telemetry level, and MCP registration choice from the existing install request/plan/apply flow.
+- For detected-agent installs, prefer actual resolved installed agents from the successful typed apply result when that data is available; fall back to planned agents only when the apply result does not provide stronger evidence.
+- Ensure failed apply attempts do not overwrite the reusable latest successful selection.
+- Keep `install.sh` delegated through the runtime CLI or shared runtime API after successful apply; it must not hand-write desktop preference internals or `firstRun.*` keys.
+
+## Acceptance Criteria
+
+1. `skill-bill install apply` can persist latest successful install choices without introducing a dependency on desktop modules.
+2. `install.sh` delegates persistence through the runtime CLI or shared runtime API after successful apply and does not hand-write desktop preference internals.
+3. Detected-agent installs persist the actual resolved installed agents when available from the typed apply result.
+4. Manual agent selections, selected platform packs, telemetry level, and MCP opt-out choices persist through the shared store.
+5. Failed install attempts are not persisted as completed reusable selections.
+
+## Non-Goals
+
+- Do not change installer prompts, option names, or install selection semantics beyond persisting the successful result.
+- Do not change desktop first-run or post-publish reinstall behavior in this subtask.
+- Do not add desktop modules to CLI/runtime dependencies.
+- Do not change shared persistence format unless subtask 1 proves the foundation is insufficient.
+
+## Dependencies
+
+Depends on subtask 1 because the CLI and shell paths must write through the shared install-selection model and persistence implementation instead of creating a second format.
+
+## Validation Strategy
+
+Primary: `bill-quality-check`.
+
+Recommended local focus before the full check:
+
+```bash
+(cd runtime-kotlin && ./gradlew :runtime-cli:test :runtime-application:test)
+```
+
+## Recommended Next Prompt
+
+Run `bill-feature-implement` on `.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_2_cli-shell-persistence.md`.
+

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_3_desktop-adapter-migration.md
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_3_desktop-adapter-migration.md
@@ -1,0 +1,51 @@
+# SKILL-53 Shared Runtime Install Architecture - Subtask 3: Desktop Adapter And Migration
+
+Parent overview: [spec.md](spec.md)  
+Issue key: SKILL-53  
+Branch model: same-branch (`feat/SKILL-53-shared-runtime-install-architecture`); commit on completion before subtask 4.
+
+## Scope
+
+Move desktop install-choice replay onto the shared install-selection store while keeping desktop-only preferences desktop-owned.
+
+This subtask owns the desktop read/write integration:
+
+- Update desktop first-run setup so successful setup persists install selections through the shared runtime store instead of maintaining a separate desktop-only install preference format.
+- Update post-publish reinstall replay in the desktop skillbill feature to read the latest shared install-selection record through an adapter/gateway rather than `DesktopFirstRunPreferences` install fields.
+- Preserve desktop-only settings, including recent repo path and UI-only state, in the desktop preference store.
+- Add migration/backward compatibility for existing desktop preference files containing `firstRun.*` keys. Existing users should still get a reusable latest install selection without losing desktop-only preferences.
+- Keep the desktop gateway mapped to existing shared install plan/apply services; do not add shell-specific behavior to desktop.
+
+## Acceptance Criteria
+
+1. Desktop first-run setup uses shared install-selection persistence for reusable install choices.
+2. Desktop post-publish reinstall uses the shared install-selection persistence instead of owning or reading a separate desktop install preference format.
+3. Existing desktop-only preferences such as recent repo path and UI-only state remain desktop-owned.
+4. Existing desktop preference files with legacy `firstRun.*` install keys migrate or adapt into the shared install-selection record.
+5. Desktop JVM code depends only on shared runtime APIs for install selection, not CLI or shell behavior.
+
+## Non-Goals
+
+- Do not change the first-run wizard prompts or user-visible install selection semantics.
+- Do not remove desktop-only preference storage for recent repo path or UI state.
+- Do not modify CLI or `install.sh` behavior except to adapt to any shared API refinements needed for desktop.
+- Do not persist failed desktop install attempts as reusable latest selections.
+
+## Dependencies
+
+Depends on subtask 1 for the shared store contract and implementation. Depends on subtask 2 for the successful apply persistence behavior that desktop post-publish reinstall will share with non-desktop installs.
+
+## Validation Strategy
+
+Primary: `bill-quality-check`.
+
+Recommended local focus before the full check:
+
+```bash
+(cd runtime-kotlin && ./gradlew :runtime-desktop:core:datastore:test :runtime-desktop:core:data:test :runtime-desktop:feature:skillbill:test)
+```
+
+## Recommended Next Prompt
+
+Run `bill-feature-implement` on `.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_3_desktop-adapter-migration.md`.
+

--- a/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_4_validation-contract-lock.md
+++ b/.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_4_validation-contract-lock.md
@@ -1,0 +1,56 @@
+# SKILL-53 Shared Runtime Install Architecture - Subtask 4: Validation And Contract Lock
+
+Parent overview: [spec.md](spec.md)  
+Issue key: SKILL-53  
+Branch model: same-branch (`feat/SKILL-53-shared-runtime-install-architecture`); commit on completion after final validation.
+
+## Scope
+
+Close the feature with cross-boundary coverage and validation after the shared foundation, CLI/shell persistence, and desktop adapter work are implemented.
+
+This subtask owns final verification and any narrow fixes required by the tests:
+
+- Add or tighten tests that prove CLI install persistence, desktop preference adapter behavior, detected/manual agent cases, MCP opt-out, failed-attempt non-persistence, and migration/backward compatibility for existing desktop preference files.
+- Verify runtime modules do not depend on `runtime-desktop:*` and desktop install-choice state has not been duplicated into a new desktop-owned format.
+- Verify `install.sh` delegates persistence through runtime CLI/shared runtime behavior and does not write desktop preference internals.
+- Run the repo validation strategy and fix root causes without suppressions.
+- Update the parent spec status only if the implementation workflow for this subtask reaches the normal completion/audit step.
+
+## Acceptance Criteria
+
+1. Tests cover CLI install persistence.
+2. Tests cover desktop preference adapter behavior.
+3. Tests cover detected-agent and manual-agent persistence cases.
+4. Tests cover MCP opt-out persistence.
+5. Tests cover migration/backward compatibility for existing desktop preference files.
+6. Full validation passes through `bill-quality-check` or the documented repo-native fallback.
+7. Dependency direction remains valid: runtime modules do not depend on desktop modules.
+
+## Non-Goals
+
+- Do not introduce new install selection semantics.
+- Do not perform broad install runtime refactors unrelated to closing coverage or validation gaps.
+- Do not change generated skill wrappers, support pointers, native-agent outputs, or install staging artifacts.
+- Do not remove legacy desktop preference compatibility unless tests prove migration is complete and behavior remains backward compatible.
+
+## Dependencies
+
+Depends on subtasks 1, 2, and 3 because this subtask validates the completed shared persistence, non-desktop write path, and desktop adapter/migration behavior together.
+
+## Validation Strategy
+
+Primary: `bill-quality-check`.
+
+Required final commands if not already covered by the routed checker:
+
+```bash
+skill-bill validate
+(cd runtime-kotlin && ./gradlew check)
+npx --yes agnix --strict .
+scripts/validate_agent_configs
+```
+
+## Recommended Next Prompt
+
+Run `bill-feature-implement` on `.feature-specs/SKILL-53-shared-runtime-install-architecture/spec_subtask_4_validation-contract-lock.md`.
+

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,11 @@
+## [2026-05-24] SKILL-53 cli-shell-persistence
+Areas: runtime-kotlin/runtime-application install service, runtime-kotlin/runtime-cli install apply, install.sh runtime delegation
+- `InstallService.applyInstall` now persists `SharedInstallSelection` through `InstallSelectionPersistencePort` only after non-failure typed apply results, keeping CLI/shell writes outside desktop modules. reusable
+- Persisted agents prefer `InstallApplyResult.resolvedInstalledAgents` and fall back to planned agents only when the apply result has no stronger evidence. reusable
+- CLI coverage now asserts manual/detected selections, platform mode, telemetry level, MCP opt-out, and failure non-persistence through the canonical `install-selection.json` record.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented
+
 ## [2026-05-24] SKILL-53 shared-install-selection-foundation
 Areas: runtime-kotlin/runtime-domain install model, runtime-kotlin/runtime-ports install selection port, runtime-kotlin/runtime-infra-fs install-selection persistence, runtime-kotlin/runtime-contracts errors, runtime-kotlin/runtime-core DI
 - Shared install selection now lives outside desktop as `SharedInstallSelection` plus `InstallSelectionPersistencePort`; requests carry explicit `installHome` so CLI/Desktop callers can persist the intended runtime install state. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -122,6 +122,13 @@ Areas: runtime-kotlin/runtime-domain, runtime-kotlin/runtime-application, runtim
 Feature flag: N/A
 Acceptance criteria: 6/6 implemented
 
+## [2026-05-24] SKILL-53 decomposition-manifest-commit-projection
+Areas: runtime-kotlin/runtime-application, runtime-kotlin/runtime-infra-fs, skills/bill-feature-implement
+- Same-branch subtask commits now include staged `decomposition-manifest.yaml` status/current-intent projections; the previous infra Git adapter behavior that unstaged manifest projections before committing was removed. reusable
+- Git-tracked decomposition manifests intentionally project `commit_sha: null`; subtask commit SHAs remain durable workflow runtime state because a commit cannot contain its own final SHA without changing that SHA. reusable
+Feature flag: N/A
+Acceptance criteria: internal defect fix
+
 ## [2026-05-23] SKILL-51 decomposition-workflow-state-validation-projection
 Areas: runtime-kotlin/runtime-application/workflow, runtime-kotlin/runtime-domain/workflow, runtime-kotlin/runtime-core application tests, skills/bill-feature-implement
 - Parent decomposition projection now updates the parent spec status in addition to subtask frontmatter, and Markdown `## Status` sections are projected when present. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-05-24] SKILL-53 shared-install-selection-foundation
+Areas: runtime-kotlin/runtime-domain install model, runtime-kotlin/runtime-ports install selection port, runtime-kotlin/runtime-infra-fs install-selection persistence, runtime-kotlin/runtime-contracts errors, runtime-kotlin/runtime-core DI
+- Shared install selection now lives outside desktop as `SharedInstallSelection` plus `InstallSelectionPersistencePort`; requests carry explicit `installHome` so CLI/Desktop callers can persist the intended runtime install state. reusable
+- `FileSystemInstallSelectionPersistence` stores canonical v1 JSON at `<installHome>/.skill-bill/install-selection.json` with atomic temp-file replacement, a 64 KiB read guard, and typed missing/unreadable/malformed errors. reusable
+- Parser locks install-selection invariants: selected platform slugs must match mode, slugs and MCP bin paths cannot be blank, and canonical JSON shape has fixture coverage.
+- `InstallApplyResult.resolvedInstalledAgents` is computed from status+skill links only: empty on failure, CREATED/SKIPPED agents on success/warning, keeping future persistence from storing stale requested agents. reusable
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented
+
 ## [2026-05-24] SKILL-52.1 final-validation-and-contract-lock
 Areas: runtime-kotlin/ARCHITECTURE.md, runtime-kotlin/runtime-core architecture tests, runtime-kotlin/runtime-domain, runtime-kotlin/runtime-application, runtime-kotlin/runtime-ports, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-mcp, runtime-kotlin/runtime-desktop/core/data
 - SKILL-52.1 closes with architecture documentation and tests aligned on raw-map open-boundary parity, inert `Path` handling outside adapters/composition, install-policy ownership with dual install-plan validation, and the narrowed runtime-core public ABI edge. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,11 @@
+## [2026-05-24] SKILL-53 desktop-adapter-migration
+Areas: runtime-kotlin/runtime-desktop/core/domain, runtime-kotlin/runtime-desktop/core/data, runtime-kotlin/runtime-desktop/core/datastore, runtime-kotlin/runtime-desktop/feature/skillbill
+- Desktop first-run and post-publish reinstall replay now flow through `DesktopFirstRunGateway.latestReusableSetupRequest`, backed by the shared `InstallSelectionPersistencePort`; no CLI or shell dependency was added. reusable
+- `LocalDesktopPreferenceStore` keeps desktop-owned completion/recent-repo state, removes reusable install-choice keys on new writes, and still loads legacy `firstRun.*` keys as a migration fallback. reusable
+- Desktop request models now preserve platform pack selection mode (`NONE`, `SELECTED`, `ALL`) so shared install-selection replay can round-trip all-pack installs.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented
+
 ## [2026-05-24] SKILL-53 cli-shell-persistence
 Areas: runtime-kotlin/runtime-application install service, runtime-kotlin/runtime-cli install apply, install.sh runtime delegation
 - `InstallService.applyInstall` now persists `SharedInstallSelection` through `InstallSelectionPersistencePort` only after non-failure typed apply results, keeping CLI/shell writes outside desktop modules. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-05-24] SKILL-53 validation-contract-lock
+Areas: runtime-kotlin/runtime-cli, runtime-kotlin/runtime-application, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-desktop, runtime-kotlin/runtime-core architecture tests
+- Final SKILL-53 coverage locks CLI install persistence, detected/manual agent replay, MCP opt-out, desktop legacy preference migration, and install.sh runtime delegation without adding desktop dependencies. reusable
+- `FileSystemInstallSelectionPersistence` now validates write payloads through the same parser and UTF-8 size guard as reads, preserving the prior durable record on invalid or oversized writes. reusable
+- Desktop replay preserves `PlatformSelectionMode.ALL`; completed desktop preferences normalize live and durable state back to desktop-owned fields only.
+- Decomposition manifests must not carry review/audit/validation payloads; workflow artifacts own those results while git-tracked manifests keep runtime projection fields only.
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented
+
 ## [2026-05-24] SKILL-53 desktop-adapter-migration
 Areas: runtime-kotlin/runtime-desktop/core/domain, runtime-kotlin/runtime-desktop/core/data, runtime-kotlin/runtime-desktop/core/datastore, runtime-kotlin/runtime-desktop/feature/skillbill
 - Desktop first-run and post-publish reinstall replay now flow through `DesktopFirstRunGateway.latestReusableSetupRequest`, backed by the shared `InstallSelectionPersistencePort`; no CLI or shell dependency was added. reusable

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestWriter.kt
@@ -120,7 +120,8 @@ object DecompositionManifestWriter {
       .let { candidate ->
         runtimeUpdate?.let { candidate.withRuntimeUpdate(request.repoRoot, it) } ?: candidate
       }
-    val yaml = encodeDecompositionManifestYaml(manifest)
+    val projectedManifest = manifest.gitTrackedProjection()
+    val yaml = encodeDecompositionManifestYaml(projectedManifest)
     writeDecompositionManifestText(manifestPath, yaml, fileStore)
     val loaded = loadDecompositionManifest(manifestPath, fileStore)
     projectCurrentSubtaskStatus(request.repoRoot, loaded, fileStore)
@@ -229,7 +230,7 @@ private fun writeProjection(
   manifestPath: Path = manifest.manifestPath(repoRoot),
   fileStore: DecompositionManifestFileStore,
 ): DecompositionManifestWriteResult? = try {
-  val yaml = encodeDecompositionManifestYaml(manifest)
+  val yaml = encodeDecompositionManifestYaml(manifest.gitTrackedProjection())
   writeDecompositionManifestText(manifestPath, yaml, fileStore)
   val loaded = loadDecompositionManifest(manifestPath, fileStore)
   projectCurrentSubtaskStatus(repoRoot, loaded, fileStore)
@@ -237,3 +238,6 @@ private fun writeProjection(
 } catch (_: IOException) {
   null
 }
+
+private fun DecompositionManifest.gitTrackedProjection(): DecompositionManifest =
+  copy(subtasks = subtasks.map { subtask -> subtask.copy(commitSha = null) })

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt
@@ -4,10 +4,14 @@ import me.tatarka.inject.annotations.Inject
 import skillbill.application.install.toPolicyInput
 import skillbill.application.install.validatedInstallPlan
 import skillbill.install.model.InstallApplyResult
+import skillbill.install.model.InstallApplyStatus
 import skillbill.install.model.InstallPlan
 import skillbill.install.model.InstallPlanRequest
 import skillbill.install.model.InstallPlatformPackDiscoverySnapshot
 import skillbill.install.model.InstallPlatformSkillMaterializationRequest
+import skillbill.install.model.PlatformPackSelection
+import skillbill.install.model.PlatformPackSelectionMode
+import skillbill.install.model.SharedInstallSelection
 import skillbill.install.policy.InstallPlanPolicy
 import skillbill.ports.install.apply.InstallApplyExecutionPort
 import skillbill.ports.install.apply.model.InstallApplyExecutionRequest
@@ -19,6 +23,8 @@ import skillbill.ports.install.plan.InstallStagingIntentPort
 import skillbill.ports.install.plan.model.InstallPlanningFactsRequest
 import skillbill.ports.install.plan.model.InstallPlatformSkillMaterializationPortRequest
 import skillbill.ports.install.plan.model.InstallStagingIntentRequest
+import skillbill.ports.install.selection.InstallSelectionPersistencePort
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionRequest
 import skillbill.ports.telemetry.TelemetryLevelMutator
 import java.nio.file.Path
 
@@ -29,6 +35,7 @@ class InstallService(
   private val stagingIntentPort: InstallStagingIntentPort,
   private val applyExecutionPort: InstallApplyExecutionPort,
   private val skillLinkPort: InstallSkillLinkPort,
+  private val installSelectionPersistencePort: InstallSelectionPersistencePort,
 ) {
   fun planInstall(request: InstallPlanRequest): InstallPlan {
     val facts = planningFactsPort.collectPlanningFacts(InstallPlanningFactsRequest(request)).facts
@@ -61,13 +68,16 @@ class InstallService(
     return validatedInstallPlan(draft, staging)
   }
 
-  fun applyInstall(plan: InstallPlan, telemetryLevelMutator: TelemetryLevelMutator? = null): InstallApplyResult =
-    applyExecutionPort.applyInstall(
+  fun applyInstall(plan: InstallPlan, telemetryLevelMutator: TelemetryLevelMutator? = null): InstallApplyResult {
+    val result = applyExecutionPort.applyInstall(
       InstallApplyExecutionRequest(
         plan = plan,
         telemetryLevelMutator = telemetryLevelMutator,
       ),
     ).result
+    persistSuccessfulInstallSelection(plan, result)
+    return result
+  }
 
   fun linkSkill(source: Path, targetDir: Path, agent: String, repoRoot: Path? = null, home: Path? = null): List<Path> =
     skillLinkPort.linkSkill(
@@ -79,4 +89,32 @@ class InstallService(
         home = home,
       ),
     ).linkedPaths
+
+  private fun persistSuccessfulInstallSelection(plan: InstallPlan, result: InstallApplyResult) {
+    if (result.status == InstallApplyStatus.FAILURE) {
+      return
+    }
+    installSelectionPersistencePort.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(
+        installHome = plan.request.home,
+        selection = SharedInstallSelection(
+          selectedAgents = result.resolvedInstalledAgents.agents.ifEmpty {
+            plan.agents.mapTo(mutableSetOf()) { target -> target.agent }
+          },
+          platformPackSelection = persistedPlatformPackSelection(plan),
+          telemetryLevel = plan.telemetryLevel,
+          mcpRegistrationChoice = plan.request.mcpRegistrationChoice,
+        ),
+      ),
+    )
+  }
+
+  private fun persistedPlatformPackSelection(plan: InstallPlan): PlatformPackSelection = PlatformPackSelection(
+    mode = plan.request.platformPackSelection.mode,
+    selectedSlugs = if (plan.request.platformPackSelection.mode == PlatformPackSelectionMode.SELECTED) {
+      plan.selectedPlatformSlugs.toSet()
+    } else {
+      emptySet()
+    },
+  )
 }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestCommitProjectionTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestCommitProjectionTest.kt
@@ -48,6 +48,42 @@ class DecompositionManifestCommitProjectionTest {
     assertEquals(null, subtask.commitSha)
   }
 
+  @Test
+  fun `workflow-state projection keeps runtime commit sha out of git-tracked manifest`() {
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-commit-sha-file-projection")
+    val parentSpecPath = repoRoot.resolve(".feature-specs/SKILL-51-decomposition/spec.md")
+    val subtaskSpec = parentSpecPath.parent.resolve("spec_subtask_1_foundation.md")
+    Files.createDirectories(parentSpecPath.parent)
+    Files.writeString(parentSpecPath, "# Parent spec\n")
+    val initial = writeIfDecomposed(
+      DecompositionManifestWriteRequest(
+        repoRoot = repoRoot,
+        parentSpecPath = parentSpecPath,
+        planningResult = decompositionPlan(parentSpecPath, subtaskSpec),
+        baseBranch = "main",
+        featureBranch = "feature/SKILL-51-decomposition",
+      ),
+    )
+    assertNotNull(initial)
+    val runtimeManifest = initial.manifest.copy(
+      subtasks = initial.manifest.subtasks.map { subtask ->
+        subtask.copy(status = "complete", commitSha = "commit-subtask-1", workflowId = "wfl-subtask-1")
+      },
+    )
+
+    val result = writeProjectionFromWorkflowState(
+      repoRoot = repoRoot,
+      artifactsJson = durableRuntimeArtifactsJson(runtimeManifest, subtaskSpec),
+    )
+
+    assertNotNull(result)
+    val projected = result.manifest.subtasks.single { it.id == 1 }
+    assertEquals("complete", projected.status)
+    assertEquals(null, projected.commitSha)
+    val loaded = loadDecompositionManifest(result.manifestPath)
+    assertEquals(null, loaded.subtasks.single { it.id == 1 }.commitSha)
+  }
+
   private fun decompositionPlan(parentSpecPath: Path, subtaskSpec: Path): Map<String, Any?> = mapOf(
     "mode" to "decompose",
     "issue_key" to "SKILL-51",

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestWriterTest.kt
@@ -171,7 +171,7 @@ class DecompositionManifestWriterTest {
     assertNotNull(result)
     val subtask = result.manifest.subtasks.single { it.id == 1 }
     assertEquals("complete", subtask.status)
-    assertEquals("commit-subtask-1", subtask.commitSha)
+    assertEquals(null, subtask.commitSha)
     assertContains(Files.readString(subtaskSpec), "status: Complete")
   }
 
@@ -320,7 +320,7 @@ class DecompositionManifestWriterTest {
 
     assertNotNull(result)
     val subtask = result.manifest.subtasks.first()
-    assertEquals("abc123", subtask.commitSha)
+    assertEquals(null, subtask.commitSha)
     assertEquals("wfl-subtask-1", subtask.workflowId)
   }
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt
@@ -2,21 +2,37 @@ package skillbill.application
 
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallAgentDefaultTarget
+import skillbill.install.model.InstallAgentLinkStatus
 import skillbill.install.model.InstallAgentSelection
 import skillbill.install.model.InstallAgentSelectionMode
+import skillbill.install.model.InstallAgentSkillLinkOutcome
+import skillbill.install.model.InstallAgentTarget
+import skillbill.install.model.InstallAgentTargetSource
+import skillbill.install.model.InstallAppliedSkill
+import skillbill.install.model.InstallApplyIssue
+import skillbill.install.model.InstallApplyIssueKind
+import skillbill.install.model.InstallApplyResult
+import skillbill.install.model.InstallApplyStatus
 import skillbill.install.model.InstallPlanRequest
 import skillbill.install.model.InstallPlanSkill
 import skillbill.install.model.InstallPlanSkillKind
 import skillbill.install.model.InstallPlatformPackSnapshot
+import skillbill.install.model.InstallSkillStagingOutcome
+import skillbill.install.model.InstallSkillStagingStatus
 import skillbill.install.model.InstallStagingIntent
 import skillbill.install.model.InstallStagingPathIntent
+import skillbill.install.model.InstallTelemetryApplyOutcome
+import skillbill.install.model.InstallTelemetryApplyStatus
 import skillbill.install.model.InstallTelemetryLevel
 import skillbill.install.model.InstallationTargetPaths
 import skillbill.install.model.McpRegistrationChoice
+import skillbill.install.model.McpRegistrationIntent
 import skillbill.install.model.PlatformPackSelection
 import skillbill.install.model.PlatformPackSelectionMode
 import skillbill.install.model.RuntimeDistributionInputs
+import skillbill.install.model.WindowsSymlinkApplyOutcome
 import skillbill.install.model.WindowsSymlinkDecision
+import skillbill.install.model.WindowsSymlinkFallbackState
 import skillbill.install.model.WindowsSymlinkPreflight
 import skillbill.install.model.WindowsSymlinkPreflightState
 import skillbill.ports.install.apply.InstallApplyExecutionPort
@@ -35,6 +51,11 @@ import skillbill.ports.install.plan.model.InstallPlatformSkillMaterializationPor
 import skillbill.ports.install.plan.model.InstallPlatformSkillMaterializationPortResult
 import skillbill.ports.install.plan.model.InstallStagingIntentRequest
 import skillbill.ports.install.plan.model.InstallStagingIntentResult
+import skillbill.ports.install.selection.InstallSelectionPersistencePort
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionResult
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionResult
 import skillbill.scaffold.model.DeclaredFiles
 import skillbill.scaffold.model.PlatformManifest
 import skillbill.scaffold.model.RoutingSignals
@@ -57,11 +78,73 @@ class InstallServiceTest {
       stagingIntentPort = SnapshotAssertingStagingIntentPort(home, platformManifests),
       applyExecutionPort = UnsupportedApplyExecutionPort,
       skillLinkPort = UnsupportedSkillLinkPort,
+      installSelectionPersistencePort = NoopInstallSelectionPersistencePort,
     )
 
     service.planInstall(request)
 
     assertEquals(1, planningFactsPort.collectCallCount)
+  }
+
+  @Test
+  fun `apply install persists latest selection from successful resolved agents`() {
+    val repoRoot = Path.of("/tmp/skillbill-install-service-success-repo")
+    val home = Path.of("/tmp/skillbill-install-service-success-home")
+    val request = request(repoRoot, home)
+    val plan = installPlan(
+      request = request,
+      agents = listOf(
+        InstallAgentTarget(InstallAgent.CODEX, home.resolve(".codex/skills"), InstallAgentTargetSource.MANUAL),
+        InstallAgentTarget(InstallAgent.CLAUDE, home.resolve(".claude/commands"), InstallAgentTargetSource.MANUAL),
+      ),
+    )
+    val selectionPort = RecordingInstallSelectionPersistencePort()
+    val service = serviceForApply(
+      result = successfulApplyResult(plan, resolvedAgent = InstallAgent.CODEX),
+      selectionPort = selectionPort,
+    )
+
+    service.applyInstall(plan)
+
+    val write = selectionPort.writeRequests.single()
+    assertEquals(home, write.installHome)
+    assertEquals(setOf(InstallAgent.CODEX), write.selection.selectedAgents)
+    assertEquals(PlatformPackSelectionMode.ALL, write.selection.platformPackSelection.mode)
+    assertEquals(emptySet(), write.selection.platformPackSelection.selectedSlugs)
+    assertEquals(InstallTelemetryLevel.ANONYMOUS, write.selection.telemetryLevel)
+    assertEquals(request.mcpRegistrationChoice, write.selection.mcpRegistrationChoice)
+  }
+
+  @Test
+  fun `apply install falls back to planned agents when apply result has no resolved agents`() {
+    val repoRoot = Path.of("/tmp/skillbill-install-service-fallback-repo")
+    val home = Path.of("/tmp/skillbill-install-service-fallback-home")
+    val plan = installPlan(request(repoRoot, home))
+    val selectionPort = RecordingInstallSelectionPersistencePort()
+    val service = serviceForApply(
+      result = successfulApplyResult(plan, resolvedAgent = null),
+      selectionPort = selectionPort,
+    )
+
+    service.applyInstall(plan)
+
+    assertEquals(setOf(InstallAgent.CODEX), selectionPort.writeRequests.single().selection.selectedAgents)
+  }
+
+  @Test
+  fun `apply install does not persist failed selections`() {
+    val repoRoot = Path.of("/tmp/skillbill-install-service-failed-repo")
+    val home = Path.of("/tmp/skillbill-install-service-failed-home")
+    val plan = installPlan(request(repoRoot, home))
+    val selectionPort = RecordingInstallSelectionPersistencePort()
+    val service = serviceForApply(
+      result = failedApplyResult(plan),
+      selectionPort = selectionPort,
+    )
+
+    service.applyInstall(plan)
+
+    assertEquals(emptyList(), selectionPort.writeRequests)
   }
 
   private fun platformManifest(repoRoot: Path, slug: String): PlatformManifest = PlatformManifest(
@@ -98,6 +181,117 @@ class InstallServiceTest {
       state = WindowsSymlinkPreflightState.NOT_WINDOWS,
       decision = WindowsSymlinkDecision.NOT_REQUIRED,
     ),
+  )
+
+  private fun installPlan(
+    request: InstallPlanRequest,
+    agents: List<InstallAgentTarget> = listOf(
+      InstallAgentTarget(InstallAgent.CODEX, request.home.resolve(".codex/skills"), InstallAgentTargetSource.MANUAL),
+    ),
+  ): skillbill.install.model.InstallPlan = skillbill.install.model.InstallPlan(
+    request = request,
+    agents = agents,
+    discoveredPlatformPacks = emptyList(),
+    selectedPlatformSlugs = emptyList(),
+    skills = listOf(
+      InstallPlanSkill(
+        name = "bill-code-review",
+        sourceDir = request.repoRoot.resolve("skills/bill-code-review"),
+        kind = InstallPlanSkillKind.BASE,
+      ),
+    ),
+    staging = InstallStagingIntent(
+      root = request.home.resolve(".skill-bill/installed-skills"),
+      skillPaths = emptyList(),
+    ),
+    telemetryLevel = request.telemetryLevel,
+    mcpRegistrationIntent = McpRegistrationIntent(
+      register = request.mcpRegistrationChoice.register,
+      runtimeMcpBin = request.mcpRegistrationChoice.runtimeMcpBin,
+      agents = agents.map(InstallAgentTarget::agent),
+    ),
+    runtimeDistributionInputs = request.runtimeDistributionInputs,
+    installationTargetPaths = request.targetPaths,
+    windowsSymlinkPreflight = request.windowsSymlinkPreflight,
+  )
+
+  private fun serviceForApply(
+    result: InstallApplyResult,
+    selectionPort: InstallSelectionPersistencePort,
+  ): InstallService = InstallService(
+    planningFactsPort = UnsupportedPlanningFactsPort,
+    platformSkillMaterializationPort = UnsupportedPlatformSkillMaterializationPort,
+    stagingIntentPort = UnsupportedStagingIntentPort,
+    applyExecutionPort = StaticApplyExecutionPort(result),
+    skillLinkPort = UnsupportedSkillLinkPort,
+    installSelectionPersistencePort = selectionPort,
+  )
+
+  private fun successfulApplyResult(
+    plan: skillbill.install.model.InstallPlan,
+    resolvedAgent: InstallAgent?,
+  ): InstallApplyResult = InstallApplyResult(
+    status = InstallApplyStatus.SUCCESS,
+    skills = listOf(
+      InstallAppliedSkill(
+        skillName = "bill-code-review",
+        kind = InstallPlanSkillKind.BASE,
+        sourceDir = plan.request.repoRoot.resolve("skills/bill-code-review"),
+        staging = InstallSkillStagingOutcome(
+          status = InstallSkillStagingStatus.STAGED,
+          sourceDir = plan.request.repoRoot.resolve("skills/bill-code-review"),
+        ),
+        links = resolvedAgent?.let { agent ->
+          listOf(
+            InstallAgentSkillLinkOutcome(
+              agent = agent,
+              targetDir = plan.request.home.resolve(".codex/skills"),
+              linkPath = plan.request.home.resolve(".codex/skills/bill-code-review"),
+              linkTarget = plan.request.home.resolve(".skill-bill/installed-skills/bill-code-review"),
+              status = InstallAgentLinkStatus.CREATED,
+            ),
+          )
+        }.orEmpty(),
+      ),
+    ),
+    nativeAgents = emptyList(),
+    telemetryOutcome = InstallTelemetryApplyOutcome(
+      level = plan.telemetryLevel,
+      status = InstallTelemetryApplyStatus.SUCCESS,
+    ),
+    mcpRegistrationOutcomes = emptyList(),
+    warnings = emptyList(),
+    failures = emptyList(),
+    windowsSymlinkOutcome = WindowsSymlinkApplyOutcome(
+      preflight = plan.windowsSymlinkPreflight,
+      fallbackState = WindowsSymlinkFallbackState.NOT_REQUIRED,
+    ),
+    telemetryLevel = plan.telemetryLevel,
+    mcpRegistrationIntent = plan.mcpRegistrationIntent,
+  )
+
+  private fun failedApplyResult(plan: skillbill.install.model.InstallPlan): InstallApplyResult = InstallApplyResult(
+    status = InstallApplyStatus.FAILURE,
+    skills = emptyList(),
+    nativeAgents = emptyList(),
+    telemetryOutcome = InstallTelemetryApplyOutcome(
+      level = plan.telemetryLevel,
+      status = InstallTelemetryApplyStatus.SKIPPED,
+    ),
+    mcpRegistrationOutcomes = emptyList(),
+    warnings = emptyList(),
+    failures = listOf(
+      InstallApplyIssue(
+        kind = InstallApplyIssueKind.WINDOWS_SYMLINK_PRECHECK_FAILED,
+        message = "failed",
+      ),
+    ),
+    windowsSymlinkOutcome = WindowsSymlinkApplyOutcome(
+      preflight = plan.windowsSymlinkPreflight,
+      fallbackState = WindowsSymlinkFallbackState.USER_ACTION_REQUIRED,
+    ),
+    telemetryLevel = plan.telemetryLevel,
+    mcpRegistrationIntent = plan.mcpRegistrationIntent,
   )
 
   private class FakePlanningFactsPort(
@@ -185,5 +379,56 @@ class InstallServiceTest {
   private object UnsupportedSkillLinkPort : InstallSkillLinkPort {
     override fun linkSkill(request: InstallSkillLinkRequest): InstallSkillLinkResult =
       error("linkSkill is not part of this test")
+  }
+
+  private object UnsupportedPlanningFactsPort : InstallPlanningFactsPort {
+    override fun collectPlanningFacts(request: InstallPlanningFactsRequest): InstallPlanningFactsResult =
+      error("planInstall is not part of this test")
+  }
+
+  private object UnsupportedPlatformSkillMaterializationPort : InstallPlatformSkillMaterializationPort {
+    override fun materializePlatformSkills(
+      request: InstallPlatformSkillMaterializationPortRequest,
+    ): InstallPlatformSkillMaterializationPortResult = error("planInstall is not part of this test")
+  }
+
+  private object UnsupportedStagingIntentPort : InstallStagingIntentPort {
+    override fun buildStagingIntent(request: InstallStagingIntentRequest): InstallStagingIntentResult =
+      error("planInstall is not part of this test")
+  }
+
+  private object NoopInstallSelectionPersistencePort : InstallSelectionPersistencePort {
+    override fun readLatestSuccessfulSelection(
+      request: ReadLatestSuccessfulInstallSelectionRequest,
+    ): ReadLatestSuccessfulInstallSelectionResult = error("readLatestSuccessfulSelection is not part of this test")
+
+    override fun writeLatestSuccessfulSelection(
+      request: WriteLatestSuccessfulInstallSelectionRequest,
+    ): WriteLatestSuccessfulInstallSelectionResult =
+      WriteLatestSuccessfulInstallSelectionResult(request.installHome.resolve(".skill-bill/install-selection.json"))
+  }
+
+  private class RecordingInstallSelectionPersistencePort : InstallSelectionPersistencePort {
+    val writeRequests = mutableListOf<WriteLatestSuccessfulInstallSelectionRequest>()
+
+    override fun readLatestSuccessfulSelection(
+      request: ReadLatestSuccessfulInstallSelectionRequest,
+    ): ReadLatestSuccessfulInstallSelectionResult = error("readLatestSuccessfulSelection is not part of this test")
+
+    override fun writeLatestSuccessfulSelection(
+      request: WriteLatestSuccessfulInstallSelectionRequest,
+    ): WriteLatestSuccessfulInstallSelectionResult {
+      writeRequests += request
+      return WriteLatestSuccessfulInstallSelectionResult(
+        request.installHome.resolve(".skill-bill/install-selection.json"),
+      )
+    }
+  }
+
+  private class StaticApplyExecutionPort(
+    private val result: InstallApplyResult,
+  ) : InstallApplyExecutionPort {
+    override fun applyInstall(request: InstallApplyExecutionRequest): InstallApplyExecutionResult =
+      InstallApplyExecutionResult(result)
   }
 }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/InstallServiceTest.kt
@@ -132,6 +132,74 @@ class InstallServiceTest {
   }
 
   @Test
+  fun `apply install persists manual selected platforms and mcp opt out`() {
+    val repoRoot = Path.of("/tmp/skillbill-install-service-manual-repo")
+    val home = Path.of("/tmp/skillbill-install-service-manual-home")
+    val request = request(repoRoot, home).copy(
+      platformPackSelection = PlatformPackSelection(
+        mode = PlatformPackSelectionMode.SELECTED,
+        selectedSlugs = setOf("kotlin"),
+      ),
+      telemetryLevel = InstallTelemetryLevel.OFF,
+      mcpRegistrationChoice = McpRegistrationChoice(register = false, runtimeMcpBin = null),
+    )
+    val plan = installPlan(
+      request = request,
+      agents = listOf(
+        InstallAgentTarget(InstallAgent.CODEX, home.resolve(".codex/skills"), InstallAgentTargetSource.MANUAL),
+        InstallAgentTarget(InstallAgent.CLAUDE, home.resolve(".claude/commands"), InstallAgentTargetSource.MANUAL),
+      ),
+      selectedPlatformSlugs = listOf("kotlin"),
+    )
+    val selectionPort = RecordingInstallSelectionPersistencePort()
+    val service = serviceForApply(
+      result = successfulApplyResult(plan, resolvedAgent = null),
+      selectionPort = selectionPort,
+    )
+
+    service.applyInstall(plan)
+
+    val selection = selectionPort.writeRequests.single().selection
+    assertEquals(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX), selection.selectedAgents)
+    assertEquals(PlatformPackSelectionMode.SELECTED, selection.platformPackSelection.mode)
+    assertEquals(setOf("kotlin"), selection.platformPackSelection.selectedSlugs)
+    assertEquals(InstallTelemetryLevel.OFF, selection.telemetryLevel)
+    assertEquals(McpRegistrationChoice(register = false, runtimeMcpBin = null), selection.mcpRegistrationChoice)
+  }
+
+  @Test
+  fun `apply install persists detected planned agents when result has no resolved agents`() {
+    val repoRoot = Path.of("/tmp/skillbill-install-service-detected-repo")
+    val home = Path.of("/tmp/skillbill-install-service-detected-home")
+    val request = request(repoRoot, home).copy(
+      agentSelection = InstallAgentSelection(mode = InstallAgentSelectionMode.DETECTED),
+    )
+    val plan = installPlan(
+      request = request,
+      agents = listOf(
+        InstallAgentTarget(InstallAgent.CLAUDE, home.resolve(".claude/commands"), InstallAgentTargetSource.DETECTED),
+        InstallAgentTarget(
+          InstallAgent.OPENCODE,
+          home.resolve(".config/opencode/skills"),
+          InstallAgentTargetSource.DETECTED,
+        ),
+      ),
+    )
+    val selectionPort = RecordingInstallSelectionPersistencePort()
+    val service = serviceForApply(
+      result = successfulApplyResult(plan, resolvedAgent = null),
+      selectionPort = selectionPort,
+    )
+
+    service.applyInstall(plan)
+
+    assertEquals(
+      setOf(InstallAgent.CLAUDE, InstallAgent.OPENCODE),
+      selectionPort.writeRequests.single().selection.selectedAgents,
+    )
+  }
+
+  @Test
   fun `apply install does not persist failed selections`() {
     val repoRoot = Path.of("/tmp/skillbill-install-service-failed-repo")
     val home = Path.of("/tmp/skillbill-install-service-failed-home")
@@ -188,11 +256,12 @@ class InstallServiceTest {
     agents: List<InstallAgentTarget> = listOf(
       InstallAgentTarget(InstallAgent.CODEX, request.home.resolve(".codex/skills"), InstallAgentTargetSource.MANUAL),
     ),
+    selectedPlatformSlugs: List<String> = emptyList(),
   ): skillbill.install.model.InstallPlan = skillbill.install.model.InstallPlan(
     request = request,
     agents = agents,
     discoveredPlatformPacks = emptyList(),
-    selectedPlatformSlugs = emptyList(),
+    selectedPlatformSlugs = selectedPlatformSlugs,
     skills = listOf(
       InstallPlanSkill(
         name = "bill-code-review",

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
@@ -155,6 +155,14 @@ class CliInstallPlanApplyRuntimeTest {
     assertEquals(false, mcp["register"])
     assertEquals(supportedAgents, (mcp["agents"] as List<*>).toSet())
     assertTrue(mcp.listOfMaps("outcomes").all { outcome -> outcome["status"] == "skipped" })
+
+    val selection = readInstallSelection(fixture.home)
+    assertEquals(supportedAgents, (selection["selected_agents"] as List<*>).toSet())
+    assertEquals("none", selection.mapValue("platform_pack_selection")["mode"])
+    assertEquals(emptyList<String>(), selection.mapValue("platform_pack_selection")["selected_slugs"])
+    assertEquals("anonymous", selection["telemetry_level"])
+    assertEquals(false, selection.mapValue("mcp_registration")["register"])
+    assertEquals(null, selection.mapValue("mcp_registration")["runtime_mcp_bin"])
   }
 
   @Test
@@ -251,6 +259,25 @@ class CliInstallPlanApplyRuntimeTest {
   }
 
   @Test
+  fun `install apply persists detected agents platform packs telemetry and mcp choice`() {
+    val fixture = installPlanApplyFixture()
+    createDetectedAgentHomes(fixture.home)
+
+    val result = CliRuntime.run(detectedApplyArguments(fixture), CliRuntimeContext(userHome = fixture.home))
+
+    assertEquals(0, result.exitCode, result.stdout)
+    val selection = readInstallSelection(fixture.home)
+    assertEquals(supportedAgents, (selection["selected_agents"] as List<*>).toSet())
+    val platformSelection = selection.mapValue("platform_pack_selection")
+    assertEquals("all", platformSelection["mode"])
+    assertEquals(emptyList<String>(), platformSelection["selected_slugs"])
+    assertEquals("off", selection["telemetry_level"])
+    val mcp = selection.mapValue("mcp_registration")
+    assertEquals(false, mcp["register"])
+    assertEquals(null, mcp["runtime_mcp_bin"])
+  }
+
+  @Test
   fun `install apply parses replace existing flag and removes legacy managed targets`() {
     val fixture = installPlanApplyFixture()
     val targetDir = fixture.home.resolve("manual-targets/codex")
@@ -300,6 +327,7 @@ class CliInstallPlanApplyRuntimeTest {
       "Windows requires elevation or Developer Mode before symlink install.",
       failures.single()["message"],
     )
+    assertFalse(Files.exists(installSelectionPath(fixture.home)))
   }
 
   @Test
@@ -467,6 +495,23 @@ class CliInstallPlanApplyRuntimeTest {
     "all",
     "--telemetry",
     telemetry,
+    "--mcp",
+    "skip",
+    "--format",
+    "json",
+  )
+
+  private fun detectedApplyArguments(fixture: InstallPlanApplyFixture): List<String> = listOf(
+    "install",
+    "apply",
+    "--repo-root",
+    fixture.repoRoot.toString(),
+    "--agent-mode",
+    "detected",
+    "--platform-mode",
+    "all",
+    "--telemetry",
+    "off",
     "--mcp",
     "skip",
     "--format",
@@ -728,6 +773,11 @@ private data class InstallPlanApplyFixture(
 private fun decodeInstallPlanApplyJson(rawJson: String): Map<String, Any?> =
   JsonSupport.anyToStringAnyMap(JsonSupport.parseObjectOrNull(rawJson)?.let(JsonSupport::jsonElementToValue))
     ?: emptyMap()
+
+private fun readInstallSelection(home: Path): Map<String, Any?> =
+  decodeInstallPlanApplyJson(Files.readString(installSelectionPath(home)))
+
+private fun installSelectionPath(home: Path): Path = home.resolve(".skill-bill/install-selection.json")
 
 private fun singleCodexPlanGoldenPayload(fixture: InstallPlanApplyFixture): Map<String, Any?> {
   val paths = SingleCodexGoldenPaths(fixture)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
@@ -278,6 +278,28 @@ class CliInstallPlanApplyRuntimeTest {
   }
 
   @Test
+  fun `install apply persists manual selected platforms and mcp registration choice`() {
+    val fixture = installPlanApplyFixture()
+    val runtimeMcpBin = fixture.home.resolve(".skill-bill/runtime/runtime-mcp/bin/runtime-mcp")
+
+    val result = CliRuntime.run(
+      manualSelectedPlatformRegisterMcpApplyArguments(fixture, runtimeMcpBin),
+      CliRuntimeContext(userHome = fixture.home),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    val selection = readInstallSelection(fixture.home)
+    assertEquals(setOf("codex"), (selection["selected_agents"] as List<*>).toSet())
+    val platformSelection = selection.mapValue("platform_pack_selection")
+    assertEquals("selected", platformSelection["mode"])
+    assertEquals(listOf("kotlin"), platformSelection["selected_slugs"])
+    assertEquals("full", selection["telemetry_level"])
+    val mcp = selection.mapValue("mcp_registration")
+    assertEquals(true, mcp["register"])
+    assertEquals(runtimeMcpBin.toString(), mcp["runtime_mcp_bin"])
+  }
+
+  @Test
   fun `install apply parses replace existing flag and removes legacy managed targets`() {
     val fixture = installPlanApplyFixture()
     val targetDir = fixture.home.resolve("manual-targets/codex")
@@ -514,6 +536,34 @@ class CliInstallPlanApplyRuntimeTest {
     "off",
     "--mcp",
     "skip",
+    "--format",
+    "json",
+  )
+
+  private fun manualSelectedPlatformRegisterMcpApplyArguments(
+    fixture: InstallPlanApplyFixture,
+    runtimeMcpBin: Path,
+  ): List<String> = listOf(
+    "install",
+    "apply",
+    "--repo-root",
+    fixture.repoRoot.toString(),
+    "--agent-mode",
+    "manual",
+    "--agent",
+    "codex",
+    "--agent-target",
+    "codex=${fixture.home.resolve("manual-targets/codex")}",
+    "--platform-mode",
+    "selected",
+    "--platform",
+    "kotlin",
+    "--telemetry",
+    "full",
+    "--mcp",
+    "register",
+    "--runtime-mcp-bin",
+    runtimeMcpBin.toString(),
     "--format",
     "json",
   )

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
@@ -111,6 +111,31 @@ class InvalidTelemetryEventSchemaError(
   cause,
 )
 
+class MissingInstallSelectionRecordError(
+  val path: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(
+  "Install selection record is missing at '${path.ifBlank { "<unknown>" }}'.",
+  cause,
+)
+
+class UnreadableInstallSelectionRecordError(
+  val path: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(
+  "Install selection record at '${path.ifBlank { "<unknown>" }}' cannot be read.",
+  cause,
+)
+
+class MalformedInstallSelectionRecordError(
+  val path: String,
+  val reason: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(
+  "Install selection record at '${path.ifBlank { "<unknown>" }}' is malformed: $reason",
+  cause,
+)
+
 class ContractVersionMismatchError(
   message: String,
   cause: Throwable? = null,

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -27,6 +27,7 @@ import skillbill.infrastructure.fs.FileSystemInstallMcpRegistration
 import skillbill.infrastructure.fs.FileSystemInstallNativeAgentLinks
 import skillbill.infrastructure.fs.FileSystemInstallPlanningFacts
 import skillbill.infrastructure.fs.FileSystemInstallPlatformSkillMaterialization
+import skillbill.infrastructure.fs.FileSystemInstallSelectionPersistence
 import skillbill.infrastructure.fs.FileSystemInstallSkillLink
 import skillbill.infrastructure.fs.FileSystemInstallStagingIntent
 import skillbill.infrastructure.fs.FileSystemRepoSourceDiscoveryGateway
@@ -55,6 +56,7 @@ import skillbill.ports.install.nativeagent.InstallNativeAgentLinkPort
 import skillbill.ports.install.plan.InstallPlanningFactsPort
 import skillbill.ports.install.plan.InstallPlatformSkillMaterializationPort
 import skillbill.ports.install.plan.InstallStagingIntentPort
+import skillbill.ports.install.selection.InstallSelectionPersistencePort
 import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.review.ReviewInputSource
 import skillbill.ports.scaffold.RepoSourceDiscoveryGateway
@@ -169,6 +171,12 @@ abstract class RuntimeComponent(
 
   @Provides
   @JvmSynthetic
+  internal fun installSelectionPersistencePort(
+    adapter: FileSystemInstallSelectionPersistence,
+  ): InstallSelectionPersistencePort = adapter
+
+  @Provides
+  @JvmSynthetic
   internal fun scaffoldGateway(gateway: FileSystemScaffoldGateway): ScaffoldGateway = gateway
 
   // SKILL-52.1 subtask 2: typed capability ports for the scaffold pipeline. These are wired
@@ -239,6 +247,7 @@ abstract class RuntimeComponent(
 
   abstract val installService: InstallService
   abstract val installAgentService: InstallAgentService
+  abstract val installSelectionPersistencePort: InstallSelectionPersistencePort
   abstract val learningService: LearningService
   abstract val lifecycleTelemetryService: LifecycleTelemetryService
   abstract val mcpRegistrationService: McpRegistrationService

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -496,7 +496,7 @@ class ApplicationPersistencePortTest {
 
     val manifest = loadTestDecompositionManifest(parentSpec.parent.resolve("decomposition-manifest.yaml"))
     assertEquals(2, continued.decompositionSubtaskId)
-    assertEquals("abc123", manifest.subtasks.first { it.id == 1 }.commitSha)
+    assertEquals(null, manifest.subtasks.first { it.id == 1 }.commitSha)
     assertEquals(listOf("SKILL-51 subtask 1: foundation"), git.commits)
   }
 
@@ -525,7 +525,7 @@ class ApplicationPersistencePortTest {
     assertEquals("complete", done.decompositionStatus)
     assertEquals("complete", manifest.status)
     assertTrue(manifest.subtasks.all { it.status == "complete" })
-    assertTrue(manifest.subtasks.all { it.commitSha == "abc123" })
+    assertTrue(manifest.subtasks.all { it.commitSha == null })
     assertEquals(listOf("SKILL-51 subtask 1: foundation", "SKILL-51 subtask 2: runtime"), git.commits)
     assertEquals("Complete", statusLine(parentSpec))
     assertEquals("Complete", statusSection(parentSpec))

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/DecompositionManifestArchitectureTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/DecompositionManifestArchitectureTest.kt
@@ -95,7 +95,35 @@ class DecompositionManifestArchitectureTest {
     assertTrue(violations.isEmpty(), violations.joinToString(separator = "\n"))
   }
 
+  @Test
+  fun `tracked decomposition manifests omit runtime result payloads`() {
+    val repoRoot = runtimeRoot.parent
+    val featureSpecRoot = repoRoot.resolve(".feature-specs")
+    val manifests = if (Files.isDirectory(featureSpecRoot)) {
+      Files.walk(featureSpecRoot).use { paths ->
+        paths
+          .filter { path -> path.isRegularFile() && path.fileName.toString() == "decomposition-manifest.yaml" }
+          .toList()
+      }
+    } else {
+      emptyList()
+    }
+
+    assertTrue(manifests.isNotEmpty(), "Expected at least one tracked decomposition manifest fixture.")
+    manifests.forEach { manifest ->
+      val text = Files.readString(manifest)
+      resultPayloadKeys.forEach { key ->
+        assertFalse(
+          Regex("""(?m)^\s+$key:""").containsMatchIn(text),
+          "${repoRoot.relativize(manifest)} must not contain git-tracked $key payloads",
+        )
+      }
+    }
+  }
+
   private companion object {
+    val resultPayloadKeys = listOf("review_result", "audit_result", "validation_result")
+
     val decompositionRuntimeEmissionPatterns =
       listOf(
         Regex("""DECOMPOSITION_RUNTIME_ARTIFACT_KEY\s+to[\s\S]*?(?=,\s*(?:"|\w+\s+to)|\n\s*\)|\z)"""),

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallSelectionRuntimeBoundaryTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallSelectionRuntimeBoundaryTest.kt
@@ -1,0 +1,70 @@
+package skillbill.architecture
+
+import skillbill.di.RuntimeComponent
+import skillbill.di.create
+import skillbill.error.MissingInstallSelectionRecordError
+import skillbill.model.RuntimeContext
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InstallSelectionRuntimeBoundaryTest {
+  private val runtimeRoot: Path =
+    Path.of("").toAbsolutePath().normalize().let { workingDir ->
+      if (workingDir.fileName.toString().startsWith("runtime-")) {
+        workingDir.parent
+      } else {
+        workingDir
+      }
+    }
+
+  @Test
+  fun `runtime component exposes shared install selection persistence port`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-di")
+    val component = RuntimeComponent::class.create(RuntimeContext(environment = emptyMap(), userHome = home))
+
+    assertFailsWith<MissingInstallSelectionRecordError> {
+      component.installSelectionPersistencePort.readLatestSuccessfulSelection(
+        ReadLatestSuccessfulInstallSelectionRequest(home),
+      )
+    }
+  }
+
+  @Test
+  fun `shared install selection runtime layers do not depend on runtime desktop`() {
+    listOf("runtime-domain", "runtime-ports", "runtime-infra-fs", "runtime-core").forEach { moduleName ->
+      val buildFile = Files.readString(runtimeRoot.resolve("$moduleName/build.gradle.kts"))
+      assertFalse(
+        buildFile.contains("project(\":runtime-desktop"),
+        "$moduleName must not depend on runtime-desktop modules",
+      )
+      assertTrue(
+        sourceFiles(moduleName).flatMap(::imports).none { importedName ->
+          importedName.startsWith("skillbill.desktop")
+        },
+        "$moduleName must not import desktop-only packages",
+      )
+    }
+  }
+
+  private fun sourceFiles(moduleName: String): List<String> {
+    val sourceRoot = runtimeRoot.resolve("$moduleName/src/main/kotlin")
+    return Files.walk(sourceRoot).use { stream ->
+      stream
+        .filter { path -> Files.isRegularFile(path) && path.fileName.toString().endsWith(".kt") }
+        .map(Files::readString)
+        .toList()
+    }
+  }
+
+  private fun imports(source: String): List<String> =
+    importPattern.findAll(source).map { match -> match.groupValues[1].substringBefore(" as ") }.toList()
+
+  private companion object {
+    val importPattern: Regex = Regex("^import\\s+([A-Za-z0-9_.*]+)", RegexOption.MULTILINE)
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -45,6 +45,8 @@ class InstallerShellDelegationTest {
     assertFalse(installScript.contains("install link-opencode-agents"))
     assertFalse(installScript.contains("install link-junie-agents"))
     assertFalse(installScript.contains("telemetry set-level"))
+    assertFalse(installScript.contains("install-selection.json"))
+    assertFalse(installScript.contains("firstRun."))
   }
 
   @Test

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/RuntimeGradleModuleLayeringTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/RuntimeGradleModuleLayeringTest.kt
@@ -81,6 +81,35 @@ class RuntimeGradleModuleLayeringTest {
   }
 
   @Test
+  fun `non desktop runtime modules do not import desktop packages`() {
+    val violations = declaredSettingsModules()
+      .filter { moduleName -> moduleName.startsWith("runtime-") && !moduleName.startsWith("runtime-desktop") }
+      .flatMap { moduleName ->
+        val sourceRoot = runtimeRoot.resolve("${moduleName.replace(':', '/')}/src/main/kotlin")
+        if (!Files.isDirectory(sourceRoot)) {
+          emptyList()
+        } else {
+          Files.walk(sourceRoot).use { paths ->
+            paths
+              .filter { path -> Files.isRegularFile(path) && path.fileName.toString().endsWith(".kt") }
+              .flatMap { path ->
+                val text = Files.readString(path)
+                importPattern.findAll(text)
+                  .map { match -> match.groupValues[1].substringBefore(" as ") }
+                  .filter { importedName -> importedName.startsWith("skillbill.desktop") }
+                  .map { importedName -> "${runtimeRoot.relativize(path)} imports $importedName" }
+                  .toList()
+                  .stream()
+              }
+              .toList()
+          }
+        }
+      }
+
+    assertTrue(violations.isEmpty(), violations.joinToString(separator = "\n"))
+  }
+
+  @Test
   fun `desktop starter modules keep app core and feature dependency direction`() {
     assertNoProjectDependencies(
       "runtime-desktop",
@@ -166,5 +195,9 @@ class RuntimeGradleModuleLayeringTest {
       violations.isEmpty(),
       "$moduleName has banned project dependencies: ${violations.joinToString()}",
     )
+  }
+
+  private companion object {
+    val importPattern: Regex = Regex("^import\\s+([A-Za-z0-9_.*]+)", RegexOption.MULTILINE)
   }
 }

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt
@@ -12,6 +12,7 @@ import skillbill.desktop.core.common.di.UserScope
 import skillbill.di.RuntimeComponent
 import skillbill.di.create
 import skillbill.model.RuntimeContext
+import skillbill.ports.install.selection.InstallSelectionPersistencePort
 import skillbill.ports.telemetry.TelemetryLevelMutator
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import java.nio.file.Path
@@ -54,6 +55,7 @@ class DesktopRuntimeApplicationServices {
 internal data class DesktopRuntimeInstallServices(
   val installService: InstallService,
   val installAgentService: InstallAgentService,
+  val installSelectionPersistencePort: InstallSelectionPersistencePort,
   val telemetryLevelMutator: TelemetryLevelMutator,
 ) {
   companion object {
@@ -62,6 +64,7 @@ internal data class DesktopRuntimeInstallServices(
       return DesktopRuntimeInstallServices(
         installService = component.installService,
         installAgentService = component.installAgentService,
+        installSelectionPersistencePort = component.installSelectionPersistencePort,
         telemetryLevelMutator = component.telemetryLevelMutator,
       )
     }

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGateway.kt
@@ -15,11 +15,13 @@ import skillbill.desktop.core.domain.model.FirstRunInstallPlanHandle
 import skillbill.desktop.core.domain.model.FirstRunInstallStatus
 import skillbill.desktop.core.domain.model.FirstRunPlanResult
 import skillbill.desktop.core.domain.model.FirstRunPlatformPackOption
+import skillbill.desktop.core.domain.model.FirstRunPlatformSelectionMode
 import skillbill.desktop.core.domain.model.FirstRunSetupAgent
 import skillbill.desktop.core.domain.model.FirstRunSetupDiscovery
 import skillbill.desktop.core.domain.model.FirstRunSetupRequest
 import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
 import skillbill.desktop.core.domain.service.DesktopFirstRunGateway
+import skillbill.error.MissingInstallSelectionRecordError
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallAgentSelection
 import skillbill.install.model.InstallAgentSelectionMode
@@ -35,9 +37,12 @@ import skillbill.install.model.McpRegistrationChoice
 import skillbill.install.model.PlatformPackSelection
 import skillbill.install.model.PlatformPackSelectionMode
 import skillbill.install.model.RuntimeDistributionInputs
+import skillbill.install.model.SharedInstallSelection
 import skillbill.install.model.WindowsSymlinkDecision
 import skillbill.install.model.WindowsSymlinkPreflight
 import skillbill.install.model.WindowsSymlinkPreflightState
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionRequest
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import java.nio.file.Files
 import java.nio.file.LinkOption
@@ -61,6 +66,9 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
   ) -> List<skillbill.install.model.AgentTarget> = { home ->
     DesktopRuntimeInstallServices.forHome(home).installAgentService.detectAgentTargets(home)
   }
+  internal var latestReusableSetupRequest: (Path, FirstRunSetupRequest?) -> FirstRunSetupRequest? = { home, legacy ->
+    latestSharedSetupRequest(home, legacy)
+  }
 
   override fun hasExistingInstall(): Boolean = runCatching {
     val stagingRoot = homeProvider()
@@ -79,6 +87,9 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
       }
     }
   }.getOrDefault(false)
+
+  override fun latestReusableSetupRequest(legacyFallback: FirstRunSetupRequest?): FirstRunSetupRequest? =
+    latestReusableSetupRequest(homeProvider().toAbsolutePath().normalize(), legacyFallback)
 
   override suspend fun discoverSetup(): FirstRunDiscoveryResult = try {
     val home = homeProvider().toAbsolutePath().normalize()
@@ -192,12 +203,12 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
         manualAgents = selectedAgents,
       ),
       platformPackSelection = PlatformPackSelection(
-        mode = if (request.selectedPlatformSlugs.isEmpty()) {
-          PlatformPackSelectionMode.NONE
+        mode = request.platformSelectionMode.toPlatformPackSelectionMode(),
+        selectedSlugs = if (request.platformSelectionMode == FirstRunPlatformSelectionMode.SELECTED) {
+          request.selectedPlatformSlugs
         } else {
-          PlatformPackSelectionMode.SELECTED
+          emptySet()
         },
-        selectedSlugs = request.selectedPlatformSlugs,
       ),
       telemetryLevel = request.telemetryLevel.toInstallTelemetryLevel(),
       mcpRegistrationChoice = McpRegistrationChoice(
@@ -221,6 +232,25 @@ class JvmDesktopFirstRunGateway : DesktopFirstRunGateway {
   }
 }
 
+private fun latestSharedSetupRequest(home: Path, legacyFallback: FirstRunSetupRequest?): FirstRunSetupRequest? {
+  val services = DesktopRuntimeInstallServices.forHome(home)
+  return try {
+    services.installSelectionPersistencePort
+      .readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
+      .selection
+      .toFirstRunSetupRequest()
+  } catch (_: MissingInstallSelectionRecordError) {
+    legacyFallback?.takeIf { fallback -> fallback.selectedAgentIds.isNotEmpty() }?.also { fallback ->
+      services.installSelectionPersistencePort.writeLatestSuccessfulSelection(
+        WriteLatestSuccessfulInstallSelectionRequest(
+          installHome = home,
+          selection = fallback.toSharedInstallSelection(),
+        ),
+      )
+    }
+  }
+}
+
 private data class RuntimeInstallPlanHandle(val plan: InstallPlan) : FirstRunInstallPlanHandle
 
 private fun FirstRunTelemetryLevel.toInstallTelemetryLevel(): InstallTelemetryLevel = when (this) {
@@ -228,6 +258,46 @@ private fun FirstRunTelemetryLevel.toInstallTelemetryLevel(): InstallTelemetryLe
   FirstRunTelemetryLevel.FULL -> InstallTelemetryLevel.FULL
   FirstRunTelemetryLevel.OFF -> InstallTelemetryLevel.OFF
 }
+
+private fun InstallTelemetryLevel.toFirstRunTelemetryLevel(): FirstRunTelemetryLevel = when (this) {
+  InstallTelemetryLevel.ANONYMOUS -> FirstRunTelemetryLevel.ANONYMOUS
+  InstallTelemetryLevel.FULL -> FirstRunTelemetryLevel.FULL
+  InstallTelemetryLevel.OFF -> FirstRunTelemetryLevel.OFF
+}
+
+private fun FirstRunPlatformSelectionMode.toPlatformPackSelectionMode(): PlatformPackSelectionMode = when (this) {
+  FirstRunPlatformSelectionMode.NONE -> PlatformPackSelectionMode.NONE
+  FirstRunPlatformSelectionMode.SELECTED -> PlatformPackSelectionMode.SELECTED
+  FirstRunPlatformSelectionMode.ALL -> PlatformPackSelectionMode.ALL
+}
+
+private fun PlatformPackSelectionMode.toFirstRunPlatformSelectionMode(): FirstRunPlatformSelectionMode = when (this) {
+  PlatformPackSelectionMode.NONE -> FirstRunPlatformSelectionMode.NONE
+  PlatformPackSelectionMode.SELECTED -> FirstRunPlatformSelectionMode.SELECTED
+  PlatformPackSelectionMode.ALL -> FirstRunPlatformSelectionMode.ALL
+}
+
+private fun SharedInstallSelection.toFirstRunSetupRequest(): FirstRunSetupRequest = FirstRunSetupRequest(
+  selectedAgentIds = selectedAgents.mapTo(mutableSetOf(), InstallAgent::id),
+  selectedPlatformSlugs = platformPackSelection.selectedSlugs,
+  telemetryLevel = telemetryLevel.toFirstRunTelemetryLevel(),
+  registerMcp = mcpRegistrationChoice.register,
+  platformSelectionMode = platformPackSelection.mode.toFirstRunPlatformSelectionMode(),
+)
+
+private fun FirstRunSetupRequest.toSharedInstallSelection(): SharedInstallSelection = SharedInstallSelection(
+  selectedAgents = selectedAgentIds.mapTo(mutableSetOf(), InstallAgent::fromId),
+  platformPackSelection = PlatformPackSelection(
+    mode = platformSelectionMode.toPlatformPackSelectionMode(),
+    selectedSlugs = if (platformSelectionMode == FirstRunPlatformSelectionMode.SELECTED) {
+      selectedPlatformSlugs
+    } else {
+      emptySet()
+    },
+  ),
+  telemetryLevel = telemetryLevel.toInstallTelemetryLevel(),
+  mcpRegistrationChoice = McpRegistrationChoice(register = registerMcp),
+)
 
 private fun InstallPlan.toFirstRunPlan(): FirstRunInstallPlan = FirstRunInstallPlan(
   handle = RuntimeInstallPlanHandle(this),

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
@@ -110,6 +110,44 @@ class JvmDesktopFirstRunGatewayTest {
   }
 
   @Test
+  fun `latest reusable setup request prefers shared selection over legacy fallback`() {
+    val home = Files.createTempDirectory("skillbill-first-run-shared-before-legacy")
+    val store = FileSystemInstallSelectionPersistence()
+    store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(
+        installHome = home,
+        selection = SharedInstallSelection(
+          selectedAgents = setOf(InstallAgent.OPENCODE),
+          platformPackSelection = PlatformPackSelection(mode = PlatformPackSelectionMode.ALL),
+          telemetryLevel = InstallTelemetryLevel.OFF,
+          mcpRegistrationChoice = McpRegistrationChoice(register = false),
+        ),
+      ),
+    )
+    val legacy = FirstRunSetupRequest(
+      selectedAgentIds = setOf("codex"),
+      selectedPlatformSlugs = setOf("kotlin"),
+      telemetryLevel = FirstRunTelemetryLevel.FULL,
+      registerMcp = true,
+    )
+    val gateway = JvmDesktopFirstRunGateway().apply {
+      homeProvider = { home }
+    }
+
+    val request = gateway.latestReusableSetupRequest(legacy)
+    val persisted = store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home)).selection
+
+    assertEquals(setOf("opencode"), request?.selectedAgentIds)
+    assertEquals(emptySet(), request?.selectedPlatformSlugs)
+    assertEquals(FirstRunPlatformSelectionMode.ALL, request?.platformSelectionMode)
+    assertEquals(FirstRunTelemetryLevel.OFF, request?.telemetryLevel)
+    assertFalse(request?.registerMcp ?: true)
+    assertEquals(setOf(InstallAgent.OPENCODE), persisted.selectedAgents)
+    assertEquals(PlatformPackSelectionMode.ALL, persisted.platformPackSelection.mode)
+    assertFalse(persisted.mcpRegistrationChoice.register)
+  }
+
+  @Test
   fun `latest reusable setup request migrates legacy fallback into shared store`() {
     val home = Files.createTempDirectory("skillbill-first-run-legacy-selection")
     val legacy = FirstRunSetupRequest(

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
@@ -4,8 +4,10 @@ import kotlinx.coroutines.runBlocking
 import skillbill.desktop.core.domain.model.FirstRunApplyResult
 import skillbill.desktop.core.domain.model.FirstRunInstallStatus
 import skillbill.desktop.core.domain.model.FirstRunPlanResult
+import skillbill.desktop.core.domain.model.FirstRunPlatformSelectionMode
 import skillbill.desktop.core.domain.model.FirstRunSetupRequest
 import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
+import skillbill.infrastructure.fs.FileSystemInstallSelectionPersistence
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallAgentSelectionMode
 import skillbill.install.model.InstallAgentTarget
@@ -24,15 +26,22 @@ import skillbill.install.model.InstallSkillStagingStatus
 import skillbill.install.model.InstallStagingIntent
 import skillbill.install.model.InstallTelemetryApplyOutcome
 import skillbill.install.model.InstallTelemetryApplyStatus
+import skillbill.install.model.InstallTelemetryLevel
 import skillbill.install.model.McpRegistrationApplyOutcome
 import skillbill.install.model.McpRegistrationApplyStatus
+import skillbill.install.model.McpRegistrationChoice
 import skillbill.install.model.McpRegistrationIntent
 import skillbill.install.model.NativeAgentApplyOutcome
 import skillbill.install.model.NativeAgentApplyStatus
 import skillbill.install.model.NativeAgentProviderId
 import skillbill.install.model.PlannedPlatformPack
+import skillbill.install.model.PlatformPackSelection
+import skillbill.install.model.PlatformPackSelectionMode
+import skillbill.install.model.SharedInstallSelection
 import skillbill.install.model.WindowsSymlinkApplyOutcome
 import skillbill.install.model.WindowsSymlinkFallbackState
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionRequest
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -68,6 +77,61 @@ class JvmDesktopFirstRunGatewayTest {
     }
 
     assertFalse(gateway.hasExistingInstall())
+  }
+
+  @Test
+  fun `latest reusable setup request reads shared install selection`() {
+    val home = Files.createTempDirectory("skillbill-first-run-shared-selection")
+    FileSystemInstallSelectionPersistence().writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(
+        installHome = home,
+        selection = SharedInstallSelection(
+          selectedAgents = setOf(InstallAgent.CLAUDE, InstallAgent.CODEX),
+          platformPackSelection = PlatformPackSelection(
+            mode = PlatformPackSelectionMode.SELECTED,
+            selectedSlugs = setOf("kotlin"),
+          ),
+          telemetryLevel = InstallTelemetryLevel.FULL,
+          mcpRegistrationChoice = McpRegistrationChoice(register = false),
+        ),
+      ),
+    )
+    val gateway = JvmDesktopFirstRunGateway().apply {
+      homeProvider = { home }
+    }
+
+    val request = gateway.latestReusableSetupRequest()
+
+    assertEquals(setOf("claude", "codex"), request?.selectedAgentIds)
+    assertEquals(setOf("kotlin"), request?.selectedPlatformSlugs)
+    assertEquals(FirstRunPlatformSelectionMode.SELECTED, request?.platformSelectionMode)
+    assertEquals(FirstRunTelemetryLevel.FULL, request?.telemetryLevel)
+    assertFalse(request?.registerMcp ?: true)
+  }
+
+  @Test
+  fun `latest reusable setup request migrates legacy fallback into shared store`() {
+    val home = Files.createTempDirectory("skillbill-first-run-legacy-selection")
+    val legacy = FirstRunSetupRequest(
+      selectedAgentIds = setOf("codex"),
+      selectedPlatformSlugs = setOf("kotlin"),
+      telemetryLevel = FirstRunTelemetryLevel.OFF,
+      registerMcp = false,
+    )
+    val store = FileSystemInstallSelectionPersistence()
+    val gateway = JvmDesktopFirstRunGateway().apply {
+      homeProvider = { home }
+    }
+
+    val request = gateway.latestReusableSetupRequest(legacy)
+    val migrated = store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home)).selection
+
+    assertEquals(legacy, request)
+    assertEquals(setOf(InstallAgent.CODEX), migrated.selectedAgents)
+    assertEquals(PlatformPackSelectionMode.SELECTED, migrated.platformPackSelection.mode)
+    assertEquals(setOf("kotlin"), migrated.platformPackSelection.selectedSlugs)
+    assertEquals(InstallTelemetryLevel.OFF, migrated.telemetryLevel)
+    assertFalse(migrated.mcpRegistrationChoice.register)
   }
 
   @Test

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
@@ -75,12 +75,13 @@ class LocalDesktopPreferenceStore : DesktopPreferenceStore {
   )
 
   private fun persistFirstRunPreferences(preferences: DesktopFirstRunPreferences) {
+    val persistedPreferences = DesktopFirstRunPreferences(completed = preferences.completed)
     properties.setProperty(KEY_FIRST_RUN_COMPLETED, preferences.completed.toString())
     properties.remove(KEY_FIRST_RUN_AGENTS)
     properties.remove(KEY_FIRST_RUN_PLATFORMS)
     properties.remove(KEY_FIRST_RUN_TELEMETRY)
     properties.remove(KEY_FIRST_RUN_MCP)
-    firstRunState.value = preferences
+    firstRunState.value = persistedPreferences
     saveProperties()
   }
 

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmMain/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStore.kt
@@ -76,10 +76,10 @@ class LocalDesktopPreferenceStore : DesktopPreferenceStore {
 
   private fun persistFirstRunPreferences(preferences: DesktopFirstRunPreferences) {
     properties.setProperty(KEY_FIRST_RUN_COMPLETED, preferences.completed.toString())
-    properties.setProperty(KEY_FIRST_RUN_AGENTS, preferences.selectedAgentIds.toPropertyValue())
-    properties.setProperty(KEY_FIRST_RUN_PLATFORMS, preferences.selectedPlatformSlugs.toPropertyValue())
-    properties.setProperty(KEY_FIRST_RUN_TELEMETRY, preferences.telemetryLevelId)
-    properties.setProperty(KEY_FIRST_RUN_MCP, preferences.registerMcp.toString())
+    properties.remove(KEY_FIRST_RUN_AGENTS)
+    properties.remove(KEY_FIRST_RUN_PLATFORMS)
+    properties.remove(KEY_FIRST_RUN_TELEMETRY)
+    properties.remove(KEY_FIRST_RUN_MCP)
     firstRunState.value = preferences
     saveProperties()
   }
@@ -104,5 +104,3 @@ private fun String?.toSetProperty(): Set<String> = this
   ?.filter(String::isNotEmpty)
   ?.toSet()
   .orEmpty()
-
-private fun Set<String>.toPropertyValue(): String = sorted().joinToString(",")

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
@@ -57,7 +57,7 @@ class LocalDesktopPreferenceStoreTest {
   }
 
   @Test
-  fun `first run preferences persist to desktop properties`() {
+  fun `first run completion persists without rewriting install choices`() {
     withTemporaryStore {
       val store = LocalDesktopPreferenceStore()
 
@@ -72,19 +72,45 @@ class LocalDesktopPreferenceStoreTest {
 
       val reloaded = LocalDesktopPreferenceStore().firstRunPreferences.value
       assertTrue(reloaded.completed)
-      assertEquals(setOf("claude", "codex"), reloaded.selectedAgentIds)
-      assertEquals(setOf("kotlin"), reloaded.selectedPlatformSlugs)
-      assertEquals("full", reloaded.telemetryLevelId)
-      assertFalse(reloaded.registerMcp)
+      assertEquals(emptySet(), reloaded.selectedAgentIds)
+      assertEquals(emptySet(), reloaded.selectedPlatformSlugs)
+      assertEquals("anonymous", reloaded.telemetryLevelId)
+      assertTrue(reloaded.registerMcp)
     }
   }
 
-  private fun withTemporaryStore(block: () -> Unit) {
+  @Test
+  fun `legacy first run install choices still load from desktop properties`() {
+    withTemporaryStorePath { preferencesPath ->
+      Files.createDirectories(preferencesPath.parent)
+      Files.writeString(
+        preferencesPath,
+        """
+        |firstRun.completed=true
+        |firstRun.agents=codex,claude
+        |firstRun.platforms=kotlin
+        |firstRun.telemetry=full
+        |firstRun.mcp=false
+        |
+        """.trimMargin(),
+      )
+
+      val loaded = LocalDesktopPreferenceStore().firstRunPreferences.value
+
+      assertTrue(loaded.completed)
+      assertEquals(setOf("claude", "codex"), loaded.selectedAgentIds)
+      assertEquals(setOf("kotlin"), loaded.selectedPlatformSlugs)
+      assertEquals("full", loaded.telemetryLevelId)
+      assertFalse(loaded.registerMcp)
+    }
+  }
+
+  private fun withTemporaryStorePath(block: (Path) -> Unit) {
     val originalPath = System.getProperty(PREFERENCES_PATH_PROPERTY)
     val preferencesPath = Files.createTempDirectory("skillbill-desktop-test").resolve("desktop.properties")
     System.setProperty(PREFERENCES_PATH_PROPERTY, preferencesPath.toString())
     try {
-      block()
+      block(preferencesPath)
     } finally {
       if (originalPath == null) {
         System.clearProperty(PREFERENCES_PATH_PROPERTY)
@@ -92,6 +118,10 @@ class LocalDesktopPreferenceStoreTest {
         System.setProperty(PREFERENCES_PATH_PROPERTY, originalPath)
       }
     }
+  }
+
+  private fun withTemporaryStore(block: () -> Unit) {
+    withTemporaryStorePath { block() }
   }
 
   private companion object {

--- a/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/datastore/src/jvmTest/kotlin/skillbill/desktop/core/datastore/LocalDesktopPreferenceStoreTest.kt
@@ -80,6 +80,57 @@ class LocalDesktopPreferenceStoreTest {
   }
 
   @Test
+  fun `first run completion removes legacy install choices while preserving desktop state`() {
+    withTemporaryStorePath { preferencesPath ->
+      Files.createDirectories(preferencesPath.parent)
+      Files.writeString(
+        preferencesPath,
+        """
+        |recentRepoPath=/repo
+        |firstRun.completed=false
+        |firstRun.agents=codex,claude
+        |firstRun.platforms=kotlin
+        |firstRun.telemetry=full
+        |firstRun.mcp=false
+        |
+        """.trimMargin(),
+      )
+      val store = LocalDesktopPreferenceStore()
+
+      store.markFirstRunCompleted(
+        DesktopFirstRunPreferences(
+          selectedAgentIds = setOf("codex"),
+          selectedPlatformSlugs = setOf("kotlin"),
+          telemetryLevelId = "off",
+          registerMcp = false,
+        ),
+      )
+
+      val persisted = Files.readString(preferencesPath)
+      assertTrue(persisted.contains("recentRepoPath=/repo"))
+      assertTrue(persisted.contains("firstRun.completed=true"))
+      assertFalse(persisted.contains("firstRun.agents"))
+      assertFalse(persisted.contains("firstRun.platforms"))
+      assertFalse(persisted.contains("firstRun.telemetry"))
+      assertFalse(persisted.contains("firstRun.mcp"))
+
+      assertTrue(store.firstRunPreferences.value.completed)
+      assertEquals(emptySet(), store.firstRunPreferences.value.selectedAgentIds)
+      assertEquals(emptySet(), store.firstRunPreferences.value.selectedPlatformSlugs)
+      assertEquals("anonymous", store.firstRunPreferences.value.telemetryLevelId)
+      assertTrue(store.firstRunPreferences.value.registerMcp)
+
+      val reloaded = LocalDesktopPreferenceStore()
+      assertEquals("/repo", reloaded.recentRepoPath.value)
+      assertTrue(reloaded.firstRunPreferences.value.completed)
+      assertEquals(emptySet(), reloaded.firstRunPreferences.value.selectedAgentIds)
+      assertEquals(emptySet(), reloaded.firstRunPreferences.value.selectedPlatformSlugs)
+      assertEquals("anonymous", reloaded.firstRunPreferences.value.telemetryLevelId)
+      assertTrue(reloaded.firstRunPreferences.value.registerMcp)
+    }
+  }
+
+  @Test
   fun `legacy first run install choices still load from desktop properties`() {
     withTemporaryStorePath { preferencesPath ->
       Files.createDirectories(preferencesPath.parent)

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
@@ -151,6 +151,11 @@ data class FirstRunSetupState(
     .map { option -> option.agentId }
     .toSet(),
   val selectedPlatformSlugs: Set<String> = emptySet(),
+  val platformSelectionMode: FirstRunPlatformSelectionMode = if (selectedPlatformSlugs.isEmpty()) {
+    FirstRunPlatformSelectionMode.NONE
+  } else {
+    FirstRunPlatformSelectionMode.SELECTED
+  },
   val telemetryLevel: FirstRunTelemetryLevel = FirstRunTelemetryLevel.default,
   val registerMcp: Boolean = true,
   val discoveryLoaded: Boolean = false,
@@ -174,6 +179,7 @@ data class FirstRunSetupState(
     selectedPlatformSlugs = selectedPlatformSlugs,
     telemetryLevel = telemetryLevel,
     registerMcp = registerMcp,
+    platformSelectionMode = platformSelectionMode,
   )
 }
 

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
@@ -42,6 +42,12 @@ enum class FirstRunTelemetryLevel(
   }
 }
 
+enum class FirstRunPlatformSelectionMode {
+  NONE,
+  SELECTED,
+  ALL,
+}
+
 data class FirstRunDetectedAgent(
   val agentId: String,
   val path: String,
@@ -74,6 +80,11 @@ data class FirstRunSetupRequest(
   val selectedPlatformSlugs: Set<String>,
   val telemetryLevel: FirstRunTelemetryLevel,
   val registerMcp: Boolean,
+  val platformSelectionMode: FirstRunPlatformSelectionMode = if (selectedPlatformSlugs.isEmpty()) {
+    FirstRunPlatformSelectionMode.NONE
+  } else {
+    FirstRunPlatformSelectionMode.SELECTED
+  },
 )
 
 interface FirstRunInstallPlanHandle
@@ -171,6 +182,11 @@ data class PostPublishReinstallState(
   val selectedPlatformSlugs: Set<String>,
   val telemetryLevel: FirstRunTelemetryLevel,
   val registerMcp: Boolean,
+  val platformSelectionMode: FirstRunPlatformSelectionMode = if (selectedPlatformSlugs.isEmpty()) {
+    FirstRunPlatformSelectionMode.NONE
+  } else {
+    FirstRunPlatformSelectionMode.SELECTED
+  },
   val busy: Boolean = false,
   val outcome: FirstRunInstallOutcome? = null,
 ) {

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/service/DesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/service/DesktopFirstRunGateway.kt
@@ -9,6 +9,8 @@ import skillbill.desktop.core.domain.model.FirstRunSetupRequest
 interface DesktopFirstRunGateway {
   fun hasExistingInstall(): Boolean
 
+  fun latestReusableSetupRequest(legacyFallback: FirstRunSetupRequest? = null): FirstRunSetupRequest?
+
   suspend fun discoverSetup(): FirstRunDiscoveryResult
 
   suspend fun planSetup(request: FirstRunSetupRequest): FirstRunPlanResult

--- a/runtime-kotlin/runtime-desktop/core/domain/src/jvmTest/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModelsTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/jvmTest/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModelsTest.kt
@@ -17,4 +17,16 @@ class FirstRunSetupModelsTest {
     assertFalse(FirstRunSetupState(selectedAgentIds = emptySet()).canContinue)
     assertTrue(FirstRunSetupState(selectedAgentIds = setOf("codex")).canContinue)
   }
+
+  @Test
+  fun `setup request preserves explicit platform selection mode`() {
+    val request = FirstRunSetupState(
+      selectedAgentIds = setOf("codex"),
+      selectedPlatformSlugs = setOf("kotlin", "kmp"),
+      platformSelectionMode = FirstRunPlatformSelectionMode.ALL,
+    ).request()
+
+    assertEquals(FirstRunPlatformSelectionMode.ALL, request.platformSelectionMode)
+    assertEquals(setOf("kotlin", "kmp"), request.selectedPlatformSlugs)
+  }
 }

--- a/runtime-kotlin/runtime-desktop/core/testing/src/commonMain/kotlin/skillbill/desktop/core/testing/install/FakeDesktopFirstRunGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/testing/src/commonMain/kotlin/skillbill/desktop/core/testing/install/FakeDesktopFirstRunGateway.kt
@@ -12,6 +12,7 @@ class FakeDesktopFirstRunGateway(
   var planResult: FirstRunPlanResult,
   var applyResult: FirstRunApplyResult,
   var existingInstall: Boolean = false,
+  var latestReusableSetupRequest: FirstRunSetupRequest? = null,
 ) : DesktopFirstRunGateway {
   val planRequests: MutableList<FirstRunSetupRequest> = mutableListOf()
   val appliedPlans: MutableList<FirstRunInstallPlan> = mutableListOf()
@@ -26,6 +27,9 @@ class FakeDesktopFirstRunGateway(
     private set
 
   override fun hasExistingInstall(): Boolean = existingInstall
+
+  override fun latestReusableSetupRequest(legacyFallback: FirstRunSetupRequest?): FirstRunSetupRequest? =
+    latestReusableSetupRequest ?: legacyFallback
 
   override suspend fun discoverSetup(): FirstRunDiscoveryResult {
     discoveryCallCount += 1

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
@@ -23,6 +23,7 @@ import skillbill.desktop.core.domain.model.FirstRunDiscoveryResult
 import skillbill.desktop.core.domain.model.FirstRunInstallOutcome
 import skillbill.desktop.core.domain.model.FirstRunInstallStatus
 import skillbill.desktop.core.domain.model.FirstRunPlanResult
+import skillbill.desktop.core.domain.model.FirstRunPlatformSelectionMode
 import skillbill.desktop.core.domain.model.FirstRunSetupDiscovery
 import skillbill.desktop.core.domain.model.FirstRunSetupRequest
 import skillbill.desktop.core.domain.model.FirstRunSetupState
@@ -172,7 +173,7 @@ class SkillBillViewModel(
     if (desktopPreferenceStore.firstRunPreferences.value.completed || firstRunGateway.hasExistingInstall()) {
       null
     } else {
-      desktopPreferenceStore.firstRunPreferences.value.toFirstRunSetupState()
+      latestInstallSetupRequest()?.toFirstRunSetupState() ?: FirstRunSetupState()
     }
   private var activeFirstRunToken: Long = 0L
   private var postPublishReinstall: PostPublishReinstallState? = null
@@ -678,7 +679,7 @@ class SkillBillViewModel(
     if (busyOperation != null || scaffoldWizard != null || firstRunSetup != null || postPublishReinstall != null) {
       return currentState
     }
-    firstRunSetup = desktopPreferenceStore.firstRunPreferences.value.toFirstRunSetupState()
+    firstRunSetup = latestInstallSetupRequest()?.toFirstRunSetupState() ?: FirstRunSetupState()
     currentState = createState()
     return currentState
   }
@@ -697,7 +698,7 @@ class SkillBillViewModel(
     firstRunSetup = when (val result = response.result) {
       is FirstRunDiscoveryResult.Success -> setup.applyDiscovery(
         discovery = result.discovery,
-        preferences = desktopPreferenceStore.firstRunPreferences.value,
+        preferredRequest = latestInstallSetupRequest(),
       )
       is FirstRunDiscoveryResult.Failed -> setup.copy(
         busy = false,
@@ -848,11 +849,10 @@ class SkillBillViewModel(
       }
     }
     firstRunSetup = nextSetup
-    val preferences = nextSetup.toPreferences()
     if (nextSetup.outcome?.status == FirstRunInstallStatus.FAILURE) {
-      desktopPreferenceStore.saveFirstRunPreferences(preferences)
+      desktopPreferenceStore.saveFirstRunPreferences(DesktopFirstRunPreferences(completed = false))
     } else {
-      desktopPreferenceStore.markFirstRunCompleted(preferences)
+      desktopPreferenceStore.markFirstRunCompleted(DesktopFirstRunPreferences())
     }
     currentState = createState()
     return currentState
@@ -1706,7 +1706,7 @@ class SkillBillViewModel(
     }
     postPublishReinstall = prompt.copy(busy = false, outcome = outcome)
     if (outcome.status != FirstRunInstallStatus.FAILURE) {
-      desktopPreferenceStore.markFirstRunCompleted(response.request.setupRequest.toPreferences())
+      desktopPreferenceStore.markFirstRunCompleted(DesktopFirstRunPreferences())
     }
     currentState = createState()
     return currentState
@@ -2251,20 +2251,13 @@ class SkillBillViewModel(
       selectedPlatformSlugs = request.selectedPlatformSlugs,
       telemetryLevel = request.telemetryLevel,
       registerMcp = request.registerMcp,
+      platformSelectionMode = request.platformSelectionMode,
     )
   }
 
   private fun latestInstallSetupRequest(): FirstRunSetupRequest? {
-    val preferences = desktopPreferenceStore.firstRunPreferences.value
-    if (!preferences.completed || preferences.selectedAgentIds.isEmpty()) {
-      return null
-    }
-    return FirstRunSetupRequest(
-      selectedAgentIds = preferences.selectedAgentIds,
-      selectedPlatformSlugs = preferences.selectedPlatformSlugs,
-      telemetryLevel = FirstRunTelemetryLevel.fromId(preferences.telemetryLevelId),
-      registerMcp = preferences.registerMcp,
-    )
+    val legacyFallback = desktopPreferenceStore.firstRunPreferences.value.toLegacySetupRequestOrNull()
+    return firstRunGateway.latestReusableSetupRequest(legacyFallback)
   }
 
   private fun containsTreeItem(itemId: String): Boolean = treeItems.flatten().any { item -> item.id == itemId }
@@ -3418,22 +3411,27 @@ data class PostPublishReinstallResponse(
   val applyResult: FirstRunApplyResult?,
 )
 
-private fun DesktopFirstRunPreferences.toFirstRunSetupState(): FirstRunSetupState = FirstRunSetupState(
+private fun FirstRunSetupRequest.toFirstRunSetupState(): FirstRunSetupState = FirstRunSetupState(
   selectedAgentIds = selectedAgentIds,
   selectedPlatformSlugs = selectedPlatformSlugs,
-  telemetryLevel = FirstRunTelemetryLevel.fromId(telemetryLevelId),
+  telemetryLevel = telemetryLevel,
   registerMcp = registerMcp,
 )
 
 private fun FirstRunSetupState.applyDiscovery(
   discovery: FirstRunSetupDiscovery,
-  preferences: DesktopFirstRunPreferences,
+  preferredRequest: FirstRunSetupRequest?,
 ): FirstRunSetupState {
-  val preferredAgents = preferences.selectedAgentIds.takeIf(Set<String>::isNotEmpty)
+  val preferredAgents = preferredRequest?.selectedAgentIds?.takeIf(Set<String>::isNotEmpty)
   val selectedAgents = preferredAgents ?: discovery.agents
     .filter { option -> option.selected }
     .mapTo(mutableSetOf()) { option -> option.agentId }
-  val selectedPlatforms = preferences.selectedPlatformSlugs.ifEmpty { discovery.selectedPlatformSlugs }
+  val selectedPlatforms = when (preferredRequest?.platformSelectionMode) {
+    FirstRunPlatformSelectionMode.ALL -> discovery.platformPacks.mapTo(mutableSetOf()) { pack -> pack.slug }
+    FirstRunPlatformSelectionMode.SELECTED -> preferredRequest.selectedPlatformSlugs
+    FirstRunPlatformSelectionMode.NONE -> emptySet()
+    null -> discovery.selectedPlatformSlugs
+  }
   return copy(
     busy = false,
     discoveryLoaded = true,
@@ -3446,26 +3444,22 @@ private fun FirstRunSetupState.applyDiscovery(
     },
     selectedAgentIds = selectedAgents,
     selectedPlatformSlugs = selectedPlatforms,
-    telemetryLevel = FirstRunTelemetryLevel.fromId(preferences.telemetryLevelId),
-    registerMcp = preferences.registerMcp,
+    telemetryLevel = preferredRequest?.telemetryLevel ?: FirstRunTelemetryLevel.default,
+    registerMcp = preferredRequest?.registerMcp ?: true,
   )
 }
 
-private fun FirstRunSetupState.toPreferences(): DesktopFirstRunPreferences = DesktopFirstRunPreferences(
-  completed = false,
-  selectedAgentIds = selectedAgentIds,
-  selectedPlatformSlugs = selectedPlatformSlugs,
-  telemetryLevelId = telemetryLevel.id,
-  registerMcp = registerMcp,
-)
-
-private fun FirstRunSetupRequest.toPreferences(): DesktopFirstRunPreferences = DesktopFirstRunPreferences(
-  completed = false,
-  selectedAgentIds = selectedAgentIds,
-  selectedPlatformSlugs = selectedPlatformSlugs,
-  telemetryLevelId = telemetryLevel.id,
-  registerMcp = registerMcp,
-)
+private fun DesktopFirstRunPreferences.toLegacySetupRequestOrNull(): FirstRunSetupRequest? {
+  if (!completed || selectedAgentIds.isEmpty()) {
+    return null
+  }
+  return FirstRunSetupRequest(
+    selectedAgentIds = selectedAgentIds,
+    selectedPlatformSlugs = selectedPlatformSlugs,
+    telemetryLevel = FirstRunTelemetryLevel.fromId(telemetryLevelId),
+    registerMcp = registerMcp,
+  )
+}
 
 private fun FirstRunSetupStep.next(): FirstRunSetupStep = when (this) {
   FirstRunSetupStep.AGENTS -> FirstRunSetupStep.PLATFORM_PACKS

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModel.kt
@@ -737,12 +737,14 @@ class SkillBillViewModel(
     if (setup.busy) {
       return currentState
     }
+    val selectedPlatformSlugs = if (selected) {
+      setup.selectedPlatformSlugs + slug
+    } else {
+      setup.selectedPlatformSlugs - slug
+    }
     firstRunSetup = setup.copy(
-      selectedPlatformSlugs = if (selected) {
-        setup.selectedPlatformSlugs + slug
-      } else {
-        setup.selectedPlatformSlugs - slug
-      },
+      selectedPlatformSlugs = selectedPlatformSlugs,
+      platformSelectionMode = selectedPlatformSlugs.toFirstRunPlatformSelectionMode(),
       platformPacks = setup.platformPacks.map { pack ->
         if (pack.slug == slug) pack.copy(selected = selected) else pack
       },
@@ -3414,6 +3416,7 @@ data class PostPublishReinstallResponse(
 private fun FirstRunSetupRequest.toFirstRunSetupState(): FirstRunSetupState = FirstRunSetupState(
   selectedAgentIds = selectedAgentIds,
   selectedPlatformSlugs = selectedPlatformSlugs,
+  platformSelectionMode = platformSelectionMode,
   telemetryLevel = telemetryLevel,
   registerMcp = registerMcp,
 )
@@ -3444,9 +3447,17 @@ private fun FirstRunSetupState.applyDiscovery(
     },
     selectedAgentIds = selectedAgents,
     selectedPlatformSlugs = selectedPlatforms,
+    platformSelectionMode = preferredRequest?.platformSelectionMode
+      ?: selectedPlatforms.toFirstRunPlatformSelectionMode(),
     telemetryLevel = preferredRequest?.telemetryLevel ?: FirstRunTelemetryLevel.default,
     registerMcp = preferredRequest?.registerMcp ?: true,
   )
+}
+
+private fun Set<String>.toFirstRunPlatformSelectionMode(): FirstRunPlatformSelectionMode = if (isEmpty()) {
+  FirstRunPlatformSelectionMode.NONE
+} else {
+  FirstRunPlatformSelectionMode.SELECTED
 }
 
 private fun DesktopFirstRunPreferences.toLegacySetupRequestOrNull(): FirstRunSetupRequest? {

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialog.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/FirstRunSetupDialog.kt
@@ -37,6 +37,7 @@ import skillbill.desktop.core.designsystem.SkillBillTheme
 import skillbill.desktop.core.domain.model.FirstRunInstallDetail
 import skillbill.desktop.core.domain.model.FirstRunInstallDetailSeverity
 import skillbill.desktop.core.domain.model.FirstRunInstallStatus
+import skillbill.desktop.core.domain.model.FirstRunPlatformSelectionMode
 import skillbill.desktop.core.domain.model.FirstRunSetupState
 import skillbill.desktop.core.domain.model.FirstRunSetupStep
 import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
@@ -182,7 +183,7 @@ fun PostPublishReinstallDialog(state: PostPublishReinstallState, callbacks: Post
         SummaryLine(label = "Agents", value = state.selectedAgentIds.sorted().joinToString(", "))
         SummaryLine(
           label = "Platform packs",
-          value = state.selectedPlatformSlugs.sorted().joinToString(", ").ifBlank { "none" },
+          value = state.platformSelectionLabel(),
         )
         SummaryLine(label = "Telemetry", value = state.telemetryLevel.id)
         SummaryLine(label = "MCP", value = if (state.registerMcp) "register" else "skip")
@@ -221,6 +222,12 @@ fun PostPublishReinstallDialog(state: PostPublishReinstallState, callbacks: Post
       }
     }
   }
+}
+
+private fun PostPublishReinstallState.platformSelectionLabel(): String = when (platformSelectionMode) {
+  FirstRunPlatformSelectionMode.ALL -> "all"
+  FirstRunPlatformSelectionMode.SELECTED -> selectedPlatformSlugs.sorted().joinToString(", ")
+  FirstRunPlatformSelectionMode.NONE -> "none"
 }
 
 @Composable

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
@@ -13,7 +13,9 @@ import skillbill.desktop.core.domain.model.FirstRunInstallPlanHandle
 import skillbill.desktop.core.domain.model.FirstRunInstallStatus
 import skillbill.desktop.core.domain.model.FirstRunPlanResult
 import skillbill.desktop.core.domain.model.FirstRunPlatformPackOption
+import skillbill.desktop.core.domain.model.FirstRunPlatformSelectionMode
 import skillbill.desktop.core.domain.model.FirstRunSetupDiscovery
+import skillbill.desktop.core.domain.model.FirstRunSetupRequest
 import skillbill.desktop.core.domain.model.FirstRunSetupStep
 import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
 import skillbill.desktop.core.domain.model.SkillBillTreeItem
@@ -185,6 +187,44 @@ class SkillBillViewModelFirstRunTest {
     assertEquals(setOf("kotlin"), discovered.firstRunSetup?.selectedPlatformSlugs)
     assertEquals(FirstRunTelemetryLevel.FULL, discovered.firstRunSetup?.telemetryLevel)
     assertFalse(discovered.firstRunSetup?.registerMcp ?: true)
+  }
+
+  @Test
+  fun `reusable all platform selection survives discovery and apply`() = runBlocking {
+    val gateway = FakeDesktopFirstRunGateway(
+      discoveryResult = FirstRunDiscoveryResult.Success(
+        discovery().copy(
+          platformPacks = listOf(
+            FirstRunPlatformPackOption(slug = "kmp", packRoot = "/repo/platform-packs/kmp"),
+            FirstRunPlatformPackOption(slug = "kotlin", packRoot = "/repo/platform-packs/kotlin"),
+          ),
+        ),
+      ),
+      planResult = FirstRunPlanResult.Planned(plan()),
+      applyResult = FirstRunApplyResult.Applied(
+        FirstRunInstallOutcome(status = FirstRunInstallStatus.SUCCESS, title = "Setup completed."),
+      ),
+      latestReusableSetupRequest = FirstRunSetupRequest(
+        selectedAgentIds = setOf("codex"),
+        selectedPlatformSlugs = emptySet(),
+        telemetryLevel = FirstRunTelemetryLevel.ANONYMOUS,
+        registerMcp = true,
+        platformSelectionMode = FirstRunPlatformSelectionMode.ALL,
+      ),
+    )
+    val viewModel = newViewModel(gateway, FakeDesktopPreferenceStore())
+
+    val discoveryRequest = assertNotNull(viewModel.beginFirstRunDiscovery())
+    val discovered = viewModel.finishFirstRunDiscovery(viewModel.runFirstRunDiscovery(discoveryRequest))
+    viewModel.advanceFirstRunStep()
+    viewModel.advanceFirstRunStep()
+    viewModel.advanceFirstRunStep()
+    val applyRequest = assertNotNull(viewModel.beginFirstRunApply())
+    viewModel.finishFirstRunApply(viewModel.runFirstRunApply(applyRequest))
+
+    assertEquals(setOf("kmp", "kotlin"), discovered.firstRunSetup?.selectedPlatformSlugs)
+    assertEquals(FirstRunPlatformSelectionMode.ALL, gateway.planRequests.single().platformSelectionMode)
+    assertEquals(setOf("kmp", "kotlin"), gateway.planRequests.single().selectedPlatformSlugs)
   }
 
   @Test

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelFirstRunTest.kt
@@ -104,7 +104,7 @@ class SkillBillViewModelFirstRunTest {
     assertEquals(1, gateway.applyCallCount)
     assertEquals(FirstRunInstallStatus.WARNING, applied.firstRunSetup?.outcome?.status)
     assertTrue(preferences.firstRunPreferences.value.completed)
-    assertEquals(setOf("claude", "codex"), preferences.firstRunPreferences.value.selectedAgentIds)
+    assertEquals(emptySet(), preferences.firstRunPreferences.value.selectedAgentIds)
 
     val finished = viewModel.finishFirstRunSetup()
     assertNull(finished.firstRunSetup)

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/jvmTest/kotlin/skillbill/desktop/feature/skillbill/state/SkillBillViewModelGitTest.kt
@@ -15,6 +15,7 @@ import skillbill.desktop.core.domain.model.FirstRunInstallStatus
 import skillbill.desktop.core.domain.model.FirstRunPlanResult
 import skillbill.desktop.core.domain.model.FirstRunPlatformPackOption
 import skillbill.desktop.core.domain.model.FirstRunSetupDiscovery
+import skillbill.desktop.core.domain.model.FirstRunSetupRequest
 import skillbill.desktop.core.domain.model.FirstRunTelemetryLevel
 import skillbill.desktop.core.domain.model.GitAheadBehind
 import skillbill.desktop.core.domain.model.GitOperationResult
@@ -1370,22 +1371,29 @@ class SkillBillViewModelGitTest {
   }
 
   @Test
-  fun `successful publish prompts reinstall when completed install preferences exist`() {
+  fun `successful publish prompts reinstall when shared install selection exists`() {
     val gitGateway = FakeGitGateway(
       scriptedPublishingStatus = GitPublishingStatus(
         pushTarget = GitPushTarget(remoteName = "origin", branchName = "feature"),
         aheadBehind = GitAheadBehind(ahead = 1, behind = 0),
       ),
     )
-    val preferenceStore = FakeDesktopPreferenceStore(
-      initialFirstRunPreferences = DesktopFirstRunPreferences(
-        completed = true,
+    val firstRunGateway = FakeDesktopFirstRunGateway(
+      discoveryResult = FirstRunDiscoveryResult.Success(
+        FirstRunSetupDiscovery(agents = emptyList(), platformPacks = emptyList()),
+      ),
+      planResult = FirstRunPlanResult.Planned(reinstallPlan()),
+      applyResult = FirstRunApplyResult.Applied(
+        FirstRunInstallOutcome(status = FirstRunInstallStatus.SUCCESS, title = "Setup completed."),
+      ),
+      latestReusableSetupRequest = FirstRunSetupRequest(
         selectedAgentIds = setOf("codex"),
         selectedPlatformSlugs = setOf("kotlin"),
-        telemetryLevelId = FirstRunTelemetryLevel.FULL.id,
+        telemetryLevel = FirstRunTelemetryLevel.FULL,
+        registerMcp = true,
       ),
     )
-    val viewModel = newViewModel(gitGateway = gitGateway, desktopPreferenceStore = preferenceStore)
+    val viewModel = newViewModel(gitGateway = gitGateway, firstRunGateway = firstRunGateway)
     viewModel.selectRepoPath("/repo")
     viewModel.refreshGit()
 
@@ -1484,14 +1492,14 @@ class SkillBillViewModelGitTest {
         aheadBehind = GitAheadBehind(ahead = 1, behind = 0),
       ),
     )
-    val preferenceStore = FakeDesktopPreferenceStore(
-      initialFirstRunPreferences = DesktopFirstRunPreferences(
-        completed = true,
-        selectedAgentIds = setOf("codex", "claude"),
-        selectedPlatformSlugs = setOf("kotlin"),
-        telemetryLevelId = FirstRunTelemetryLevel.OFF.id,
-      ),
+    gateway.latestReusableSetupRequest = FirstRunSetupRequest(
+      selectedAgentIds = setOf("codex", "claude"),
+      selectedPlatformSlugs = setOf("kotlin"),
+      telemetryLevel = FirstRunTelemetryLevel.OFF,
+      registerMcp = true,
     )
+    val preferenceStore =
+      FakeDesktopPreferenceStore(initialFirstRunPreferences = DesktopFirstRunPreferences(completed = true))
     val viewModel = newViewModel(
       gitGateway = gitGateway,
       firstRunGateway = gateway,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
@@ -268,6 +268,32 @@ data class InstallAgentSkillLinkOutcome(
   val issue: InstallApplyIssue? = null,
 )
 
+data class ResolvedInstalledAgents(
+  val agents: Set<InstallAgent>,
+) {
+  companion object {
+    val EMPTY: ResolvedInstalledAgents = ResolvedInstalledAgents(emptySet())
+
+    fun fromApplyResult(status: InstallApplyStatus, skills: List<InstallAppliedSkill>): ResolvedInstalledAgents {
+      if (status == InstallApplyStatus.FAILURE) {
+        return EMPTY
+      }
+      return fromSuccessfulApplyOutcomes(skills)
+    }
+
+    fun fromSuccessfulApplyOutcomes(skills: List<InstallAppliedSkill>): ResolvedInstalledAgents {
+      val resolvedAgents =
+        skills
+          .flatMap(InstallAppliedSkill::links)
+          .filter { link ->
+            link.status == InstallAgentLinkStatus.CREATED || link.status == InstallAgentLinkStatus.SKIPPED
+          }
+          .mapTo(mutableSetOf(), InstallAgentSkillLinkOutcome::agent)
+      return ResolvedInstalledAgents(resolvedAgents)
+    }
+  }
+}
+
 data class InstallAppliedSkill(
   val skillName: String,
   val kind: InstallPlanSkillKind,
@@ -343,4 +369,7 @@ data class InstallApplyResult(
   val windowsSymlinkOutcome: WindowsSymlinkApplyOutcome,
   val telemetryLevel: InstallTelemetryLevel,
   val mcpRegistrationIntent: McpRegistrationIntent,
-)
+) {
+  val resolvedInstalledAgents: ResolvedInstalledAgents
+    get() = ResolvedInstalledAgents.fromApplyResult(status, skills)
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/SharedInstallSelection.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/SharedInstallSelection.kt
@@ -1,0 +1,8 @@
+package skillbill.install.model
+
+data class SharedInstallSelection(
+  val selectedAgents: Set<InstallAgent>,
+  val platformPackSelection: PlatformPackSelection,
+  val telemetryLevel: InstallTelemetryLevel,
+  val mcpRegistrationChoice: McpRegistrationChoice,
+)

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/SharedInstallSelectionModelTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/SharedInstallSelectionModelTest.kt
@@ -1,0 +1,104 @@
+package skillbill.install.model
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SharedInstallSelectionModelTest {
+  @Test
+  fun `shared install selection contains only runtime install choices`() {
+    assertEquals(
+      setOf("selectedAgents", "platformPackSelection", "telemetryLevel", "mcpRegistrationChoice"),
+      SharedInstallSelection::class.java.declaredFields
+        .filterNot { field -> field.isSynthetic }
+        .mapTo(mutableSetOf()) { field -> field.name },
+    )
+  }
+
+  @Test
+  fun `resolved installed agents derive only reusable links from non failure apply results`() {
+    val successResult = installApplyResult(
+      status = InstallApplyStatus.SUCCESS,
+      links = listOf(
+        link(InstallAgent.CODEX, InstallAgentLinkStatus.CREATED),
+        link(InstallAgent.CLAUDE, InstallAgentLinkStatus.SKIPPED),
+        link(InstallAgent.OPENCODE, InstallAgentLinkStatus.WARNING),
+        link(InstallAgent.JUNIE, InstallAgentLinkStatus.FAILED),
+      ),
+    )
+    val warningResult = installApplyResult(
+      status = InstallApplyStatus.WARNING,
+      links = listOf(
+        link(InstallAgent.CODEX, InstallAgentLinkStatus.CREATED),
+        link(InstallAgent.CLAUDE, InstallAgentLinkStatus.SKIPPED),
+        link(InstallAgent.JUNIE, InstallAgentLinkStatus.FAILED),
+      ),
+    )
+    val failureResult = installApplyResult(
+      status = InstallApplyStatus.FAILURE,
+      links = listOf(
+        link(InstallAgent.CODEX, InstallAgentLinkStatus.CREATED),
+        link(InstallAgent.CLAUDE, InstallAgentLinkStatus.SKIPPED),
+      ),
+    )
+
+    assertEquals(setOf(InstallAgent.CODEX, InstallAgent.CLAUDE), successResult.resolvedInstalledAgents.agents)
+    assertEquals(setOf(InstallAgent.CODEX, InstallAgent.CLAUDE), warningResult.resolvedInstalledAgents.agents)
+    assertEquals(emptySet(), failureResult.resolvedInstalledAgents.agents)
+  }
+
+  private fun installApplyResult(
+    status: InstallApplyStatus,
+    links: List<InstallAgentSkillLinkOutcome>,
+  ): InstallApplyResult = InstallApplyResult(
+    status = status,
+    skills = listOf(
+      InstallAppliedSkill(
+        skillName = "bill-code-review",
+        kind = InstallPlanSkillKind.BASE,
+        sourceDir = Path.of("/repo/skills/bill-code-review"),
+        staging = InstallSkillStagingOutcome(
+          status = InstallSkillStagingStatus.STAGED,
+          sourceDir = Path.of("/repo/skills/bill-code-review"),
+          stagingDir = Path.of("/home/.skill-bill/installed-skills/bill-code-review-hash"),
+        ),
+        links = links,
+      ),
+    ),
+    nativeAgents = emptyList(),
+    telemetryOutcome = InstallTelemetryApplyOutcome(
+      level = InstallTelemetryLevel.ANONYMOUS,
+      status = InstallTelemetryApplyStatus.SUCCESS,
+    ),
+    mcpRegistrationOutcomes = listOf(
+      McpRegistrationApplyOutcome(
+        agent = InstallAgent.OPENCODE,
+        status = McpRegistrationApplyStatus.SUCCESS,
+      ),
+    ),
+    warnings = emptyList(),
+    failures = emptyList(),
+    windowsSymlinkOutcome = WindowsSymlinkApplyOutcome(
+      preflight = WindowsSymlinkPreflight(
+        state = WindowsSymlinkPreflightState.NOT_WINDOWS,
+        decision = WindowsSymlinkDecision.NOT_REQUIRED,
+      ),
+      fallbackState = WindowsSymlinkFallbackState.NOT_REQUIRED,
+    ),
+    telemetryLevel = InstallTelemetryLevel.ANONYMOUS,
+    mcpRegistrationIntent = McpRegistrationIntent(
+      register = true,
+      runtimeMcpBin = Path.of("/runtime-mcp"),
+      agents = listOf(InstallAgent.OPENCODE),
+    ),
+  )
+
+  private fun link(agent: InstallAgent, status: InstallAgentLinkStatus): InstallAgentSkillLinkOutcome =
+    InstallAgentSkillLinkOutcome(
+      agent = agent,
+      targetDir = Path.of("/home/.${agent.id}/skills"),
+      linkPath = Path.of("/home/.${agent.id}/skills/bill-code-review"),
+      linkTarget = Path.of("/home/.skill-bill/installed-skills/bill-code-review-hash"),
+      status = status,
+    )
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionParser.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionParser.kt
@@ -1,0 +1,107 @@
+package skillbill.infrastructure.fs
+
+import skillbill.contracts.JsonSupport
+import skillbill.install.model.InstallAgent
+import skillbill.install.model.InstallTelemetryLevel
+import skillbill.install.model.McpRegistrationChoice
+import skillbill.install.model.PlatformPackSelection
+import skillbill.install.model.PlatformPackSelectionMode
+import skillbill.install.model.SharedInstallSelection
+import java.nio.file.Path
+
+internal fun parseInstallSelectionPayload(path: Path, rawPayload: String): SharedInstallSelection {
+  val payload = JsonSupport.anyToStringAnyMap(
+    JsonSupport.parseObjectOrNull(rawPayload)?.let(JsonSupport::jsonElementToValue),
+  ) ?: throw malformedInstallSelection(path, "Root value must be a JSON object.")
+  return runCatching { payload.toInstallSelection(path) }
+    .getOrElse { error -> throw error.toMalformedInstallSelection(path) }
+}
+
+private fun Map<String, Any?>.toInstallSelection(path: Path): SharedInstallSelection {
+  requireExactKeys(path, keys, INSTALL_SELECTION_KEYS, "root")
+  requireContractVersion(path, requireString(path, "contract_version"))
+  return SharedInstallSelection(
+    selectedAgents = requireStringList(path, "selected_agents").mapTo(mutableSetOf(), InstallAgent::fromId),
+    platformPackSelection = requireObject(path, "platform_pack_selection").toPlatformPackSelection(path),
+    telemetryLevel = requireTelemetryLevel(path, requireString(path, "telemetry_level")),
+    mcpRegistrationChoice = requireObject(path, "mcp_registration").toMcpRegistrationChoice(path),
+  )
+}
+
+private fun requireContractVersion(path: Path, version: String) {
+  if (version != INSTALL_SELECTION_CONTRACT_VERSION) {
+    throw malformedInstallSelection(
+      path = path,
+      reason = "Unsupported contract_version '$version'; expected '$INSTALL_SELECTION_CONTRACT_VERSION'.",
+    )
+  }
+}
+
+private fun Map<String, Any?>.toPlatformPackSelection(path: Path): PlatformPackSelection {
+  requireExactKeys(path, keys, PLATFORM_PACK_SELECTION_KEYS, "platform_pack_selection")
+  val mode = when (val rawMode = requireString(path, "mode")) {
+    "none" -> PlatformPackSelectionMode.NONE
+    "selected" -> PlatformPackSelectionMode.SELECTED
+    "all" -> PlatformPackSelectionMode.ALL
+    else -> throw malformedInstallSelection(path, "Unknown platform pack selection mode '$rawMode'.")
+  }
+  val selectedSlugs = requireStringList(path, "selected_slugs").toSet()
+  if (selectedSlugs.any(String::isBlank)) {
+    throw malformedInstallSelection(path, "Field 'platform_pack_selection.selected_slugs' must not contain blanks.")
+  }
+  requirePlatformPackSelectionInvariants(path, mode, selectedSlugs)
+  return PlatformPackSelection(
+    mode = mode,
+    selectedSlugs = selectedSlugs,
+  )
+}
+
+private fun Map<String, Any?>.toMcpRegistrationChoice(path: Path): McpRegistrationChoice {
+  requireExactKeys(path, keys, MCP_REGISTRATION_KEYS, "mcp_registration")
+  val runtimeMcpBin = when (val rawPath = get("runtime_mcp_bin")) {
+    null -> null
+    is String ->
+      if (rawPath.isBlank()) {
+        throw malformedInstallSelection(path, "Field 'runtime_mcp_bin' must not be blank.")
+      } else {
+        Path.of(rawPath)
+      }
+    else -> throw malformedInstallSelection(path, "Field 'runtime_mcp_bin' must be a string or null.")
+  }
+  return McpRegistrationChoice(
+    register = requireBoolean(path, "register"),
+    runtimeMcpBin = runtimeMcpBin,
+  )
+}
+
+private fun requireTelemetryLevel(path: Path, rawLevel: String): InstallTelemetryLevel =
+  InstallTelemetryLevel.entries.firstOrNull { level -> level.id == rawLevel }
+    ?: throw malformedInstallSelection(path, "Unknown telemetry level '$rawLevel'.")
+
+private fun requirePlatformPackSelectionInvariants(
+  path: Path,
+  mode: PlatformPackSelectionMode,
+  selectedSlugs: Set<String>,
+) {
+  when (mode) {
+    PlatformPackSelectionMode.SELECTED -> {
+      if (selectedSlugs.isEmpty()) {
+        throw malformedInstallSelection(
+          path,
+          "Field 'platform_pack_selection.selected_slugs' must not be empty when mode is 'selected'.",
+        )
+      }
+    }
+
+    PlatformPackSelectionMode.NONE,
+    PlatformPackSelectionMode.ALL,
+    -> {
+      if (selectedSlugs.isNotEmpty()) {
+        throw malformedInstallSelection(
+          path,
+          "Field 'platform_pack_selection.selected_slugs' must be empty when mode is '${mode.name.lowercase()}'.",
+        )
+      }
+    }
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt
@@ -29,7 +29,13 @@ class FileSystemInstallSelectionPersistence : InstallSelectionPersistencePort {
   ): WriteLatestSuccessfulInstallSelectionResult {
     val selectionPath = selectionPath(request.installHome)
     selectionPath.parent?.let(Files::createDirectories)
-    writeInstallSelectionRecord(selectionPath, request.selection.toInstallSelectionJson() + "\n")
+    val payload = request.selection.toInstallSelectionJson()
+    val durablePayload = payload + "\n"
+    if (durablePayload.toByteArray(StandardCharsets.UTF_8).size > MAX_INSTALL_SELECTION_RECORD_BYTES) {
+      throw UnreadableInstallSelectionRecordError(selectionPath.toString())
+    }
+    parseInstallSelectionPayload(selectionPath, payload)
+    writeInstallSelectionRecord(selectionPath, durablePayload)
     return WriteLatestSuccessfulInstallSelectionResult(path = selectionPath)
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionPersistence.kt
@@ -1,0 +1,86 @@
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.error.MissingInstallSelectionRecordError
+import skillbill.error.UnreadableInstallSelectionRecordError
+import skillbill.install.model.SharedInstallSelection
+import skillbill.ports.install.selection.InstallSelectionPersistencePort
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionResult
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionResult
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+@Inject
+class FileSystemInstallSelectionPersistence : InstallSelectionPersistencePort {
+  override fun readLatestSuccessfulSelection(
+    request: ReadLatestSuccessfulInstallSelectionRequest,
+  ): ReadLatestSuccessfulInstallSelectionResult =
+    ReadLatestSuccessfulInstallSelectionResult(readInstallSelectionRecord(selectionPath(request.installHome)))
+
+  override fun writeLatestSuccessfulSelection(
+    request: WriteLatestSuccessfulInstallSelectionRequest,
+  ): WriteLatestSuccessfulInstallSelectionResult {
+    val selectionPath = selectionPath(request.installHome)
+    selectionPath.parent?.let(Files::createDirectories)
+    writeInstallSelectionRecord(selectionPath, request.selection.toInstallSelectionJson() + "\n")
+    return WriteLatestSuccessfulInstallSelectionResult(path = selectionPath)
+  }
+}
+
+internal fun readInstallSelectionRecord(path: Path): SharedInstallSelection {
+  if (!Files.exists(path)) {
+    throw MissingInstallSelectionRecordError(path.toString())
+  }
+  val size = installSelectionRecordSize(path)
+  if (size > MAX_INSTALL_SELECTION_RECORD_BYTES) {
+    throw UnreadableInstallSelectionRecordError(path.toString())
+  }
+  return parseInstallSelectionPayload(path, readInstallSelectionPayload(path))
+}
+
+private fun writeInstallSelectionRecord(path: Path, payload: String) {
+  val parent = path.parent ?: path.toAbsolutePath().normalize().parent
+  val tempFile = Files.createTempFile(parent, "${path.fileName}.", ".tmp")
+  try {
+    Files.writeString(tempFile, payload, StandardCharsets.UTF_8)
+    try {
+      Files.move(tempFile, path, ATOMIC_MOVE, REPLACE_EXISTING)
+    } catch (_: AtomicMoveNotSupportedException) {
+      Files.move(tempFile, path, REPLACE_EXISTING)
+    }
+  } finally {
+    Files.deleteIfExists(tempFile)
+  }
+}
+
+private fun installSelectionRecordSize(path: Path): Long = try {
+  Files.size(path)
+} catch (error: IOException) {
+  throw UnreadableInstallSelectionRecordError(path.toString(), error)
+} catch (error: SecurityException) {
+  throw UnreadableInstallSelectionRecordError(path.toString(), error)
+}
+
+private fun readInstallSelectionPayload(path: Path): String = try {
+  Files.readString(path)
+} catch (error: IOException) {
+  throw UnreadableInstallSelectionRecordError(path.toString(), error)
+} catch (error: SecurityException) {
+  throw UnreadableInstallSelectionRecordError(path.toString(), error)
+}
+
+private fun selectionPath(installHome: Path): Path = installHome
+  .resolve(".skill-bill")
+  .resolve(INSTALL_SELECTION_FILE_NAME)
+  .toAbsolutePath()
+  .normalize()
+
+private const val INSTALL_SELECTION_FILE_NAME = "install-selection.json"
+private const val MAX_INSTALL_SELECTION_RECORD_BYTES = 64 * 1024

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionValidation.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionValidation.kt
@@ -1,0 +1,53 @@
+package skillbill.infrastructure.fs
+
+import skillbill.contracts.JsonSupport
+import skillbill.error.MalformedInstallSelectionRecordError
+import java.nio.file.Path
+
+internal fun requireExactKeys(path: Path, actualKeys: Set<String>, expectedKeys: Set<String>, objectName: String) {
+  requireNoUnknownKeys(path, actualKeys, expectedKeys, objectName)
+  val missingKeys = expectedKeys - actualKeys
+  if (missingKeys.isNotEmpty()) {
+    throw malformedInstallSelection(path, "Object '$objectName' is missing keys: ${missingKeys.sorted()}.")
+  }
+}
+
+internal fun Map<String, Any?>.requireObject(path: Path, key: String): Map<String, Any?> =
+  JsonSupport.anyToStringAnyMap(get(key))
+    ?: throw malformedInstallSelection(path, "Field '$key' must be an object.")
+
+internal fun Map<String, Any?>.requireString(path: Path, key: String): String = get(key) as? String
+  ?: throw malformedInstallSelection(path, "Field '$key' must be a string.")
+
+internal fun Map<String, Any?>.requireStringList(path: Path, key: String): List<String> {
+  val entries = get(key) as? List<*>
+    ?: throw malformedInstallSelection(path, "Field '$key' must be an array of strings.")
+  return entries.map { entry ->
+    entry as? String
+      ?: throw malformedInstallSelection(path, "Field '$key' must be an array of strings.")
+  }
+}
+
+internal fun Map<String, Any?>.requireBoolean(path: Path, key: String): Boolean = get(key) as? Boolean
+  ?: throw malformedInstallSelection(path, "Field '$key' must be a boolean.")
+
+internal fun Throwable.toMalformedInstallSelection(path: Path): MalformedInstallSelectionRecordError =
+  this as? MalformedInstallSelectionRecordError
+    ?: malformedInstallSelection(path, message.orEmpty(), this)
+
+internal fun malformedInstallSelection(
+  path: Path,
+  reason: String,
+  cause: Throwable? = null,
+): MalformedInstallSelectionRecordError = MalformedInstallSelectionRecordError(
+  path = path.toString(),
+  reason = reason.ifBlank { "No reason provided." },
+  cause = cause,
+)
+
+private fun requireNoUnknownKeys(path: Path, actualKeys: Set<String>, expectedKeys: Set<String>, objectName: String) {
+  val unknownKeys = actualKeys - expectedKeys
+  if (unknownKeys.isNotEmpty()) {
+    throw malformedInstallSelection(path, "Object '$objectName' contains unknown keys: ${unknownKeys.sorted()}.")
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt
@@ -1,0 +1,34 @@
+package skillbill.infrastructure.fs
+
+import skillbill.contracts.JsonSupport
+import skillbill.install.model.InstallAgent
+import skillbill.install.model.McpRegistrationChoice
+import skillbill.install.model.PlatformPackSelection
+import skillbill.install.model.SharedInstallSelection
+
+internal fun SharedInstallSelection.toInstallSelectionJson(): String = JsonSupport.mapToJsonString(toWireMap())
+
+private fun SharedInstallSelection.toWireMap(): Map<String, Any?> = linkedMapOf(
+  "contract_version" to INSTALL_SELECTION_CONTRACT_VERSION,
+  "selected_agents" to selectedAgents.map(InstallAgent::id).sorted(),
+  "platform_pack_selection" to platformPackSelection.toWireMap(),
+  "telemetry_level" to telemetryLevel.id,
+  "mcp_registration" to mcpRegistrationChoice.toWireMap(),
+)
+
+private fun PlatformPackSelection.toWireMap(): Map<String, Any?> = linkedMapOf(
+  "mode" to mode.name.lowercase(),
+  "selected_slugs" to selectedSlugs.sorted(),
+)
+
+private fun McpRegistrationChoice.toWireMap(): Map<String, Any?> = linkedMapOf(
+  "register" to register,
+  "runtime_mcp_bin" to runtimeMcpBin?.toString(),
+)
+
+internal const val INSTALL_SELECTION_CONTRACT_VERSION = "1.0"
+
+internal val INSTALL_SELECTION_KEYS =
+  setOf("contract_version", "selected_agents", "platform_pack_selection", "telemetry_level", "mcp_registration")
+internal val PLATFORM_PACK_SELECTION_KEYS = setOf("mode", "selected_slugs")
+internal val MCP_REGISTRATION_KEYS = setOf("register", "runtime_mcp_bin")

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperations.kt
@@ -31,13 +31,7 @@ class GitWorkflowGitOperations : WorkflowGitOperations {
   override fun currentBranch(repoRoot: Path): WorkflowGitOperationResult = runGit(repoRoot, "branch", "--show-current")
 
   override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult {
-    val unstagedRuntimeManifests = unstageDecompositionManifests(repoRoot)
-    val commit =
-      if (unstagedRuntimeManifests.ok) {
-        runGit(repoRoot, "commit", "-m", message)
-      } else {
-        unstagedRuntimeManifests
-      }
+    val commit = runGit(repoRoot, "commit", "-m", message)
     return if (commit.ok) runGit(repoRoot, "rev-parse", "HEAD") else commit
   }
 
@@ -84,25 +78,6 @@ class GitWorkflowGitOperations : WorkflowGitOperations {
         status = "error",
         error = "git ${args.joinToString(" ")} failed with exit code ${process.exitValue()}: $output",
       )
-    }
-  }
-
-  private fun unstageDecompositionManifests(repoRoot: Path): WorkflowGitOperationResult {
-    val staged = runGit(repoRoot, "diff", "--cached", "--name-only", "--", ".feature-specs")
-    val manifestPaths =
-      if (staged.ok) {
-        staged.value
-          .lineSequence()
-          .map(String::trim)
-          .filter { it.endsWith("/decomposition-manifest.yaml") }
-          .toList()
-      } else {
-        emptyList()
-      }
-    return when {
-      !staged.ok -> staged
-      manifestPaths.isEmpty() -> WorkflowGitOperationResult(status = "ok")
-      else -> runGit(repoRoot, listOf("reset", "--") + manifestPaths)
     }
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperationsTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperationsTest.kt
@@ -5,12 +5,11 @@ import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class GitWorkflowGitOperationsTest {
   @Test
-  fun `create commit leaves decomposition manifest uncommitted`() {
+  fun `create commit includes staged decomposition manifest projection`() {
     val repoRoot = Files.createTempDirectory("skillbill-git-workflow")
     git(repoRoot, "init")
     git(repoRoot, "config", "user.email", "skill-bill@example.test")
@@ -26,8 +25,8 @@ class GitWorkflowGitOperationsTest {
     assertTrue(result.ok, result.error)
     val committedFiles = git(repoRoot, "show", "--name-only", "--format=", "HEAD")
     assertContains(committedFiles, "runtime.txt")
-    assertFalse("decomposition-manifest.yaml" in committedFiles)
-    assertEquals("?? .feature-specs/", git(repoRoot, "status", "--short").lineSequence().first())
+    assertContains(committedFiles, ".feature-specs/SKILL-52-demo/decomposition-manifest.yaml")
+    assertEquals("", git(repoRoot, "status", "--short"))
   }
 
   private fun git(repoRoot: Path, vararg args: String): String {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class FileSystemInstallSelectionPersistenceTest {
   @Test
@@ -165,6 +166,82 @@ class FileSystemInstallSelectionPersistenceTest {
   }
 
   @Test
+  fun `write rejects platform selections that read parser would reject`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-write-invariants")
+    val store = FileSystemInstallSelectionPersistence()
+    val validSelection = selection(selectedAgents = setOf(InstallAgent.CLAUDE))
+    store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = validSelection),
+    )
+
+    val invalidSelections = mapOf(
+      "selected mode with empty slugs" to selection(
+        platformPackSelection = PlatformPackSelection(mode = PlatformPackSelectionMode.SELECTED),
+      ),
+      "all mode with selected slugs" to selection(
+        platformPackSelection = PlatformPackSelection(
+          mode = PlatformPackSelectionMode.ALL,
+          selectedSlugs = setOf("kotlin"),
+        ),
+      ),
+    )
+
+    invalidSelections.forEach { (caseName, invalidSelection) ->
+      assertFailsWith<MalformedInstallSelectionRecordError>(caseName) {
+        store.writeLatestSuccessfulSelection(
+          WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = invalidSelection),
+        )
+      }
+    }
+    assertEquals(
+      validSelection,
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home)).selection,
+    )
+  }
+
+  @Test
+  fun `canonical record round trips manual and detected reusable selections`() {
+    val cases = mapOf(
+      "manual single-agent opt out" to selection(
+        selectedAgents = setOf(InstallAgent.CODEX),
+        telemetryLevel = InstallTelemetryLevel.OFF,
+        mcpRegistrationChoice = McpRegistrationChoice(register = false, runtimeMcpBin = null),
+      ),
+      "detected multi-agent registration" to selection(
+        selectedAgents = setOf(InstallAgent.CLAUDE, InstallAgent.OPENCODE),
+        platformPackSelection = PlatformPackSelection(PlatformPackSelectionMode.ALL),
+        telemetryLevel = InstallTelemetryLevel.ANONYMOUS,
+        mcpRegistrationChoice = McpRegistrationChoice(
+          register = true,
+          runtimeMcpBin = Path.of("/runtime-mcp/bin/runtime-mcp"),
+        ),
+      ),
+    )
+    val store = FileSystemInstallSelectionPersistence()
+
+    cases.forEach { (caseName, expectedSelection) ->
+      val home = Files.createTempDirectory("skillbill-install-selection-$caseName")
+
+      store.writeLatestSuccessfulSelection(
+        WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = expectedSelection),
+      )
+
+      assertEquals(
+        expectedSelection,
+        store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home)).selection,
+        caseName,
+      )
+      val emittedPayload = JsonSupport.anyToStringAnyMap(
+        JsonSupport.parseObjectOrNull(Files.readString(home.resolve(".skill-bill/install-selection.json")))
+          ?.let(JsonSupport::jsonElementToValue),
+      ).orEmpty()
+      assertFalse("recentRepoPath" in emittedPayload, caseName)
+      assertFalse("firstRun.agents" in emittedPayload, caseName)
+      assertEquals("1.0", emittedPayload["contract_version"], caseName)
+    }
+  }
+
+  @Test
   fun `missing install selection record fails loudly`() {
     val home = Files.createTempDirectory("skillbill-install-selection-missing")
     val store = FileSystemInstallSelectionPersistence()
@@ -203,6 +280,33 @@ class FileSystemInstallSelectionPersistenceTest {
     assertFailsWith<UnreadableInstallSelectionRecordError> {
       store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
     }
+  }
+
+  @Test
+  fun `oversized install selection write fails without replacing previous record`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-oversized-write")
+    val store = FileSystemInstallSelectionPersistence()
+    val previousSelection = selection(selectedAgents = setOf(InstallAgent.CLAUDE))
+    store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = previousSelection),
+    )
+    val oversizedSelection = selection(
+      platformPackSelection = PlatformPackSelection(
+        mode = PlatformPackSelectionMode.SELECTED,
+        selectedSlugs = (1..900).mapTo(mutableSetOf()) { index -> "slug-$index-${"a".repeat(80)}" },
+      ),
+    )
+
+    assertFailsWith<UnreadableInstallSelectionRecordError> {
+      store.writeLatestSuccessfulSelection(
+        WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = oversizedSelection),
+      )
+    }
+
+    assertEquals(
+      previousSelection,
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home)).selection,
+    )
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/FileSystemInstallSelectionPersistenceTest.kt
@@ -1,0 +1,289 @@
+package skillbill.install
+
+import skillbill.contracts.JsonSupport
+import skillbill.error.MalformedInstallSelectionRecordError
+import skillbill.error.MissingInstallSelectionRecordError
+import skillbill.error.UnreadableInstallSelectionRecordError
+import skillbill.infrastructure.fs.FileSystemInstallSelectionPersistence
+import skillbill.install.model.InstallAgent
+import skillbill.install.model.InstallTelemetryLevel
+import skillbill.install.model.McpRegistrationChoice
+import skillbill.install.model.PlatformPackSelection
+import skillbill.install.model.PlatformPackSelectionMode
+import skillbill.install.model.SharedInstallSelection
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionRequest
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FileSystemInstallSelectionPersistenceTest {
+  @Test
+  fun `writes and reads latest successful install selection`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-home")
+    val store = FileSystemInstallSelectionPersistence()
+    val selection = SharedInstallSelection(
+      selectedAgents = setOf(InstallAgent.CODEX, InstallAgent.CLAUDE),
+      platformPackSelection = PlatformPackSelection(
+        mode = PlatformPackSelectionMode.SELECTED,
+        selectedSlugs = setOf("kotlin", "kmp"),
+      ),
+      telemetryLevel = InstallTelemetryLevel.FULL,
+      mcpRegistrationChoice = McpRegistrationChoice(
+        register = true,
+        runtimeMcpBin = Path.of("/runtime-mcp/bin/runtime-mcp"),
+      ),
+    )
+
+    val writeResult = store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = selection),
+    )
+    val readResult = store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
+
+    assertEquals(home.resolve(".skill-bill/install-selection.json"), writeResult.path)
+    assertEquals(selection, readResult.selection)
+  }
+
+  @Test
+  fun `reads canonical v1 json record and writer preserves durable keys`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-canonical")
+    val path = home.resolve(".skill-bill/install-selection.json")
+    Files.createDirectories(path.parent)
+    Files.writeString(
+      path,
+      """
+      {
+        "contract_version": "1.0",
+        "selected_agents": ["claude", "codex"],
+        "platform_pack_selection": {
+          "mode": "selected",
+          "selected_slugs": ["kmp", "kotlin"]
+        },
+        "telemetry_level": "full",
+        "mcp_registration": {
+          "register": true,
+          "runtime_mcp_bin": "/runtime-mcp/bin/runtime-mcp"
+        }
+      }
+      """.trimIndent(),
+    )
+    val store = FileSystemInstallSelectionPersistence()
+
+    val selection = store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home)).selection
+
+    assertEquals(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX), selection.selectedAgents)
+    assertEquals(PlatformPackSelectionMode.SELECTED, selection.platformPackSelection.mode)
+    assertEquals(setOf("kmp", "kotlin"), selection.platformPackSelection.selectedSlugs)
+    assertEquals(InstallTelemetryLevel.FULL, selection.telemetryLevel)
+    assertEquals(true, selection.mcpRegistrationChoice.register)
+    assertEquals(Path.of("/runtime-mcp/bin/runtime-mcp"), selection.mcpRegistrationChoice.runtimeMcpBin)
+
+    store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = selection),
+    )
+    val emittedPayload = JsonSupport.anyToStringAnyMap(
+      JsonSupport.parseObjectOrNull(Files.readString(path))?.let(JsonSupport::jsonElementToValue),
+    ).orEmpty()
+    assertEquals(
+      mapOf(
+        "contract_version" to "1.0",
+        "selected_agents" to listOf("claude", "codex"),
+        "platform_pack_selection" to mapOf(
+          "mode" to "selected",
+          "selected_slugs" to listOf("kmp", "kotlin"),
+        ),
+        "telemetry_level" to "full",
+        "mcp_registration" to mapOf(
+          "register" to true,
+          "runtime_mcp_bin" to "/runtime-mcp/bin/runtime-mcp",
+        ),
+      ),
+      emittedPayload,
+    )
+  }
+
+  @Test
+  fun `requests select alternate install home per operation`() {
+    val firstHome = Files.createTempDirectory("skillbill-install-selection-first")
+    val alternateHome = Files.createTempDirectory("skillbill-install-selection-alternate")
+    val store = FileSystemInstallSelectionPersistence()
+    val selection = selection(
+      selectedAgents = setOf(InstallAgent.OPENCODE),
+      platformPackSelection = PlatformPackSelection(PlatformPackSelectionMode.ALL),
+    )
+
+    val writeResult = store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(installHome = alternateHome, selection = selection),
+    )
+
+    assertEquals(alternateHome.resolve(".skill-bill/install-selection.json"), writeResult.path)
+    assertEquals(
+      selection,
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(alternateHome)).selection,
+    )
+    assertFailsWith<MissingInstallSelectionRecordError> {
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(firstHome))
+    }
+  }
+
+  @Test
+  fun `latest successful selection write overwrites previous record and persists mcp opt out`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-overwrite")
+    val store = FileSystemInstallSelectionPersistence()
+    val initialSelection = selection(
+      selectedAgents = setOf(InstallAgent.CLAUDE),
+      telemetryLevel = InstallTelemetryLevel.FULL,
+      mcpRegistrationChoice = McpRegistrationChoice(
+        register = true,
+        runtimeMcpBin = Path.of("/runtime-mcp/bin/runtime-mcp"),
+      ),
+    )
+    val latestSelection = selection(
+      selectedAgents = setOf(InstallAgent.CODEX),
+      platformPackSelection = PlatformPackSelection(
+        mode = PlatformPackSelectionMode.SELECTED,
+        selectedSlugs = setOf("kotlin"),
+      ),
+      telemetryLevel = InstallTelemetryLevel.OFF,
+      mcpRegistrationChoice = McpRegistrationChoice(register = false, runtimeMcpBin = null),
+    )
+
+    store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = initialSelection),
+    )
+    store.writeLatestSuccessfulSelection(
+      WriteLatestSuccessfulInstallSelectionRequest(installHome = home, selection = latestSelection),
+    )
+
+    assertEquals(
+      latestSelection,
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home)).selection,
+    )
+  }
+
+  @Test
+  fun `missing install selection record fails loudly`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-missing")
+    val store = FileSystemInstallSelectionPersistence()
+
+    val error = assertFailsWith<MissingInstallSelectionRecordError> {
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
+    }
+
+    assertContains(error.message.orEmpty(), "install-selection.json")
+  }
+
+  @Test
+  fun `malformed install selection record fails loudly`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-malformed")
+    val path = home.resolve(".skill-bill/install-selection.json")
+    Files.createDirectories(path.parent)
+    Files.writeString(path, "{\"recentRepoPath\":\"/repo\"}")
+    val store = FileSystemInstallSelectionPersistence()
+
+    val error = assertFailsWith<MalformedInstallSelectionRecordError> {
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
+    }
+
+    assertContains(error.message.orEmpty(), "unknown keys")
+    assertContains(error.message.orEmpty(), "recentRepoPath")
+  }
+
+  @Test
+  fun `oversized install selection record fails before parsing`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-oversized")
+    val path = home.resolve(".skill-bill/install-selection.json")
+    Files.createDirectories(path.parent)
+    Files.writeString(path, "x".repeat(64 * 1024 + 1))
+    val store = FileSystemInstallSelectionPersistence()
+
+    assertFailsWith<UnreadableInstallSelectionRecordError> {
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
+    }
+  }
+
+  @Test
+  fun `invalid install selection records fail loudly`() {
+    val cases = mapOf(
+      "unsupported contract version" to validPayload(contractVersion = "2.0"),
+      "missing required field" to """
+        {
+          "contract_version": "1.0",
+          "selected_agents": [],
+          "platform_pack_selection": {"mode": "none", "selected_slugs": []},
+          "telemetry_level": "anonymous"
+        }
+      """.trimIndent(),
+      "bad agent id" to validPayload(selectedAgents = listOf("codex", "unknown-agent")),
+      "selected platform mode with empty slugs" to validPayload(platformMode = "selected", platformSlugs = emptyList()),
+      "selected platform mode with empty slug" to validPayload(platformMode = "selected", platformSlugs = listOf("")),
+      "selected platform mode with whitespace slug" to validPayload(
+        platformMode = "selected",
+        platformSlugs = listOf("   "),
+      ),
+      "none platform mode with selected slugs" to validPayload(platformMode = "none", platformSlugs = listOf("kotlin")),
+      "invalid nested mcp field" to validPayload(runtimeMcpBin = "\"\""),
+    )
+    val store = FileSystemInstallSelectionPersistence()
+
+    cases.forEach { (caseName, payload) ->
+      val home = Files.createTempDirectory("skillbill-install-selection-invalid")
+      val path = home.resolve(".skill-bill/install-selection.json")
+      Files.createDirectories(path.parent)
+      Files.writeString(path, payload)
+
+      assertFailsWith<MalformedInstallSelectionRecordError>(caseName) {
+        store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
+      }
+    }
+  }
+
+  @Test
+  fun `unreadable install selection record fails loudly`() {
+    val home = Files.createTempDirectory("skillbill-install-selection-unreadable")
+    val path = home.resolve(".skill-bill/install-selection.json")
+    Files.createDirectories(path)
+    val store = FileSystemInstallSelectionPersistence()
+
+    assertFailsWith<UnreadableInstallSelectionRecordError> {
+      store.readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(home))
+    }
+  }
+
+  private fun selection(
+    selectedAgents: Set<InstallAgent> = setOf(InstallAgent.CODEX),
+    platformPackSelection: PlatformPackSelection = PlatformPackSelection(PlatformPackSelectionMode.NONE),
+    telemetryLevel: InstallTelemetryLevel = InstallTelemetryLevel.ANONYMOUS,
+    mcpRegistrationChoice: McpRegistrationChoice = McpRegistrationChoice(register = false),
+  ): SharedInstallSelection = SharedInstallSelection(
+    selectedAgents = selectedAgents,
+    platformPackSelection = platformPackSelection,
+    telemetryLevel = telemetryLevel,
+    mcpRegistrationChoice = mcpRegistrationChoice,
+  )
+
+  private fun validPayload(
+    contractVersion: String = "1.0",
+    selectedAgents: List<String> = listOf("codex"),
+    platformMode: String = "none",
+    platformSlugs: List<String> = emptyList(),
+    runtimeMcpBin: String = "null",
+  ): String = """
+    {
+      "contract_version": "$contractVersion",
+      "selected_agents": [${selectedAgents.joinToString { "\"$it\"" }}],
+      "platform_pack_selection": {
+        "mode": "$platformMode",
+        "selected_slugs": [${platformSlugs.joinToString { "\"$it\"" }}]
+      },
+      "telemetry_level": "anonymous",
+      "mcp_registration": {
+        "register": false,
+        "runtime_mcp_bin": $runtimeMcpBin
+      }
+    }
+  """.trimIndent()
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/InstallSelectionPersistencePort.kt
@@ -1,0 +1,16 @@
+package skillbill.ports.install.selection
+
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionResult
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionRequest
+import skillbill.ports.install.selection.model.WriteLatestSuccessfulInstallSelectionResult
+
+interface InstallSelectionPersistencePort {
+  fun readLatestSuccessfulSelection(
+    request: ReadLatestSuccessfulInstallSelectionRequest,
+  ): ReadLatestSuccessfulInstallSelectionResult
+
+  fun writeLatestSuccessfulSelection(
+    request: WriteLatestSuccessfulInstallSelectionRequest,
+  ): WriteLatestSuccessfulInstallSelectionResult
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/model/InstallSelectionPersistenceModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/selection/model/InstallSelectionPersistenceModels.kt
@@ -1,0 +1,21 @@
+package skillbill.ports.install.selection.model
+
+import skillbill.install.model.SharedInstallSelection
+import java.nio.file.Path
+
+data class ReadLatestSuccessfulInstallSelectionRequest(
+  val installHome: Path,
+)
+
+data class ReadLatestSuccessfulInstallSelectionResult(
+  val selection: SharedInstallSelection,
+)
+
+data class WriteLatestSuccessfulInstallSelectionRequest(
+  val installHome: Path,
+  val selection: SharedInstallSelection,
+)
+
+data class WriteLatestSuccessfulInstallSelectionResult(
+  val path: Path,
+)

--- a/skills/bill-feature-implement/content.md
+++ b/skills/bill-feature-implement/content.md
@@ -577,6 +577,10 @@ Decomposition rules:
 - Same-branch decompositions advance one subtask at a time on the parent feature
   branch. Each completed subtask gets an individual commit before the next
   pending dependency-complete subtask starts.
+- The Git-tracked decomposition manifest is a human recovery ledger: commit
+  subtask status/current-intent projections with the subtask, but keep the
+  resulting commit SHA in durable workflow runtime state rather than trying to
+  write it into the same commit's manifest projection.
 - Stacked decompositions are opt-in only. Every subtask must declare its branch
   and expected base in stack order so continuation can check out the right branch
   and reject advancement onto the wrong base.


### PR DESCRIPTION
# Summary

Completes SKILL-53 by moving latest successful install selections into a shared runtime-owned persistence path for CLI/shell and desktop flows. This locks the validation contract for the shared runtime install architecture so desktop replay, CLI install apply, and install.sh delegation reuse the same typed state without introducing desktop dependencies into runtime modules.

- Adds and tightens coverage across CLI apply, application services, infra-fs persistence, desktop datastore/gateway/ViewModel replay, migration fallback, and Gradle module boundaries.
- Preserves `PlatformSelectionMode.ALL` through desktop replay and keeps completed `LocalDesktopPreferenceStore` live/durable state limited to desktop-owned fields while retaining legacy `firstRun.*` fallback compatibility.
- Hardens `FileSystemInstallSelectionPersistence` writes by validating through the read parser and enforcing the UTF-8 64 KiB payload guard before atomic replacement.
- Keeps workflow artifact details out of decomposition manifest projections and records runtime-kotlin boundary history.

## Feature Flags

N/A

# How Has This Been Tested?

1. `skill-bill validate`
2. `(cd runtime-kotlin && ./gradlew check)` after clearing stale `runtime-kotlin/.gradle/configuration-cache`
3. `npx --yes agnix --strict .`
4. `scripts/validate_agent_configs`
5. Post-history validation: `git diff --check` and `npx --yes agnix --strict .`