### PR TITLE
feat: [SKILL-56] add agent-independent goal runner

### DIFF
--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
@@ -9,18 +9,18 @@ base_branch: "main"
 feature_branch: "feat/SKILL-56-agent-independent-goal-runner"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 1
-  action: "resume"
+  subtask_id: 2
+  action: "start"
 subtasks:
 - id: 1
   name: "headless-continuation-contract"
   spec_path: ".feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_1_headless-continuation-contract.md"
-  status: "in_progress"
+  status: "complete"
   branch: "feat/SKILL-56-agent-independent-goal-runner"
   commit_sha: null
   workflow_id: "wfl-20260529-194727-0h8b"
   blocked_reason: null
-  last_resumable_step: "review"
+  last_resumable_step: "commit_push"
   dependencies: []
 - id: 2
   name: "agent-agnostic-launcher"

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
@@ -3,7 +3,7 @@ contract_version: "0.2"
 issue_key: "SKILL-56"
 feature_name: "agent-independent-goal-runner"
 parent_spec_path: ".feature-specs/SKILL-56-agent-independent-goal-runner/spec.md"
-status: "in_progress"
+status: "complete"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-56-agent-independent-goal-runner"
@@ -54,12 +54,12 @@ subtasks:
 - id: 4
   name: "cli-and-bill-goal-skill"
   spec_path: ".feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_4_cli-and-bill-goal-skill.md"
-  status: "pending"
-  branch: null
+  status: "complete"
+  branch: "feat/SKILL-56-agent-independent-goal-runner"
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wfl-20260530-095108-337u"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "finish"
   dependencies:
   - subtask_id: 3
     optional: false

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
@@ -9,8 +9,8 @@ base_branch: "main"
 feature_branch: "feat/SKILL-56-agent-independent-goal-runner"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 2
-  action: "start"
+  subtask_id: 0
+  action: "none"
 subtasks:
 - id: 1
   name: "headless-continuation-contract"
@@ -25,12 +25,12 @@ subtasks:
 - id: 2
   name: "agent-agnostic-launcher"
   spec_path: ".feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_2_agent-agnostic-launcher.md"
-  status: "pending"
-  branch: null
+  status: "complete"
+  branch: "feat/SKILL-56-agent-independent-goal-runner"
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wfl-20260530-074310-dm7q"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "finish"
   dependencies:
   - subtask_id: 1
     optional: false

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
@@ -38,12 +38,12 @@ subtasks:
 - id: 3
   name: "goal-runner-service"
   spec_path: ".feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_3_goal-runner-service.md"
-  status: "pending"
-  branch: null
+  status: "complete"
+  branch: "feat/SKILL-56-agent-independent-goal-runner"
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wfl-20260530-083900-29zk"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "finish"
   dependencies:
   - subtask_id: 1
     optional: false

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml
@@ -3,24 +3,24 @@ contract_version: "0.2"
 issue_key: "SKILL-56"
 feature_name: "agent-independent-goal-runner"
 parent_spec_path: ".feature-specs/SKILL-56-agent-independent-goal-runner/spec.md"
-status: "pending"
+status: "in_progress"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-56-agent-independent-goal-runner"
 stack_branches: []
 current_subtask_intent:
   subtask_id: 1
-  action: "start"
+  action: "resume"
 subtasks:
 - id: 1
   name: "headless-continuation-contract"
   spec_path: ".feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_1_headless-continuation-contract.md"
-  status: "pending"
-  branch: null
+  status: "in_progress"
+  branch: "feat/SKILL-56-agent-independent-goal-runner"
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wfl-20260529-194727-0h8b"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "review"
   dependencies: []
 - id: 2
   name: "agent-agnostic-launcher"

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_1_headless-continuation-contract.md
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_1_headless-continuation-contract.md
@@ -1,6 +1,6 @@
 # SKILL-56 Subtask 1 - Headless Continuation Contract for feature-implement
 
-Status: In Progress
+Status: Complete
 Sources: Parent spec `.feature-specs/SKILL-56-agent-independent-goal-runner/spec.md`; decomposition manifest `.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml`; accepted subtask briefing for workflow `wfl-20260529-194727-0h8b`.
 Parent spec: [.feature-specs/SKILL-56-agent-independent-goal-runner/spec.md](./spec.md)
 Issue key: SKILL-56

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_1_headless-continuation-contract.md
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_1_headless-continuation-contract.md
@@ -1,5 +1,7 @@
 # SKILL-56 Subtask 1 - Headless Continuation Contract for feature-implement
 
+Status: In Progress
+Sources: Parent spec `.feature-specs/SKILL-56-agent-independent-goal-runner/spec.md`; decomposition manifest `.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml`; accepted subtask briefing for workflow `wfl-20260529-194727-0h8b`.
 Parent spec: [.feature-specs/SKILL-56-agent-independent-goal-runner/spec.md](./spec.md)
 Issue key: SKILL-56
 Subtask order: 1 of 4
@@ -123,6 +125,17 @@ npx --yes agnix --strict .
 #     on stdout parsing.
 # Record which agents passed and any context that had to be injected.
 ```
+
+## Headless Availability Exercise
+
+Recorded during SKILL-56 subtask 1 implementation against the real
+`.feature-specs/SKILL-56-agent-independent-goal-runner/decomposition-manifest.yaml`
+manifest.
+
+- Agent binaries present on this host: Codex (`/home/sermilion/.local/bin/codex`), Claude (`/home/sermilion/.local/bin/claude`), and Opencode (`/home/sermilion/.opencode/bin/opencode`).
+- Installed Skill Bill MCP runtime is present for active agents, but it reflects the last installed runtime under `~/.skill-bill/runtime`; source-only changes are not visible there until `./install.sh` refreshes the local install.
+- The source runtime accepts the new constrained entry (`skill-bill workflow continue <issue-key> --subtask-id <id>`) in tests. The previously installed `skill-bill` binary did not yet expose `--subtask-id`, confirming that subtask 2 launch adapters must either run after install refresh or inject the built source/runtime path deliberately.
+- The current durable workflow database does not contain a terminal decomposed parent workflow row for `SKILL-56`; it contains this in-progress subtask run and the git-tracked manifest projection. Goal runners must read outcomes from durable workflow state created by the goal-continuation entry, not by scanning stdout or assuming `.feature-specs` files alone are sufficient.
 
 ## Implementation Notes
 

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_4_cli-and-bill-goal-skill.md
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/spec_subtask_4_cli-and-bill-goal-skill.md
@@ -121,3 +121,7 @@ npx --yes agnix --strict .
 - Foreground progress should be honest: show the active agent and the current
   subtask/step; on stop, print exactly which subtask blocked and why, and how to
   resume (`skill-bill goal <issue_key>` again).
+## E2E Evidence
+
+Subtask 4 goal CLI evidence is recorded in
+`.feature-specs/SKILL-56-agent-independent-goal-runner/subtask_4_goal_cli_e2e_evidence.md`.

--- a/.feature-specs/SKILL-56-agent-independent-goal-runner/subtask_4_goal_cli_e2e_evidence.md
+++ b/.feature-specs/SKILL-56-agent-independent-goal-runner/subtask_4_goal_cli_e2e_evidence.md
@@ -1,0 +1,64 @@
+# SKILL-56 Subtask 4 Goal CLI E2E Evidence
+
+Date: 2026-05-30
+
+Command surface exercised:
+
+- `runtime-kotlin/runtime-cli/build/install/runtime-cli/bin/runtime-cli goal <issue_key>`
+- `runtime-kotlin/runtime-cli/build/install/runtime-cli/bin/runtime-cli goal status <issue_key>`
+
+Harness:
+
+- Temporary git repositories under `/tmp/tmp.9RP5z3X1VF`.
+- A fake `codex` executable was placed first on `PATH`; the real goal runner launched it through the normal headless Codex adapter.
+- A fake `gh` executable was placed first on `PATH`; it recorded PR calls and returned a deterministic PR URL.
+- No real hosted Codex, Claude, OpenCode, Copilot, Junie, or GitHub service was exercised.
+
+Successful decomposed goal:
+
+- Issue: `SKILL-901`
+- Subtasks: 2
+- Exit status: `0`
+- Foreground output showed:
+  - `goal SKILL-901: subtask 1 start`
+  - `goal SKILL-901: subtask 1 complete`
+  - `goal SKILL-901: subtask 2 start`
+  - `goal SKILL-901: subtask 2 complete`
+  - `goal SKILL-901: complete (https://github.com/example/skill-bill/pull/901)`
+- Child stdout/stderr was live-tee'd:
+  - `child stdout subtask 1`
+  - `child stderr subtask 1`
+  - `child stdout subtask 2`
+  - `child stderr subtask 2`
+- Fresh process per subtask was observed in the fake Codex log:
+  - subtask 1: `codex pid=95746`
+  - subtask 2: `codex pid=95888`
+- Manifest advancement was observed through the runner completing both subtasks and opening the final PR with both commit SHAs in the body:
+  - `- 1. Part 1 (sha-1)`
+  - `- 2. Part 2 (sha-2)`
+- Single PR finalization was observed:
+  - one `gh pr create --head feat/SKILL-901-goal --base main --draft ...` call after subtask 2 completed.
+
+Forced-failure decomposed goal:
+
+- Issue: `SKILL-902`
+- Subtasks: 3
+- Forced failure: subtask 2
+- Exit status: `1`
+- Foreground output showed:
+  - `goal SKILL-902: subtask 1 complete`
+  - `goal SKILL-902: subtask 2 stopped (failed): forced e2e failure`
+  - final status `stopped`
+  - `subtask_id: 2`
+  - `reason: failed`
+  - `last_resumable_step: review`
+- Fresh process per attempted subtask was observed:
+  - subtask 1: `codex pid=96077`
+  - subtask 2: `codex pid=96187`
+- Read-only status after the forced failure reported the subtask-3 projection:
+  - `complete: 1`
+  - `pending: 1`
+  - `blocked: 1`
+  - `current_subtask: 2`
+  - `current_step: review`
+  - `active_agent: codex`

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Routing, validation, and installation are manifest-driven, so the system accepts
 | `/bill-feature-guard-cleanup` | Remove feature flags and legacy code after rollout |
 | `/bill-feature-implement` | End-to-end feature workflow from spec through review and validation |
 | `/bill-feature-verify` | Verify a PR against a task spec or design doc |
+| `/bill-goal` | Interactively decompose larger goals and hand confirmed runs to the foreground goal loop |
 | `/bill-grill-plan` | Stress-test a plan or design by walking the decision tree |
 | `/bill-pr-description` | Generate a PR title, description, and QA steps |
 | `/bill-pr-review-fix` | Resolve PR review comments end-to-end with an approval gate and reply automation |

--- a/orchestration/contracts/telemetry-event-schema.yaml
+++ b/orchestration/contracts/telemetry-event-schema.yaml
@@ -528,6 +528,8 @@ $defs:
         type: string
       issue_key:
         type: string
+      subtask_id:
+        type: integer
 
   featureImplementWorkflowGetEvent:
     type: object

--- a/orchestration/workflow-contract/PLAYBOOK.md
+++ b/orchestration/workflow-contract/PLAYBOOK.md
@@ -193,9 +193,22 @@ The CLI exposes the same recovery surface through:
 - `skill-bill workflow show <workflow-id>`
 - `skill-bill workflow resume <workflow-id>`
 - `skill-bill workflow continue <workflow-id>`
+- `skill-bill workflow continue <issue-key> [--subtask-id <id>]`
 - `skill-bill verify-workflow show <workflow-id>`
 - `skill-bill verify-workflow resume <workflow-id>`
 - `skill-bill verify-workflow continue <workflow-id>`
+
+For decomposed feature parents, `feature_implement_workflow_continue` also
+accepts a parent `issue_key` and optional `subtask_id`. The issue-key path is a
+goal-continuation entry for one subtask: it starts or resumes only the selected
+runnable subtask, derives the subtask contract from persisted artifacts and the
+subtask spec, suppresses PR creation, and records the machine-readable outcome
+in durable workflow state. The optional `subtask_id` is a constraint, not a
+skip-ahead flag; a later subtask blocks until dependencies are complete.
+Outcome fields are `issue_key`, `subtask_id`, terminal `status`, `commit_sha`,
+`workflow_id`, `blocked_reason`, and `last_resumable_step`. Runtime state is the
+authoritative channel; stdout and git-tracked manifest projections are
+diagnostic/recovery views.
 
 ## Pilot: `bill-feature-implement`
 

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-05-30] SKILL-56 subtask 4 cli-and-bill-goal-skill
+Areas: runtime-kotlin/runtime-cli, runtime-kotlin/runtime-application, runtime-kotlin/runtime-ports, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-core, skills/bill-goal
+- Added the foreground `skill-bill goal` command and read-only `goal status` surface over the subtask-3 `GoalRunner`/status projection; CLI remains a thin adapter with text/payload mapping only. reusable
+- Live child stdout/stderr teeing is a narrow `AgentRunOutputSink` carried through request models into infra-fs `JvmAgentRunProcessRunner`; captured bounded output remains intact and process IO stays outside application/domain. reusable
+- `GoalRunnerRunEvent` gives the CLI readable per-subtask progress without parsing workflow internals or changing loop semantics; stop reports still use workflow-store outcomes as authority.
+- Added canonical `skills/bill-goal/content.md` plus README catalog row; source remains content.md-only and install/render sync produced agent links without committing generated wrappers.
+- E2E evidence uses fake `codex`/`gh` executables to exercise the real foreground driver, fresh process per subtask, manifest advancement, final PR call, and forced-failure stop report; it does not claim hosted-agent/GitHub coverage.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented (subtask scope)
+
 ## [2026-05-30] SKILL-56 subtask 3 goal-runner-service
 Areas: runtime-kotlin/runtime-domain, runtime-kotlin/runtime-ports, runtime-kotlin/runtime-application, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-core
 - Added `GoalRunner` as the parent loop over decomposed manifests: select dependency-ready subtasks, launch one fresh agent process per subtask, reconcile process facts with workflow-store outcomes, and advance manifest runtime state. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-05-30] SKILL-56 subtask 3 goal-runner-service
+Areas: runtime-kotlin/runtime-domain, runtime-kotlin/runtime-ports, runtime-kotlin/runtime-application, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-core
+- Added `GoalRunner` as the parent loop over decomposed manifests: select dependency-ready subtasks, launch one fresh agent process per subtask, reconcile process facts with workflow-store outcomes, and advance manifest runtime state. reusable
+- Goal-runner success is workflow-store authoritative: completed PR-suppressed subtask workflows must expose `commit_push_result.commit_sha`; stdout remains diagnostic only and missing terminal state blocks the parent.
+- Added typed goal-runner ports for manifest state, workflow outcome reads, subtask launching, and final goal PR creation; domain policy stays pure while application adapts to launcher/workflow/PR ports. reusable
+- Added status projection for complete/pending/blocked counts, current subtask/step, and active agent so the CLI front can render status without re-parsing workflow internals. reusable
+- Known limitation: CLI/bill-goal entrypoint and human progress rendering remain subtask 4; this subtask wires service/composition and the gh-backed PR port only.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented (subtask scope)
+
 ## [2026-05-30] SKILL-56 subtask 2 agent-agnostic-launcher
 Areas: runtime-kotlin/runtime-ports, runtime-kotlin/runtime-application, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-core
 - Added `AgentRunLauncher` as a technology-neutral port with typed launch request/outcome models; launcher outcomes are process facts only and never infer subtask success from stdout. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-05-30] SKILL-56 subtask 2 agent-agnostic-launcher
+Areas: runtime-kotlin/runtime-ports, runtime-kotlin/runtime-application, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-core
+- Added `AgentRunLauncher` as a technology-neutral port with typed launch request/outcome models; launcher outcomes are process facts only and never infer subtask success from stdout. reusable
+- Added `AgentRunService` to resolve configured override before invoked `bill-goal` agent via `InstallAgent`; unknown agents fail before launch and supported agents without headless paths return explicit unsupported outcomes.
+- Infra-fs owns fresh-process spawning, command construction, environment inheritance, bounded UTF-8 stdout/stderr capture, timeout destroy+wait, and spawn-failure mapping; keep all process/env work out of application/domain/ports. reusable
+- Headless adapters currently cover Claude, Codex, and OpenCode; Copilot and Junie are deliberately unsupported until a proven headless skill-run path exists.
+- RuntimeComponent exposes the service and architecture/surface tests lock the composition-only binding plus launcher operation surface.
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented (subtask scope)
+
 ## [2026-05-29] SKILL-56 subtask 1 headless-continuation-contract
 Areas: runtime-kotlin/runtime-application, runtime-kotlin/runtime-domain, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-mcp, orchestration/contracts, skills/bill-feature-implement
 - Added issue-key goal continuation for decomposed feature-implement parents with optional `subtask_id` constraint; domain selector now has a terminal-subtask outcome so retrying a completed requested subtask is idempotent while later work remains. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,14 @@
+## [2026-05-29] SKILL-56 subtask 1 headless-continuation-contract
+Areas: runtime-kotlin/runtime-application, runtime-kotlin/runtime-domain, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-mcp, orchestration/contracts, skills/bill-feature-implement
+- Added issue-key goal continuation for decomposed feature-implement parents with optional `subtask_id` constraint; domain selector now has a terminal-subtask outcome so retrying a completed requested subtask is idempotent while later work remains. reusable
+- New subtask workflows start at `preplan` with `assessment`/`branch`/`goal_continuation` artifacts already persisted; interactive feature-implement still owns confirmation and PR creation.
+- Goal-continuation outcomes are typed in application results and mapped to stable CLI/MCP wire fields: `issue_key`, `subtask_id`, `status`, `commit_sha`, `workflow_id`, `blocked_reason`, `last_resumable_step`. reusable
+- PR-suppressed completion treats completed `commit_push` plus nonblank `commit_push_result.commit_sha` as terminal success; missing commit SHA blocks loudly instead of duplicating later commit advancement.
+- MCP `feature_implement_workflow_continue` now accepts strict integer `subtask_id`; telemetry event schema mirrors the registry input schema to keep parity tests green.
+- Headless exercise recorded in the subtask spec: installed runtime must be refreshed before launcher adapters depend on new options; durable workflow state is authoritative, not stdout or git-tracked manifest projections.
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented (subtask scope)
+
 ## [2026-05-29] SKILL-55 subtask 2 desktop-app-installers
 Areas: runtime-kotlin/runtime-desktop, runtime-kotlin/build-logic/convention, runtime-kotlin/agent/decisions.md, runtime-kotlin/README.md
 - Turned the existing Compose `nativeDistributions` (`packageDmg/Msi/Deb/Rpm`) into canonically-named, checksummed per-OS installers. jpackage AND the Compose Dmg validator (eager at config time) reject qualified/non-numeric versions, and macOS requires MAJOR>=1: derive a jpackage-legal `MAJOR.MINOR.PATCH` from `project.version` via the new pure `dev.skillbill.runtime.buildlogic.toJpackageVersion` (strips `-SNAPSHOT`/qualifier, pads, leading-digit run per component), plus a macOS-only `toMacAppVersion` that bumps a zero major to 1 (`0.1.0`->`1.1.0`). reusable

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/AgentRunGoalRunnerSubtaskLauncher.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/AgentRunGoalRunnerSubtaskLauncher.kt
@@ -1,0 +1,20 @@
+package skillbill.application
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.AgentRunStartRequest
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
+import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
+
+@Inject
+class AgentRunGoalRunnerSubtaskLauncher(
+  private val agentRunService: AgentRunService,
+) : GoalRunnerSubtaskLauncher {
+  override fun launch(request: GoalRunnerSubtaskLaunchRequest): AgentRunLaunchOutcome = agentRunService.launch(
+    AgentRunStartRequest(
+      invokedAgentId = request.invokedAgentId,
+      configuredAgentOverrideId = request.configuredAgentOverrideId,
+      skillRunRequest = request.skillRunRequest,
+    ),
+  ).launchOutcome
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/AgentRunService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/AgentRunService.kt
@@ -1,0 +1,35 @@
+package skillbill.application
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.AgentRunAgentResolution
+import skillbill.application.model.AgentRunResult
+import skillbill.application.model.AgentRunStartRequest
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.AgentRunLauncher
+import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+
+@Inject
+class AgentRunService(
+  private val agentRunLauncher: AgentRunLauncher,
+) {
+  fun launch(request: AgentRunStartRequest): AgentRunResult {
+    val invokedAgent = InstallAgent.fromNormalizedId(request.invokedAgentId, label = "invokedAgentId")
+    val overrideAgent = request.configuredAgentOverrideId
+      ?.let { id -> InstallAgent.fromNormalizedId(id, label = "configuredAgentOverrideId") }
+    val effectiveAgent = overrideAgent ?: invokedAgent
+    val resolution = AgentRunAgentResolution(
+      invokedAgent = invokedAgent,
+      configuredOverrideAgent = overrideAgent,
+      effectiveAgent = effectiveAgent,
+    )
+    return AgentRunResult(
+      resolution = resolution,
+      launchOutcome = agentRunLauncher.launch(
+        AgentRunLaunchRequest(
+          agentId = effectiveAgent.id,
+          skillRunRequest = request.skillRunRequest,
+        ),
+      ),
+    )
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/ContinuationStepResult.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/ContinuationStepResult.kt
@@ -1,5 +1,6 @@
 package skillbill.application
 
+import skillbill.application.model.GoalContinuationOutcome
 import skillbill.application.model.WorkflowContinueResult
 import skillbill.contracts.JsonSupport
 import skillbill.ports.persistence.UnitOfWork
@@ -30,23 +31,33 @@ internal data class ContinuationStepResult(
       this
     }
 
-  fun withDecompositionFields(subtaskId: Int, specPath: String): ContinuationStepResult {
+  fun withDecompositionFields(
+    issueKey: String,
+    subtaskId: Int,
+    specPath: String,
+    outcome: GoalContinuationOutcome,
+  ): ContinuationStepResult {
     val decorated: WorkflowContinueResult = when (val current = result) {
       is WorkflowContinueResult.Standard -> WorkflowContinueResult.DecompositionStandard(
         dbPath = current.dbPath,
         view = current.view,
         decompositionSubtaskId = subtaskId,
         decompositionSubtaskSpecPath = specPath,
+        issueKey = issueKey,
+        outcome = outcome,
       )
       is WorkflowContinueResult.DecompositionStandard -> current.copy(
         decompositionSubtaskId = subtaskId,
         decompositionSubtaskSpecPath = specPath,
+        issueKey = issueKey,
+        outcome = outcome,
       )
       is WorkflowContinueResult.UnknownWorkflow,
       is WorkflowContinueResult.DecompositionMissingSubtaskWorkflow,
       is WorkflowContinueResult.DecompositionBlockedSubtask,
       is WorkflowContinueResult.DecompositionBlockedBranchStart,
       is WorkflowContinueResult.DecompositionDone,
+      is WorkflowContinueResult.DecompositionSubtaskOutcome,
       is WorkflowContinueResult.DecompositionBlockedGit,
       is WorkflowContinueResult.Error,
       -> error(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
@@ -20,8 +20,15 @@ internal fun DecompositionSubtask.withRuntimeFields(
   val nextStatus = status ?: this.status
   return copy(
     status = nextStatus,
-    branch = branchName(artifacts["branch"]).ifBlank { manifest.branchFor(id) ?: branch },
+    branch = branchName(artifacts["branch"]).ifBlank {
+      when (manifest.executionModel) {
+        DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK -> manifest.featureBranch
+        DecompositionExecutionModel.STACKED_BRANCHES ->
+          manifest.stackBranches.firstOrNull { it.subtaskId == id }?.branch
+      } ?: branch
+    },
     workflowId = update.workflowId.ifBlank { workflowId },
+    commitSha = commitShaFrom(artifacts) ?: commitSha,
     blockedReason = blockedReasonFrom(update, nextStatus) ?: blockedReason.takeUnless { nextStatus != "blocked" },
     lastResumableStep = update.currentStepId.takeIf(String::isNotBlank) ?: lastResumableStep,
   )
@@ -45,6 +52,8 @@ internal fun statusFromUpdate(update: DecompositionManifestRuntimeUpdate): Strin
   val stepUpdates = update.stepUpdates.orEmpty()
   return when {
     update.workflowStatus == "blocked" || stepUpdates.any { it["status"] == "blocked" } -> "blocked"
+    prSuppressedCommitStatus(update) == "complete" -> "complete"
+    prSuppressedCommitStatus(update) == "blocked" -> "blocked"
     stepUpdates.any { it["status"] == "skipped" && it["step_id"] in terminalSkippedSteps } -> "skipped"
     update.workflowStatus == "completed" ||
       stepUpdates.any { it["status"] == "completed" && it["step_id"] in completionSteps } -> "complete"
@@ -78,11 +87,6 @@ private fun DecompositionManifest.matchingSubtaskId(repoRoot: Path, specPath: St
   }?.id
 }
 
-private fun DecompositionManifest.branchFor(subtaskId: Int): String? = when (executionModel) {
-  DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK -> featureBranch
-  DecompositionExecutionModel.STACKED_BRANCHES -> stackBranches.firstOrNull { it.subtaskId == subtaskId }?.branch
-}
-
 private fun mergedArtifacts(update: DecompositionManifestRuntimeUpdate): Map<String, Any?> =
   LinkedHashMap(update.existingArtifacts).apply { update.artifactsPatch?.let(::putAll) }
 
@@ -90,7 +94,27 @@ private fun blockedReasonFrom(update: DecompositionManifestRuntimeUpdate, status
   if (status == "blocked") {
     val artifacts = mergedArtifacts(update)
     artifacts["blocked_reason"]?.toString()?.takeIf(String::isNotBlank)
+      ?: "Goal-continuation commit_push completed without commit_push_result.commit_sha."
+        .takeIf { prSuppressedCommitStatus(update) == "blocked" }
       ?: "Workflow step '${update.currentStepId.ifBlank { "unknown" }}' is blocked."
   } else {
     null
   }
+
+private fun prSuppressedCommitStatus(update: DecompositionManifestRuntimeUpdate): String? {
+  val artifacts = mergedArtifacts(update)
+  val goalContinuation = artifacts["goal_continuation"] as? Map<*, *> ?: return null
+  val suppressPr = goalContinuation["suppress_pr"] == true
+  val commitPushCompleted =
+    update.stepUpdates.orEmpty().any { it["step_id"] == "commit_push" && it["status"] == "completed" }
+  return when {
+    !suppressPr || !commitPushCompleted -> null
+    commitShaFrom(artifacts) != null -> "complete"
+    else -> "blocked"
+  }
+}
+
+private fun commitShaFrom(artifacts: Map<String, Any?>): String? = (artifacts["commit_push_result"] as? Map<*, *>)
+  ?.get("commit_sha")
+  ?.toString()
+  ?.takeIf(String::isNotBlank)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuation.kt
@@ -1,5 +1,6 @@
 package skillbill.application
 
+import skillbill.application.model.GoalContinuationOutcome
 import skillbill.application.model.WorkflowContinueResult
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.workflow.DecompositionManifestFileStore
@@ -19,7 +20,11 @@ internal class DecompositionWorkflowContinuation(
   private val validator: DecompositionManifestValidator,
   private val fileStore: DecompositionManifestFileStore = UnavailableDecompositionManifestFileStore,
 ) {
-  fun continueDecomposedParentByIssueKey(issueKey: String, unitOfWork: UnitOfWork): ContinuationStepResult {
+  fun continueDecomposedParentByIssueKey(
+    issueKey: String,
+    unitOfWork: UnitOfWork,
+    requestedSubtaskId: Int? = null,
+  ): ContinuationStepResult {
     val parentRecord = unitOfWork.workflowStates
       .findDecomposedParentWorkflow(issueKey, validator)
       ?.toSnapshot()
@@ -32,7 +37,7 @@ internal class DecompositionWorkflowContinuation(
         ),
       )
     } else {
-      continueManifest(parentRecord, manifest, unitOfWork)
+      continueManifest(parentRecord, manifest, unitOfWork, requestedSubtaskId)
     }
     return result
   }
@@ -41,6 +46,7 @@ internal class DecompositionWorkflowContinuation(
     parentRecord: WorkflowStateSnapshot,
     manifest: DecompositionManifest,
     unitOfWork: UnitOfWork,
+    requestedSubtaskId: Int?,
   ): ContinuationStepResult {
     val advancement = advanceCompletedSubtasks(parentRecord, manifest, unitOfWork)
     if (advancement.error != null) {
@@ -52,7 +58,7 @@ internal class DecompositionWorkflowContinuation(
     val advancedManifest = advancement.manifest
     val projectionArtifactsJson =
       if (advancedManifest != manifest) decompositionRuntimeArtifactsJson(advancedManifest, validator) else null
-    return selectedContinuation(parentRecord, advancedManifest, unitOfWork)
+    return selectedContinuation(parentRecord, advancedManifest, unitOfWork, requestedSubtaskId)
       .withProjectionArtifactsIfMissing(projectionArtifactsJson)
   }
 
@@ -60,16 +66,22 @@ internal class DecompositionWorkflowContinuation(
     parentRecord: WorkflowStateSnapshot,
     manifest: DecompositionManifest,
     unitOfWork: UnitOfWork,
-  ): ContinuationStepResult = when (val selection = DecompositionContinuationSelector.select(manifest)) {
-    is DecompositionContinuationSelection.Resume -> continueSelectedSubtask(selection, unitOfWork)
+    requestedSubtaskId: Int?,
+  ): ContinuationStepResult = when (
+    val selection = DecompositionContinuationSelector.select(manifest, requestedSubtaskId)
+  ) {
+    is DecompositionContinuationSelection.Resume -> continueSelectedSubtask(manifest, selection, unitOfWork)
     is DecompositionContinuationSelection.Start -> startSelectedSubtask(parentRecord, manifest, selection, unitOfWork)
     is DecompositionContinuationSelection.Blocked ->
       ContinuationStepResult(blockedSubtaskResult(parentRecord, manifest, selection, unitOfWork.dbPath.toString()))
+    is DecompositionContinuationSelection.TerminalSubtask ->
+      ContinuationStepResult(terminalSubtaskResult(parentRecord, manifest, selection, unitOfWork.dbPath.toString()))
     is DecompositionContinuationSelection.Done ->
       ContinuationStepResult(doneDecompositionResult(parentRecord, selection.manifest, unitOfWork.dbPath.toString()))
   }
 
   private fun continueSelectedSubtask(
+    manifest: DecompositionManifest,
     selection: DecompositionContinuationSelection.Resume,
     unitOfWork: UnitOfWork,
   ): ContinuationStepResult {
@@ -86,7 +98,12 @@ internal class DecompositionWorkflowContinuation(
         unitOfWork,
         validator,
         fileStore,
-      ).withDecompositionFields(selection.subtask.id, selection.subtask.specPath)
+      ).withDecompositionFields(
+        issueKey = manifest.issueKey,
+        subtaskId = selection.subtask.id,
+        specPath = selection.subtask.specPath,
+        outcome = selection.subtask.toGoalContinuationOutcome(manifest.issueKey),
+      )
     }
   }
 
@@ -146,15 +163,19 @@ internal class DecompositionWorkflowContinuation(
       WorkflowFamily.IMPLEMENT.definition,
       workflowId,
       parentRecord.sessionId.orEmpty(),
-      WorkflowFamily.IMPLEMENT.definition.defaultInitialStepId,
+      "preplan",
     )
     val started = engine.updateRecord(
       WorkflowFamily.IMPLEMENT.definition,
       opened,
       WorkflowUpdateInput(
         workflowStatus = "running",
-        currentStepId = "assess",
-        stepUpdates = null,
+        currentStepId = "preplan",
+        stepUpdates = listOf(
+          mapOf("step_id" to "assess", "status" to "completed", "attempt_count" to 1),
+          mapOf("step_id" to "create_branch", "status" to "completed", "attempt_count" to 1),
+          mapOf("step_id" to "preplan", "status" to "running", "attempt_count" to 1),
+        ),
         artifactsPatch = subtaskStartArtifacts(selection, updatedManifest),
         sessionId = parentRecord.sessionId.orEmpty(),
       ),
@@ -170,15 +191,38 @@ internal class DecompositionWorkflowContinuation(
       fileStore,
     )
       .withProjection(updatedManifest, validator)
-      .withDecompositionFields(selection.subtask.id, selection.subtask.specPath)
+      .withDecompositionFields(
+        issueKey = manifest.issueKey,
+        subtaskId = selection.subtask.id,
+        specPath = selection.subtask.specPath,
+        outcome = updatedManifest.subtasks.single { it.id == selection.subtask.id }
+          .toGoalContinuationOutcome(manifest.issueKey),
+      )
   }
 
   private fun subtaskStartArtifacts(
     selection: DecompositionContinuationSelection.Start,
     manifest: DecompositionManifest,
   ): Map<String, Any?> = mapOf(
-    "assessment" to mapOf("spec_path" to selection.subtask.specPath),
-    "branch" to mapOf("branch_name" to selection.branchPlan.branch),
+    "assessment" to mapOf(
+      "spec_path" to selection.subtask.specPath,
+      "goal_continuation" to true,
+      "issue_key" to manifest.issueKey,
+      "subtask_id" to selection.subtask.id,
+      "accepted_without_user_confirmation" to true,
+    ),
+    "branch" to mapOf(
+      "branch_name" to selection.branchPlan.branch,
+      "branch" to selection.branchPlan.branch,
+      "goal_continuation" to true,
+    ),
+    "goal_continuation" to mapOf(
+      "enabled" to true,
+      "issue_key" to manifest.issueKey,
+      "subtask_id" to selection.subtask.id,
+      "suppress_pr" to true,
+      "outcome_authority" to "workflow_store",
+    ),
     DECOMPOSITION_RUNTIME_ARTIFACT_KEY to encodeDecompositionManifestMap(
       manifest,
       validator,
@@ -232,6 +276,32 @@ internal class DecompositionWorkflowContinuation(
     }
   }
 }
+
+private fun terminalSubtaskResult(
+  parentRecord: WorkflowStateSnapshot,
+  manifest: DecompositionManifest,
+  selection: DecompositionContinuationSelection.TerminalSubtask,
+  dbPath: String,
+): WorkflowContinueResult = WorkflowContinueResult.DecompositionSubtaskOutcome(
+  dbPath = dbPath,
+  workflowId = parentRecord.workflowId,
+  issueKey = manifest.issueKey,
+  subtaskId = selection.subtask.id,
+  subtaskSpecPath = selection.subtask.specPath,
+  outcome = selection.subtask.toGoalContinuationOutcome(manifest.issueKey),
+)
+
+private fun skillbill.workflow.model.DecompositionSubtask.toGoalContinuationOutcome(
+  issueKey: String,
+): GoalContinuationOutcome = GoalContinuationOutcome(
+  issueKey = issueKey,
+  subtaskId = id,
+  status = status,
+  workflowId = workflowId.orEmpty(),
+  commitSha = commitSha,
+  blockedReason = blockedReason,
+  lastResumableStep = lastResumableStep,
+)
 
 private data class AdvancementResult(
   val manifest: DecompositionManifest,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuationSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionWorkflowContinuationSupport.kt
@@ -113,7 +113,7 @@ internal fun DecompositionManifest.withStartedSubtask(
         status = "in_progress",
         workflowId = workflowId,
         branch = branch.takeIf(String::isNotBlank) ?: subtask.branch,
-        lastResumableStep = "assess",
+        lastResumableStep = "preplan",
       )
     } else {
       subtask

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunner.kt
@@ -3,6 +3,7 @@
 package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.GoalRunnerRunEvent
 import skillbill.application.model.GoalRunnerRunRequest
 import skillbill.goalrunner.GoalRunnerOutcomeReconciler
 import skillbill.goalrunner.GoalRunnerPlanner
@@ -38,6 +39,7 @@ class GoalRunner(
       ?: return unknownGoal(request.issueKey)
     val attempted = mutableListOf<Int>()
     var terminalReport: GoalRunnerRunReport? = null
+    request.eventSink.emit(GoalRunnerRunEvent.Started(state.manifest.issueKey))
     while (terminalReport == null) {
       val selection = GoalRunnerPlanner.selectNext(state.manifest)
       when (selection) {
@@ -56,6 +58,14 @@ class GoalRunner(
             workflowId = selection.subtask.workflowId,
             lastResumableStep = selection.subtask.lastResumableStep.orEmpty().ifBlank { "preplan" },
           )
+          request.eventSink.emit(
+            GoalRunnerRunEvent.SubtaskStopped(
+              issueKey = state.manifest.issueKey,
+              subtaskId = selection.subtask.id,
+              reason = GoalRunnerStopReason.DEPENDENCIES_BLOCKED.name.lowercase(),
+              blockedReason = selection.reason,
+            ),
+          )
         }
         is GoalRunnerSelection.Run -> {
           val result = runSelectedSubtask(state, selection, request, attempted)
@@ -63,6 +73,15 @@ class GoalRunner(
           terminalReport = result.report
         }
       }
+    }
+    if (terminalReport is GoalRunnerRunReport.Completed) {
+      request.eventSink.emit(
+        GoalRunnerRunEvent.Completed(
+          issueKey = terminalReport.issueKey,
+          completedCount = terminalReport.subtasksCompleted,
+          pullRequestUrl = terminalReport.pullRequestUrl,
+        ),
+      )
     }
     return terminalReport
   }
@@ -79,6 +98,13 @@ class GoalRunner(
       request.dbPathOverride,
     )
     attempted += subtaskId
+    request.eventSink.emit(
+      GoalRunnerRunEvent.SubtaskStarted(
+        issueKey = attemptedState.manifest.issueKey,
+        subtaskId = subtaskId,
+        action = selection.decision.action.name.lowercase(),
+      ),
+    )
     val launchOutcome = subtaskLauncher.launch(
       subtaskLaunchRequest(attemptedState.manifest.issueKey, subtaskId, request),
     )
@@ -89,12 +115,14 @@ class GoalRunner(
       storedOutcome = storedOutcome(refreshed, subtaskId, request),
     )
     return when (reconciled) {
-      is GoalRunnerReconciledOutcome.Complete -> GoalRunnerIterationResult(
-        state = manifestStore.save(
+      is GoalRunnerReconciledOutcome.Complete -> {
+        val completed = manifestStore.save(
           refreshed.copy(manifest = refreshed.manifest.withCompletedSubtask(subtaskId, reconciled)),
           request.dbPathOverride,
-        ),
-      )
+        )
+        request.eventSink.emit(GoalRunnerRunEvent.SubtaskCompleted(completed.manifest.issueKey, subtaskId))
+        GoalRunnerIterationResult(state = completed)
+      }
       is GoalRunnerReconciledOutcome.Stop -> stoppedIteration(refreshed, subtaskId, reconciled, request, attempted)
     }
   }
@@ -112,6 +140,7 @@ class GoalRunner(
       subtaskId = subtaskId,
       dbPathOverride = request.dbPathOverride,
       timeout = request.timeout,
+      outputSink = request.outputSink,
     ),
   )
 
@@ -136,6 +165,14 @@ class GoalRunner(
   ): GoalRunnerIterationResult {
     val blocked = state.manifest.withStoppedSubtask(subtaskId, reconciled)
     val saved = manifestStore.save(state.copy(manifest = blocked), request.dbPathOverride)
+    request.eventSink.emit(
+      GoalRunnerRunEvent.SubtaskStopped(
+        issueKey = saved.manifest.issueKey,
+        subtaskId = subtaskId,
+        reason = reconciled.reason.name.lowercase(),
+        blockedReason = reconciled.blockedReason,
+      ),
+    )
     return GoalRunnerIterationResult(
       state = saved,
       report = stopped(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunner.kt
@@ -1,0 +1,332 @@
+@file:Suppress("LongParameterList")
+
+package skillbill.application
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.GoalRunnerRunRequest
+import skillbill.goalrunner.GoalRunnerOutcomeReconciler
+import skillbill.goalrunner.GoalRunnerPlanner
+import skillbill.goalrunner.model.GoalRunnerLaunchFacts
+import skillbill.goalrunner.model.GoalRunnerReconciledOutcome
+import skillbill.goalrunner.model.GoalRunnerRunReport
+import skillbill.goalrunner.model.GoalRunnerSelection
+import skillbill.goalrunner.model.GoalRunnerStopReason
+import skillbill.goalrunner.model.GoalRunnerStopReport
+import skillbill.ports.agentrun.model.AgentRunLaunchFacts
+import skillbill.ports.agentrun.model.SkillRunRequest
+import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
+import skillbill.ports.goalrunner.GoalPullRequestPort
+import skillbill.ports.goalrunner.GoalRunnerManifestStore
+import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
+import skillbill.ports.goalrunner.GoalRunnerWorkflowOutcomeStore
+import skillbill.ports.goalrunner.model.GoalPullRequestRequest
+import skillbill.ports.goalrunner.model.GoalPullRequestResult
+import skillbill.ports.goalrunner.model.GoalRunnerManifestState
+import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionManifest
+
+@Inject
+class GoalRunner(
+  private val manifestStore: GoalRunnerManifestStore,
+  private val subtaskLauncher: GoalRunnerSubtaskLauncher,
+  private val outcomeStore: GoalRunnerWorkflowOutcomeStore,
+  private val pullRequestPort: GoalPullRequestPort,
+) {
+  fun run(request: GoalRunnerRunRequest): GoalRunnerRunReport {
+    var state = manifestStore.loadByIssueKey(request.issueKey, request.dbPathOverride)
+      ?: return unknownGoal(request.issueKey)
+    val attempted = mutableListOf<Int>()
+    var terminalReport: GoalRunnerRunReport? = null
+    while (terminalReport == null) {
+      val selection = GoalRunnerPlanner.selectNext(state.manifest)
+      when (selection) {
+        is GoalRunnerSelection.Done -> terminalReport = finalizeGoal(state, request, attempted)
+        is GoalRunnerSelection.Blocked -> {
+          state = manifestStore.save(
+            state.copy(manifest = state.manifest.withBlockedSelection(selection.subtask.id, selection.reason)),
+            request.dbPathOverride,
+          )
+          terminalReport = stopped(
+            issueKey = state.manifest.issueKey,
+            attempted = attempted,
+            subtaskId = selection.subtask.id,
+            reason = GoalRunnerStopReason.DEPENDENCIES_BLOCKED,
+            blockedReason = selection.reason,
+            workflowId = selection.subtask.workflowId,
+            lastResumableStep = selection.subtask.lastResumableStep.orEmpty().ifBlank { "preplan" },
+          )
+        }
+        is GoalRunnerSelection.Run -> {
+          val result = runSelectedSubtask(state, selection, request, attempted)
+          state = result.state
+          terminalReport = result.report
+        }
+      }
+    }
+    return terminalReport
+  }
+
+  private fun runSelectedSubtask(
+    state: GoalRunnerManifestState,
+    selection: GoalRunnerSelection.Run,
+    request: GoalRunnerRunRequest,
+    attempted: MutableList<Int>,
+  ): GoalRunnerIterationResult {
+    val subtaskId = selection.decision.subtask.id
+    val attemptedState = manifestStore.save(
+      state.copy(manifest = state.manifest.withAttemptedSubtask(subtaskId)),
+      request.dbPathOverride,
+    )
+    attempted += subtaskId
+    val launchOutcome = subtaskLauncher.launch(
+      subtaskLaunchRequest(attemptedState.manifest.issueKey, subtaskId, request),
+    )
+    val refreshed = manifestStore.loadByIssueKey(request.issueKey, request.dbPathOverride) ?: attemptedState
+    val reconciled = GoalRunnerOutcomeReconciler.reconcile(
+      subtaskId = subtaskId,
+      launchFacts = launchOutcome.toGoalRunnerLaunchFacts(),
+      storedOutcome = storedOutcome(refreshed, subtaskId, request),
+    )
+    return when (reconciled) {
+      is GoalRunnerReconciledOutcome.Complete -> GoalRunnerIterationResult(
+        state = manifestStore.save(
+          refreshed.copy(manifest = refreshed.manifest.withCompletedSubtask(subtaskId, reconciled)),
+          request.dbPathOverride,
+        ),
+      )
+      is GoalRunnerReconciledOutcome.Stop -> stoppedIteration(refreshed, subtaskId, reconciled, request, attempted)
+    }
+  }
+
+  private fun subtaskLaunchRequest(
+    issueKey: String,
+    subtaskId: Int,
+    request: GoalRunnerRunRequest,
+  ): GoalRunnerSubtaskLaunchRequest = GoalRunnerSubtaskLaunchRequest(
+    invokedAgentId = request.invokedAgentId,
+    configuredAgentOverrideId = request.configuredAgentOverrideId,
+    skillRunRequest = SkillRunRequest(
+      issueKey = issueKey,
+      repoRoot = request.repoRoot,
+      subtaskId = subtaskId,
+      dbPathOverride = request.dbPathOverride,
+      timeout = request.timeout,
+    ),
+  )
+
+  private fun storedOutcome(state: GoalRunnerManifestState, subtaskId: Int, request: GoalRunnerRunRequest) =
+    state.manifest.subtasks.firstOrNull { it.id == subtaskId }?.workflowId
+      ?.takeIf(String::isNotBlank)
+      ?.let { workflowId ->
+        outcomeStore.terminalOutcome(
+          workflowId = workflowId,
+          issueKey = state.manifest.issueKey,
+          subtaskId = subtaskId,
+          dbPathOverride = request.dbPathOverride,
+        )
+      }
+
+  private fun stoppedIteration(
+    state: GoalRunnerManifestState,
+    subtaskId: Int,
+    reconciled: GoalRunnerReconciledOutcome.Stop,
+    request: GoalRunnerRunRequest,
+    attempted: List<Int>,
+  ): GoalRunnerIterationResult {
+    val blocked = state.manifest.withStoppedSubtask(subtaskId, reconciled)
+    val saved = manifestStore.save(state.copy(manifest = blocked), request.dbPathOverride)
+    return GoalRunnerIterationResult(
+      state = saved,
+      report = stopped(
+        issueKey = saved.manifest.issueKey,
+        attempted = attempted,
+        subtaskId = subtaskId,
+        reason = reconciled.reason,
+        blockedReason = reconciled.blockedReason,
+        workflowId = reconciled.workflowId,
+        lastResumableStep = reconciled.lastResumableStep,
+      ),
+    )
+  }
+
+  private fun finalizeGoal(
+    state: GoalRunnerManifestState,
+    request: GoalRunnerRunRequest,
+    attempted: List<Int>,
+  ): GoalRunnerRunReport {
+    val result = pullRequestPort.open(state.manifest.toPullRequestRequest(request.repoRoot))
+    return when (result) {
+      is GoalPullRequestResult.Opened -> completed(state.manifest, attempted, result.url)
+      is GoalPullRequestResult.Existing -> completed(state.manifest, attempted, result.url)
+      is GoalPullRequestResult.Failed -> stopped(
+        issueKey = state.manifest.issueKey,
+        attempted = attempted,
+        subtaskId = state.manifest.currentSubtaskIntent.subtaskId.takeIf { it > 0 }
+          ?: state.manifest.subtasks.last().id,
+        reason = GoalRunnerStopReason.PULL_REQUEST_FAILED,
+        blockedReason = result.reason,
+        workflowId = null,
+        lastResumableStep = "pr_description",
+      )
+    }
+  }
+
+  private fun completed(
+    manifest: DecompositionManifest,
+    attempted: List<Int>,
+    pullRequestUrl: String?,
+  ): GoalRunnerRunReport.Completed = GoalRunnerRunReport.Completed(
+    issueKey = manifest.issueKey,
+    attemptedSubtasks = attempted,
+    pullRequestUrl = pullRequestUrl,
+    subtasksCompleted = manifest.subtasks.count { it.status == "complete" || it.status == "skipped" },
+  )
+
+  private fun unknownGoal(issueKey: String): GoalRunnerRunReport.Stopped = stopped(
+    issueKey = issueKey,
+    attempted = emptyList(),
+    subtaskId = 0,
+    reason = GoalRunnerStopReason.BLOCKED,
+    blockedReason = "No decomposed parent workflow was found for $issueKey.",
+    workflowId = null,
+    lastResumableStep = "preplan",
+  )
+
+  private fun stopped(
+    issueKey: String,
+    attempted: List<Int>,
+    subtaskId: Int,
+    reason: GoalRunnerStopReason,
+    blockedReason: String,
+    workflowId: String?,
+    lastResumableStep: String,
+  ): GoalRunnerRunReport.Stopped = GoalRunnerRunReport.Stopped(
+    issueKey = issueKey,
+    attemptedSubtasks = attempted,
+    stop = GoalRunnerStopReport(
+      issueKey = issueKey,
+      subtaskId = subtaskId,
+      reason = reason,
+      blockedReason = blockedReason,
+      workflowId = workflowId,
+      lastResumableStep = lastResumableStep,
+    ),
+  )
+}
+
+private fun skillbill.ports.agentrun.model.AgentRunLaunchOutcome.toGoalRunnerLaunchFacts(): GoalRunnerLaunchFacts =
+  when (this) {
+    is AgentRunLaunchFacts -> GoalRunnerLaunchFacts(
+      timedOut = timedOut,
+      spawnFailed = spawnFailed,
+      exitStatus = exitStatus,
+    )
+    is UnsupportedAgentRunLaunch -> GoalRunnerLaunchFacts(spawnFailed = true)
+  }
+
+private fun DecompositionManifest.withAttemptedSubtask(subtaskId: Int): DecompositionManifest = copy(
+  status = "in_progress",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = subtaskId, action = "resume"),
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId && subtask.status == "blocked") {
+      subtask.copy(status = "in_progress", blockedReason = null)
+    } else {
+      subtask
+    }
+  },
+)
+
+private fun DecompositionManifest.withCompletedSubtask(
+  subtaskId: Int,
+  outcome: GoalRunnerReconciledOutcome.Complete,
+): DecompositionManifest {
+  val updated = copy(
+    currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 0, action = "none"),
+    subtasks = subtasks.map { subtask ->
+      if (subtask.id == subtaskId) {
+        subtask.copy(
+          status = "complete",
+          workflowId = outcome.workflowId,
+          commitSha = outcome.commitSha,
+          blockedReason = null,
+          lastResumableStep = outcome.lastResumableStep,
+        )
+      } else {
+        subtask
+      }
+    },
+  )
+  return if (updated.subtasks.all { it.status == "complete" || it.status == "skipped" }) {
+    updated.copy(status = "complete")
+  } else {
+    updated.copy(status = "in_progress")
+  }
+}
+
+private fun DecompositionManifest.withStoppedSubtask(
+  subtaskId: Int,
+  outcome: GoalRunnerReconciledOutcome.Stop,
+): DecompositionManifest = copy(
+  status = "blocked",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = subtaskId, action = "blocked"),
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) {
+      subtask.copy(
+        status = "blocked",
+        workflowId = outcome.workflowId ?: subtask.workflowId,
+        commitSha = outcome.commitSha ?: subtask.commitSha,
+        blockedReason = outcome.blockedReason,
+        lastResumableStep = outcome.lastResumableStep,
+      )
+    } else {
+      subtask
+    }
+  },
+)
+
+private fun DecompositionManifest.withBlockedSelection(subtaskId: Int, reason: String): DecompositionManifest = copy(
+  status = "blocked",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = subtaskId, action = "blocked"),
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) {
+      subtask.copy(
+        status = "blocked",
+        blockedReason = reason,
+        lastResumableStep = subtask.lastResumableStep ?: "preplan",
+      )
+    } else {
+      subtask
+    }
+  },
+)
+
+private fun DecompositionManifest.toPullRequestRequest(repoRoot: java.nio.file.Path): GoalPullRequestRequest {
+  val title = "$issueKey: $featureName"
+  val body = buildString {
+    appendLine("Goal: $featureName")
+    appendLine()
+    appendLine("Subtasks:")
+    subtasks.forEach { subtask ->
+      append("- ${subtask.id}. ${subtask.name}")
+      subtask.commitSha?.let { append(" ($it)") }
+      appendLine()
+    }
+  }
+  return GoalPullRequestRequest(
+    repoRoot = repoRoot,
+    issueKey = issueKey,
+    featureName = featureName,
+    baseBranch = baseBranch,
+    headBranch = featureBranch.orEmpty().ifBlank { branchForFinalPullRequest() },
+    title = title,
+    body = body,
+  )
+}
+
+private fun DecompositionManifest.branchForFinalPullRequest(): String = stackBranches.lastOrNull()?.branch.orEmpty()
+
+private data class GoalRunnerIterationResult(
+  val state: GoalRunnerManifestState,
+  val report: GoalRunnerRunReport? = null,
+)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunnerStatusService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunnerStatusService.kt
@@ -1,0 +1,22 @@
+package skillbill.application
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.GoalRunnerStatusRequest
+import skillbill.goalrunner.model.GoalRunnerStatusProjection
+import skillbill.goalrunner.model.GoalRunnerStatusProjector
+import skillbill.install.model.InstallAgent
+import skillbill.ports.goalrunner.GoalRunnerManifestStore
+
+@Inject
+class GoalRunnerStatusService(
+  private val manifestStore: GoalRunnerManifestStore,
+) {
+  fun status(request: GoalRunnerStatusRequest): GoalRunnerStatusProjection? {
+    val effectiveAgent = request.configuredAgentOverrideId
+      ?.let { InstallAgent.fromNormalizedId(it, label = "configuredAgentOverrideId") }
+      ?: InstallAgent.fromNormalizedId(request.invokedAgentId, label = "invokedAgentId")
+    return manifestStore.loadByIssueKey(request.issueKey, request.dbPathOverride)
+      ?.manifest
+      ?.let { manifest -> GoalRunnerStatusProjector.project(manifest, activeAgent = effectiveAgent.id) }
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunnerWorkflowStores.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunnerWorkflowStores.kt
@@ -1,0 +1,173 @@
+package skillbill.application
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.contracts.JsonSupport
+import skillbill.goalrunner.model.GoalRunnerStoredOutcome
+import skillbill.goalrunner.model.GoalRunnerTerminalStatus
+import skillbill.ports.goalrunner.GoalRunnerManifestStore
+import skillbill.ports.goalrunner.GoalRunnerWorkflowOutcomeStore
+import skillbill.ports.goalrunner.model.GoalRunnerManifestState
+import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.workflow.DecompositionManifestFileStore
+import skillbill.workflow.DecompositionManifestValidator
+import skillbill.workflow.WorkflowEngine
+import skillbill.workflow.WorkflowSnapshotValidator
+import skillbill.workflow.model.WorkflowStateSnapshot
+import skillbill.workflow.model.WorkflowStepState
+import skillbill.workflow.model.WorkflowUpdateInput
+import java.nio.file.Path
+
+@Inject
+class WorkflowGoalRunnerManifestStore(
+  private val database: DatabaseSessionFactory,
+  private val workflowSnapshotValidator: WorkflowSnapshotValidator,
+  private val decompositionManifestValidator: DecompositionManifestValidator,
+  private val decompositionManifestFileStore: DecompositionManifestFileStore,
+) : GoalRunnerManifestStore {
+  private val engine: WorkflowEngine = WorkflowEngine(workflowSnapshotValidator)
+
+  override fun loadByIssueKey(issueKey: String, dbPathOverride: String?): GoalRunnerManifestState? =
+    database.read(dbPathOverride) { unitOfWork ->
+      val record = unitOfWork.workflowStates.findDecomposedParentWorkflow(issueKey, decompositionManifestValidator)
+        ?: return@read null
+      val snapshot = record.toSnapshot()
+      val manifest = snapshot.decompositionRuntime(decompositionManifestValidator) ?: return@read null
+      GoalRunnerManifestState(
+        parentWorkflowId = snapshot.workflowId,
+        dbPath = unitOfWork.dbPath.toString(),
+        manifest = manifest,
+      )
+    }
+
+  override fun save(state: GoalRunnerManifestState, dbPathOverride: String?): GoalRunnerManifestState {
+    var projectionArtifactsJson: String? = null
+    val saved = database.transaction(dbPathOverride) { unitOfWork ->
+      val existing = WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, state.parentWorkflowId)
+        ?: unitOfWork.workflowStates.findDecomposedParentWorkflow(
+          state.manifest.issueKey,
+          decompositionManifestValidator,
+        )?.toSnapshot()
+        ?: error("Unknown decomposed parent workflow '${state.parentWorkflowId}'.")
+      val existingSnapshot = existing
+      val updated = engine.updateRecord(
+        WorkflowFamily.IMPLEMENT.definition,
+        existingSnapshot,
+        WorkflowUpdateInput(
+          workflowStatus = existingSnapshot.workflowStatus,
+          currentStepId = existingSnapshot.currentStepId,
+          stepUpdates = null,
+          artifactsPatch = mapOf(
+            DECOMPOSITION_RUNTIME_ARTIFACT_KEY to encodeDecompositionManifestMap(
+              state.manifest,
+              decompositionManifestValidator,
+              DECOMPOSITION_RUNTIME_ARTIFACT_KEY,
+            ),
+          ),
+          sessionId = existingSnapshot.sessionId.orEmpty(),
+        ),
+      )
+      WorkflowFamily.IMPLEMENT.save(unitOfWork.workflowStates, updated)
+      val refreshed = WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, updated.workflowId) ?: updated
+      projectionArtifactsJson = refreshed.artifactsJson
+      GoalRunnerManifestState(
+        parentWorkflowId = refreshed.workflowId,
+        dbPath = unitOfWork.dbPath.toString(),
+        manifest = refreshed.decompositionRuntime(decompositionManifestValidator) ?: state.manifest,
+      )
+    }
+    projectionArtifactsJson?.let { artifactsJson ->
+      DecompositionManifestWriter.writeProjectionFromWorkflowState(
+        Path.of("").toAbsolutePath(),
+        artifactsJson,
+        decompositionManifestValidator,
+        decompositionManifestFileStore,
+      )
+    }
+    return saved
+  }
+}
+
+@Inject
+class WorkflowGoalRunnerOutcomeStore(
+  private val database: DatabaseSessionFactory,
+  private val workflowSnapshotValidator: WorkflowSnapshotValidator,
+) : GoalRunnerWorkflowOutcomeStore {
+  private val engine: WorkflowEngine = WorkflowEngine(workflowSnapshotValidator)
+
+  override fun terminalOutcome(
+    workflowId: String,
+    issueKey: String,
+    subtaskId: Int,
+    dbPathOverride: String?,
+  ): GoalRunnerStoredOutcome? = database.read(dbPathOverride) { unitOfWork ->
+    val record = WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, workflowId) ?: return@read null
+    val snapshot = record
+    engine.snapshotView(WorkflowFamily.IMPLEMENT.definition, snapshot)
+    val artifacts = decodeArtifacts(snapshot.artifactsJson)
+    val goalContinuation = artifacts["goal_continuation"] as? Map<*, *> ?: return@read null
+    if (goalContinuation["issue_key"]?.toString() != issueKey) return@read null
+    if (goalContinuation["subtask_id"].asGoalRunnerIntOrNull() != subtaskId) return@read null
+    val suppressPr = goalContinuation["suppress_pr"] == true
+    val commitSha = commitShaFrom(artifacts)
+    val steps = decodeWorkflowSteps(snapshot.stepsJson)
+    val status = terminalStatus(snapshot, steps, suppressPr, commitSha) ?: return@read null
+    GoalRunnerStoredOutcome(
+      status = status,
+      workflowId = snapshot.workflowId,
+      commitSha = commitSha,
+      blockedReason = blockedReasonFrom(artifacts, steps, status),
+      lastResumableStep = snapshot.currentStepId,
+      suppressPr = suppressPr,
+    )
+  }
+}
+
+private fun terminalStatus(
+  snapshot: WorkflowStateSnapshot,
+  steps: List<WorkflowStepState>,
+  suppressPr: Boolean,
+  commitSha: String?,
+): GoalRunnerTerminalStatus? = when {
+  suppressPr && steps.any { it.stepId == "commit_push" && it.status == "completed" } ->
+    if (commitSha.isNullOrBlank()) {
+      GoalRunnerTerminalStatus.NO_TERMINAL_STORE_OUTCOME
+    } else {
+      GoalRunnerTerminalStatus.COMPLETE
+    }
+  snapshot.workflowStatus == "failed" || steps.any { it.status == "failed" } -> GoalRunnerTerminalStatus.FAILED
+  snapshot.workflowStatus == "blocked" || steps.any { it.status == "blocked" } -> GoalRunnerTerminalStatus.BLOCKED
+  snapshot.workflowStatus in setOf("completed", "abandoned") -> GoalRunnerTerminalStatus.NO_TERMINAL_STORE_OUTCOME
+  else -> null
+}
+
+private fun blockedReasonFrom(
+  artifacts: Map<String, Any?>,
+  steps: List<WorkflowStepState>,
+  status: GoalRunnerTerminalStatus,
+): String? = artifacts["blocked_reason"]?.toString()?.takeIf(String::isNotBlank)
+  ?: steps.firstOrNull { it.status in setOf("failed", "blocked") }
+    ?.let { step -> "Workflow step '${step.stepId}' is ${step.status}." }
+  ?: "Workflow reached a terminal state without a goal-continuation commit SHA."
+    .takeIf { status == GoalRunnerTerminalStatus.NO_TERMINAL_STORE_OUTCOME }
+
+private fun commitShaFrom(artifacts: Map<String, Any?>): String? =
+  (artifacts["commit_push_result"] as? Map<*, *>)?.get("commit_sha")?.toString()?.takeIf(String::isNotBlank)
+
+private fun decodeWorkflowSteps(stepsJson: String): List<WorkflowStepState> {
+  val element = runCatching { JsonSupport.json.parseToJsonElement(stepsJson) }.getOrNull() ?: return emptyList()
+  return (JsonSupport.jsonElementToValue(element) as? List<*>).orEmpty().mapNotNull { raw ->
+    val item = raw as? Map<*, *> ?: return@mapNotNull null
+    WorkflowStepState(
+      stepId = item["step_id"]?.toString().orEmpty(),
+      status = item["status"]?.toString().orEmpty(),
+      attemptCount = item["attempt_count"].asGoalRunnerIntOrNull() ?: 0,
+    )
+  }
+}
+
+private fun Any?.asGoalRunnerIntOrNull(): Int? = when (this) {
+  is Int -> this
+  is Number -> toInt()
+  is String -> toIntOrNull()
+  else -> null
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/WorkflowService.kt
@@ -188,6 +188,7 @@ class WorkflowService(
   fun continueWorkflow(
     kind: WorkflowFamilyKind,
     workflowId: String,
+    subtaskId: Int? = null,
     dbOverride: String? = null,
   ): WorkflowContinueResult {
     var projectionArtifactsJson: String? = null
@@ -201,7 +202,7 @@ class WorkflowService(
             gitOperations,
             decompositionManifestValidator,
             decompositionManifestFileStore,
-          ).continueDecomposedParentByIssueKey(workflowId, unitOfWork)
+          ).continueDecomposedParentByIssueKey(workflowId, unitOfWork, subtaskId)
         projectionArtifactsJson = resolved.projectionArtifactsJson ?: projectionArtifactsJson
         return@transaction resolved.result
       }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/AgentRunResults.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/AgentRunResults.kt
@@ -1,0 +1,29 @@
+package skillbill.application.model
+
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.agentrun.model.SkillRunRequest
+
+data class AgentRunStartRequest(
+  val invokedAgentId: String,
+  val configuredAgentOverrideId: String? = null,
+  val skillRunRequest: SkillRunRequest,
+) {
+  init {
+    require(invokedAgentId.isNotBlank()) { "invokedAgentId is required." }
+    configuredAgentOverrideId?.let { overrideId ->
+      require(overrideId.isNotBlank()) { "configuredAgentOverrideId must not be blank when provided." }
+    }
+  }
+}
+
+data class AgentRunAgentResolution(
+  val invokedAgent: InstallAgent,
+  val configuredOverrideAgent: InstallAgent?,
+  val effectiveAgent: InstallAgent,
+)
+
+data class AgentRunResult(
+  val resolution: AgentRunAgentResolution,
+  val launchOutcome: AgentRunLaunchOutcome,
+)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalRunnerRequests.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalRunnerRequests.kt
@@ -1,5 +1,6 @@
 package skillbill.application.model
 
+import skillbill.ports.agentrun.model.AgentRunOutputSink
 import java.nio.file.Path
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -11,12 +12,52 @@ data class GoalRunnerRunRequest(
   val configuredAgentOverrideId: String? = null,
   val dbPathOverride: String? = null,
   val timeout: Duration = 60.minutes,
+  val outputSink: AgentRunOutputSink = AgentRunOutputSink.NONE,
+  val eventSink: GoalRunnerEventSink = GoalRunnerEventSink.NONE,
 ) {
   init {
     require(issueKey.isNotBlank()) { "issueKey is required." }
     require(invokedAgentId.isNotBlank()) { "invokedAgentId is required." }
     configuredAgentOverrideId?.let { require(it.isNotBlank()) { "configuredAgentOverrideId must not be blank." } }
     require(timeout.isPositive()) { "timeout must be positive." }
+  }
+}
+
+sealed interface GoalRunnerRunEvent {
+  val issueKey: String
+
+  data class Started(override val issueKey: String) : GoalRunnerRunEvent
+
+  data class SubtaskStarted(
+    override val issueKey: String,
+    val subtaskId: Int,
+    val action: String,
+  ) : GoalRunnerRunEvent
+
+  data class SubtaskCompleted(
+    override val issueKey: String,
+    val subtaskId: Int,
+  ) : GoalRunnerRunEvent
+
+  data class SubtaskStopped(
+    override val issueKey: String,
+    val subtaskId: Int,
+    val reason: String,
+    val blockedReason: String,
+  ) : GoalRunnerRunEvent
+
+  data class Completed(
+    override val issueKey: String,
+    val completedCount: Int,
+    val pullRequestUrl: String?,
+  ) : GoalRunnerRunEvent
+}
+
+fun interface GoalRunnerEventSink {
+  fun emit(event: GoalRunnerRunEvent)
+
+  companion object {
+    val NONE: GoalRunnerEventSink = GoalRunnerEventSink {}
   }
 }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalRunnerRequests.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalRunnerRequests.kt
@@ -1,0 +1,34 @@
+package skillbill.application.model
+
+import java.nio.file.Path
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+data class GoalRunnerRunRequest(
+  val issueKey: String,
+  val repoRoot: Path,
+  val invokedAgentId: String,
+  val configuredAgentOverrideId: String? = null,
+  val dbPathOverride: String? = null,
+  val timeout: Duration = 60.minutes,
+) {
+  init {
+    require(issueKey.isNotBlank()) { "issueKey is required." }
+    require(invokedAgentId.isNotBlank()) { "invokedAgentId is required." }
+    configuredAgentOverrideId?.let { require(it.isNotBlank()) { "configuredAgentOverrideId must not be blank." } }
+    require(timeout.isPositive()) { "timeout must be positive." }
+  }
+}
+
+data class GoalRunnerStatusRequest(
+  val issueKey: String,
+  val invokedAgentId: String,
+  val configuredAgentOverrideId: String? = null,
+  val dbPathOverride: String? = null,
+) {
+  init {
+    require(issueKey.isNotBlank()) { "issueKey is required." }
+    require(invokedAgentId.isNotBlank()) { "invokedAgentId is required." }
+    configuredAgentOverrideId?.let { require(it.isNotBlank()) { "configuredAgentOverrideId must not be blank." } }
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/WorkflowResults.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/WorkflowResults.kt
@@ -55,6 +55,16 @@ data class WorkflowListResult(
   val workflows: List<WorkflowSummaryView>,
 )
 
+data class GoalContinuationOutcome(
+  val issueKey: String,
+  val subtaskId: Int,
+  val status: String,
+  val commitSha: String?,
+  val workflowId: String,
+  val blockedReason: String?,
+  val lastResumableStep: String?,
+)
+
 sealed interface WorkflowLatestResult {
   data class Ok(val dbPath: String, val summary: WorkflowSummaryView) : WorkflowLatestResult
   data class Error(val dbPath: String, val error: String) : WorkflowLatestResult
@@ -126,6 +136,15 @@ sealed interface WorkflowContinueResult {
     val decompositionStatus: String,
   ) : WorkflowContinueResult
 
+  data class DecompositionSubtaskOutcome(
+    override val dbPath: String,
+    val workflowId: String,
+    val issueKey: String,
+    val subtaskId: Int,
+    val subtaskSpecPath: String,
+    val outcome: GoalContinuationOutcome,
+  ) : WorkflowContinueResult
+
   data class DecompositionBlockedGit(
     override val dbPath: String,
     val workflowId: String,
@@ -144,6 +163,8 @@ sealed interface WorkflowContinueResult {
     val view: WorkflowContinueView,
     val decompositionSubtaskId: Int,
     val decompositionSubtaskSpecPath: String,
+    val issueKey: String = "",
+    val outcome: GoalContinuationOutcome? = null,
   ) : WorkflowContinueResult
 
   /** Generic error wrapper (unused except for upstream framework errors). */

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/AgentRunServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/AgentRunServiceTest.kt
@@ -1,0 +1,92 @@
+package skillbill.application
+
+import skillbill.application.model.AgentRunStartRequest
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.AgentRunLauncher
+import skillbill.ports.agentrun.model.AgentRunLaunchFacts
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+import skillbill.ports.agentrun.model.SkillRunRequest
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AgentRunServiceTest {
+  @Test
+  fun `configured override wins over invoked bill-goal agent`() {
+    val launcher = RecordingAgentRunLauncher()
+    val service = AgentRunService(launcher)
+
+    val result = service.launch(
+      AgentRunStartRequest(
+        invokedAgentId = "claude",
+        configuredAgentOverrideId = "codex",
+        skillRunRequest = skillRunRequest(),
+      ),
+    )
+
+    assertEquals(InstallAgent.CLAUDE, result.resolution.invokedAgent)
+    assertEquals(InstallAgent.CODEX, result.resolution.configuredOverrideAgent)
+    assertEquals(InstallAgent.CODEX, result.resolution.effectiveAgent)
+    assertEquals("codex", launcher.requests.single().agentId)
+  }
+
+  @Test
+  fun `invoked bill-goal agent is the default without hardcoded fallback`() {
+    val launcher = RecordingAgentRunLauncher()
+    val service = AgentRunService(launcher)
+
+    val result = service.launch(
+      AgentRunStartRequest(
+        invokedAgentId = "opencode",
+        configuredAgentOverrideId = null,
+        skillRunRequest = skillRunRequest(),
+      ),
+    )
+
+    assertEquals(InstallAgent.OPENCODE, result.resolution.effectiveAgent)
+    assertEquals("opencode", launcher.requests.single().agentId)
+  }
+
+  @Test
+  fun `unknown configured agent fails loudly before launch`() {
+    val launcher = RecordingAgentRunLauncher()
+    val service = AgentRunService(launcher)
+
+    assertFailsWith<IllegalArgumentException> {
+      service.launch(
+        AgentRunStartRequest(
+          invokedAgentId = "codex",
+          configuredAgentOverrideId = "unknown",
+          skillRunRequest = skillRunRequest(),
+        ),
+      )
+    }
+
+    assertEquals(emptyList(), launcher.requests)
+  }
+
+  private fun skillRunRequest(): SkillRunRequest = SkillRunRequest(
+    issueKey = "SKILL-56",
+    repoRoot = Path.of("/tmp/skillbill-agent-run-service"),
+    subtaskId = 2,
+    dbPathOverride = "/tmp/skillbill-agent-run-service/metrics.db",
+  )
+}
+
+private class RecordingAgentRunLauncher : AgentRunLauncher {
+  val requests: MutableList<AgentRunLaunchRequest> = mutableListOf()
+
+  override fun launch(request: AgentRunLaunchRequest): AgentRunLaunchOutcome {
+    requests += request
+    return AgentRunLaunchFacts(
+      agent = InstallAgent.fromId(request.agentId),
+      exitStatus = 0,
+      stdout = "diagnostic",
+      stderr = "",
+      timedOut = false,
+      spawnFailed = false,
+    )
+  }
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
@@ -1,0 +1,313 @@
+package skillbill.application
+
+import skillbill.application.model.GoalRunnerRunRequest
+import skillbill.application.model.GoalRunnerStatusRequest
+import skillbill.goalrunner.model.GoalRunnerRunReport
+import skillbill.goalrunner.model.GoalRunnerStopReason
+import skillbill.goalrunner.model.GoalRunnerStoredOutcome
+import skillbill.goalrunner.model.GoalRunnerTerminalStatus
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.model.AgentRunLaunchFacts
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.goalrunner.GoalPullRequestPort
+import skillbill.ports.goalrunner.GoalRunnerManifestStore
+import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
+import skillbill.ports.goalrunner.GoalRunnerWorkflowOutcomeStore
+import skillbill.ports.goalrunner.model.GoalPullRequestRequest
+import skillbill.ports.goalrunner.model.GoalPullRequestResult
+import skillbill.ports.goalrunner.model.GoalRunnerManifestState
+import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionDependency
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionSubtask
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class GoalRunnerTest {
+  @Test
+  fun `happy path launches each subtask once and opens one final pr`() {
+    val store = InMemoryGoalManifestStore(manifest = manifest(subtaskCount = 2))
+    val outcomes = RecordingOutcomeStore()
+    val launcher = RecordingSubtaskLauncher { request ->
+      val subtaskId = requireNotNull(request.skillRunRequest.subtaskId)
+      store.mutate { current -> current.withWorkflowId(subtaskId, "wfl-$subtaskId") }
+      outcomes["wfl-$subtaskId"] = completeOutcome(subtaskId)
+      launchFacts()
+    }
+    val pr = RecordingPullRequestPort()
+    val runner = GoalRunner(store, launcher, outcomes, pr)
+
+    val report = runner.run(runRequest())
+
+    val completed = assertIs<GoalRunnerRunReport.Completed>(report)
+    assertEquals(listOf(1, 2), completed.attemptedSubtasks)
+    assertEquals(2, completed.subtasksCompleted)
+    assertEquals("https://github.com/canonical/skill-bill/pull/56", completed.pullRequestUrl)
+    assertEquals(listOf(1, 2), launcher.requests.map { it.skillRunRequest.subtaskId })
+    assertEquals(1, pr.requests.size)
+    assertEquals("feat/SKILL-56-goal", pr.requests.single().headBranch)
+    assertEquals("complete", store.manifest.status)
+    assertEquals(listOf("sha-1", "sha-2"), store.manifest.subtasks.map { it.commitSha })
+  }
+
+  @Test
+  fun `forced failure stops on current subtask and does not run later subtasks`() {
+    val store = InMemoryGoalManifestStore(manifest = manifest(subtaskCount = 3))
+    val outcomes = RecordingOutcomeStore()
+    val launcher = RecordingSubtaskLauncher { request ->
+      val subtaskId = requireNotNull(request.skillRunRequest.subtaskId)
+      store.mutate { current -> current.withWorkflowId(subtaskId, "wfl-$subtaskId") }
+      outcomes["wfl-$subtaskId"] =
+        if (subtaskId == 2) {
+          GoalRunnerStoredOutcome(
+            status = GoalRunnerTerminalStatus.FAILED,
+            workflowId = "wfl-2",
+            blockedReason = "review failed",
+            lastResumableStep = "review",
+            suppressPr = true,
+          )
+        } else {
+          completeOutcome(subtaskId)
+        }
+      launchFacts()
+    }
+    val runner = GoalRunner(store, launcher, outcomes, RecordingPullRequestPort())
+
+    val report = runner.run(runRequest())
+
+    val stopped = assertIs<GoalRunnerRunReport.Stopped>(report)
+    assertEquals(listOf(1, 2), stopped.attemptedSubtasks)
+    assertEquals(2, stopped.stop.subtaskId)
+    assertEquals(GoalRunnerStopReason.FAILED, stopped.stop.reason)
+    assertEquals("review failed", stopped.stop.blockedReason)
+    assertEquals(CurrentSubtaskIntent(subtaskId = 2, action = "blocked"), store.manifest.currentSubtaskIntent)
+    assertEquals("blocked", store.manifest.subtasks.single { it.id == 2 }.status)
+    assertEquals("pending", store.manifest.subtasks.single { it.id == 3 }.status)
+  }
+
+  @Test
+  fun `resume after stop skips completed subtasks and continues from blocked subtask`() {
+    val initial = manifest(subtaskCount = 3)
+      .withCompletedSubtask(1, workflowId = "wfl-1", commitSha = "sha-1")
+      .withBlockedSubtask(2, workflowId = "wfl-2", reason = "validation failed")
+    val store = InMemoryGoalManifestStore(manifest = initial)
+    val outcomes = RecordingOutcomeStore()
+    outcomes["wfl-2"] = completeOutcome(2)
+    val launcher = RecordingSubtaskLauncher { request ->
+      val subtaskId = requireNotNull(request.skillRunRequest.subtaskId)
+      if (subtaskId == 3) {
+        store.mutate { current -> current.withWorkflowId(3, "wfl-3") }
+        outcomes["wfl-3"] = completeOutcome(3)
+      }
+      launchFacts()
+    }
+    val runner = GoalRunner(store, launcher, outcomes, RecordingPullRequestPort())
+
+    val report = runner.run(runRequest())
+
+    assertIs<GoalRunnerRunReport.Completed>(report)
+    assertEquals(listOf(2, 3), launcher.requests.map { it.skillRunRequest.subtaskId })
+    assertEquals("complete", store.manifest.status)
+    assertEquals(listOf("sha-1", "sha-2", "sha-3"), store.manifest.subtasks.map { it.commitSha })
+  }
+
+  @Test
+  fun `missing terminal workflow-store outcome stops on attempted subtask`() {
+    val store = InMemoryGoalManifestStore(manifest = manifest(subtaskCount = 2))
+    val launcher = RecordingSubtaskLauncher { request ->
+      val subtaskId = requireNotNull(request.skillRunRequest.subtaskId)
+      store.mutate { current -> current.withWorkflowId(subtaskId, "wfl-$subtaskId") }
+      launchFacts()
+    }
+    val runner = GoalRunner(store, launcher, RecordingOutcomeStore(), RecordingPullRequestPort())
+
+    val report = runner.run(runRequest())
+
+    val stopped = assertIs<GoalRunnerRunReport.Stopped>(report)
+    assertEquals(listOf(1), stopped.attemptedSubtasks)
+    assertEquals(GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME, stopped.stop.reason)
+    assertEquals(1, stopped.stop.subtaskId)
+    assertEquals("blocked", store.manifest.subtasks.single { it.id == 1 }.status)
+    assertEquals("pending", store.manifest.subtasks.single { it.id == 2 }.status)
+  }
+
+  @Test
+  fun `status projection reports counts current step and active agent`() {
+    val store = InMemoryGoalManifestStore(
+      manifest = manifest(subtaskCount = 3)
+        .withCompletedSubtask(1, workflowId = "wfl-1", commitSha = "sha-1")
+        .withBlockedSubtask(2, workflowId = "wfl-2", reason = "needs review"),
+    )
+    val service = GoalRunnerStatusService(store)
+
+    val status = service.status(
+      GoalRunnerStatusRequest(
+        issueKey = "SKILL-56",
+        invokedAgentId = "claude",
+        configuredAgentOverrideId = "codex",
+      ),
+    )
+
+    requireNotNull(status)
+    assertEquals(1, status.completeCount)
+    assertEquals(1, status.pendingCount)
+    assertEquals(1, status.blockedCount)
+    assertEquals(2, status.currentSubtaskId)
+    assertEquals("validate", status.currentStep)
+    assertEquals("codex", status.activeAgent)
+  }
+
+  private fun runRequest(): GoalRunnerRunRequest = GoalRunnerRunRequest(
+    issueKey = "SKILL-56",
+    repoRoot = Path.of("/tmp/skillbill-goal-runner"),
+    invokedAgentId = "claude",
+    dbPathOverride = "/tmp/skillbill-goal-runner/metrics.db",
+  )
+}
+
+private class InMemoryGoalManifestStore(
+  manifest: DecompositionManifest,
+) : GoalRunnerManifestStore {
+  var manifest: DecompositionManifest = manifest
+    private set
+
+  override fun loadByIssueKey(issueKey: String, dbPathOverride: String?): GoalRunnerManifestState? =
+    GoalRunnerManifestState(
+      parentWorkflowId = "wfl-parent",
+      dbPath = dbPathOverride.orEmpty().ifBlank { "/tmp/skillbill-goal-runner/metrics.db" },
+      manifest = manifest,
+    ).takeIf { manifest.issueKey == issueKey }
+
+  override fun save(state: GoalRunnerManifestState, dbPathOverride: String?): GoalRunnerManifestState {
+    manifest = state.manifest
+    return state.copy(dbPath = dbPathOverride ?: state.dbPath, manifest = manifest)
+  }
+
+  fun mutate(block: (DecompositionManifest) -> DecompositionManifest) {
+    manifest = block(manifest)
+  }
+}
+
+private class RecordingOutcomeStore : GoalRunnerWorkflowOutcomeStore {
+  private val outcomes: MutableMap<String, GoalRunnerStoredOutcome> = mutableMapOf()
+
+  operator fun set(workflowId: String, outcome: GoalRunnerStoredOutcome) {
+    outcomes[workflowId] = outcome
+  }
+
+  override fun terminalOutcome(
+    workflowId: String,
+    issueKey: String,
+    subtaskId: Int,
+    dbPathOverride: String?,
+  ): GoalRunnerStoredOutcome? = outcomes[workflowId]
+}
+
+private class RecordingSubtaskLauncher(
+  private val result: (GoalRunnerSubtaskLaunchRequest) -> AgentRunLaunchOutcome,
+) : GoalRunnerSubtaskLauncher {
+  val requests: MutableList<GoalRunnerSubtaskLaunchRequest> = mutableListOf()
+
+  override fun launch(request: GoalRunnerSubtaskLaunchRequest): AgentRunLaunchOutcome {
+    requests += request
+    return result(request)
+  }
+}
+
+private class RecordingPullRequestPort : GoalPullRequestPort {
+  val requests: MutableList<GoalPullRequestRequest> = mutableListOf()
+
+  override fun open(request: GoalPullRequestRequest): GoalPullRequestResult {
+    requests += request
+    return GoalPullRequestResult.Opened("https://github.com/canonical/skill-bill/pull/56")
+  }
+}
+
+private fun manifest(subtaskCount: Int): DecompositionManifest = DecompositionManifest(
+  issueKey = "SKILL-56",
+  featureName = "goal",
+  parentSpecPath = ".feature-specs/SKILL-56-goal/spec.md",
+  baseBranch = "main",
+  featureBranch = "feat/SKILL-56-goal",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 1, action = "start"),
+  subtasks = (1..subtaskCount).map { id ->
+    DecompositionSubtask(
+      id = id,
+      name = "Subtask $id",
+      specPath = ".feature-specs/SKILL-56-goal/spec_subtask_$id.md",
+      dependencies = if (id == 1) emptyList() else listOf(DecompositionDependency(id - 1)),
+    )
+  },
+)
+
+private fun completeOutcome(subtaskId: Int): GoalRunnerStoredOutcome = GoalRunnerStoredOutcome(
+  status = GoalRunnerTerminalStatus.COMPLETE,
+  workflowId = "wfl-$subtaskId",
+  commitSha = "sha-$subtaskId",
+  lastResumableStep = "commit_push",
+  suppressPr = true,
+)
+
+private fun launchFacts(): AgentRunLaunchFacts = AgentRunLaunchFacts(
+  agent = InstallAgent.CLAUDE,
+  exitStatus = 0,
+  stdout = "diagnostic only",
+  stderr = "",
+  timedOut = false,
+  spawnFailed = false,
+)
+
+private fun DecompositionManifest.withWorkflowId(subtaskId: Int, workflowId: String): DecompositionManifest = copy(
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) {
+      subtask.copy(workflowId = workflowId)
+    } else {
+      subtask
+    }
+  },
+)
+
+private fun DecompositionManifest.withCompletedSubtask(
+  subtaskId: Int,
+  workflowId: String,
+  commitSha: String,
+): DecompositionManifest = copy(
+  status = if (subtasks.all { it.id == subtaskId || it.status == "complete" }) "complete" else "in_progress",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 0, action = "none"),
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) {
+      subtask.copy(
+        status = "complete",
+        workflowId = workflowId,
+        commitSha = commitSha,
+        lastResumableStep = "commit_push",
+      )
+    } else {
+      subtask
+    }
+  },
+)
+
+private fun DecompositionManifest.withBlockedSubtask(
+  subtaskId: Int,
+  workflowId: String,
+  reason: String,
+): DecompositionManifest = copy(
+  status = "blocked",
+  currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = subtaskId, action = "blocked"),
+  subtasks = subtasks.map { subtask ->
+    if (subtask.id == subtaskId) {
+      subtask.copy(
+        status = "blocked",
+        workflowId = workflowId,
+        blockedReason = reason,
+        lastResumableStep = "validate",
+      )
+    } else {
+      subtask
+    }
+  },
+)

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/CliCommandGroups.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/CliCommandGroups.kt
@@ -27,12 +27,14 @@ class ScaffoldCliCommandGroup(
 class UtilityCliCommandGroup(
   workflowCommands: WorkflowTopLevelCommands,
   repoValidationCommands: RepoValidationCliCommands,
+  goalRunCommand: GoalRunCommand,
   versionCommand: VersionCommand,
   doctorCommand: DoctorCliCommand,
   removeCommand: RemoveCliCommand,
 ) {
   val commands: List<CliktCommand> =
     workflowCommands.commands + repoValidationCommands.commands + listOf(
+      goalRunCommand,
       versionCommand,
       doctorCommand,
       removeCommand,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/CliRunState.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/CliRunState.kt
@@ -9,6 +9,8 @@ class CliRunState {
   var stdinText: String? = null
   var environment: Map<String, String> = System.getenv()
   var userHome: Path = Path.of(System.getProperty("user.home"))
+  var liveStdout: (String) -> Unit = {}
+  var liveStderr: (String) -> Unit = {}
   var result: CliExecutionResult? = null
 
   fun complete(payload: Map<String, Any?>, format: CliFormat, exitCode: Int = 0) {

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/CliRuntime.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/CliRuntime.kt
@@ -13,6 +13,8 @@ object CliRuntime {
         stdinText = context.stdinText
         environment = context.environment
         userHome = context.userHome
+        liveStdout = context.liveStdout
+        liveStderr = context.liveStderr
       }
     val cliComponent = CliComponent::class.create(runtimeComponent, runState)
     val rootCommand = cliComponent.rootCommand

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/GoalCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/GoalCliCommands.kt
@@ -1,0 +1,210 @@
+package skillbill.cli
+
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.optional
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.GoalRunner
+import skillbill.application.GoalRunnerStatusService
+import skillbill.application.model.GoalRunnerRunEvent
+import skillbill.application.model.GoalRunnerRunRequest
+import skillbill.application.model.GoalRunnerStatusRequest
+import skillbill.goalrunner.model.GoalRunnerRunReport
+import skillbill.goalrunner.model.GoalRunnerStatusProjection
+import skillbill.ports.agentrun.model.AgentRunOutputSink
+import skillbill.ports.agentrun.model.AgentRunOutputStream
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.minutes
+
+@Inject
+class GoalRunCommand(
+  private val goalRunner: GoalRunner,
+  goalStatusCommand: GoalStatusCommand,
+  private val state: CliRunState,
+) : DocumentedCliCommand("goal", "Run a decomposed goal in the foreground.") {
+  private val issueKey by argument(help = "Parent issue key for the decomposed goal.").optional()
+  private val agent by option(
+    "--agent",
+    help = "Agent invoking bill-goal. Defaults to SKILL_BILL_AGENT or codex.",
+  )
+  private val agentOverride by option(
+    "--agent-override",
+    help = "Optional agent to use for child subtask runs instead of the invoking agent.",
+  )
+  private val repoRoot by option("--repo-root", help = "Repository root for child agent runs.")
+  private val timeoutMinutes by option("--timeout-minutes", help = "Per-subtask timeout in minutes.").int()
+    .default(DEFAULT_GOAL_TIMEOUT_MINUTES)
+  private val noLiveOutput by option(
+    "--no-live-output",
+    help = "Do not tee child stdout and stderr to this terminal.",
+  ).flag(default = false)
+
+  override val invokeWithoutSubcommand: Boolean = true
+
+  init {
+    subcommands(goalStatusCommand)
+  }
+
+  override fun run() {
+    if (currentContext.invokedSubcommand != null) {
+      return
+    }
+    val runIssueKey = issueKey ?: throw UsageError("issue_key is required for goal run.")
+    val presenter = GoalRunPresenter(state, liveOutput = !noLiveOutput)
+    val report = goalRunner.run(
+      GoalRunnerRunRequest(
+        issueKey = runIssueKey,
+        repoRoot = repoRoot?.let(Path::of) ?: Path.of("").toAbsolutePath().normalize(),
+        invokedAgentId = agent ?: state.environment["SKILL_BILL_AGENT"] ?: DEFAULT_GOAL_AGENT,
+        configuredAgentOverrideId = agentOverride,
+        dbPathOverride = state.dbOverride,
+        timeout = timeoutMinutes.minutes,
+        outputSink = presenter.outputSink(),
+        eventSink = presenter.eventSink(),
+      ),
+    )
+    val payload = report.toGoalRunCliMap()
+    state.completeText(goalRunText(payload), payload, exitCode = payload.goalExitCode())
+  }
+}
+
+@Inject
+class GoalStatusCommand(
+  private val goalRunnerStatusService: GoalRunnerStatusService,
+  private val state: CliRunState,
+) : DocumentedCliCommand("status", "Show read-only decomposed goal status.") {
+  private val issueKey by argument(help = "Parent issue key for the decomposed goal.")
+  private val agent by option(
+    "--agent",
+    help = "Agent invoking bill-goal. Defaults to SKILL_BILL_AGENT or codex.",
+  )
+  private val agentOverride by option(
+    "--agent-override",
+    help = "Optional agent override whose id should be shown as active.",
+  )
+
+  override fun run() {
+    val projection = goalRunnerStatusService.status(
+      GoalRunnerStatusRequest(
+        issueKey = issueKey,
+        invokedAgentId = agent ?: state.environment["SKILL_BILL_AGENT"] ?: DEFAULT_GOAL_AGENT,
+        configuredAgentOverrideId = agentOverride,
+        dbPathOverride = state.dbOverride,
+      ),
+    )
+    val payload = projection.toGoalStatusCliMap(issueKey)
+    state.completeText(goalStatusText(payload), payload, exitCode = payload.goalStatusExitCode())
+  }
+}
+
+private class GoalRunPresenter(
+  private val state: CliRunState,
+  private val liveOutput: Boolean,
+) {
+  fun eventSink(): skillbill.application.model.GoalRunnerEventSink =
+    skillbill.application.model.GoalRunnerEventSink { event ->
+      state.liveStdout(event.progressLine())
+    }
+
+  fun outputSink(): AgentRunOutputSink = if (!liveOutput) {
+    AgentRunOutputSink.NONE
+  } else {
+    AgentRunOutputSink { stream, text ->
+      when (stream) {
+        AgentRunOutputStream.STDOUT -> state.liveStdout(text)
+        AgentRunOutputStream.STDERR -> state.liveStderr(text)
+      }
+    }
+  }
+}
+
+private fun GoalRunnerRunEvent.progressLine(): String = when (this) {
+  is GoalRunnerRunEvent.Started -> "goal $issueKey: started\n"
+  is GoalRunnerRunEvent.SubtaskStarted -> "goal $issueKey: subtask $subtaskId $action\n"
+  is GoalRunnerRunEvent.SubtaskCompleted -> "goal $issueKey: subtask $subtaskId complete\n"
+  is GoalRunnerRunEvent.SubtaskStopped ->
+    "goal $issueKey: subtask $subtaskId stopped ($reason): $blockedReason\n"
+  is GoalRunnerRunEvent.Completed -> buildString {
+    append("goal $issueKey: complete")
+    pullRequestUrl?.let { append(" ($it)") }
+    append('\n')
+  }
+}
+
+private fun GoalRunnerRunReport.toGoalRunCliMap(): Map<String, Any?> = when (this) {
+  is GoalRunnerRunReport.Completed -> linkedMapOf(
+    "status" to "complete",
+    "issue_key" to issueKey,
+    "attempted_subtasks" to attemptedSubtasks,
+    "subtasks_completed" to subtasksCompleted,
+    "pull_request_url" to pullRequestUrl,
+  )
+  is GoalRunnerRunReport.Stopped -> linkedMapOf(
+    "status" to "stopped",
+    "issue_key" to issueKey,
+    "attempted_subtasks" to attemptedSubtasks,
+    "subtask_id" to stop.subtaskId,
+    "reason" to stop.reason.name.lowercase(),
+    "blocked_reason" to stop.blockedReason,
+    "workflow_id" to stop.workflowId,
+    "last_resumable_step" to stop.lastResumableStep,
+  )
+}
+
+private fun goalRunText(payload: Map<String, Any?>): String = buildString {
+  appendLine("goal: ${payload["issue_key"]}")
+  appendLine("status: ${payload["status"]}")
+  appendLine("attempted_subtasks: ${(payload["attempted_subtasks"] as? List<*>).orEmpty().joinToString()}")
+  payload["subtasks_completed"]?.let { appendLine("subtasks_completed: $it") }
+  payload["pull_request_url"]?.let { appendLine("pull_request_url: $it") }
+  payload["subtask_id"]?.let { appendLine("subtask_id: $it") }
+  payload["reason"]?.let { appendLine("reason: $it") }
+  payload["blocked_reason"]?.let { appendLine("blocked_reason: $it") }
+  payload["workflow_id"]?.let { appendLine("workflow_id: $it") }
+  payload["last_resumable_step"]?.let { appendLine("last_resumable_step: $it") }
+}
+
+private fun Map<String, Any?>.goalExitCode(): Int = if (this["status"] == "complete") 0 else 1
+
+private fun GoalRunnerStatusProjection?.toGoalStatusCliMap(issueKey: String): Map<String, Any?> = this?.let {
+  linkedMapOf(
+    "status" to "ok",
+    "issue_key" to it.issueKey,
+    "complete_count" to it.completeCount,
+    "pending_count" to it.pendingCount,
+    "blocked_count" to it.blockedCount,
+    "current_subtask" to it.currentSubtaskId,
+    "current_step" to it.currentStep,
+    "active_agent" to it.activeAgent,
+  )
+} ?: linkedMapOf(
+  "status" to "not_found",
+  "issue_key" to issueKey,
+  "complete_count" to 0,
+  "pending_count" to 0,
+  "blocked_count" to 0,
+  "current_subtask" to null,
+  "current_step" to null,
+  "active_agent" to null,
+)
+
+private fun goalStatusText(payload: Map<String, Any?>): String = buildString {
+  appendLine("goal: ${payload["issue_key"]}")
+  appendLine("status: ${payload["status"]}")
+  appendLine("complete: ${payload["complete_count"]}")
+  appendLine("pending: ${payload["pending_count"]}")
+  appendLine("blocked: ${payload["blocked_count"]}")
+  appendLine("current_subtask: ${payload["current_subtask"] ?: "none"}")
+  appendLine("current_step: ${payload["current_step"] ?: "none"}")
+  appendLine("active_agent: ${payload["active_agent"] ?: "none"}")
+}
+
+private fun Map<String, Any?>.goalStatusExitCode(): Int = if (this["status"] == "ok") 0 else 1
+
+private const val DEFAULT_GOAL_TIMEOUT_MINUTES = 60
+private const val DEFAULT_GOAL_AGENT = "codex"

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/Main.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/Main.kt
@@ -7,7 +7,14 @@ fun main(args: Array<String>) {
     } else {
       null
     }
-  val result = CliRuntime.run(args.toList(), CliRuntimeContext(stdinText = stdinText))
+  val result = CliRuntime.run(
+    args.toList(),
+    CliRuntimeContext(
+      stdinText = stdinText,
+      liveStdout = { print(it) },
+      liveStderr = { System.err.print(it) },
+    ),
+  )
   print(result.stdout)
   if (result.stdout.isNotEmpty() && !result.stdout.endsWith("\n")) {
     println()

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliCommands.kt
@@ -331,6 +331,10 @@ open class WorkflowContinueCommand(
   private val workflowId by argument(
     help = "Workflow id to continue, or an issue key for a decomposed feature parent.",
   ).optional()
+  private val subtaskId by option(
+    "--subtask-id",
+    help = "Optional decomposed parent subtask id constraint for issue-key continuation.",
+  ).int()
   private val latest by option("--latest", help = "Resolve the most recently updated workflow.").flag(default = false)
   private val format by formatOption()
 
@@ -340,7 +344,12 @@ open class WorkflowContinueCommand(
       if (resolution.errorPayload != null) {
         resolution.errorPayload
       } else {
-        service.continueWorkflow(kind, requireNotNull(resolution.workflowId), state.dbOverride).toCliMap()
+        service.continueWorkflow(
+          kind,
+          requireNotNull(resolution.workflowId),
+          subtaskId = subtaskId,
+          dbOverride = state.dbOverride,
+        ).toCliMap()
       }
     state.complete(payload, format, exitCode = payload.exitCode())
   }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/WorkflowCliResultMappers.kt
@@ -1,5 +1,6 @@
 package skillbill.cli
 
+import skillbill.application.model.GoalContinuationOutcome
 import skillbill.application.model.WorkflowContinueResult
 import skillbill.application.model.WorkflowGetResult
 import skillbill.application.model.WorkflowLatestResult
@@ -99,8 +100,10 @@ internal fun WorkflowContinueResult.toCliMap(): Map<String, Any?> = when (this) 
     view = view,
     dbPath = dbPath,
     decompositionExtras = linkedMapOf(
+      "issue_key" to (outcome?.issueKey ?: issueKey),
       "decomposition_subtask_id" to decompositionSubtaskId,
       "decomposition_subtask_spec_path" to decompositionSubtaskSpecPath,
+      "goal_continuation_outcome" to outcome.toWireMap(),
     ),
   )
   is WorkflowContinueResult.UnknownWorkflow -> linkedMapOf(
@@ -143,6 +146,16 @@ internal fun WorkflowContinueResult.toCliMap(): Map<String, Any?> = when (this) 
     "decomposition_status" to decompositionStatus,
     "db_path" to dbPath,
   )
+  is WorkflowContinueResult.DecompositionSubtaskOutcome -> linkedMapOf(
+    "status" to "ok",
+    "continue_status" to "done",
+    "workflow_id" to workflowId,
+    "issue_key" to issueKey,
+    "decomposition_subtask_id" to subtaskId,
+    "decomposition_subtask_spec_path" to subtaskSpecPath,
+    "goal_continuation_outcome" to outcome.toWireMap(),
+    "db_path" to dbPath,
+  )
   is WorkflowContinueResult.DecompositionBlockedGit -> linkedMapOf(
     "status" to "error",
     "continue_status" to "blocked",
@@ -159,6 +172,18 @@ internal fun WorkflowContinueResult.toCliMap(): Map<String, Any?> = when (this) 
     "db_path" to dbPath,
   )
 }
+
+private fun GoalContinuationOutcome?.toWireMap(): Map<String, Any?> = this?.let { outcome ->
+  linkedMapOf(
+    "issue_key" to outcome.issueKey,
+    "subtask_id" to outcome.subtaskId,
+    "status" to outcome.status,
+    "commit_sha" to outcome.commitSha,
+    "workflow_id" to outcome.workflowId,
+    "blocked_reason" to outcome.blockedReason,
+    "last_resumable_step" to outcome.lastResumableStep,
+  )
+}.orEmpty()
 
 private fun standardContinueMap(
   view: skillbill.workflow.model.WorkflowContinueView,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/models/CliRuntimeContext.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/models/CliRuntimeContext.kt
@@ -1,6 +1,8 @@
 package skillbill.cli.models
 
 import skillbill.model.RuntimeContext
+import skillbill.ports.agentrun.AgentRunLauncher
+import skillbill.ports.goalrunner.GoalPullRequestPort
 import skillbill.ports.telemetry.HttpRequester
 import skillbill.ports.telemetry.UnconfiguredHttpRequester
 import skillbill.ports.workflow.NoopWorkflowGitOperations
@@ -14,6 +16,10 @@ data class CliRuntimeContext(
   val userHome: Path = Path.of(System.getProperty("user.home")),
   val requester: HttpRequester = UnconfiguredHttpRequester,
   val workflowGitOperations: WorkflowGitOperations = NoopWorkflowGitOperations,
+  val agentRunLauncher: AgentRunLauncher? = null,
+  val goalPullRequestPort: GoalPullRequestPort? = null,
+  val liveStdout: (String) -> Unit = {},
+  val liveStderr: (String) -> Unit = {},
 ) {
   fun toRuntimeContext(): RuntimeContext = RuntimeContext(
     dbPathOverride = dbPathOverride,
@@ -22,5 +28,7 @@ data class CliRuntimeContext(
     userHome = userHome,
     requester = requester,
     workflowGitOperations = workflowGitOperations,
+    agentRunLauncher = agentRunLauncher,
+    goalPullRequestPort = goalPullRequestPort,
   )
 }

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -1,0 +1,345 @@
+package skillbill.cli
+
+import skillbill.contracts.JsonSupport
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.AgentRunLauncher
+import skillbill.ports.agentrun.model.AgentRunLaunchFacts
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+import skillbill.ports.agentrun.model.AgentRunOutputStream
+import skillbill.ports.goalrunner.GoalPullRequestPort
+import skillbill.ports.goalrunner.model.GoalPullRequestRequest
+import skillbill.ports.goalrunner.model.GoalPullRequestResult
+import skillbill.ports.workflow.WorkflowGitOperations
+import skillbill.ports.workflow.model.WorkflowGitOperationResult
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class CliGoalRuntimeTest {
+  @Test
+  fun `goal command is registered with status subcommand`() {
+    val result = CliRuntime.run(listOf("goal", "--help"), CliRuntimeContext())
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Run a decomposed goal in the foreground.")
+    assertContains(result.stdout, "status")
+  }
+
+  @Test
+  fun `goal foreground run completes all subtasks and prints live progress`() {
+    val fixture = goalFixture(subtaskCount = 2)
+    val liveStdout = StringBuilder()
+    val liveStderr = StringBuilder()
+    val launcher = GoalFixtureAgentRunLauncher(fixture)
+
+    val result = CliRuntime.run(
+      fixture.goalCommand(),
+      fixture.context(
+        launcher = launcher,
+        liveStdout = { liveStdout.append(it) },
+        liveStderr = { liveStderr.append(it) },
+      ),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "status: complete")
+    assertContains(result.stdout, "attempted_subtasks: 1, 2")
+    assertContains(result.stdout, "pull_request_url: https://github.com/example/skill-bill/pull/901")
+    assertEquals(listOf(1, 2), launcher.requests.map { it.skillRunRequest.subtaskId })
+    assertContains(liveStdout.toString(), "goal SKILL-901: subtask 1 start")
+    assertContains(liveStdout.toString(), "child-1-stdout")
+    assertContains(liveStdout.toString(), "goal SKILL-901: complete")
+    assertContains(liveStderr.toString(), "child-1-stderr")
+    assertEquals(1, fixture.pullRequests.requests.size)
+  }
+
+  @Test
+  fun `goal no-live-output keeps progress but suppresses child output tee`() {
+    val fixture = goalFixture(subtaskCount = 1)
+    val liveStdout = StringBuilder()
+    val liveStderr = StringBuilder()
+
+    val result = CliRuntime.run(
+      fixture.goalCommand(extra = listOf("--no-live-output")),
+      fixture.context(
+        launcher = GoalFixtureAgentRunLauncher(fixture),
+        liveStdout = { liveStdout.append(it) },
+        liveStderr = { liveStderr.append(it) },
+      ),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(liveStdout.toString(), "goal SKILL-901: subtask 1 start")
+    assertEquals(false, liveStdout.toString().contains("child-1-stdout"), liveStdout.toString())
+    assertEquals("", liveStderr.toString())
+  }
+
+  @Test
+  fun `goal forced failure exits non-zero and status reports blocked projection`() {
+    val fixture = goalFixture(subtaskCount = 3)
+    val launcher = GoalFixtureAgentRunLauncher(fixture, failSubtask = 2)
+
+    val result = CliRuntime.run(fixture.goalCommand(), fixture.context(launcher = launcher))
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "status: stopped")
+    assertContains(result.stdout, "subtask_id: 2")
+    assertContains(result.stdout, "reason: failed")
+    assertEquals(listOf(1, 2), launcher.requests.map { it.skillRunRequest.subtaskId })
+    assertEquals(0, fixture.pullRequests.requests.size)
+
+    val status = CliRuntime.run(
+      listOf("--db", fixture.dbPath.toString(), "goal", "status", "SKILL-901", "--agent", "codex"),
+      fixture.context(launcher = launcher),
+    )
+
+    assertEquals(0, status.exitCode, status.stdout)
+    assertContains(status.stdout, "complete: 1")
+    assertContains(status.stdout, "pending: 1")
+    assertContains(status.stdout, "blocked: 1")
+    assertContains(status.stdout, "current_subtask: 2")
+    assertContains(status.stdout, "current_step: review")
+    assertContains(status.stdout, "active_agent: codex")
+  }
+}
+
+private data class GoalCliFixture(
+  val tempDir: Path,
+  val dbPath: Path,
+  val parentSpec: Path,
+  val subtaskSpecs: List<Path>,
+  val pullRequests: RecordingGoalPullRequestPort = RecordingGoalPullRequestPort(),
+) {
+  fun context(
+    launcher: AgentRunLauncher,
+    liveStdout: (String) -> Unit = {},
+    liveStderr: (String) -> Unit = {},
+  ): CliRuntimeContext = CliRuntimeContext(
+    userHome = tempDir,
+    workflowGitOperations = GoalTestWorkflowGitOperations,
+    agentRunLauncher = launcher,
+    goalPullRequestPort = pullRequests,
+    liveStdout = liveStdout,
+    liveStderr = liveStderr,
+  )
+
+  fun goalCommand(extra: List<String> = emptyList()): List<String> = buildList {
+    add("--db")
+    add(dbPath.toString())
+    add("goal")
+    add("SKILL-901")
+    add("--agent")
+    add("codex")
+    add("--repo-root")
+    add(tempDir.toString())
+    addAll(extra)
+  }
+}
+
+private class GoalFixtureAgentRunLauncher(
+  private val fixture: GoalCliFixture,
+  private val failSubtask: Int? = null,
+) : AgentRunLauncher {
+  val requests: MutableList<AgentRunLaunchRequest> = mutableListOf()
+
+  override fun launch(request: AgentRunLaunchRequest): AgentRunLaunchOutcome {
+    requests += request
+    val subtaskId = requireNotNull(request.skillRunRequest.subtaskId)
+    request.skillRunRequest.outputSink.write(AgentRunOutputStream.STDOUT, "child-$subtaskId-stdout\n")
+    request.skillRunRequest.outputSink.write(AgentRunOutputStream.STDERR, "child-$subtaskId-stderr\n")
+    val workflowId = startSubtaskWorkflow(subtaskId)
+    if (subtaskId == failSubtask) {
+      failSubtaskWorkflow(workflowId)
+    } else {
+      completeSubtaskWorkflow(workflowId, subtaskId)
+    }
+    return AgentRunLaunchFacts(
+      agent = InstallAgent.CODEX,
+      exitStatus = 0,
+      stdout = "captured child $subtaskId",
+      stderr = "",
+      timedOut = false,
+      spawnFailed = false,
+    )
+  }
+
+  private fun startSubtaskWorkflow(subtaskId: Int): String {
+    val payload = runGoalJson(
+      listOf(
+        "--db",
+        fixture.dbPath.toString(),
+        "workflow",
+        "continue",
+        "SKILL-901",
+        "--subtask-id",
+        subtaskId.toString(),
+        "--format",
+        "json",
+      ),
+      fixture.context(launcher = this),
+    )
+    return payload["workflow_id"] as String
+  }
+
+  private fun completeSubtaskWorkflow(workflowId: String, subtaskId: Int) {
+    runGoalJson(
+      workflowUpdateCommand(
+        WorkflowUpdateFixture(
+          dbPath = fixture.dbPath,
+          workflowId = workflowId,
+          currentStep = "commit_push",
+          stepUpdates = """[{"step_id":"commit_push","status":"completed","attempt_count":1}]""",
+          artifactsPatch = jsonString(mapOf("commit_push_result" to mapOf("commit_sha" to "sha-$subtaskId"))),
+        ),
+      ),
+      fixture.context(launcher = this),
+    )
+  }
+
+  private fun failSubtaskWorkflow(workflowId: String) {
+    runGoalJson(
+      workflowUpdateCommand(
+        WorkflowUpdateFixture(
+          dbPath = fixture.dbPath,
+          workflowId = workflowId,
+          workflowStatus = "failed",
+          currentStep = "review",
+          stepUpdates = """[{"step_id":"review","status":"failed","attempt_count":1}]""",
+          artifactsPatch = jsonString(mapOf("blocked_reason" to "forced failure")),
+        ),
+      ),
+      fixture.context(launcher = this),
+    )
+  }
+}
+
+private class RecordingGoalPullRequestPort : GoalPullRequestPort {
+  val requests: MutableList<GoalPullRequestRequest> = mutableListOf()
+
+  override fun open(request: GoalPullRequestRequest): GoalPullRequestResult {
+    requests += request
+    return GoalPullRequestResult.Opened("https://github.com/example/skill-bill/pull/901")
+  }
+}
+
+private fun goalFixture(subtaskCount: Int): GoalCliFixture {
+  val tempDir = Files.createTempDirectory("skillbill-cli-goal")
+  val parentSpec = tempDir.resolve(".feature-specs/SKILL-901-goal/spec.md")
+  Files.createDirectories(parentSpec.parent)
+  Files.writeString(parentSpec, "# Parent")
+  val subtaskSpecs = (1..subtaskCount).map { id ->
+    parentSpec.parent.resolve("spec_subtask_${id}_part.md").also { path ->
+      Files.writeString(path, "---\nstatus: Pending\n---\n\n# Subtask $id")
+    }
+  }
+  val fixture = GoalCliFixture(
+    tempDir = tempDir,
+    dbPath = tempDir.resolve("metrics.db"),
+    parentSpec = parentSpec,
+    subtaskSpecs = subtaskSpecs,
+  )
+  seedParentWorkflow(fixture)
+  return fixture
+}
+
+private fun seedParentWorkflow(fixture: GoalCliFixture) {
+  val opened = runGoalJson(
+    listOf("--db", fixture.dbPath.toString(), "workflow", "open", "--format", "json"),
+    fixture.context(launcher = NoopGoalTestAgentRunLauncher),
+  )
+  val workflowId = opened["workflow_id"] as String
+  runGoalJson(
+    workflowUpdateCommand(
+      WorkflowUpdateFixture(
+        dbPath = fixture.dbPath,
+        workflowId = workflowId,
+        currentStep = "plan",
+        stepUpdates = """[{"step_id":"plan","status":"completed","attempt_count":1}]""",
+        artifactsPatch = parentArtifactsPatch(fixture),
+      ),
+    ),
+    fixture.context(launcher = NoopGoalTestAgentRunLauncher),
+  )
+}
+
+private fun parentArtifactsPatch(fixture: GoalCliFixture): String = jsonString(
+  mapOf(
+    "branch" to mapOf("branch" to "feat/SKILL-901-goal"),
+    "plan" to mapOf(
+      "mode" to "decompose",
+      "parent_spec_path" to fixture.parentSpec.toString(),
+      "recommended_first_subtask_id" to 1,
+      "subtasks" to fixture.subtaskSpecs.mapIndexed { index, path ->
+        mapOf(
+          "id" to index + 1,
+          "name" to "Part ${index + 1}",
+          "spec_path" to path.toString(),
+          "depends_on" to if (index == 0) emptyList<Int>() else listOf(index),
+        )
+      },
+    ),
+  ),
+)
+
+private data class WorkflowUpdateFixture(
+  val dbPath: Path,
+  val workflowId: String,
+  val workflowStatus: String = "running",
+  val currentStep: String,
+  val stepUpdates: String,
+  val artifactsPatch: String,
+)
+
+private fun workflowUpdateCommand(fixture: WorkflowUpdateFixture): List<String> = listOf(
+  "--db",
+  fixture.dbPath.toString(),
+  "workflow",
+  "update",
+  fixture.workflowId,
+  "--workflow-status",
+  fixture.workflowStatus,
+  "--current-step-id",
+  fixture.currentStep,
+  "--step-updates",
+  fixture.stepUpdates,
+  "--artifacts-patch",
+  fixture.artifactsPatch,
+  "--format",
+  "json",
+)
+
+private fun runGoalJson(arguments: List<String>, context: CliRuntimeContext): Map<String, Any?> {
+  val result = CliRuntime.run(arguments, context)
+  assertEquals(0, result.exitCode, result.stdout)
+  val parsed = requireNotNull(JsonSupport.parseObjectOrNull(result.stdout))
+  return requireNotNull(JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(parsed)))
+}
+
+private fun jsonString(value: Any?): String = JsonSupport.json.encodeToString(
+  kotlinx.serialization.json.JsonElement.serializer(),
+  JsonSupport.valueToJsonElement(value),
+)
+
+private object NoopGoalTestAgentRunLauncher : AgentRunLauncher {
+  override fun launch(request: AgentRunLaunchRequest): AgentRunLaunchOutcome = error("Unexpected launch")
+}
+
+private object GoalTestWorkflowGitOperations : WorkflowGitOperations {
+  override fun checkoutBranch(repoRoot: Path, branch: String, baseBranch: String?): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = branch)
+
+  override fun currentBranch(repoRoot: Path): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = "")
+
+  override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult =
+    WorkflowGitOperationResult(status = "ok", value = "test-commit")
+
+  override fun validateBranchBase(
+    repoRoot: Path,
+    branch: String,
+    expectedBaseBranch: String,
+  ): WorkflowGitOperationResult = WorkflowGitOperationResult(status = "ok", value = expectedBaseBranch)
+}

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliWorkflowContinuationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliWorkflowContinuationRuntimeTest.kt
@@ -22,6 +22,21 @@ class CliWorkflowContinuationRuntimeTest {
     assertEquals(1, continued["decomposition_subtask_id"])
     assertEquals(fixture.subtaskSpec.toString(), continued["decomposition_subtask_spec_path"])
   }
+
+  @Test
+  fun `workflow continue reports blocked when requested decomposed subtask is not runnable`() {
+    val fixture = cliDecompositionFixture()
+    val opened = runJson(fixture.openCommand(), fixture.context)
+    val workflowId = opened["workflow_id"] as String
+
+    runJson(fixture.updateCommand(workflowId), fixture.context)
+    val continued = runJson(fixture.continueCommand(subtaskId = 2), fixture.context, expectedExitCode = 1)
+
+    assertEquals("error", continued["status"])
+    assertEquals("blocked", continued["continue_status"])
+    assertEquals(2, continued["decomposition_subtask_id"])
+    assertEquals("Requested subtask 2 is not the next runnable subtask for SKILL-51.", continued["blocked_reason"])
+  }
 }
 
 private data class CliDecompositionFixture(
@@ -29,6 +44,7 @@ private data class CliDecompositionFixture(
   val context: CliRuntimeContext,
   val parentSpec: Path,
   val subtaskSpec: Path,
+  val secondSubtaskSpec: Path,
 ) {
   fun openCommand(): List<String> = listOf("--db", dbPath.toString(), "workflow", "open", "--format", "json")
 
@@ -50,8 +66,17 @@ private data class CliDecompositionFixture(
     "json",
   )
 
-  fun continueCommand(): List<String> =
-    listOf("--db", dbPath.toString(), "workflow", "continue", "SKILL-51", "--format", "json")
+  fun continueCommand(subtaskId: Int = 1): List<String> = listOf(
+    "--db",
+    dbPath.toString(),
+    "workflow",
+    "continue",
+    "SKILL-51",
+    "--subtask-id",
+    subtaskId.toString(),
+    "--format",
+    "json",
+  )
 
   private fun artifactsPatch(): String = jsonString(
     mapOf(
@@ -67,6 +92,12 @@ private data class CliDecompositionFixture(
             "spec_path" to subtaskSpec.toString(),
             "depends_on" to emptyList<Int>(),
           ),
+          mapOf(
+            "id" to 2,
+            "name" to "runtime",
+            "spec_path" to secondSubtaskSpec.toString(),
+            "depends_on" to listOf(1),
+          ),
         ),
       ),
     ),
@@ -77,20 +108,27 @@ private fun cliDecompositionFixture(): CliDecompositionFixture {
   val tempDir = Files.createTempDirectory("skillbill-cli-decomposition-continue")
   val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
   val subtaskSpec = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+  val secondSubtaskSpec = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
   Files.createDirectories(parentSpec.parent)
   Files.writeString(parentSpec, "# Parent")
   Files.writeString(subtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
+  Files.writeString(secondSubtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
   return CliDecompositionFixture(
     dbPath = tempDir.resolve("metrics.db"),
     context = CliRuntimeContext(userHome = tempDir, workflowGitOperations = TestWorkflowGitOperations),
     parentSpec = parentSpec,
     subtaskSpec = subtaskSpec,
+    secondSubtaskSpec = secondSubtaskSpec,
   )
 }
 
-private fun runJson(arguments: List<String>, context: CliRuntimeContext): Map<String, Any?> {
+private fun runJson(
+  arguments: List<String>,
+  context: CliRuntimeContext,
+  expectedExitCode: Int = 0,
+): Map<String, Any?> {
   val result = CliRuntime.run(arguments, context)
-  assertEquals(0, result.exitCode, result.stdout)
+  assertEquals(expectedExitCode, result.exitCode, result.stdout)
   return decodeJsonObject(result.stdout)
 }
 

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -190,7 +190,8 @@ abstract class RuntimeComponent(
 
   @Provides
   @JvmSynthetic
-  internal fun agentRunLauncher(adapter: FileSystemAgentRunLauncher): AgentRunLauncher = adapter
+  internal fun agentRunLauncher(context: RuntimeContext, adapter: FileSystemAgentRunLauncher): AgentRunLauncher =
+    context.agentRunLauncher ?: adapter
 
   @Provides
   @JvmSynthetic
@@ -209,7 +210,8 @@ abstract class RuntimeComponent(
 
   @Provides
   @JvmSynthetic
-  internal fun goalPullRequestPort(adapter: GhGoalPullRequestPort): GoalPullRequestPort = adapter
+  internal fun goalPullRequestPort(context: RuntimeContext, adapter: GhGoalPullRequestPort): GoalPullRequestPort =
+    context.goalPullRequestPort ?: adapter
 
   @Provides
   @JvmSynthetic

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -2,7 +2,10 @@ package skillbill.di
 
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
+import skillbill.application.AgentRunGoalRunnerSubtaskLauncher
 import skillbill.application.AgentRunService
+import skillbill.application.GoalRunner
+import skillbill.application.GoalRunnerStatusService
 import skillbill.application.InstallAgentService
 import skillbill.application.InstallService
 import skillbill.application.LearningService
@@ -19,6 +22,8 @@ import skillbill.application.SystemService
 import skillbill.application.TelemetryLevelMutationService
 import skillbill.application.TelemetryService
 import skillbill.application.UnsupportedScaffoldService
+import skillbill.application.WorkflowGoalRunnerManifestStore
+import skillbill.application.WorkflowGoalRunnerOutcomeStore
 import skillbill.application.WorkflowService
 import skillbill.domain.skillremove.SkillRemoveFileSystem
 import skillbill.infrastructure.fs.DecompositionManifestValidatorAdapter
@@ -45,6 +50,7 @@ import skillbill.infrastructure.fs.FileSystemScaffoldSourceLoader
 import skillbill.infrastructure.fs.FileSystemSkillRemoveFileSystem
 import skillbill.infrastructure.fs.FileSystemUnsupportedScaffoldGateway
 import skillbill.infrastructure.fs.FileTelemetryConfigStore
+import skillbill.infrastructure.fs.GhGoalPullRequestPort
 import skillbill.infrastructure.fs.GitWorkflowGitOperations
 import skillbill.infrastructure.fs.InstallPlanWireValidatorAdapter
 import skillbill.infrastructure.fs.WorkflowSnapshotValidatorInfraAdapter
@@ -55,6 +61,10 @@ import skillbill.install.model.InstallPlanWireValidator
 import skillbill.launcher.FileSystemAgentRunLauncher
 import skillbill.model.RuntimeContext
 import skillbill.ports.agentrun.AgentRunLauncher
+import skillbill.ports.goalrunner.GoalPullRequestPort
+import skillbill.ports.goalrunner.GoalRunnerManifestStore
+import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
+import skillbill.ports.goalrunner.GoalRunnerWorkflowOutcomeStore
 import skillbill.ports.install.agent.InstallAgentTargetPort
 import skillbill.ports.install.apply.InstallApplyExecutionPort
 import skillbill.ports.install.link.InstallSkillLinkPort
@@ -184,6 +194,25 @@ abstract class RuntimeComponent(
 
   @Provides
   @JvmSynthetic
+  internal fun goalRunnerSubtaskLauncher(adapter: AgentRunGoalRunnerSubtaskLauncher): GoalRunnerSubtaskLauncher =
+    adapter
+
+  @Provides
+  @JvmSynthetic
+  internal fun goalRunnerManifestStore(adapter: WorkflowGoalRunnerManifestStore): GoalRunnerManifestStore = adapter
+
+  @Provides
+  @JvmSynthetic
+  internal fun goalRunnerWorkflowOutcomeStore(
+    adapter: WorkflowGoalRunnerOutcomeStore,
+  ): GoalRunnerWorkflowOutcomeStore = adapter
+
+  @Provides
+  @JvmSynthetic
+  internal fun goalPullRequestPort(adapter: GhGoalPullRequestPort): GoalPullRequestPort = adapter
+
+  @Provides
+  @JvmSynthetic
   internal fun installSelectionPersistencePort(
     adapter: FileSystemInstallSelectionPersistence,
   ): InstallSelectionPersistencePort = adapter
@@ -280,6 +309,8 @@ abstract class RuntimeComponent(
 
   abstract val installService: InstallService
   abstract val agentRunService: AgentRunService
+  abstract val goalRunner: GoalRunner
+  abstract val goalRunnerStatusService: GoalRunnerStatusService
   abstract val installAgentService: InstallAgentService
   abstract val installSelectionPersistencePort: InstallSelectionPersistencePort
   abstract val learningService: LearningService

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -2,6 +2,7 @@ package skillbill.di
 
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
+import skillbill.application.AgentRunService
 import skillbill.application.InstallAgentService
 import skillbill.application.InstallService
 import skillbill.application.LearningService
@@ -51,7 +52,9 @@ import skillbill.infrastructure.http.HttpTelemetryClient
 import skillbill.infrastructure.http.JdkHttpRequester
 import skillbill.infrastructure.sqlite.SQLiteDatabaseSessionFactory
 import skillbill.install.model.InstallPlanWireValidator
+import skillbill.launcher.FileSystemAgentRunLauncher
 import skillbill.model.RuntimeContext
+import skillbill.ports.agentrun.AgentRunLauncher
 import skillbill.ports.install.agent.InstallAgentTargetPort
 import skillbill.ports.install.apply.InstallApplyExecutionPort
 import skillbill.ports.install.link.InstallSkillLinkPort
@@ -177,6 +180,10 @@ abstract class RuntimeComponent(
 
   @Provides
   @JvmSynthetic
+  internal fun agentRunLauncher(adapter: FileSystemAgentRunLauncher): AgentRunLauncher = adapter
+
+  @Provides
+  @JvmSynthetic
   internal fun installSelectionPersistencePort(
     adapter: FileSystemInstallSelectionPersistence,
   ): InstallSelectionPersistencePort = adapter
@@ -272,6 +279,7 @@ abstract class RuntimeComponent(
     adapter
 
   abstract val installService: InstallService
+  abstract val agentRunService: AgentRunService
   abstract val installAgentService: InstallAgentService
   abstract val installSelectionPersistencePort: InstallSelectionPersistencePort
   abstract val learningService: LearningService

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/AgentRunServiceRuntimeComponentTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/AgentRunServiceRuntimeComponentTest.kt
@@ -1,0 +1,41 @@
+package skillbill.application
+
+import skillbill.application.model.AgentRunStartRequest
+import skillbill.di.RuntimeComponent
+import skillbill.di.create
+import skillbill.install.model.InstallAgent
+import skillbill.model.RuntimeContext
+import skillbill.ports.agentrun.model.SkillRunRequest
+import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class AgentRunServiceRuntimeComponentTest {
+  @Test
+  fun `runtime component exposes agent run service with filesystem launcher binding`() {
+    val tempDir = Files.createTempDirectory("skillbill-agent-run-component")
+    val service = RuntimeComponent::class.create(
+      RuntimeContext(
+        dbPathOverride = tempDir.resolve("metrics.db").toString(),
+        environment = emptyMap(),
+        userHome = tempDir,
+      ),
+    ).agentRunService
+
+    val result = service.launch(
+      AgentRunStartRequest(
+        invokedAgentId = "copilot",
+        skillRunRequest = SkillRunRequest(
+          issueKey = "SKILL-56",
+          repoRoot = tempDir,
+          subtaskId = 2,
+        ),
+      ),
+    )
+
+    assertEquals(InstallAgent.COPILOT, result.resolution.effectiveAgent)
+    assertIs<UnsupportedAgentRunLaunch>(result.launchOutcome)
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -263,7 +263,7 @@ class ApplicationPersistencePortTest {
     val opened = service.open(WorkflowFamilyKind.IMPLEMENT, sessionId = "fis-001", dbOverride = null)
       as WorkflowOpenResult.Ok
     val workflowId = opened.workflowId
-    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, workflowId, null)
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, workflowId, dbOverride = null)
       as WorkflowContinueResult.Standard
     val sessionSummary = continued.view.sessionSummary
 
@@ -481,8 +481,39 @@ class ApplicationPersistencePortTest {
 
     val manifest = loadTestDecompositionManifest(parentSpec.parent.resolve("decomposition-manifest.yaml"))
     assertEquals(1, continued.decompositionSubtaskId)
+    assertEquals("SKILL-51", continued.issueKey)
+    assertEquals("SKILL-51", continued.outcome?.issueKey)
+    assertEquals(1, continued.outcome?.subtaskId)
+    assertEquals("in_progress", continued.outcome?.status)
+    assertEquals("preplan", continued.outcome?.lastResumableStep)
+    assertEquals("preplan", continued.view.continueStepId)
     assertEquals("in_progress", manifest.subtasks.first { it.id == 1 }.status)
+    assertEquals("preplan", manifest.subtasks.first { it.id == 1 }.lastResumableStep)
     assertEquals(listOf("feat/SKILL-51-demo@main"), git.checkouts)
+  }
+
+  @Test
+  fun `workflow service constrains decomposed issue key continuation to requested subtask`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-subtask-constraint")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val service = testWorkflowService(
+      FakeDatabaseSessionFactory(workflows = InMemoryWorkflowStateRepository()),
+      FakeWorkflowGitOperations(),
+    )
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+
+    val blocked = service.continueWorkflow(
+      WorkflowFamilyKind.IMPLEMENT,
+      "SKILL-51",
+      subtaskId = 2,
+      dbOverride = null,
+    ) as WorkflowContinueResult.DecompositionBlockedSubtask
+
+    assertEquals(2, blocked.subtaskId)
+    assertEquals("Requested subtask 2 is not the next runnable subtask for SKILL-51.", blocked.blockedReason)
   }
 
   @Test
@@ -507,6 +538,136 @@ class ApplicationPersistencePortTest {
     assertEquals(2, continued.decompositionSubtaskId)
     assertEquals(null, manifest.subtasks.first { it.id == 1 }.commitSha)
     assertEquals(listOf("SKILL-51 subtask 1: foundation"), git.commits)
+  }
+
+  @Test
+  fun `workflow service records pr suppressed commit completion as durable subtask outcome`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-headless-complete")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val service = testWorkflowService(
+      FakeDatabaseSessionFactory(workflows = workflowRepository),
+      FakeWorkflowGitOperations(),
+    )
+    val parentWorkflowId = createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    val first = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+      as WorkflowContinueResult.DecompositionStandard
+
+    service.update(
+      WorkflowFamilyKind.IMPLEMENT,
+      WorkflowUpdateRequest(
+        workflowId = first.view.resume.snapshot.workflowId,
+        workflowStatus = "running",
+        currentStepId = "commit_push",
+        stepUpdates = listOf(mapOf("step_id" to "commit_push", "status" to "completed", "attempt_count" to 1)),
+        artifactsPatch = mapOf(
+          "assessment" to mapOf("spec_path" to subtaskOne.toString()),
+          "goal_continuation" to mapOf("enabled" to true, "suppress_pr" to true),
+          "commit_push_result" to mapOf("commit_sha" to "abc123"),
+        ),
+      ),
+      dbOverride = null,
+    )
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+      as WorkflowContinueResult.DecompositionStandard
+    val manifest = loadTestDecompositionManifest(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    val parent = service.get(WorkflowFamilyKind.IMPLEMENT, parentWorkflowId, dbOverride = null) as WorkflowGetResult.Ok
+    val runtime = parent.snapshot.artifacts["decomposition_runtime"] as Map<*, *>
+    val firstRuntimeSubtask = (runtime["subtasks"] as List<*>)
+      .filterIsInstance<Map<*, *>>()
+      .single { it["id"] == 1 }
+
+    assertEquals(2, continued.decompositionSubtaskId)
+    assertEquals(null, manifest.subtasks.first { it.id == 1 }.commitSha)
+    assertEquals("complete", firstRuntimeSubtask["status"])
+    assertEquals("abc123", firstRuntimeSubtask["commit_sha"])
+    assertEquals(first.view.resume.snapshot.workflowId, firstRuntimeSubtask["workflow_id"])
+    assertEquals(null, firstRuntimeSubtask["blocked_reason"])
+    assertEquals("commit_push", firstRuntimeSubtask["last_resumable_step"])
+    assertEquals("SKILL-51", continued.outcome?.issueKey)
+    assertEquals(2, continued.outcome?.subtaskId)
+    assertEquals("in_progress", continued.outcome?.status)
+    assertEquals(null, continued.outcome?.blockedReason)
+    assertEquals("preplan", continued.outcome?.lastResumableStep)
+  }
+
+  @Test
+  fun `workflow service blocks pr suppressed commit completion without durable commit sha`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-headless-missing-sha")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val workflowRepository = InMemoryWorkflowStateRepository()
+    val service = testWorkflowService(
+      FakeDatabaseSessionFactory(workflows = workflowRepository),
+      FakeWorkflowGitOperations(),
+    )
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    val first = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+      as WorkflowContinueResult.DecompositionStandard
+
+    service.update(
+      WorkflowFamilyKind.IMPLEMENT,
+      WorkflowUpdateRequest(
+        workflowId = first.view.resume.snapshot.workflowId,
+        workflowStatus = "running",
+        currentStepId = "commit_push",
+        stepUpdates = listOf(mapOf("step_id" to "commit_push", "status" to "completed", "attempt_count" to 1)),
+        artifactsPatch = mapOf(
+          "assessment" to mapOf("spec_path" to subtaskOne.toString()),
+          "goal_continuation" to mapOf("enabled" to true, "suppress_pr" to true),
+        ),
+      ),
+      dbOverride = null,
+    )
+
+    val continued = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+      as WorkflowContinueResult.DecompositionBlockedSubtask
+    val manifest = loadTestDecompositionManifest(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+    val blockedSubtask = manifest.subtasks.first { it.id == 1 }
+
+    assertEquals(1, continued.subtaskId)
+    assertEquals("blocked", blockedSubtask.status)
+    assertEquals(null, blockedSubtask.commitSha)
+    assertEquals(
+      "Goal-continuation commit_push completed without commit_push_result.commit_sha.",
+      blockedSubtask.blockedReason,
+    )
+  }
+
+  @Test
+  fun `workflow service returns requested terminal subtask outcome without advancing later subtasks`() {
+    val tempDir = Files.createTempDirectory("skillbill-app-decomposition-terminal-subtask")
+    val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
+    val subtaskOne = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+    val subtaskTwo = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
+    writeSpecs(parentSpec, subtaskOne, subtaskTwo)
+    val service = testWorkflowService(
+      FakeDatabaseSessionFactory(workflows = InMemoryWorkflowStateRepository()),
+      FakeWorkflowGitOperations(),
+    )
+    createDecompositionWorkflow(service, parentSpec, subtaskOne, subtaskTwo)
+    val first = service.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", dbOverride = null)
+      as WorkflowContinueResult.DecompositionStandard
+    markDecompositionSubtaskComplete(service, first.view.resume.snapshot.workflowId, subtaskOne)
+
+    val continued = service.continueWorkflow(
+      WorkflowFamilyKind.IMPLEMENT,
+      "SKILL-51",
+      subtaskId = 1,
+      dbOverride = null,
+    ) as WorkflowContinueResult.DecompositionSubtaskOutcome
+    val manifest = loadTestDecompositionManifest(parentSpec.parent.resolve("decomposition-manifest.yaml"))
+
+    assertEquals(1, continued.subtaskId)
+    assertEquals("complete", continued.outcome.status)
+    assertEquals("pr_description", continued.outcome.lastResumableStep)
+    assertEquals("pending", manifest.subtasks.first { it.id == 2 }.status)
   }
 
   @Test
@@ -723,7 +884,7 @@ class ApplicationPersistencePortTest {
     val opened = service.open(WorkflowFamilyKind.VERIFY, sessionId = "fvr-001", dbOverride = null)
       as WorkflowOpenResult.Ok
     val workflowId = opened.workflowId
-    val continued = service.continueWorkflow(WorkflowFamilyKind.VERIFY, workflowId, null)
+    val continued = service.continueWorkflow(WorkflowFamilyKind.VERIFY, workflowId, dbOverride = null)
       as WorkflowContinueResult.Standard
     val sessionSummary = continued.view.sessionSummary
 

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/ImplementationOwnershipArchitectureTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/ImplementationOwnershipArchitectureTest.kt
@@ -150,12 +150,12 @@ class ImplementationOwnershipArchitectureTest {
       "skillbill.skillremove",
       "skillbill.workflow",
     )
-    // SKILL-52.3 subtask 1: the composition root must reference the three
-    // domain-owned validator PORTS by type to declare its `@Provides`
-    // bindings (port -> infra-fs adapter). These are domain port interfaces,
-    // not implementation packages, so they are explicitly allowed.
-    val allowedDomainPortImports = setOf(
+    // The composition root may reference port types and concrete adapters only
+    // where it declares @Provides bindings. These explicit imports are not
+    // runtime-core implementation ownership.
+    val allowedCompositionImports = setOf(
       "skillbill.install.model.InstallPlanWireValidator",
+      "skillbill.launcher.FileSystemAgentRunLauncher",
       "skillbill.workflow.DecompositionManifestValidator",
       "skillbill.workflow.WorkflowSnapshotValidator",
     )
@@ -164,7 +164,7 @@ class ImplementationOwnershipArchitectureTest {
         sourceFile.readText().lineSequence()
           .mapNotNull { line -> line.trim().removePrefix("import ").takeIf { line.trim().startsWith("import ") } }
           .filter { importedName -> bannedImplementationImports.any(importedName::startsWith) }
-          .filterNot { importedName -> importedName in allowedDomainPortImports }
+          .filterNot { importedName -> importedName in allowedCompositionImports }
           .map { importedName -> "${runtimeRoot.relativize(sourceFile)} imports $importedName" }
       }
       .sorted()

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/contract/RuntimeSurfaceContractTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/contract/RuntimeSurfaceContractTest.kt
@@ -24,6 +24,7 @@ class RuntimeSurfaceContractTest {
         "select-mcp-runtime",
         "register-mcp",
         "unregister-mcp",
+        "launch-agent-run",
       ),
     )
   }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalRunnerPolicy.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalRunnerPolicy.kt
@@ -1,0 +1,148 @@
+package skillbill.goalrunner
+
+import skillbill.goalrunner.model.GoalRunnerLaunchFacts
+import skillbill.goalrunner.model.GoalRunnerReconciledOutcome
+import skillbill.goalrunner.model.GoalRunnerSelection
+import skillbill.goalrunner.model.GoalRunnerStopReason
+import skillbill.goalrunner.model.GoalRunnerStoredOutcome
+import skillbill.goalrunner.model.GoalRunnerSubtaskAction
+import skillbill.goalrunner.model.GoalRunnerSubtaskDecision
+import skillbill.goalrunner.model.GoalRunnerTerminalStatus
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionSubtask
+
+object GoalRunnerPlanner {
+  fun selectNext(manifest: DecompositionManifest): GoalRunnerSelection {
+    val intended = manifest.currentSubtaskIntent.subtaskId
+      .takeIf { it > 0 }
+      ?.let { id -> manifest.subtasks.firstOrNull { it.id == id } }
+    val candidate = intended?.takeUnless { it.status in setOf("complete", "skipped") }
+      ?: manifest.subtasks.firstOrNull { it.status == "in_progress" }
+      ?: manifest.subtasks.firstOrNull { it.status == "blocked" }
+      ?: manifest.subtasks.firstOrNull { it.status == "pending" && dependenciesComplete(manifest, it) }
+    return when {
+      candidate == null -> {
+        val blockedByDependency = manifest.subtasks.firstOrNull { it.status == "pending" }
+        if (blockedByDependency == null) {
+          GoalRunnerSelection.Done
+        } else {
+          GoalRunnerSelection.Blocked(
+            subtask = blockedByDependency,
+            reason = "Subtask ${blockedByDependency.id} is waiting for incomplete dependencies.",
+          )
+        }
+      }
+      candidate.status == "pending" && !dependenciesComplete(manifest, candidate) ->
+        GoalRunnerSelection.Blocked(
+          subtask = candidate,
+          reason = "Subtask ${candidate.id} is waiting for incomplete dependencies.",
+        )
+      else -> GoalRunnerSelection.Run(
+        GoalRunnerSubtaskDecision(
+          subtask = candidate,
+          action = if (candidate.status == "pending") GoalRunnerSubtaskAction.START else GoalRunnerSubtaskAction.RESUME,
+        ),
+      )
+    }
+  }
+
+  private fun dependenciesComplete(manifest: DecompositionManifest, subtask: DecompositionSubtask): Boolean {
+    val subtasksById = manifest.subtasks.associateBy(DecompositionSubtask::id)
+    return subtask.dependencies.all { dependency ->
+      val dependencySubtask = subtasksById[dependency.subtaskId] ?: return@all false
+      dependencySubtask.status == "complete" ||
+        dependencySubtask.status == "skipped" ||
+        dependency.optional && dependency.skipped
+    }
+  }
+}
+
+object GoalRunnerOutcomeReconciler {
+  fun reconcile(
+    subtaskId: Int,
+    launchFacts: GoalRunnerLaunchFacts,
+    storedOutcome: GoalRunnerStoredOutcome?,
+  ): GoalRunnerReconciledOutcome = when {
+    launchFacts.timedOut -> stop(
+      reason = GoalRunnerStopReason.TIMEOUT,
+      blockedReason = "Subtask $subtaskId timed out before reaching a terminal workflow-store outcome.",
+      storedOutcome = storedOutcome,
+    )
+    launchFacts.spawnFailed -> stop(
+      reason = GoalRunnerStopReason.BLOCKED,
+      blockedReason = "Subtask $subtaskId could not start a fresh agent process.",
+      storedOutcome = storedOutcome,
+    )
+    storedOutcome == null -> GoalRunnerReconciledOutcome.Stop(
+      reason = GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME,
+      blockedReason = "Subtask $subtaskId finished without a terminal workflow-store outcome.",
+      workflowId = null,
+      commitSha = null,
+      lastResumableStep = "preplan",
+    )
+    !storedOutcome.suppressPr -> stop(
+      reason = GoalRunnerStopReason.BLOCKED,
+      blockedReason = "Subtask $subtaskId did not suppress per-subtask PR creation.",
+      storedOutcome = storedOutcome,
+    )
+    else -> reconcileStoredOutcome(subtaskId, storedOutcome)
+  }
+
+  private fun reconcileStoredOutcome(
+    subtaskId: Int,
+    storedOutcome: GoalRunnerStoredOutcome,
+  ): GoalRunnerReconciledOutcome = when (storedOutcome.status) {
+    GoalRunnerTerminalStatus.COMPLETE -> completeOutcome(subtaskId, storedOutcome)
+    GoalRunnerTerminalStatus.FAILED -> stop(
+      reason = GoalRunnerStopReason.FAILED,
+      blockedReason = storedOutcome.blockedReason.orEmpty().ifBlank { "Subtask $subtaskId failed." },
+      storedOutcome = storedOutcome,
+    )
+    GoalRunnerTerminalStatus.BLOCKED -> stop(
+      reason = GoalRunnerStopReason.BLOCKED,
+      blockedReason = storedOutcome.blockedReason.orEmpty().ifBlank { "Subtask $subtaskId is blocked." },
+      storedOutcome = storedOutcome,
+    )
+    GoalRunnerTerminalStatus.TIMEOUT -> stop(
+      reason = GoalRunnerStopReason.TIMEOUT,
+      blockedReason = storedOutcome.blockedReason.orEmpty()
+        .ifBlank { "Subtask $subtaskId timed out before completion." },
+      storedOutcome = storedOutcome,
+    )
+    GoalRunnerTerminalStatus.NO_TERMINAL_STORE_OUTCOME -> stop(
+      reason = GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME,
+      blockedReason = storedOutcome.blockedReason.orEmpty()
+        .ifBlank { "Subtask $subtaskId has no terminal workflow-store outcome." },
+      storedOutcome = storedOutcome,
+    )
+  }
+
+  private fun completeOutcome(subtaskId: Int, storedOutcome: GoalRunnerStoredOutcome): GoalRunnerReconciledOutcome {
+    val commitSha = storedOutcome.commitSha
+    return if (commitSha.isNullOrBlank()) {
+      stop(
+        reason = GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME,
+        blockedReason = "Subtask $subtaskId completed without commit_sha in the workflow store.",
+        storedOutcome = storedOutcome,
+      )
+    } else {
+      GoalRunnerReconciledOutcome.Complete(
+        workflowId = storedOutcome.workflowId,
+        commitSha = commitSha,
+        lastResumableStep = storedOutcome.lastResumableStep.orEmpty().ifBlank { "commit_push" },
+      )
+    }
+  }
+
+  private fun stop(
+    reason: GoalRunnerStopReason,
+    blockedReason: String,
+    storedOutcome: GoalRunnerStoredOutcome?,
+  ): GoalRunnerReconciledOutcome.Stop = GoalRunnerReconciledOutcome.Stop(
+    reason = reason,
+    blockedReason = blockedReason,
+    workflowId = storedOutcome?.workflowId,
+    commitSha = storedOutcome?.commitSha,
+    lastResumableStep = storedOutcome?.lastResumableStep.orEmpty().ifBlank { "preplan" },
+  )
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
@@ -1,0 +1,126 @@
+package skillbill.goalrunner.model
+
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionSubtask
+
+enum class GoalRunnerTerminalStatus {
+  COMPLETE,
+  FAILED,
+  BLOCKED,
+  TIMEOUT,
+  NO_TERMINAL_STORE_OUTCOME,
+}
+
+enum class GoalRunnerStopReason {
+  FAILED,
+  BLOCKED,
+  TIMEOUT,
+  NO_TERMINAL_STORE_OUTCOME,
+  PULL_REQUEST_FAILED,
+  DEPENDENCIES_BLOCKED,
+}
+
+data class GoalRunnerLaunchFacts(
+  val timedOut: Boolean = false,
+  val spawnFailed: Boolean = false,
+  val exitStatus: Int? = null,
+)
+
+data class GoalRunnerStoredOutcome(
+  val status: GoalRunnerTerminalStatus,
+  val workflowId: String,
+  val commitSha: String? = null,
+  val blockedReason: String? = null,
+  val lastResumableStep: String? = null,
+  val suppressPr: Boolean,
+)
+
+sealed interface GoalRunnerReconciledOutcome {
+  data class Complete(
+    val workflowId: String,
+    val commitSha: String,
+    val lastResumableStep: String,
+  ) : GoalRunnerReconciledOutcome
+
+  data class Stop(
+    val reason: GoalRunnerStopReason,
+    val blockedReason: String,
+    val workflowId: String?,
+    val commitSha: String?,
+    val lastResumableStep: String,
+  ) : GoalRunnerReconciledOutcome
+}
+
+data class GoalRunnerSubtaskDecision(
+  val subtask: DecompositionSubtask,
+  val action: GoalRunnerSubtaskAction,
+)
+
+enum class GoalRunnerSubtaskAction {
+  START,
+  RESUME,
+}
+
+sealed interface GoalRunnerSelection {
+  data class Run(val decision: GoalRunnerSubtaskDecision) : GoalRunnerSelection
+  data class Blocked(val subtask: DecompositionSubtask, val reason: String) : GoalRunnerSelection
+  data object Done : GoalRunnerSelection
+}
+
+data class GoalRunnerStopReport(
+  val issueKey: String,
+  val subtaskId: Int,
+  val reason: GoalRunnerStopReason,
+  val blockedReason: String,
+  val workflowId: String?,
+  val lastResumableStep: String,
+)
+
+data class GoalRunnerCompletedReport(
+  val issueKey: String,
+  val pullRequestUrl: String?,
+  val subtasksCompleted: Int,
+)
+
+sealed interface GoalRunnerRunReport {
+  val issueKey: String
+  val attemptedSubtasks: List<Int>
+
+  data class Completed(
+    override val issueKey: String,
+    override val attemptedSubtasks: List<Int>,
+    val pullRequestUrl: String?,
+    val subtasksCompleted: Int,
+  ) : GoalRunnerRunReport
+
+  data class Stopped(
+    override val issueKey: String,
+    override val attemptedSubtasks: List<Int>,
+    val stop: GoalRunnerStopReport,
+  ) : GoalRunnerRunReport
+}
+
+data class GoalRunnerStatusProjection(
+  val issueKey: String,
+  val completeCount: Int,
+  val pendingCount: Int,
+  val blockedCount: Int,
+  val currentSubtaskId: Int?,
+  val currentStep: String?,
+  val activeAgent: String?,
+)
+
+object GoalRunnerStatusProjector {
+  fun project(manifest: DecompositionManifest, activeAgent: String? = null): GoalRunnerStatusProjection {
+    val currentSubtask = manifest.subtasks.firstOrNull { it.id == manifest.currentSubtaskIntent.subtaskId }
+    return GoalRunnerStatusProjection(
+      issueKey = manifest.issueKey,
+      completeCount = manifest.subtasks.count { it.status == "complete" || it.status == "skipped" },
+      pendingCount = manifest.subtasks.count { it.status !in setOf("complete", "skipped", "blocked") },
+      blockedCount = manifest.subtasks.count { it.status == "blocked" },
+      currentSubtaskId = currentSubtask?.id,
+      currentStep = currentSubtask?.lastResumableStep,
+      activeAgent = activeAgent?.takeIf(String::isNotBlank),
+    )
+  }
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
@@ -22,6 +22,12 @@ enum class InstallAgent(
 
     fun fromId(id: String): InstallAgent = entries.firstOrNull { agent -> agent.id == id }
       ?: throw IllegalArgumentException("Unknown agent '$id'. Supported agents: ${supportedIds.joinToString(", ")}.")
+
+    fun fromNormalizedId(id: String, label: String = "agent"): InstallAgent {
+      val normalized = id.trim().lowercase()
+      require(normalized.isNotBlank()) { "$label is required. Supported agents: ${supportedIds.joinToString(", ")}." }
+      return fromId(normalized)
+    }
   }
 }
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionContinuationSelector.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/DecompositionContinuationSelector.kt
@@ -8,11 +8,11 @@ import skillbill.workflow.model.DecompositionManifest
 import skillbill.workflow.model.DecompositionSubtask
 
 object DecompositionContinuationSelector {
-  fun select(manifest: DecompositionManifest): DecompositionContinuationSelection {
+  fun select(manifest: DecompositionManifest, requestedSubtaskId: Int? = null): DecompositionContinuationSelection {
     val inProgress = manifest.subtasks.firstOrNull { it.status == "in_progress" }
     val firstPending = manifest.subtasks.firstOrNull { it.status == "pending" && dependenciesComplete(manifest, it) }
     val blocked = manifest.subtasks.firstOrNull { it.status == "blocked" }
-    return when {
+    val unconstrained = when {
       inProgress != null -> DecompositionContinuationSelection.Resume(
         subtask = inProgress,
         workflowId = inProgress.workflowId.orEmpty(),
@@ -28,6 +28,37 @@ object DecompositionContinuationSelector {
           ?: "Subtask ${blocked.id} is blocked.",
       )
       else -> DecompositionContinuationSelection.Done(manifest = manifest)
+    }
+    return requestedSubtaskId?.let { requestedId -> constrainToRequestedSubtask(manifest, unconstrained, requestedId) }
+      ?: unconstrained
+  }
+
+  private fun constrainToRequestedSubtask(
+    manifest: DecompositionManifest,
+    unconstrained: DecompositionContinuationSelection,
+    requestedSubtaskId: Int,
+  ): DecompositionContinuationSelection {
+    val requested = manifest.subtasks.firstOrNull { it.id == requestedSubtaskId }
+    val selectedSubtask = when (unconstrained) {
+      is DecompositionContinuationSelection.Resume -> unconstrained.subtask
+      is DecompositionContinuationSelection.Start -> unconstrained.subtask
+      is DecompositionContinuationSelection.Blocked -> unconstrained.subtask
+      is DecompositionContinuationSelection.TerminalSubtask -> unconstrained.subtask
+      is DecompositionContinuationSelection.Done -> null
+    }
+    return when {
+      requested == null -> DecompositionContinuationSelection.Blocked(
+        subtask = manifest.subtasks.first(),
+        reason = "Requested subtask $requestedSubtaskId is not declared in ${manifest.issueKey}.",
+      )
+      requested.status in setOf("complete", "skipped") ->
+        DecompositionContinuationSelection.TerminalSubtask(requested)
+      unconstrained is DecompositionContinuationSelection.Done -> unconstrained
+      selectedSubtask?.id == requestedSubtaskId -> unconstrained
+      else -> DecompositionContinuationSelection.Blocked(
+        subtask = requested,
+        reason = "Requested subtask $requestedSubtaskId is not the next runnable subtask for ${manifest.issueKey}.",
+      )
     }
   }
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionContinuationModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/model/DecompositionContinuationModels.kt
@@ -17,6 +17,8 @@ sealed class DecompositionContinuationSelection {
     val reason: String,
   ) : DecompositionContinuationSelection()
 
+  data class TerminalSubtask(val subtask: DecompositionSubtask) : DecompositionContinuationSelection()
+
   data class Done(val manifest: DecompositionManifest) : DecompositionContinuationSelection()
 }
 

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionContinuationSelectorTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/DecompositionContinuationSelectorTest.kt
@@ -42,6 +42,63 @@ class DecompositionContinuationSelectorTest {
   }
 
   @Test
+  fun `select honors explicit runnable subtask constraint`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        subtask(1, status = "complete"),
+        subtask(2, dependencies = listOf(DecompositionDependency(1))),
+      ),
+      requestedSubtaskId = 2,
+    )
+
+    val started = assertIs<DecompositionContinuationSelection.Start>(selection)
+    assertEquals(2, started.subtask.id)
+  }
+
+  @Test
+  fun `select blocks explicit subtask that is not next runnable`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        subtask(1),
+        subtask(2, dependencies = listOf(DecompositionDependency(1))),
+      ),
+      requestedSubtaskId = 2,
+    )
+
+    val blocked = assertIs<DecompositionContinuationSelection.Blocked>(selection)
+    assertEquals(2, blocked.subtask.id)
+    assertEquals("Requested subtask 2 is not the next runnable subtask for SKILL-51.", blocked.reason)
+  }
+
+  @Test
+  fun `select reports terminal outcome for explicit complete subtask`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        subtask(1, status = "complete"),
+        subtask(2, status = "complete", dependencies = listOf(DecompositionDependency(1))),
+      ),
+      requestedSubtaskId = 2,
+    )
+
+    val terminal = assertIs<DecompositionContinuationSelection.TerminalSubtask>(selection)
+    assertEquals(2, terminal.subtask.id)
+  }
+
+  @Test
+  fun `select reports terminal outcome for explicit complete subtask while later work remains`() {
+    val selection = DecompositionContinuationSelector.select(
+      manifest(
+        subtask(1, status = "complete"),
+        subtask(2, dependencies = listOf(DecompositionDependency(1))),
+      ),
+      requestedSubtaskId = 1,
+    )
+
+    val terminal = assertIs<DecompositionContinuationSelection.TerminalSubtask>(selection)
+    assertEquals(1, terminal.subtask.id)
+  }
+
+  @Test
   fun `select reports blocked subtask when dependent pending work is not explicitly skippable`() {
     val selection = DecompositionContinuationSelector.select(
       manifest(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/GhGoalPullRequestPort.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/GhGoalPullRequestPort.kt
@@ -1,0 +1,159 @@
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.ports.goalrunner.GoalPullRequestPort
+import skillbill.ports.goalrunner.model.GoalPullRequestRequest
+import skillbill.ports.goalrunner.model.GoalPullRequestResult
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+@Inject
+class GhGoalPullRequestPort() : GoalPullRequestPort {
+  private var ghExecutableResolver: (Path) -> Path? = ::resolveGhExecutable
+
+  internal constructor(ghExecutableResolver: (Path) -> Path?) : this() {
+    this.ghExecutableResolver = ghExecutableResolver
+  }
+
+  override fun open(request: GoalPullRequestRequest): GoalPullRequestResult =
+    request.headBranch.takeIf(String::isNotBlank)
+      ?.let { head -> openWithHead(request, head) }
+      ?: GoalPullRequestResult.Failed("A head branch is required before creating the goal pull request.")
+
+  private fun openWithHead(request: GoalPullRequestRequest, head: String): GoalPullRequestResult {
+    val root = request.repoRoot.toAbsolutePath().normalize()
+    val existing = runGh(
+      root,
+      listOf("pr", "list", "--head", head, "--json", "url", "--jq", ".[0].url", "--limit", "1"),
+    )
+    return if (existing.exitCode == 0 && existing.stdout.trim().startsWith("http")) {
+      GoalPullRequestResult.Existing(existing.stdout.trim())
+    } else {
+      createPullRequest(root, request, head)
+    }
+  }
+
+  private fun createPullRequest(root: Path, request: GoalPullRequestRequest, head: String): GoalPullRequestResult {
+    val create = runGh(root, createArgs(request, head))
+    return if (create.exitCode == 0) {
+      create.stdout.lineSequence()
+        .map(String::trim)
+        .firstOrNull { it.startsWith("http://") || it.startsWith("https://") }
+        ?.let(GoalPullRequestResult::Opened)
+        ?: GoalPullRequestResult.Failed("Goal pull request was created but no PR URL was returned.")
+    } else {
+      GoalPullRequestResult.Failed(describeGhFailure(create))
+    }
+  }
+
+  private fun createArgs(request: GoalPullRequestRequest, head: String): List<String> = listOf(
+    "pr",
+    "create",
+    "--head",
+    head,
+    "--base",
+    request.baseBranch,
+    "--draft",
+    "--title",
+    request.title,
+    "--body",
+    request.body,
+  )
+
+  private fun runGh(root: Path, args: List<String>): CommandResult = runCatching {
+    val executable = ghExecutableResolver(root)
+      ?: return CommandResult(exitCode = 1, stdout = "GitHub CLI executable was not found on PATH.")
+    val processBuilder = ProcessBuilder(listOf(executable.toString()) + args)
+      .directory(root.toFile())
+      .redirectErrorStream(true)
+    processBuilder.environment()["GIT_TERMINAL_PROMPT"] = "0"
+    val process = processBuilder.start()
+    val capturedBytes = ByteArrayOutputStream()
+    val truncated = booleanArrayOf(false)
+    val readerThread = Thread {
+      drainCapped(process.inputStream, capturedBytes, truncated)
+    }.apply {
+      isDaemon = true
+      name = "GhGoalPullRequestPort-reader"
+      start()
+    }
+    val completed = process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    if (!completed) {
+      process.destroyForcibly()
+      readerThread.join(READER_JOIN_TIMEOUT_MILLIS)
+      return CommandResult(exitCode = 124, stdout = "GitHub CLI timed out.")
+    }
+    readerThread.join(READER_JOIN_TIMEOUT_MILLIS)
+    if (truncated[0]) {
+      CommandResult(exitCode = 1, stdout = "GitHub CLI output exceeded $MAX_OUTPUT_BYTES bytes.")
+    } else {
+      CommandResult(exitCode = process.exitValue(), stdout = capturedBytes.toString(Charsets.UTF_8))
+    }
+  }.getOrElse { error ->
+    CommandResult(
+      exitCode = 1,
+      stdout = error.message?.let { "${error::class.simpleName}: $it" } ?: (error::class.simpleName ?: "Error"),
+    )
+  }
+
+  private fun drainCapped(stream: InputStream, sink: ByteArrayOutputStream, truncated: BooleanArray) {
+    val buffer = ByteArray(BUFFER_BYTES)
+    try {
+      var done = false
+      while (!done) {
+        val count = stream.read(buffer)
+        if (count < 0) {
+          done = true
+        } else if (sink.size() + count > MAX_OUTPUT_BYTES) {
+          truncated[0] = true
+          done = true
+        } else {
+          sink.write(buffer, 0, count)
+        }
+      }
+    } catch (_: java.io.IOException) {
+      // Reader shutdown is best-effort after the process exits.
+    }
+  }
+
+  private fun describeGhFailure(result: CommandResult): String {
+    val output = result.stdout.trim().replace(Regex("(?i)(https?://)([^\\s/@]+)@")) { match ->
+      "${match.groupValues[1]}<redacted>@"
+    }
+    return if (output.isBlank()) "GitHub provider exited with code ${result.exitCode}." else output
+  }
+
+  private fun resolveGhExecutable(root: Path): Path? {
+    val names = executableNames("gh")
+    return System.getenv("PATH")
+      .orEmpty()
+      .split(java.io.File.pathSeparator)
+      .asSequence()
+      .mapNotNull { raw -> raw.takeIf(String::isNotBlank)?.let(Path::of) }
+      .flatMap { directory -> names.asSequence().map(directory::resolve) }
+      .firstOrNull { candidate -> Files.isRegularFile(candidate) && Files.isExecutable(candidate) }
+      ?: names.asSequence()
+        .map(root::resolve)
+        .firstOrNull { candidate -> Files.isRegularFile(candidate) && Files.isExecutable(candidate) }
+  }
+
+  private fun executableNames(base: String): List<String> =
+    if (System.getProperty("os.name").contains("windows", ignoreCase = true)) {
+      listOf("$base.exe", "$base.cmd", "$base.bat", base)
+    } else {
+      listOf(base)
+    }
+}
+
+private data class CommandResult(
+  val exitCode: Int,
+  val stdout: String,
+)
+
+private const val COMMAND_TIMEOUT_SECONDS: Long = 30
+private const val READER_JOIN_TIMEOUT_MILLIS: Long = 1_000
+private const val BUFFER_BYTES: Int = 4096
+private const val MAX_OUTPUT_BYTES: Int = 64 * 1024

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunAdapters.kt
@@ -23,6 +23,7 @@ class ProcessAgentRunAdapter(
         timeout = command.timeout,
         environment = command.environment,
         inheritEnvironment = command.inheritEnvironment,
+        outputSink = request.outputSink,
       ),
     )
     return AgentRunLaunchFacts(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunAdapters.kt
@@ -1,0 +1,49 @@
+package skillbill.launcher
+
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.model.AgentRunLaunchFacts
+import skillbill.ports.agentrun.model.SkillRunRequest
+
+interface AgentRunAdapter {
+  val agent: InstallAgent
+  fun launch(request: SkillRunRequest): AgentRunLaunchFacts
+}
+
+class ProcessAgentRunAdapter(
+  override val agent: InstallAgent,
+  private val commandBuilder: AgentRunCommandBuilder,
+  private val processRunner: AgentRunProcessRunner,
+) : AgentRunAdapter {
+  override fun launch(request: SkillRunRequest): AgentRunLaunchFacts {
+    val command = commandBuilder.build(request)
+    val result = processRunner.run(
+      AgentRunProcessRequest(
+        command = command.command,
+        workingDirectory = command.workingDirectory,
+        timeout = command.timeout,
+        environment = command.environment,
+        inheritEnvironment = command.inheritEnvironment,
+      ),
+    )
+    return AgentRunLaunchFacts(
+      agent = agent,
+      exitStatus = result.exitStatus,
+      stdout = result.stdout,
+      stderr = result.stderr,
+      timedOut = result.timedOut,
+      spawnFailed = result.spawnFailed,
+    )
+  }
+}
+
+fun headlessAgentRunAdapters(processRunner: AgentRunProcessRunner): Map<InstallAgent, AgentRunAdapter> = listOf(
+  ClaudeAgentRunCommandBuilder(),
+  CodexAgentRunCommandBuilder(),
+  OpencodeAgentRunCommandBuilder(),
+).associate { builder ->
+  builder.agent to ProcessAgentRunAdapter(
+    agent = builder.agent,
+    commandBuilder = builder,
+    processRunner = processRunner,
+  )
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunCommandBuilders.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunCommandBuilders.kt
@@ -1,0 +1,101 @@
+package skillbill.launcher
+
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.model.SkillRunRequest
+import java.nio.file.Path
+
+data class AgentRunCommand(
+  val command: List<String>,
+  val workingDirectory: Path,
+  val timeout: kotlin.time.Duration,
+  val environment: Map<String, String> = emptyMap(),
+  val inheritEnvironment: Boolean = true,
+)
+
+interface AgentRunCommandBuilder {
+  val agent: InstallAgent
+  fun build(request: SkillRunRequest): AgentRunCommand
+}
+
+class ClaudeAgentRunCommandBuilder : AgentRunCommandBuilder {
+  override val agent: InstallAgent = InstallAgent.CLAUDE
+
+  override fun build(request: SkillRunRequest): AgentRunCommand = AgentRunCommand(
+    command = listOf(
+      "claude",
+      "--print",
+      "--output-format",
+      "text",
+      "--dangerously-skip-permissions",
+      "--add-dir",
+      request.repoRoot.toString(),
+      continuationPrompt(request),
+    ),
+    workingDirectory = request.repoRoot,
+    timeout = request.timeout,
+  )
+}
+
+class CodexAgentRunCommandBuilder : AgentRunCommandBuilder {
+  override val agent: InstallAgent = InstallAgent.CODEX
+
+  override fun build(request: SkillRunRequest): AgentRunCommand = AgentRunCommand(
+    command = listOf(
+      "codex",
+      "exec",
+      "--cd",
+      request.repoRoot.toString(),
+      "--sandbox",
+      "danger-full-access",
+      "--ask-for-approval",
+      "never",
+      "--config",
+      "shell_environment_policy.inherit=\"all\"",
+      continuationPrompt(request),
+    ),
+    workingDirectory = request.repoRoot,
+    timeout = request.timeout,
+  )
+}
+
+class OpencodeAgentRunCommandBuilder : AgentRunCommandBuilder {
+  override val agent: InstallAgent = InstallAgent.OPENCODE
+
+  override fun build(request: SkillRunRequest): AgentRunCommand = AgentRunCommand(
+    command = listOf(
+      "opencode",
+      "run",
+      "--dir",
+      request.repoRoot.toString(),
+      "--dangerously-skip-permissions",
+      continuationPrompt(request),
+    ),
+    workingDirectory = request.repoRoot,
+    timeout = request.timeout,
+  )
+}
+
+internal fun continuationPrompt(request: SkillRunRequest): String {
+  val dbOption = request.dbPathOverride?.let { db -> " --db ${shellDisplay(db)}" }.orEmpty()
+  val subtaskOption = request.subtaskId?.let { id -> " --subtask-id $id" }.orEmpty()
+  val subtaskLine = request.subtaskId?.let { id -> "\nSubtask id: $id" }.orEmpty()
+  return """
+    Use the installed `bill-feature-implement` skill in non-interactive goal-continuation mode.
+
+    Issue key: ${request.issueKey}$subtaskLine
+    Goal-continuation: enabled.
+    suppress_pr: true.
+
+    Recover the durable workflow state with:
+    `skill-bill$dbOption workflow continue ${shellDisplay(request.issueKey)}$subtaskOption`
+
+    Treat durable workflow state as authoritative. Do not infer subtask success from stdout.
+    Return exactly the `RESULT:` block required by the bill-feature-implement implementation subagent contract.
+  """.trimIndent()
+}
+
+private fun shellDisplay(value: String): String = if (value.all { char -> char.isLetterOrDigit() || char in "-_./:" }) {
+  value
+} else {
+  "'" + value.replace("'", "'\"'\"'") + "'"
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunProcessRunner.kt
@@ -1,5 +1,6 @@
 package skillbill.launcher
 
+import skillbill.ports.agentrun.model.AgentRunOutputSink
 import java.nio.file.Path
 import kotlin.time.Duration
 
@@ -11,6 +12,7 @@ data class AgentRunProcessRequest(
   val timeout: Duration,
   val environment: Map<String, String> = emptyMap(),
   val inheritEnvironment: Boolean = true,
+  val outputSink: AgentRunOutputSink = AgentRunOutputSink.NONE,
 ) {
   init {
     require(command.isNotEmpty()) { "Agent run command is required." }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/AgentRunProcessRunner.kt
@@ -1,0 +1,32 @@
+package skillbill.launcher
+
+import java.nio.file.Path
+import kotlin.time.Duration
+
+internal const val AGENT_RUN_OUTPUT_LIMIT_BYTES: Int = 1024 * 1024
+
+data class AgentRunProcessRequest(
+  val command: List<String>,
+  val workingDirectory: Path,
+  val timeout: Duration,
+  val environment: Map<String, String> = emptyMap(),
+  val inheritEnvironment: Boolean = true,
+) {
+  init {
+    require(command.isNotEmpty()) { "Agent run command is required." }
+    require(command.first().isNotBlank()) { "Agent run executable is required." }
+    require(timeout.isPositive()) { "Agent run timeout must be positive." }
+  }
+}
+
+data class AgentRunProcessResult(
+  val exitStatus: Int?,
+  val stdout: String,
+  val stderr: String,
+  val timedOut: Boolean,
+  val spawnFailed: Boolean,
+)
+
+interface AgentRunProcessRunner {
+  fun run(request: AgentRunProcessRequest): AgentRunProcessResult
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/FileSystemAgentRunLauncher.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/FileSystemAgentRunLauncher.kt
@@ -1,0 +1,25 @@
+package skillbill.launcher
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.AgentRunLauncher
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
+
+@Inject
+class FileSystemAgentRunLauncher(
+  processRunner: JvmAgentRunProcessRunner,
+) : AgentRunLauncher {
+  private val adapters: Map<InstallAgent, AgentRunAdapter> = headlessAgentRunAdapters(processRunner)
+
+  override fun launch(request: AgentRunLaunchRequest): AgentRunLaunchOutcome {
+    val agent = InstallAgent.fromNormalizedId(request.agentId)
+    val adapter = adapters[agent]
+      ?: return UnsupportedAgentRunLaunch(
+        agent = agent,
+        reason = "Agent '${agent.id}' does not have a supported headless bill-feature-implement launch path.",
+      )
+    return adapter.launch(request.skillRunRequest)
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/JvmAgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/JvmAgentRunProcessRunner.kt
@@ -1,6 +1,8 @@
 package skillbill.launcher
 
 import me.tatarka.inject.annotations.Inject
+import skillbill.ports.agentrun.model.AgentRunOutputSink
+import skillbill.ports.agentrun.model.AgentRunOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
@@ -18,8 +20,18 @@ class JvmAgentRunProcessRunner : AgentRunProcessRunner {
     }
     val process = (processStart as ProcessStart.Started).process
 
-    val stdout = CappedUtf8Drain(process.inputStream, AGENT_RUN_OUTPUT_LIMIT_BYTES).also { it.start() }
-    val stderr = CappedUtf8Drain(process.errorStream, AGENT_RUN_OUTPUT_LIMIT_BYTES).also { it.start() }
+    val stdout = CappedUtf8Drain(
+      input = process.inputStream,
+      limitBytes = AGENT_RUN_OUTPUT_LIMIT_BYTES,
+      outputStream = AgentRunOutputStream.STDOUT,
+      outputSink = request.outputSink,
+    ).also { it.start() }
+    val stderr = CappedUtf8Drain(
+      input = process.errorStream,
+      limitBytes = AGENT_RUN_OUTPUT_LIMIT_BYTES,
+      outputStream = AgentRunOutputStream.STDERR,
+      outputSink = request.outputSink,
+    ).also { it.start() }
     val timeoutMillis = request.timeout.toLong(DurationUnit.MILLISECONDS).coerceAtLeast(MIN_TIMEOUT_MILLIS)
     val finished = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
     if (!finished) {
@@ -72,6 +84,8 @@ private sealed interface ProcessStart {
 private class CappedUtf8Drain(
   private val input: InputStream,
   private val limitBytes: Int,
+  private val outputStream: AgentRunOutputStream,
+  private val outputSink: AgentRunOutputSink,
 ) {
   private val output = ByteArrayOutputStream(limitBytes.coerceAtMost(INITIAL_OUTPUT_BUFFER_BYTES))
   private val worker = thread(start = false, isDaemon = true, name = "skillbill-agent-run-output-drain") {
@@ -84,6 +98,7 @@ private class CappedUtf8Drain(
           break
         }
         output.write(buffer, 0, read)
+        outputSink.write(outputStream, String(buffer, 0, read, StandardCharsets.UTF_8))
         remaining -= read
       }
       while (stream.read(buffer) != -1) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/JvmAgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/JvmAgentRunProcessRunner.kt
@@ -1,0 +1,110 @@
+package skillbill.launcher
+
+import me.tatarka.inject.annotations.Inject
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.time.DurationUnit
+
+@Inject
+class JvmAgentRunProcessRunner : AgentRunProcessRunner {
+  override fun run(request: AgentRunProcessRequest): AgentRunProcessResult {
+    val processStart = startProcess(request)
+    if (processStart is ProcessStart.Failed) {
+      return spawnFailure(processStart.error)
+    }
+    val process = (processStart as ProcessStart.Started).process
+
+    val stdout = CappedUtf8Drain(process.inputStream, AGENT_RUN_OUTPUT_LIMIT_BYTES).also { it.start() }
+    val stderr = CappedUtf8Drain(process.errorStream, AGENT_RUN_OUTPUT_LIMIT_BYTES).also { it.start() }
+    val timeoutMillis = request.timeout.toLong(DurationUnit.MILLISECONDS).coerceAtLeast(MIN_TIMEOUT_MILLIS)
+    val finished = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      process.waitFor(DESTROY_WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+    }
+    stdout.join()
+    stderr.join()
+    return AgentRunProcessResult(
+      exitStatus = if (finished) process.exitValue() else null,
+      stdout = stdout.text(),
+      stderr = stderr.text(),
+      timedOut = !finished,
+      spawnFailed = false,
+    )
+  }
+
+  private fun spawnFailure(error: Exception): AgentRunProcessResult = AgentRunProcessResult(
+    exitStatus = null,
+    stdout = "",
+    stderr = error.message.orEmpty(),
+    timedOut = false,
+    spawnFailed = true,
+  )
+
+  private fun startProcess(request: AgentRunProcessRequest): ProcessStart = try {
+    ProcessStart.Started(
+      ProcessBuilder(request.command)
+        .directory(request.workingDirectory.toFile())
+        .apply {
+          if (!request.inheritEnvironment) {
+            environment().clear()
+          }
+          environment().putAll(request.environment)
+        }
+        .start(),
+    )
+  } catch (error: IOException) {
+    ProcessStart.Failed(error)
+  } catch (error: SecurityException) {
+    ProcessStart.Failed(error)
+  }
+}
+
+private sealed interface ProcessStart {
+  data class Started(val process: Process) : ProcessStart
+  data class Failed(val error: Exception) : ProcessStart
+}
+
+private class CappedUtf8Drain(
+  private val input: InputStream,
+  private val limitBytes: Int,
+) {
+  private val output = ByteArrayOutputStream(limitBytes.coerceAtMost(INITIAL_OUTPUT_BUFFER_BYTES))
+  private val worker = thread(start = false, isDaemon = true, name = "skillbill-agent-run-output-drain") {
+    input.use { stream ->
+      val buffer = ByteArray(DEFAULT_DRAIN_BUFFER_BYTES)
+      var remaining = limitBytes
+      while (remaining > 0) {
+        val read = stream.read(buffer, 0, remaining.coerceAtMost(buffer.size))
+        if (read == -1) {
+          break
+        }
+        output.write(buffer, 0, read)
+        remaining -= read
+      }
+      while (stream.read(buffer) != -1) {
+        // Keep draining so the child cannot block on a full pipe after the cap is reached.
+      }
+    }
+  }
+
+  fun start() {
+    worker.start()
+  }
+
+  fun join() {
+    worker.join(DRAIN_JOIN_TIMEOUT_MILLIS)
+  }
+
+  fun text(): String = String(output.toByteArray(), StandardCharsets.UTF_8)
+}
+
+private const val DEFAULT_DRAIN_BUFFER_BYTES = 8192
+private const val INITIAL_OUTPUT_BUFFER_BYTES = DEFAULT_DRAIN_BUFFER_BYTES
+private const val DRAIN_JOIN_TIMEOUT_MILLIS = 1_000L
+private const val MIN_TIMEOUT_MILLIS = 1L
+private const val DESTROY_WAIT_TIMEOUT_MILLIS = 1_000L

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/LauncherRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/LauncherRuntime.kt
@@ -17,6 +17,7 @@ object LauncherRuntime {
       "select-mcp-runtime",
       "register-mcp",
       "unregister-mcp",
+      "launch-agent-run",
     ),
   )
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/McpRegistrationOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/McpRegistrationOperations.kt
@@ -1,5 +1,6 @@
 package skillbill.launcher
 
+import skillbill.install.model.InstallAgent
 import skillbill.install.model.McpMutationResult
 import java.nio.file.Path
 
@@ -7,27 +8,37 @@ object McpRegistrationOperations {
   fun register(agent: String, runtimeMcpBin: Path, home: Path? = null): McpMutationResult {
     val resolvedHome = home ?: Path.of(System.getProperty("user.home"))
     val command = runtimeMcpBin.toAbsolutePath().normalize().toString()
-    return when (agent) {
-      "claude" -> McpJsonConfig.register(agent, resolvedHome.resolve(".claude.json"), command)
-      "copilot" -> McpJsonConfig.register(agent, resolvedHome.resolve(".copilot/mcp-config.json"), command)
-      "codex" -> McpTomlConfig.register(agent, resolvedHome.resolve(".codex/config.toml"), command)
-      "opencode" -> McpOpenCodeConfig.register(agent, resolvedHome.resolve(".config/opencode/opencode.json"), command)
-      "junie" -> McpJsonConfig.register(agent, resolvedHome.resolve(".junie/mcp/mcp.json"), command)
-      "glm" -> McpJsonConfig.register(agent, resolvedHome.resolve(".glm/mcp-config.json"), command)
-      else -> throw IllegalArgumentException("Unknown MCP agent '$agent'.")
+    if (agent == "glm") {
+      return McpJsonConfig.register(agent, resolvedHome.resolve(".glm/mcp-config.json"), command)
+    }
+    return when (val installAgent = InstallAgent.fromId(agent)) {
+      InstallAgent.CLAUDE -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
+      InstallAgent.COPILOT -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
+      InstallAgent.CODEX -> McpTomlConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
+      InstallAgent.OPENCODE -> McpOpenCodeConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
+      InstallAgent.JUNIE -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
     }
   }
 
   fun unregister(agent: String, home: Path? = null): McpMutationResult {
     val resolvedHome = home ?: Path.of(System.getProperty("user.home"))
-    return when (agent) {
-      "claude" -> McpJsonConfig.unregister(agent, resolvedHome.resolve(".claude.json"))
-      "copilot" -> McpJsonConfig.unregister(agent, resolvedHome.resolve(".copilot/mcp-config.json"))
-      "codex" -> McpTomlConfig.unregister(agent, resolvedHome.resolve(".codex/config.toml"))
-      "opencode" -> McpOpenCodeConfig.unregister(agent, resolvedHome.resolve(".config/opencode/opencode.json"))
-      "junie" -> McpJsonConfig.unregister(agent, resolvedHome.resolve(".junie/mcp/mcp.json"))
-      "glm" -> McpJsonConfig.unregister(agent, resolvedHome.resolve(".glm/mcp-config.json"))
-      else -> throw IllegalArgumentException("Unknown MCP agent '$agent'.")
+    if (agent == "glm") {
+      return McpJsonConfig.unregister(agent, resolvedHome.resolve(".glm/mcp-config.json"))
     }
+    return when (val installAgent = InstallAgent.fromId(agent)) {
+      InstallAgent.CLAUDE -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+      InstallAgent.COPILOT -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+      InstallAgent.CODEX -> McpTomlConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+      InstallAgent.OPENCODE -> McpOpenCodeConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+      InstallAgent.JUNIE -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+    }
+  }
+
+  fun configPathFor(agent: InstallAgent, home: Path): Path = when (agent) {
+    InstallAgent.CLAUDE -> home.resolve(".claude.json")
+    InstallAgent.COPILOT -> home.resolve(".copilot/mcp-config.json")
+    InstallAgent.CODEX -> home.resolve(".codex/config.toml")
+    InstallAgent.OPENCODE -> home.resolve(".config/opencode/opencode.json")
+    InstallAgent.JUNIE -> home.resolve(".junie/mcp/mcp.json")
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -2,6 +2,7 @@ package skillbill.launcher
 
 import skillbill.install.model.InstallAgent
 import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+import skillbill.ports.agentrun.model.AgentRunOutputStream
 import skillbill.ports.agentrun.model.SkillRunRequest
 import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
 import java.nio.file.Path
@@ -126,6 +127,25 @@ class AgentRunLauncherTest {
     assertEquals(2, runner.requests.size)
     assertContains(runner.requests[0].command.last(), "SKILL-56")
     assertContains(runner.requests[1].command.last(), "SKILL-57")
+  }
+
+  @Test
+  fun `jvm process runner tees live output while preserving captured output`() {
+    val events = mutableListOf<Pair<AgentRunOutputStream, String>>()
+    val result = JvmAgentRunProcessRunner().run(
+      AgentRunProcessRequest(
+        command = listOf("sh", "-c", "printf stdout-line; printf stderr-line >&2"),
+        workingDirectory = Path.of(".").toAbsolutePath().normalize(),
+        timeout = 3.seconds,
+        outputSink = { stream, text -> events += stream to text },
+      ),
+    )
+
+    assertEquals(0, result.exitStatus)
+    assertEquals("stdout-line", result.stdout)
+    assertEquals("stderr-line", result.stderr)
+    assertTrue(events.any { it.first == AgentRunOutputStream.STDOUT && it.second == "stdout-line" })
+    assertTrue(events.any { it.first == AgentRunOutputStream.STDERR && it.second == "stderr-line" })
   }
 
   private fun skillRunRequest(issueKey: String = "SKILL-56"): SkillRunRequest = SkillRunRequest(

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -1,0 +1,155 @@
+package skillbill.launcher
+
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+import skillbill.ports.agentrun.model.SkillRunRequest
+import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class AgentRunLauncherTest {
+  @Test
+  fun `claude adapter builds a fresh inherited-config process command`() {
+    val runner = RecordingAgentRunProcessRunner()
+    val outcome = requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.CLAUDE]).launch(skillRunRequest())
+
+    assertEquals(InstallAgent.CLAUDE, outcome.agent)
+    val request = runner.requests.single()
+    assertEquals("claude", request.command[0])
+    assertContains(request.command, "--print")
+    assertContains(request.command, "--dangerously-skip-permissions")
+    assertContains(request.command, "--add-dir")
+    assertContains(request.command.last(), "bill-feature-implement")
+    assertContains(
+      request.command.last(),
+      "skill-bill --db /tmp/skillbill-agent-run/metrics.db workflow continue SKILL-56 --subtask-id 2",
+    )
+    assertTrue(request.inheritEnvironment)
+    assertEquals(emptyMap(), request.environment)
+  }
+
+  @Test
+  fun `codex adapter builds a non-interactive command with inherited shell environment`() {
+    val runner = RecordingAgentRunProcessRunner()
+    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.CODEX]).launch(skillRunRequest())
+
+    val request = runner.requests.single()
+    assertEquals(listOf("codex", "exec"), request.command.take(2))
+    assertContains(request.command, "--cd")
+    assertContains(request.command, "--sandbox")
+    assertContains(request.command, "danger-full-access")
+    assertContains(request.command, "--ask-for-approval")
+    assertContains(request.command, "never")
+    assertContains(request.command, "shell_environment_policy.inherit=\"all\"")
+    assertContains(request.command.last(), "Return exactly the `RESULT:` block")
+    assertTrue(request.inheritEnvironment)
+  }
+
+  @Test
+  fun `opencode adapter builds a headless run command without disabling user config`() {
+    val runner = RecordingAgentRunProcessRunner()
+    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.OPENCODE]).launch(skillRunRequest())
+
+    val request = runner.requests.single()
+    assertEquals(listOf("opencode", "run"), request.command.take(2))
+    assertContains(request.command, "--dir")
+    assertContains(request.command, "--dangerously-skip-permissions")
+    assertFalse("--pure" in request.command)
+    assertContains(request.command.last(), "Goal-continuation: enabled.")
+  }
+
+  @Test
+  fun `supported agent without headless path returns unsupported outcome`() {
+    val launcher = FileSystemAgentRunLauncher(JvmAgentRunProcessRunner())
+
+    val outcome = launcher.launch(
+      AgentRunLaunchRequest(
+        agentId = "copilot",
+        skillRunRequest = skillRunRequest(),
+      ),
+    )
+
+    assertIs<UnsupportedAgentRunLaunch>(outcome)
+    assertEquals(InstallAgent.COPILOT, outcome.agent)
+    assertContains(outcome.reason, "does not have a supported headless")
+  }
+
+  @Test
+  fun `timeout and spawn-failure paths stay launch-level facts`() {
+    val timeoutRunner = RecordingAgentRunProcessRunner(
+      result = AgentRunProcessResult(
+        exitStatus = null,
+        stdout = "partial",
+        stderr = "slow",
+        timedOut = true,
+        spawnFailed = false,
+      ),
+    )
+    val timeout = requireNotNull(
+      headlessAgentRunAdapters(timeoutRunner)[InstallAgent.CODEX],
+    ).launch(skillRunRequest())
+    assertTrue(timeout.timedOut)
+    assertFalse(timeout.spawnFailed)
+    assertEquals(null, timeout.exitStatus)
+
+    val spawnRunner = RecordingAgentRunProcessRunner(
+      result = AgentRunProcessResult(
+        exitStatus = null,
+        stdout = "",
+        stderr = "missing executable",
+        timedOut = false,
+        spawnFailed = true,
+      ),
+    )
+    val spawnFailure = requireNotNull(
+      headlessAgentRunAdapters(spawnRunner)[InstallAgent.CODEX],
+    ).launch(skillRunRequest())
+    assertFalse(spawnFailure.timedOut)
+    assertTrue(spawnFailure.spawnFailed)
+    assertEquals("missing executable", spawnFailure.stderr)
+  }
+
+  @Test
+  fun `adapter invokes process runner once per launch`() {
+    val runner = RecordingAgentRunProcessRunner()
+    val adapter = requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.CODEX])
+
+    adapter.launch(skillRunRequest(issueKey = "SKILL-56"))
+    adapter.launch(skillRunRequest(issueKey = "SKILL-57"))
+
+    assertEquals(2, runner.requests.size)
+    assertContains(runner.requests[0].command.last(), "SKILL-56")
+    assertContains(runner.requests[1].command.last(), "SKILL-57")
+  }
+
+  private fun skillRunRequest(issueKey: String = "SKILL-56"): SkillRunRequest = SkillRunRequest(
+    issueKey = issueKey,
+    repoRoot = Path.of("/tmp/skillbill-agent-run"),
+    subtaskId = 2,
+    dbPathOverride = "/tmp/skillbill-agent-run/metrics.db",
+    timeout = 3.seconds,
+  )
+}
+
+private class RecordingAgentRunProcessRunner(
+  private val result: AgentRunProcessResult = AgentRunProcessResult(
+    exitStatus = 0,
+    stdout = "ok",
+    stderr = "",
+    timedOut = false,
+    spawnFailed = false,
+  ),
+) : AgentRunProcessRunner {
+  val requests: MutableList<AgentRunProcessRequest> = mutableListOf()
+
+  override fun run(request: AgentRunProcessRequest): AgentRunProcessResult {
+    requests += request
+    return result
+  }
+}

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpRuntime.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpRuntime.kt
@@ -254,9 +254,11 @@ object McpWorkflowRuntime {
     kind: WorkflowFamilyKind,
     workflowId: String,
     context: McpRuntimeContext = McpRuntimeContext(),
+    subtaskId: Int? = null,
   ): Map<String, Any?> = services(context).workflowService.continueWorkflow(
     kind,
     workflowId,
+    subtaskId = subtaskId,
     dbOverride = null,
   ).toMcpMap()
 }

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolArguments.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolArguments.kt
@@ -20,6 +20,25 @@ internal fun Map<String, Any?>.int(name: String, default: Int): Int = when (val 
   else -> default
 }
 
+internal fun Map<String, Any?>.optionalInt(name: String): Int? = when (val value = this[name]) {
+  null -> null
+  is Int -> value
+  is Long -> {
+    require(value >= Int.MIN_VALUE.toLong() && value <= Int.MAX_VALUE.toLong()) {
+      "$name must fit in a 32-bit integer."
+    }
+    value.toInt()
+  }
+  is Double -> {
+    require(value % 1.0 == 0.0 && value >= Int.MIN_VALUE && value <= Int.MAX_VALUE) {
+      "$name must be an integer."
+    }
+    value.toInt()
+  }
+  is String -> value.toIntOrNull() ?: error("$name must be an integer.")
+  else -> error("$name must be an integer.")
+}
+
 internal fun Map<String, Any?>.stringList(name: String): List<String> =
   (this[name] as? List<*>).orEmpty().map { it.toString() }
 

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolRegistry.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpToolRegistry.kt
@@ -195,6 +195,7 @@ object McpToolRegistry {
         properties = mapOf(
           "workflow_id" to stringSchema(),
           "issue_key" to stringSchema(),
+          "subtask_id" to integerSchema,
         ),
       ),
       "feature_implement_workflow_get" to workflowIdSchema(),

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpWorkflowToolHandlers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/McpWorkflowToolHandlers.kt
@@ -58,5 +58,10 @@ internal fun workflowContinue(
   val workflowIdOrIssueKey = arguments.optionalString("workflow_id")
     ?: arguments.optionalString("issue_key")
     ?: return mapOf("status" to "error", "error" to "Provide workflow_id or issue_key.")
-  return McpWorkflowRuntime.continueWorkflow(kind, workflowIdOrIssueKey, context)
+  return McpWorkflowRuntime.continueWorkflow(
+    kind,
+    workflowIdOrIssueKey,
+    subtaskId = arguments.optionalInt("subtask_id"),
+    context = context,
+  )
 }

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/WorkflowMcpResultMappers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/WorkflowMcpResultMappers.kt
@@ -1,5 +1,6 @@
 package skillbill.mcp
 
+import skillbill.application.model.GoalContinuationOutcome
 import skillbill.application.model.WorkflowContinueResult
 import skillbill.application.model.WorkflowGetResult
 import skillbill.application.model.WorkflowLatestResult
@@ -99,8 +100,10 @@ internal fun WorkflowContinueResult.toMcpMap(): Map<String, Any?> = when (this) 
     view = view,
     dbPath = dbPath,
     decompositionExtras = linkedMapOf(
+      "issue_key" to (outcome?.issueKey ?: issueKey),
       "decomposition_subtask_id" to decompositionSubtaskId,
       "decomposition_subtask_spec_path" to decompositionSubtaskSpecPath,
+      "goal_continuation_outcome" to outcome.toWireMap(),
     ),
   )
   is WorkflowContinueResult.UnknownWorkflow -> linkedMapOf(
@@ -143,6 +146,16 @@ internal fun WorkflowContinueResult.toMcpMap(): Map<String, Any?> = when (this) 
     "decomposition_status" to decompositionStatus,
     "db_path" to dbPath,
   )
+  is WorkflowContinueResult.DecompositionSubtaskOutcome -> linkedMapOf(
+    "status" to "ok",
+    "continue_status" to "done",
+    "workflow_id" to workflowId,
+    "issue_key" to issueKey,
+    "decomposition_subtask_id" to subtaskId,
+    "decomposition_subtask_spec_path" to subtaskSpecPath,
+    "goal_continuation_outcome" to outcome.toWireMap(),
+    "db_path" to dbPath,
+  )
   is WorkflowContinueResult.DecompositionBlockedGit -> linkedMapOf(
     "status" to "error",
     "continue_status" to "blocked",
@@ -159,6 +172,18 @@ internal fun WorkflowContinueResult.toMcpMap(): Map<String, Any?> = when (this) 
     "db_path" to dbPath,
   )
 }
+
+private fun GoalContinuationOutcome?.toWireMap(): Map<String, Any?> = this?.let { outcome ->
+  linkedMapOf(
+    "issue_key" to outcome.issueKey,
+    "subtask_id" to outcome.subtaskId,
+    "status" to outcome.status,
+    "commit_sha" to outcome.commitSha,
+    "workflow_id" to outcome.workflowId,
+    "blocked_reason" to outcome.blockedReason,
+    "last_resumable_step" to outcome.lastResumableStep,
+  )
+}.orEmpty()
 
 private fun standardMcpContinueMap(
   view: skillbill.workflow.model.WorkflowContinueView,

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
@@ -158,8 +158,12 @@ class McpStdioServerTest {
       tools.schemaFor("feature_implement_workflow_update").properties().enumFor("workflow_status"),
     )
     assertEquals(
-      setOf("workflow_id", "issue_key"),
+      setOf("workflow_id", "issue_key", "subtask_id"),
       tools.schemaFor("feature_implement_workflow_continue").properties().keys,
+    )
+    assertEquals(
+      "integer",
+      tools.schemaFor("feature_implement_workflow_continue").properties().map("subtask_id")["type"],
     )
     tools.schemaFor("telemetry_remote_stats").assertRequired("workflow")
     assertEquals(

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpWorkflowContinuationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpWorkflowContinuationRuntimeTest.kt
@@ -22,11 +22,39 @@ class McpWorkflowContinuationRuntimeTest {
     val workflowId = opened["workflow_id"] as String
 
     McpWorkflowRuntime.update(WorkflowFamilyKind.IMPLEMENT, fixture.updateRequest(workflowId), fixture.context)
-    val continued = McpWorkflowRuntime.continueWorkflow(WorkflowFamilyKind.IMPLEMENT, "SKILL-51", fixture.context)
+    val continued = McpWorkflowRuntime.continueWorkflow(
+      WorkflowFamilyKind.IMPLEMENT,
+      "SKILL-51",
+      fixture.context,
+      subtaskId = 1,
+    )
 
     assertEquals("ok", continued["status"])
     assertEquals(1, continued["decomposition_subtask_id"])
     assertEquals(fixture.subtaskSpec.toString(), continued["decomposition_subtask_spec_path"])
+  }
+
+  @Test
+  fun `mcp workflow continue handler forwards requested decomposed subtask constraint`() {
+    val fixture = mcpDecompositionFixture()
+    val opened = McpWorkflowRuntime.open(
+      WorkflowFamilyKind.IMPLEMENT,
+      sessionId = "fis-mcp-decomp",
+      context = fixture.context,
+    )
+    val workflowId = opened["workflow_id"] as String
+
+    McpWorkflowRuntime.update(WorkflowFamilyKind.IMPLEMENT, fixture.updateRequest(workflowId), fixture.context)
+    val continued = workflowContinue(
+      WorkflowFamilyKind.IMPLEMENT,
+      mapOf("issue_key" to "SKILL-51", "subtask_id" to 2),
+      fixture.context,
+    )
+
+    assertEquals("error", continued["status"])
+    assertEquals("blocked", continued["continue_status"])
+    assertEquals(2, continued["decomposition_subtask_id"])
+    assertEquals("Requested subtask 2 is not the next runnable subtask for SKILL-51.", continued["blocked_reason"])
   }
 }
 
@@ -34,6 +62,7 @@ private data class McpDecompositionFixture(
   val context: McpRuntimeContext,
   val parentSpec: Path,
   val subtaskSpec: Path,
+  val secondSubtaskSpec: Path,
 ) {
   fun updateRequest(workflowId: String): WorkflowUpdateRequest = WorkflowUpdateRequest(
     workflowId = workflowId,
@@ -53,6 +82,12 @@ private data class McpDecompositionFixture(
             "spec_path" to subtaskSpec.toString(),
             "depends_on" to emptyList<Int>(),
           ),
+          mapOf(
+            "id" to 2,
+            "name" to "runtime",
+            "spec_path" to secondSubtaskSpec.toString(),
+            "depends_on" to listOf(1),
+          ),
         ),
       ),
     ),
@@ -65,9 +100,11 @@ private fun mcpDecompositionFixture(): McpDecompositionFixture {
   Files.writeString(configPath, """{"install_id":"test","telemetry":{"level":"off"}}""")
   val parentSpec = tempDir.resolve(".feature-specs/SKILL-51-demo/spec.md")
   val subtaskSpec = parentSpec.parent.resolve("spec_subtask_1_foundation.md")
+  val secondSubtaskSpec = parentSpec.parent.resolve("spec_subtask_2_runtime.md")
   Files.createDirectories(parentSpec.parent)
   Files.writeString(parentSpec, "# Parent")
   Files.writeString(subtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
+  Files.writeString(secondSubtaskSpec, "---\nstatus: Pending\n---\n\n# Subtask")
   return McpDecompositionFixture(
     context = McpRuntimeContext(
       environment = mapOf(
@@ -79,6 +116,7 @@ private fun mcpDecompositionFixture(): McpDecompositionFixture {
     ),
     parentSpec = parentSpec,
     subtaskSpec = subtaskSpec,
+    secondSubtaskSpec = secondSubtaskSpec,
   )
 }
 

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/model/RuntimeContext.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/model/RuntimeContext.kt
@@ -1,5 +1,7 @@
 package skillbill.model
 
+import skillbill.ports.agentrun.AgentRunLauncher
+import skillbill.ports.goalrunner.GoalPullRequestPort
 import skillbill.ports.telemetry.HttpRequester
 import skillbill.ports.telemetry.UnconfiguredHttpRequester
 import skillbill.ports.workflow.NoopWorkflowGitOperations
@@ -13,6 +15,8 @@ data class RuntimeContext(
   val userHome: Path = UnspecifiedUserHome,
   val requester: HttpRequester = UnconfiguredHttpRequester,
   val workflowGitOperations: WorkflowGitOperations = NoopWorkflowGitOperations,
+  val agentRunLauncher: AgentRunLauncher? = null,
+  val goalPullRequestPort: GoalPullRequestPort? = null,
 ) {
   companion object {
     val UnspecifiedEnvironment: Map<String, String> = object : AbstractMap<String, String>() {

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/AgentRunLauncher.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/AgentRunLauncher.kt
@@ -1,0 +1,8 @@
+package skillbill.ports.agentrun
+
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+
+interface AgentRunLauncher {
+  fun launch(request: AgentRunLaunchRequest): AgentRunLaunchOutcome
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
@@ -11,11 +11,25 @@ data class SkillRunRequest(
   val subtaskId: Int? = null,
   val dbPathOverride: String? = null,
   val timeout: Duration = DEFAULT_AGENT_RUN_TIMEOUT,
+  val outputSink: AgentRunOutputSink = AgentRunOutputSink.NONE,
 ) {
   init {
     require(issueKey.isNotBlank()) { "issueKey is required." }
     subtaskId?.let { id -> require(id > 0) { "subtaskId must be positive when provided." } }
     require(timeout.isPositive()) { "timeout must be positive." }
+  }
+}
+
+enum class AgentRunOutputStream {
+  STDOUT,
+  STDERR,
+}
+
+fun interface AgentRunOutputSink {
+  fun write(stream: AgentRunOutputStream, text: String)
+
+  companion object {
+    val NONE: AgentRunOutputSink = AgentRunOutputSink { _, _ -> }
   }
 }
 

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
@@ -1,0 +1,58 @@
+package skillbill.ports.agentrun.model
+
+import skillbill.install.model.InstallAgent
+import java.nio.file.Path
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+data class SkillRunRequest(
+  val issueKey: String,
+  val repoRoot: Path,
+  val subtaskId: Int? = null,
+  val dbPathOverride: String? = null,
+  val timeout: Duration = DEFAULT_AGENT_RUN_TIMEOUT,
+) {
+  init {
+    require(issueKey.isNotBlank()) { "issueKey is required." }
+    subtaskId?.let { id -> require(id > 0) { "subtaskId must be positive when provided." } }
+    require(timeout.isPositive()) { "timeout must be positive." }
+  }
+}
+
+data class AgentRunLaunchRequest(
+  val agentId: String,
+  val skillRunRequest: SkillRunRequest,
+) {
+  init {
+    require(agentId.isNotBlank()) { "agentId is required." }
+  }
+}
+
+sealed interface AgentRunLaunchOutcome {
+  val agent: InstallAgent
+}
+
+data class AgentRunLaunchFacts(
+  override val agent: InstallAgent,
+  val exitStatus: Int?,
+  val stdout: String,
+  val stderr: String,
+  val timedOut: Boolean,
+  val spawnFailed: Boolean,
+) : AgentRunLaunchOutcome {
+  init {
+    require(!timedOut || exitStatus == null) { "timedOut launch facts must not report an exitStatus." }
+    require(!spawnFailed || exitStatus == null) { "spawnFailed launch facts must not report an exitStatus." }
+  }
+}
+
+data class UnsupportedAgentRunLaunch(
+  override val agent: InstallAgent,
+  val reason: String,
+) : AgentRunLaunchOutcome {
+  init {
+    require(reason.isNotBlank()) { "Unsupported-agent reason is required." }
+  }
+}
+
+val DEFAULT_AGENT_RUN_TIMEOUT: Duration = 60.minutes

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/GoalRunnerPorts.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/GoalRunnerPorts.kt
@@ -1,0 +1,31 @@
+package skillbill.ports.goalrunner
+
+import skillbill.goalrunner.model.GoalRunnerStoredOutcome
+import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
+import skillbill.ports.goalrunner.model.GoalPullRequestRequest
+import skillbill.ports.goalrunner.model.GoalPullRequestResult
+import skillbill.ports.goalrunner.model.GoalRunnerManifestState
+import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
+
+interface GoalRunnerManifestStore {
+  fun loadByIssueKey(issueKey: String, dbPathOverride: String? = null): GoalRunnerManifestState?
+
+  fun save(state: GoalRunnerManifestState, dbPathOverride: String? = null): GoalRunnerManifestState
+}
+
+interface GoalRunnerWorkflowOutcomeStore {
+  fun terminalOutcome(
+    workflowId: String,
+    issueKey: String,
+    subtaskId: Int,
+    dbPathOverride: String? = null,
+  ): GoalRunnerStoredOutcome?
+}
+
+fun interface GoalRunnerSubtaskLauncher {
+  fun launch(request: GoalRunnerSubtaskLaunchRequest): AgentRunLaunchOutcome
+}
+
+fun interface GoalPullRequestPort {
+  fun open(request: GoalPullRequestRequest): GoalPullRequestResult
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/model/GoalRunnerPortModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/model/GoalRunnerPortModels.kt
@@ -1,0 +1,33 @@
+package skillbill.ports.goalrunner.model
+
+import skillbill.ports.agentrun.model.SkillRunRequest
+import skillbill.workflow.model.DecompositionManifest
+import java.nio.file.Path
+
+data class GoalRunnerManifestState(
+  val parentWorkflowId: String,
+  val dbPath: String,
+  val manifest: DecompositionManifest,
+)
+
+data class GoalRunnerSubtaskLaunchRequest(
+  val invokedAgentId: String,
+  val configuredAgentOverrideId: String?,
+  val skillRunRequest: SkillRunRequest,
+)
+
+data class GoalPullRequestRequest(
+  val repoRoot: Path,
+  val issueKey: String,
+  val featureName: String,
+  val baseBranch: String,
+  val headBranch: String,
+  val title: String,
+  val body: String,
+)
+
+sealed interface GoalPullRequestResult {
+  data class Opened(val url: String) : GoalPullRequestResult
+  data class Existing(val url: String) : GoalPullRequestResult
+  data class Failed(val reason: String) : GoalPullRequestResult
+}

--- a/runtime-kotlin/runtime-ports/src/test/kotlin/skillbill/ports/agentrun/AgentRunLauncherModelsTest.kt
+++ b/runtime-kotlin/runtime-ports/src/test/kotlin/skillbill/ports/agentrun/AgentRunLauncherModelsTest.kt
@@ -1,0 +1,45 @@
+package skillbill.ports.agentrun
+
+import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.model.AgentRunLaunchFacts
+import skillbill.ports.agentrun.model.SkillRunRequest
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
+
+class AgentRunLauncherModelsTest {
+  @Test
+  fun `skill run request requires positive timeout and subtask id`() {
+    assertFailsWith<IllegalArgumentException> {
+      SkillRunRequest(issueKey = "SKILL-56", repoRoot = Path.of("."), timeout = 0.seconds)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      SkillRunRequest(issueKey = "SKILL-56", repoRoot = Path.of("."), subtaskId = 0)
+    }
+  }
+
+  @Test
+  fun `launch facts do not allow terminal process status on timeout or spawn failure`() {
+    assertFailsWith<IllegalArgumentException> {
+      AgentRunLaunchFacts(
+        agent = InstallAgent.CODEX,
+        exitStatus = 1,
+        stdout = "",
+        stderr = "timeout",
+        timedOut = true,
+        spawnFailed = false,
+      )
+    }
+    assertFailsWith<IllegalArgumentException> {
+      AgentRunLaunchFacts(
+        agent = InstallAgent.CODEX,
+        exitStatus = 1,
+        stdout = "",
+        stderr = "spawn failed",
+        timedOut = false,
+        spawnFailed = true,
+      )
+    }
+  }
+}

--- a/skills/bill-feature-implement/content.md
+++ b/skills/bill-feature-implement/content.md
@@ -49,6 +49,21 @@ Continuation-mode rules:
 - If `continue_status` is `done`, do not rerun the workflow; summarize the terminal state instead.
 - If `continue_status` is `blocked`, stop and restore the missing artifacts named by the workflow payload before continuing.
 
+## Goal-Continuation Entry (non-interactive)
+
+External goal runners may invoke `feature_implement_workflow_continue` / `skill-bill workflow continue` with a decomposed parent `issue_key` and, optionally, `subtask_id`. This is a non-interactive entry for exactly one runnable decomposed subtask.
+
+Goal-continuation rules:
+
+- Reuse the existing decomposition continuation selector: resume the in-progress subtask, otherwise start the first pending subtask whose dependencies are complete, otherwise report blocked or all-complete.
+- If `subtask_id` is provided, treat it as a constraint on the next runnable subtask. Do not skip dependencies or run a later subtask; report blocked when the requested subtask is not the selected runnable subtask.
+- Derive the subtask contract from the selected subtask spec and recovered workflow artifacts. Do not ask the user to reconfirm acceptance criteria for the subtask.
+- Start new subtask workflows at `preplan` with `assessment`, `branch`, and `goal_continuation` artifacts already persisted from the parent manifest.
+- Set `goal_continuation.suppress_pr=true`. Run the normal implementation, review, audit, validation, history, and commit steps, then suppress `pr_description` so the parent goal runner can open one PR for the whole goal.
+- Treat a completed `commit_push` step as the terminal success signal for this entry when PR suppression is active. Persist the subtask outcome in durable workflow state; stdout is diagnostic only.
+- The structured outcome fields are `issue_key`, `subtask_id`, `status`, `commit_sha`, `workflow_id`, `blocked_reason`, and `last_resumable_step`. Runtime state is authoritative; git-tracked `decomposition-manifest.yaml` projections may omit runtime-only commit SHAs.
+- Interactive `bill-feature-implement` behavior is unchanged: direct user runs still perform Step 1 confirmation and create a PR in Step 9.
+
 ## Orchestrator vs Subagent Split
 
 Step 1 (collect design doc + assess) runs in the orchestrator because it requires user interaction. Step 1b (create feature branch) runs in the orchestrator because it is a trivial git op that should stay visible. Step 2 (pre-planning), Step 3 (planning), Step 4 (implementation), Step 6 (completeness audit), Step 6b (quality check), and Step 9 (PR description) run as subagents. Step 5 (code review via `bill-code-review`) runs in the orchestrator because it already spawns specialist subagents internally — do not nest further. Step 7 (boundary history via `bill-boundary-history`) and Step 8 (commit and push) run in the orchestrator.

--- a/skills/bill-goal/content.md
+++ b/skills/bill-goal/content.md
@@ -1,0 +1,60 @@
+---
+name: bill-goal
+description: Use when a user asks to complete a larger implementation goal through interactive decomposition, one confirmation gate, and the foreground `skill-bill goal` runner; complete small non-decomposed goals directly without starting the loop.
+---
+
+# Goal Runner Content
+
+`bill-goal` is the interactive front door for a goal that may need multiple decomposed implementation subtasks. It decides whether decomposition is necessary, asks for exactly one confirmation before starting any automated loop, and hands confirmed decompositions to the local `skill-bill goal` driver.
+
+## Intake
+
+Clarify the user's goal enough to identify:
+
+- the issue key
+- the intended outcome
+- the acceptance criteria
+- known constraints, affected areas, and non-goals
+
+If the issue key is missing, stop and ask for it. Do not invent one.
+
+Classify the goal before decomposing:
+
+- If the goal is small enough for one normal implementation pass, complete it directly in the current agent session. Do not create a decomposition manifest and do not invoke `skill-bill goal`.
+- If the goal needs multiple independently resumable implementation subtasks, prepare a decomposition proposal.
+
+## Decomposition Proposal
+
+For decomposed goals, present a concise proposal that includes:
+
+- the issue key and feature name
+- the parent acceptance criteria
+- two or more ordered subtasks with dependency notes
+- the expected first runnable subtask
+- the agent that will be used for child runs, including any explicit override
+
+Ask one confirmation question: whether to proceed with this decomposition and start the foreground goal loop.
+
+Do not start `skill-bill goal` while the decomposition is unconfirmed. If the user declines, stop and either revise the proposal or leave the goal unstarted, depending on their response.
+
+## Confirmed Handoff
+
+After confirmation, ensure the decomposed parent workflow and runtime manifest have been created by the normal feature-implementation decomposition path. Then hand off to the foreground driver:
+
+```bash
+skill-bill goal <issue_key>
+```
+
+Use `--agent` when the invoking agent id is known and `--agent-override` only when the user explicitly selected a different child agent. Keep live output enabled unless the user asks for quieter output.
+
+During the run, treat workflow state as authoritative. Child stdout and stderr are diagnostic. If the driver stops and reports a blocked or failed subtask, do not continue the loop manually; summarize the stopped subtask, reason, workflow id when present, and resumable step.
+
+## Status Checks
+
+Use the read-only status command whenever the user asks where a decomposed goal stands:
+
+```bash
+skill-bill goal status <issue_key>
+```
+
+Report complete, pending, and blocked counts, the current subtask and step, and the active agent exactly as returned by the command. Do not mutate workflow state during a status-only request.


### PR DESCRIPTION
## Summary
- add non-interactive feature-implement continuation for decomposed goal subtasks
- add agent-agnostic fresh-process launch support and the goal-runner service
- expose `skill-bill goal` / `goal status` plus the new `/bill-goal` governed skill
- document goal CLI E2E evidence and complete the decomposition manifest

## Validation
- skill-bill validate
- scripts/validate_agent_configs
- npx --yes agnix --strict .
- (cd runtime-kotlin && ./gradlew check)
- focused CLI/launcher tests for goal run, status, live output, and forced failure

## Notes
- Final goal-loop E2E used fake `codex` and `gh` executables; no hosted-agent or real GitHub service behavior is claimed beyond updating this PR.
- Subtask PR creation remained suppressed; this PR is the single parent PR for the SKILL-56 branch.