### PR TITLE
SKILL-62: Reuse last install selection

### DIFF
--- a/.feature-specs/SKILL-62-install-sh-reuse-last-selection/spec.md
+++ b/.feature-specs/SKILL-62-install-sh-reuse-last-selection/spec.md
@@ -1,0 +1,83 @@
+---
+status: Complete
+---
+
+# SKILL-62 - install-sh-reuse-last-selection
+
+## Mode
+
+single_spec
+
+## Intended Outcome
+
+Add an `install.sh` option that reuses the latest successful install selections instead of prompting for agents, platform packs, telemetry, and MCP registration again.
+
+## Overview
+
+`install.sh` currently prompts every full install even though successful installs already persist a runtime-owned selection record at `~/.skill-bill/install-selection.json`. Desktop can reuse that shared record for post-publish reinstall, but the shell installer cannot.
+
+Add a non-interactive reuse path for repeat installs after source changes, renderer changes, or scaffold work. The shell should still perform the normal runtime installation, clean-slate reset, staging, linking, telemetry, MCP, and optional desktop-app work; only the installer choice collection should be skipped.
+
+The saved selection must be resolved before `run_pre_install_uninstall`, because that reset wipes `~/.skill-bill`. Missing, malformed, or no-longer-valid saved selections must fail loudly before destructive cleanup.
+
+## Acceptance Criteria
+
+1. `./install.sh --reuse-last-selection` is accepted by usage text and argument parsing.
+2. When `--reuse-last-selection` is provided, the full installer skips these prompts:
+   - agent selection mode and manual agent list;
+   - platform pack selection;
+   - telemetry level;
+   - MCP registration choice.
+3. Reuse reads the latest successful runtime install selection from the shared install-selection store, not from any desktop-only preference file.
+4. Reuse resolves and validates the saved selection before `run_pre_install_uninstall` deletes `~/.skill-bill`.
+5. If the saved selection record is missing, malformed, unreadable, or contract-version incompatible, the installer exits non-zero before cleanup and prints a remediation hint to run `./install.sh` without `--reuse-last-selection`.
+6. Saved selected agents are replayed as the installer’s manual agent list, preserving existing `get_agent_path` target resolution and duplicate handling.
+7. Saved platform pack selection is replayed exactly:
+   - `none` means base skills only;
+   - `all` means all currently available platform packs;
+   - `selected` means only the saved slugs.
+8. Reuse fails before cleanup if a saved `selected` platform slug is not present in the current `platform-packs/` manifest-backed list.
+9. Saved telemetry level is replayed as the runtime install telemetry setting.
+10. Saved MCP registration replays the saved `register` boolean, but uses the freshly installed runtime MCP binary path for the current install rather than trusting a stale stored binary path.
+11. `--reuse-last-selection` remains compatible with install-source and desktop options, including:
+    - `--from-source`;
+    - `--release TAG`;
+    - `--with-desktop-app`;
+    - `--no-desktop-app`;
+    - `--desktop-app-dir PATH`.
+12. `--reuse-last-selection` is rejected with `--desktop-app-only`, because desktop-only install intentionally skips full runtime install selection.
+13. The final install summary clearly indicates that saved selections were reused and still reports agents, platforms, telemetry, MCP, and desktop app outcome.
+14. The runtime apply path still persists the latest successful selection after a reused install, so subsequent reuse reflects actual resolved installed agents.
+15. Tests cover:
+    - happy-path reuse from a canonical shared selection record;
+    - missing/malformed record exits before cleanup;
+    - stale selected platform slug exits before cleanup;
+    - MCP registration uses the current runtime MCP binary path;
+    - incompatible `--desktop-app-only --reuse-last-selection` argument rejection;
+    - usage text documents the new option.
+
+## Constraints
+
+- Do not hand-write or duplicate desktop preference internals.
+- Prefer routing shared selection parsing through runtime-owned code or a runtime CLI entry point rather than ad hoc shell JSON parsing.
+- Preserve the existing clean-slate install behavior after a saved selection has been successfully captured and validated.
+- Do not change the install-selection JSON schema unless strictly required.
+- Do not change default `./install.sh` behavior; prompting remains the default.
+- Keep generated runtime artifacts and install staging output out of source.
+
+## Non-Goals
+
+- No automatic reuse without an explicit flag.
+- No desktop first-run UI changes.
+- No change to `skill-bill install apply` defaults unless needed as the runtime-owned seam for `install.sh`.
+- No migration of old desktop-only preference records beyond what existing shared selection persistence already supports.
+
+## Validation Strategy
+
+Add focused installer/runtime tests around the new replay path, then run:
+
+- targeted installer shell tests or architecture tests covering `install.sh`;
+- targeted runtime install-selection tests if a runtime CLI replay/read seam is added;
+- `(cd runtime-kotlin && ./gradlew check)` if the runtime CLI or shared install code changes;
+- `skill-bill validate`;
+- `scripts/validate_agent_configs`.

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ DESKTOP_APP_PREBUILT_SOURCE_PATH=""
 INSTALL_SOURCE="prebuilt"
 RELEASE_TAG="${SKILL_BILL_RELEASE_TAG:-}"
 DESKTOP_APP_ONLY=0
+REUSE_LAST_SELECTION=0
 RELEASE_REPO="${SKILL_BILL_RELEASE_REPO:-Sermilion/skill-bill}"
 # Offline / test overrides. When SKILL_BILL_RELEASE_DIR is set, assets are copied
 # from that local directory (no network). When SKILL_BILL_RELEASE_BASE_URL is set,
@@ -68,7 +69,7 @@ usage() {
   cat <<USAGE
 Usage: ./install.sh [--from-source] [--release TAG]
                     [--with-desktop-app|--no-desktop-app] [--desktop-app-dir PATH]
-                    [--desktop-app-only]
+                    [--desktop-app-only] [--reuse-last-selection]
 
 By default the installer downloads and checksum-verifies the prebuilt runtime
 images from the matching GitHub release — no JDK and no Gradle build required.
@@ -86,6 +87,8 @@ Options:
   --desktop-app-only       Install ONLY the prebuilt desktop app (skip the full
                            installer). Use this to add the desktop app later
                            without re-running the full install.
+  --reuse-last-selection   Reuse the latest successful agent, platform,
+                           telemetry, and MCP choices from ~/.skill-bill.
 USAGE
 }
 
@@ -110,6 +113,10 @@ parse_args() {
         ;;
       --desktop-app-only)
         DESKTOP_APP_ONLY=1
+        shift
+        ;;
+      --reuse-last-selection)
+        REUSE_LAST_SELECTION=1
         shift
         ;;
       --release)
@@ -151,6 +158,12 @@ parse_args() {
         ;;
     esac
   done
+
+  if [[ "$DESKTOP_APP_ONLY" -eq 1 && "$REUSE_LAST_SELECTION" -eq 1 ]]; then
+    err "--reuse-last-selection cannot be combined with --desktop-app-only."
+    err "Run the full installer with --reuse-last-selection, or run --desktop-app-only by itself."
+    exit 1
+  fi
 }
 
 host_path() {
@@ -774,6 +787,19 @@ build_kotlin_runtime_distributions() {
 
 run_runtime_cli() {
   SKILL_BILL_RUNTIME_EXECUTABLE="$RUNTIME_CLI_BIN" "$RUNTIME_CLI_BIN" --home "$HOME" "$@"
+}
+
+run_selection_runtime_cli() {
+  local runtime_bin="$RUNTIME_CLI_BUILD_BIN"
+  if [[ ! -x "$runtime_bin" ]]; then
+    runtime_bin="$RUNTIME_CLI_BIN"
+  fi
+  if [[ ! -x "$runtime_bin" ]]; then
+    err "Cannot reuse saved install selections: no Skill Bill runtime CLI is available before cleanup."
+    err "Run ./install.sh without --reuse-last-selection to choose install options again."
+    exit 1
+  fi
+  SKILL_BILL_RUNTIME_EXECUTABLE="$runtime_bin" "$runtime_bin" --home "$HOME" "$@"
 }
 
 path_contains_dir() {
@@ -1606,6 +1632,108 @@ prompt_for_telemetry_preference() {
   done
 }
 
+replay_last_install_selection() {
+  local output
+  local kind
+  local value
+  local extra
+
+  if ! output="$(
+    run_selection_runtime_cli install replay-last-selection \
+      --skills "$SKILLS_DIR" \
+      --platform-packs "$PLATFORM_PACKS_DIR" 2>&1
+  )"; then
+    err "Cannot reuse saved install selections."
+    if [[ -n "$(trim_string "$output")" ]]; then
+      err "$(trim_string "$output")"
+    fi
+    err "Run ./install.sh without --reuse-last-selection to choose install options again."
+    exit 1
+  fi
+
+  AGENT_SELECTION_MODE="manual"
+  AGENT_NAMES=()
+  AGENT_PATHS=()
+  PLATFORM_SELECTION_MODE="none"
+  SELECTED_PLATFORM_PACKAGES=()
+  TELEMETRY_LEVEL="anonymous"
+  MCP_REGISTRATION="register"
+
+  while IFS=$'\t' read -r kind value extra; do
+    [[ -z "${kind:-}" ]] && continue
+    case "$kind" in
+      agent)
+        if [[ -z "${value:-}" || -z "${extra:-}" ]]; then
+          err "Cannot reuse saved install selections: malformed replay agent entry."
+          exit 1
+        fi
+        AGENT_NAMES+=("$value")
+        AGENT_PATHS+=("$extra")
+        ;;
+      platform-mode)
+        case "$value" in
+          none|selected|all)
+            PLATFORM_SELECTION_MODE="$value"
+            ;;
+          *)
+            err "Cannot reuse saved install selections: unknown platform mode '$value'."
+            exit 1
+            ;;
+        esac
+        ;;
+      platform)
+        if [[ -z "${value:-}" ]]; then
+          err "Cannot reuse saved install selections: malformed replay platform entry."
+          exit 1
+        fi
+        SELECTED_PLATFORM_PACKAGES+=("$value")
+        ;;
+      telemetry)
+        case "$value" in
+          anonymous|full|off)
+            TELEMETRY_LEVEL="$value"
+            ;;
+          *)
+            err "Cannot reuse saved install selections: unknown telemetry level '$value'."
+            exit 1
+            ;;
+        esac
+        ;;
+      mcp)
+        case "$value" in
+          register|skip)
+            MCP_REGISTRATION="$value"
+            ;;
+          *)
+            err "Cannot reuse saved install selections: unknown MCP registration choice '$value'."
+            exit 1
+            ;;
+        esac
+        ;;
+      *)
+        err "Cannot reuse saved install selections: unknown replay field '$kind'."
+        exit 1
+        ;;
+    esac
+  done <<< "$output"
+
+  if [[ ${#AGENT_NAMES[@]} -eq 0 ]]; then
+    err "Cannot reuse saved install selections: saved selection has no agents."
+    err "Run ./install.sh without --reuse-last-selection to choose install options again."
+    exit 1
+  fi
+  if [[ "$PLATFORM_SELECTION_MODE" == "selected" && ${#SELECTED_PLATFORM_PACKAGES[@]} -eq 0 ]]; then
+    err "Cannot reuse saved install selections: selected platform mode has no saved platform slugs."
+    err "Run ./install.sh without --reuse-last-selection to choose install options again."
+    exit 1
+  fi
+  if [[ "$PLATFORM_SELECTION_MODE" == "all" ]]; then
+    SELECTED_PLATFORM_PACKAGES=("${PLATFORM_PACKAGES[@]}")
+  fi
+
+  ok "Reusing latest successful install selections from $SKILL_BILL_STATE_DIR/install-selection.json"
+}
+
 build_runtime_install_args() {
   local i
 
@@ -1739,18 +1867,28 @@ run_desktop_only_install() {
 
 run_full_install() {
   print_install_plan "full"
+  if [[ "$REUSE_LAST_SELECTION" -eq 1 ]]; then
+    build_platform_packages
+    replay_last_install_selection
+  fi
   run_pre_install_uninstall
   install_runtime_distributions
-  build_platform_packages
+  if [[ "$REUSE_LAST_SELECTION" -ne 1 ]]; then
+    build_platform_packages
+  fi
 
   echo ""
   printf "${CYAN}━━━ Skill Bill Installer ━━━${NC}\n"
   echo ""
   info "Supported agents: copilot, claude, codex, opencode, junie"
-  info "Install behavior: collect choices, then delegate planning and apply to the Kotlin runtime."
-  prompt_for_agent_selection
-  prompt_for_platform_selection
-  prompt_for_telemetry_preference
+  if [[ "$REUSE_LAST_SELECTION" -eq 1 ]]; then
+    info "Install behavior: reuse saved choices, then delegate planning and apply to the Kotlin runtime."
+  else
+    info "Install behavior: collect choices, then delegate planning and apply to the Kotlin runtime."
+    prompt_for_agent_selection
+    prompt_for_platform_selection
+    prompt_for_telemetry_preference
+  fi
   prompt_for_desktop_app_install
   install_runtime_launchers
   build_desktop_app_distribution
@@ -1765,6 +1903,9 @@ run_full_install() {
   info "Telemetry:      $TELEMETRY_LEVEL"
   info "MCP:            $MCP_REGISTRATION"
   info "Desktop app:    $DESKTOP_APP_INSTALL"
+  if [[ "$REUSE_LAST_SELECTION" -eq 1 ]]; then
+    info "Selections:     reused latest successful install selection"
+  fi
   echo ""
 
   apply_runtime_install
@@ -1778,6 +1919,9 @@ run_full_install() {
   info "Launchers:       $RUNTIME_LAUNCHER_BIN_DIR/skill-bill, $RUNTIME_LAUNCHER_BIN_DIR/skill-bill-mcp"
   info "Telemetry:       $TELEMETRY_LEVEL"
   info "MCP:             $MCP_REGISTRATION"
+  if [[ "$REUSE_LAST_SELECTION" -eq 1 ]]; then
+    info "Selections:      reused latest successful install selection"
+  fi
   if [[ "$DESKTOP_APP_INSTALL" == "yes" ]]; then
     info "Desktop app:     ${DESKTOP_APP_INSTALLED_PATH:-installed for $(desktop_host_os)}"
     if [[ -n "$DESKTOP_APP_LAUNCHER_PATH" ]]; then

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-06-01] SKILL-62 install-sh-reuse-last-selection
+Areas: install.sh, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-application, runtime-kotlin/runtime-core tests
+- `install.sh --reuse-last-selection` now resolves the latest shared install selection before cleanup, skips agent/platform/telemetry/MCP prompts, rejects desktop-only reuse, and reports reused selections in the install summary. reusable
+- Added a runtime-owned `install replay-last-selection` CLI seam so shell replay uses the shared selection parser, current agent target resolution, manifest-backed platform slug validation, and a fresh current-install MCP binary path. reusable
+- `InstallService.discoverPlatformPackSlugs` exposes platform manifest discovery without pulling filesystem or planning-port internals into the CLI boundary.
+- Regression coverage locks happy-path replay, missing/malformed records, stale selected platform slugs, desktop-only rejection, cleanup-before-failure behavior, and usage/delegation wiring.
+Feature flag: N/A
+Acceptance criteria: 15/15 implemented
+
 ## [2026-06-01] SKILL-61 subtask 3 cli-watch-status-diff-ux
 Areas: runtime-kotlin/runtime-cli, runtime-kotlin/runtime-application, runtime-kotlin/runtime-domain, runtime-kotlin/runtime-ports, runtime-kotlin/runtime-infra-fs
 - Goal foreground output now emits default `goal_observability:` lines at the existing bounded heartbeat cadence while keeping raw child stdout/stderr hidden unless `--debug-child-output` is explicit. reusable

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/InstallService.kt
@@ -90,6 +90,12 @@ class InstallService(
     InstallPlanPolicy.validateInstallPlanSnapshot(plan, installPlanWireValidator)
   }
 
+  fun discoverPlatformPackSlugs(request: InstallPlanRequest): Set<String> = planningPorts.planningFactsPort
+    .collectPlanningFacts(InstallPlanningFactsRequest(request))
+    .facts
+    .platformManifests
+    .mapTo(mutableSetOf()) { manifest -> manifest.slug }
+
   fun linkSkill(source: Path, targetDir: Path, agent: String, repoRoot: Path? = null, home: Path? = null): List<Path> =
     skillLinkPort.linkSkill(
       InstallSkillLinkRequest(

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/InstallCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/InstallCliCommands.kt
@@ -14,6 +14,7 @@ import skillbill.application.McpRegistrationService
 import skillbill.application.NativeAgentInstallService
 import skillbill.di.RuntimeComponent
 import skillbill.di.create
+import skillbill.error.SkillBillRuntimeException
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallAgentSelection
 import skillbill.install.model.InstallAgentSelectionMode
@@ -34,6 +35,8 @@ import skillbill.model.RuntimeContext
 import skillbill.ports.install.model.NativeAgentLinkOutcome
 import skillbill.ports.install.model.NativeAgentLinkProvider
 import skillbill.ports.install.model.NativeAgentLinkRequest
+import skillbill.ports.install.selection.InstallSelectionPersistencePort
+import skillbill.ports.install.selection.model.ReadLatestSuccessfulInstallSelectionRequest
 import skillbill.ports.telemetry.TelemetryLevelMutator
 import java.nio.file.Path
 
@@ -111,6 +114,89 @@ class InstallApplyCommand(
       userHome = plan.request.home,
     )
     return RuntimeComponent::class.create(reboundContext).telemetryLevelMutator
+  }
+}
+
+@Inject
+class InstallReplayLastSelectionCommand(
+  private val state: CliRunState,
+  private val installAgentService: InstallAgentService,
+  private val installService: InstallService,
+  private val installSelectionPersistencePort: InstallSelectionPersistencePort,
+) : DocumentedCliCommand(
+  "replay-last-selection",
+  "Print the latest successful install choices as tab-separated replay fields.",
+) {
+  private val platformPacksRoot by option(
+    "--platform-packs",
+    help = "Platform packs root used to validate saved selected platform slugs.",
+  ).required()
+  private val skillsRoot by option(
+    "--skills",
+    help = "Base skills root used by the install planning fact collector.",
+  ).required()
+
+  override fun run() {
+    try {
+      val selection = installSelectionPersistencePort
+        .readLatestSuccessfulSelection(ReadLatestSuccessfulInstallSelectionRequest(state.userHome))
+        .selection
+      val availablePlatformSlugs = installService.discoverPlatformPackSlugs(replayDiscoveryRequest())
+      val staleSlugs = selection.platformPackSelection.selectedSlugs - availablePlatformSlugs
+      require(staleSlugs.isEmpty()) {
+        "Saved install selection references unavailable platform pack slug(s): " +
+          "${staleSlugs.sorted().joinToString(", ")}."
+      }
+      state.completeText(selection.toReplayText(), emptyMap())
+    } catch (error: SkillBillRuntimeException) {
+      state.completeText("${error.message.orEmpty()}\n", emptyMap(), exitCode = 1)
+    } catch (error: IllegalArgumentException) {
+      state.completeText("${error.message.orEmpty()}\n", emptyMap(), exitCode = 1)
+    }
+  }
+
+  private fun replayDiscoveryRequest(): InstallPlanRequest = InstallPlanRequest(
+    repoRoot = Path.of(platformPacksRoot).toAbsolutePath().normalize().parent ?: Path.of(".").toAbsolutePath(),
+    home = state.userHome,
+    agentSelection = InstallAgentSelection(mode = InstallAgentSelectionMode.DETECTED),
+    platformPackSelection = PlatformPackSelection(mode = PlatformPackSelectionMode.NONE),
+    telemetryLevel = InstallTelemetryLevel.ANONYMOUS,
+    mcpRegistrationChoice = McpRegistrationChoice(register = false),
+    runtimeDistributionInputs = RuntimeDistributionInputs(
+      runtimeInstallRoot = state.userHome.resolve(".skill-bill/runtime"),
+    ),
+    targetPaths = InstallationTargetPaths(
+      skillsRoot = Path.of(skillsRoot),
+      platformPacksRoot = Path.of(platformPacksRoot),
+    ),
+    windowsSymlinkPreflight = WindowsSymlinkPreflight(
+      state = WindowsSymlinkPreflightState.NOT_WINDOWS,
+      decision = WindowsSymlinkDecision.NOT_REQUIRED,
+    ),
+  )
+
+  private fun skillbill.install.model.SharedInstallSelection.toReplayText(): String = buildString {
+    selectedAgents.map(InstallAgent::id).sorted().forEach { agentId ->
+      append("agent\t")
+      append(agentId)
+      append('\t')
+      append(installAgentService.agentPath(agentId, state.userHome))
+      append('\n')
+    }
+    append("platform-mode\t")
+    append(platformPackSelection.mode.name.lowercase())
+    append('\n')
+    platformPackSelection.selectedSlugs.sorted().forEach { slug ->
+      append("platform\t")
+      append(slug)
+      append('\n')
+    }
+    append("telemetry\t")
+    append(telemetryLevel.id)
+    append('\n')
+    append("mcp\t")
+    append(if (mcpRegistrationChoice.register) "register" else "skip")
+    append('\n')
   }
 }
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/ScaffoldCliCommands.kt
@@ -72,6 +72,7 @@ class ScaffoldTopLevelCommands(
 class InstallTopLevelCommands(
   planCommand: InstallPlanCommand,
   applyCommand: InstallApplyCommand,
+  replayLastSelectionCommand: InstallReplayLastSelectionCommand,
   agentPathCommand: InstallAgentPathCommand,
   detectAgentsCommand: InstallDetectAgentsCommand,
   linkSkillCommand: InstallLinkSkillCommand,
@@ -99,6 +100,7 @@ class InstallTopLevelCommands(
       .subcommands(
         planCommand,
         applyCommand,
+        replayLastSelectionCommand,
         agentPathCommand,
         detectAgentsCommand,
         linkSkillCommand,

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallReplayLastSelectionRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallReplayLastSelectionRuntimeTest.kt
@@ -1,0 +1,182 @@
+package skillbill.cli
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class CliInstallReplayLastSelectionRuntimeTest {
+  @Test
+  fun `install replay last selection emits reusable fields without stale mcp path`() {
+    val fixture = replayFixture()
+    val staleMcpBin = fixture.home.resolve(".skill-bill/old-runtime/runtime-mcp/bin/runtime-mcp")
+    writeInstallSelection(
+      fixture.home,
+      TestInstallSelection(
+        selectedAgents = listOf("codex"),
+        platformMode = "selected",
+        selectedSlugs = listOf("kotlin"),
+        telemetryLevel = "full",
+        registerMcp = true,
+        runtimeMcpBin = staleMcpBin.toString(),
+      ),
+    )
+
+    val result = CliRuntime.run(replayLastSelectionArguments(fixture), CliRuntimeContext(userHome = fixture.home))
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "agent\tcodex\t${fixture.home.resolve(".agents/skills")}")
+    assertContains(result.stdout, "platform-mode\tselected")
+    assertContains(result.stdout, "platform\tkotlin")
+    assertContains(result.stdout, "telemetry\tfull")
+    assertContains(result.stdout, "mcp\tregister")
+    assertFalse(result.stdout.contains(staleMcpBin.toString()))
+  }
+
+  @Test
+  fun `install replay last selection fails on stale selected platform slug`() {
+    val fixture = replayFixture()
+    writeInstallSelection(
+      fixture.home,
+      TestInstallSelection(
+        selectedAgents = listOf("codex"),
+        platformMode = "selected",
+        selectedSlugs = listOf("retired"),
+        telemetryLevel = "anonymous",
+        registerMcp = false,
+        runtimeMcpBin = null,
+      ),
+    )
+
+    val result = CliRuntime.run(replayLastSelectionArguments(fixture), CliRuntimeContext(userHome = fixture.home))
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "retired")
+  }
+
+  @Test
+  fun `install replay last selection fails when shared record is missing`() {
+    val fixture = replayFixture()
+
+    val result = CliRuntime.run(replayLastSelectionArguments(fixture), CliRuntimeContext(userHome = fixture.home))
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Install selection record is missing")
+  }
+
+  @Test
+  fun `install replay last selection fails when shared record is malformed`() {
+    val fixture = replayFixture()
+    Files.createDirectories(installSelectionPath(fixture.home).parent)
+    Files.writeString(installSelectionPath(fixture.home), "[]")
+
+    val result = CliRuntime.run(replayLastSelectionArguments(fixture), CliRuntimeContext(userHome = fixture.home))
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Install selection record")
+    assertContains(result.stdout, "is malformed")
+  }
+
+  private fun replayFixture(): ReplayFixture {
+    val home = Files.createTempDirectory("skillbill-cli-replay-selection-home")
+    val repoRoot = Files.createTempDirectory("skillbill-cli-replay-selection-repo")
+    val skillRoot = repoRoot.resolve("skills/bill-code-review")
+    Files.createDirectories(skillRoot)
+    Files.writeString(skillRoot.resolve("content.md"), testSkillContent())
+    listOf("kotlin", "python").forEach { slug -> seedPlatformPack(repoRoot, slug) }
+    return ReplayFixture(repoRoot, home)
+  }
+
+  private fun seedPlatformPack(repoRoot: Path, slug: String) {
+    val codeReviewName = "bill-$slug-code-review"
+    val qualityCheckName = "bill-$slug-code-check"
+    val packRoot = repoRoot.resolve("platform-packs/$slug")
+    Files.createDirectories(packRoot.resolve("code-review/$codeReviewName"))
+    Files.createDirectories(packRoot.resolve("quality-check/$qualityCheckName"))
+    Files.writeString(packRoot.resolve("platform.yaml"), platformManifest(slug, codeReviewName, qualityCheckName))
+    Files.writeString(packRoot.resolve("code-review/$codeReviewName/content.md"), testSkillContent(codeReviewName))
+    Files.writeString(
+      packRoot.resolve("quality-check/$qualityCheckName/content.md"),
+      testSkillContent(qualityCheckName),
+    )
+  }
+
+  private fun replayLastSelectionArguments(fixture: ReplayFixture): List<String> = listOf(
+    "install",
+    "replay-last-selection",
+    "--skills",
+    fixture.repoRoot.resolve("skills").toString(),
+    "--platform-packs",
+    fixture.repoRoot.resolve("platform-packs").toString(),
+  )
+
+  private fun platformManifest(slug: String, codeReviewName: String, qualityCheckName: String): String = """
+    |platform: "$slug"
+    |contract_version: "1.1"
+    |routing_signals:
+    |  strong:
+    |    - "$slug"
+    |  tie_breakers: []
+    |declared_code_review_areas: []
+    |declared_files:
+    |  baseline: "code-review/$codeReviewName/content.md"
+    |  areas: {}
+    |area_metadata: {}
+    |display_name: "$slug"
+    |declared_quality_check_file: "quality-check/$qualityCheckName/content.md"
+    |
+  """.trimMargin()
+
+  private fun testSkillContent(skillName: String = "bill-code-review"): String = """
+    |---
+    |name: $skillName
+    |description: Test skill.
+    |---
+    |
+    |# $skillName
+    |
+    |Test body.
+    |
+  """.trimMargin()
+
+  private fun writeInstallSelection(home: Path, selection: TestInstallSelection) {
+    val mcpRuntimeBin = selection.runtimeMcpBin?.let { "\"$it\"" } ?: "null"
+    Files.createDirectories(installSelectionPath(home).parent)
+    Files.writeString(installSelectionPath(home), selection.toJson(mcpRuntimeBin))
+  }
+
+  private fun TestInstallSelection.toJson(mcpRuntimeBin: String): String = """
+    |{
+    |  "contract_version": "1.0",
+    |  "selected_agents": [${selectedAgents.joinToString(",") { "\"$it\"" }}],
+    |  "platform_pack_selection": {
+    |    "mode": "$platformMode",
+    |    "selected_slugs": [${selectedSlugs.joinToString(",") { "\"$it\"" }}]
+    |  },
+    |  "telemetry_level": "$telemetryLevel",
+    |  "mcp_registration": {
+    |    "register": $registerMcp,
+    |    "runtime_mcp_bin": $mcpRuntimeBin
+    |  }
+    |}
+    |
+  """.trimMargin()
+
+  private fun installSelectionPath(home: Path): Path = home.resolve(".skill-bill/install-selection.json")
+
+  private data class ReplayFixture(
+    val repoRoot: Path,
+    val home: Path,
+  )
+
+  private data class TestInstallSelection(
+    val selectedAgents: List<String>,
+    val platformMode: String,
+    val selectedSlugs: List<String>,
+    val telemetryLevel: String,
+    val registerMcp: Boolean,
+    val runtimeMcpBin: String?,
+  )
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -32,6 +32,8 @@ class InstallerShellDelegationTest {
     assertContains(installScript, "--telemetry \"\$TELEMETRY_LEVEL\"")
     assertContains(installScript, "--mcp \"\$MCP_REGISTRATION\"")
     assertContains(installScript, "--runtime-mcp-bin \"\$RUNTIME_MCP_BIN\"")
+    assertContains(installScript, "--reuse-last-selection")
+    assertContains(installScript, "install replay-last-selection")
     assertContains(installScript, "SKILL_BILL_RUNTIME_EXECUTABLE=\"\$RUNTIME_CLI_BIN\"")
     // The Gradle desktop build is now gated behind --from-source: the helper and the
     // Gradle task must still exist (from-source coverage), but only run when
@@ -52,7 +54,6 @@ class InstallerShellDelegationTest {
     assertFalse(installScript.contains("install link-opencode-agents"))
     assertFalse(installScript.contains("install link-junie-agents"))
     assertFalse(installScript.contains("telemetry set-level"))
-    assertFalse(installScript.contains("install-selection.json"))
     assertFalse(installScript.contains("firstRun."))
   }
 

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellReuseLastSelectionTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellReuseLastSelectionTest.kt
@@ -1,0 +1,213 @@
+package skillbill.architecture
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class InstallerShellReuseLastSelectionTest {
+  private val repoRoot: Path =
+    Path.of("").toAbsolutePath().normalize().let { workingDir ->
+      if (workingDir.fileName.toString().startsWith("runtime-")) {
+        workingDir.parent
+      } else {
+        workingDir
+      }
+    }.parent
+
+  @Test
+  fun `installer shell reuses last selection without prompting and applies fresh mcp path`() {
+    val run = runInstaller(extraArgs = listOf("--reuse-last-selection"))
+
+    assertEquals(0, run.exitCode, run.output)
+    assertContains(run.output, "Reusing latest successful install selections")
+    assertContains(run.output, "Selections:     reused latest successful install selection")
+    assertEquals(
+      expectedApplyArgs(run) + listOf(
+        "--agent",
+        "codex",
+        "--agent-target",
+        "codex=${run.home.resolve("agent-targets/codex")}",
+        "--platform",
+        "kotlin",
+      ),
+      run.applyArgs,
+    )
+  }
+
+  @Test
+  fun `installer shell rejects desktop-only with reuse-last-selection`() {
+    val run = runInstaller(
+      extraArgs = listOf("--desktop-app-only", "--reuse-last-selection"),
+      skipPreinstallUninstall = false,
+    )
+
+    assertFalse(run.exitCode == 0, "installer should fail. Output:\n${run.output}")
+    assertContains(run.output, "--reuse-last-selection cannot be combined with --desktop-app-only")
+    assertFalse(run.output.contains("Pre-install cleanup"), "cleanup must not run for incompatible arguments")
+  }
+
+  @Test
+  fun `installer shell reuse failure exits before cleanup`() {
+    val run = runInstaller(
+      extraArgs = listOf("--reuse-last-selection"),
+      reuseSelection = "missing",
+      skipPreinstallUninstall = false,
+    )
+
+    assertFalse(run.exitCode == 0, "installer should fail. Output:\n${run.output}")
+    assertContains(run.output, "Cannot reuse saved install selections")
+    assertContains(run.output, "Run ./install.sh without --reuse-last-selection")
+    assertFalse(run.output.contains("Pre-install cleanup"), "cleanup must not run after reuse validation failure")
+  }
+
+  private fun runInstaller(
+    extraArgs: List<String>,
+    reuseSelection: String = "ok",
+    skipPreinstallUninstall: Boolean = true,
+  ): InstallerRun {
+    val testRepo = Files.createTempDirectory("skillbill-installer-reuse-repo")
+    val home = Files.createTempDirectory("skillbill-installer-reuse-home")
+    val binDir = Files.createTempDirectory("skillbill-installer-reuse-bin")
+    val logPath = Files.createTempFile("skillbill-installer-reuse-runtime", ".log")
+    seedRepo(testRepo)
+
+    val command = mutableListOf("bash", testRepo.resolve("install.sh").toString()).apply { addAll(extraArgs) }
+    val process = ProcessBuilder(command)
+      .directory(testRepo.toFile())
+      .redirectErrorStream(true)
+      .apply {
+        environment()["HOME"] = home.toString()
+        environment()["SKILL_BILL_BIN_DIR"] = binDir.toString()
+        environment()["SKILL_BILL_SKIP_RUNTIME_DISTRIBUTION_BUILD"] = "1"
+        environment()["SKILL_BILL_TEST_RUNTIME_LOG"] = logPath.toString()
+        environment()["SKILL_BILL_TEST_REUSE_SELECTION"] = reuseSelection
+        if (skipPreinstallUninstall) {
+          environment()["SKILL_BILL_SKIP_PREINSTALL_UNINSTALL"] = "1"
+        }
+        environment().remove("DISPLAY")
+        environment().remove("WAYLAND_DISPLAY")
+        environment().remove("SKILL_BILL_GOAL_CONTINUATION")
+      }
+      .start()
+    process.outputStream.bufferedWriter().use { writer -> writer.write("") }
+    val output = process.inputStream.bufferedReader().readText()
+    val exitCode = process.waitFor()
+    return InstallerRun(testRepo, home, binDir, output, exitCode, parseApplyArgs(logPath))
+  }
+
+  private fun seedRepo(testRepo: Path) {
+    Files.writeString(testRepo.resolve("install.sh"), Files.readString(repoRoot.resolve("install.sh")))
+    testRepo.resolve("install.sh").toFile().setExecutable(true)
+    Files.createDirectories(testRepo.resolve("skills"))
+    listOf("kotlin", "python").forEach { slug ->
+      val packRoot = testRepo.resolve("platform-packs/$slug")
+      Files.createDirectories(packRoot)
+      Files.writeString(packRoot.resolve("platform.yaml"), "platform: \"$slug\"\n")
+    }
+    val cliBin = testRepo.resolve("runtime-kotlin/runtime-cli/build/install/runtime-cli/bin/runtime-cli")
+    val mcpBin = testRepo.resolve("runtime-kotlin/runtime-mcp/build/install/runtime-mcp/bin/runtime-mcp")
+    Files.createDirectories(cliBin.parent)
+    Files.createDirectories(mcpBin.parent)
+    Files.writeString(cliBin, runtimeCliStub())
+    Files.writeString(mcpBin, "#!/usr/bin/env bash\nexit 0\n")
+    cliBin.toFile().setExecutable(true)
+    mcpBin.toFile().setExecutable(true)
+  }
+
+  private fun runtimeCliStub(): String = """
+    |#!/usr/bin/env bash
+    |set -euo pipefail
+    |{
+    |  echo CALL
+    |  for arg in "${'$'}@"; do
+    |    printf 'ARG\t%s\n' "${'$'}arg"
+    |  done
+    |} >> "${'$'}{SKILL_BILL_TEST_RUNTIME_LOG:?}"
+    |home=""
+    |if [[ "${'$'}{1:-}" == "--home" ]]; then
+    |  home="${'$'}2"
+    |  shift 2
+    |fi
+    |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "agent-path" ]]; then
+    |  printf '%s\n' "${'$'}home/agent-targets/${'$'}3"
+    |  exit 0
+    |fi
+    |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "replay-last-selection" ]]; then
+    |  if [[ "${'$'}{SKILL_BILL_TEST_REUSE_SELECTION:-ok}" == "missing" ]]; then
+    |    printf '%s\n' "Install selection record is missing at '${'$'}home/.skill-bill/install-selection.json'."
+    |    exit 1
+    |  fi
+    |  printf 'agent\tcodex\t%s\n' "${'$'}home/agent-targets/codex"
+    |  printf 'platform-mode\tselected\nplatform\tkotlin\ntelemetry\tfull\nmcp\tregister\n'
+    |  exit 0
+    |fi
+    |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "apply" ]]; then
+    |  exit 0
+    |fi
+    |exit 2
+    |
+  """.trimMargin()
+
+  private fun parseApplyArgs(logPath: Path): List<String> {
+    if (!Files.exists(logPath)) {
+      return emptyList()
+    }
+    val calls = mutableListOf<MutableList<String>>()
+    Files.readAllLines(logPath).forEach { line ->
+      if (line == "CALL") {
+        calls.add(mutableListOf())
+      } else if (line.startsWith("ARG\t")) {
+        calls.last().add(line.removePrefix("ARG\t"))
+      }
+    }
+    return calls.singleOrNull { args -> args.drop(2).take(2) == listOf("install", "apply") }.orEmpty()
+  }
+
+  private fun expectedApplyArgs(run: InstallerRun): List<String> = listOf(
+    "--home",
+    run.home.toString(),
+    "install",
+    "apply",
+    "--repo-root",
+    run.repoRoot.toString(),
+    "--skills",
+    run.repoRoot.resolve("skills").toString(),
+    "--platform-packs",
+    run.repoRoot.resolve("platform-packs").toString(),
+    "--agent-mode",
+    "manual",
+    "--platform-mode",
+    "selected",
+    "--telemetry",
+    "full",
+    "--mcp",
+    "register",
+    "--replace-existing-skill-bill-links",
+    "--runtime-install-root",
+    run.home.resolve(".skill-bill/runtime").toString(),
+    "--runtime-cli-build-dir",
+    run.repoRoot.resolve("runtime-kotlin/runtime-cli/build/install/runtime-cli").toString(),
+    "--runtime-mcp-build-dir",
+    run.repoRoot.resolve("runtime-kotlin/runtime-mcp/build/install/runtime-mcp").toString(),
+    "--runtime-cli-install-dir",
+    run.home.resolve(".skill-bill/runtime/runtime-cli").toString(),
+    "--runtime-mcp-install-dir",
+    run.home.resolve(".skill-bill/runtime/runtime-mcp").toString(),
+    "--runtime-launcher-bin-dir",
+    run.binDir.toString(),
+    "--runtime-mcp-bin",
+    run.home.resolve(".skill-bill/runtime/runtime-mcp/bin/runtime-mcp").toString(),
+  )
+
+  private data class InstallerRun(
+    val repoRoot: Path,
+    val home: Path,
+    val binDir: Path,
+    val output: String,
+    val exitCode: Int,
+    val applyArgs: List<String>,
+  )
+}


### PR DESCRIPTION
## Summary
- add ./install.sh --reuse-last-selection with pre-cleanup runtime-owned selection replay
- add install replay-last-selection CLI seam with platform slug validation and fresh MCP binary usage
- cover shell replay, missing/malformed records, stale platform slugs, and desktop-only rejection

## Validation
- (cd runtime-kotlin && ./gradlew check)
- skill-bill validate
- scripts/validate_agent_configs
- npx --yes agnix --strict .