### PR TITLE
Fix SKILL-62 reuse selection replay

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -89,6 +89,9 @@ Options:
                            without re-running the full install.
   --reuse-last-selection   Reuse the latest successful agent, platform,
                            telemetry, and MCP choices from ~/.skill-bill.
+                           Desktop app install uses the normal non-interactive
+                           default unless --with-desktop-app or --no-desktop-app
+                           is provided.
 USAGE
 }
 
@@ -514,8 +517,10 @@ prompt_for_desktop_app_install() {
     default_choice="no"
   fi
 
-  # Non-interactive (no TTY): resolve to the gated default WITHOUT blocking on read.
-  if [[ ! -t 0 ]]; then
+  # Non-interactive (no TTY) and reuse mode resolve to the gated default WITHOUT
+  # blocking on read. The shared install-selection record owns runtime choices
+  # only; explicit --with/--no-desktop-app remains the desktop override.
+  if [[ ! -t 0 || "$REUSE_LAST_SELECTION" -eq 1 ]]; then
     DESKTOP_APP_INSTALL="$default_choice"
     return 0
   fi
@@ -789,13 +794,40 @@ run_runtime_cli() {
   SKILL_BILL_RUNTIME_EXECUTABLE="$RUNTIME_CLI_BIN" "$RUNTIME_CLI_BIN" --home "$HOME" "$@"
 }
 
-run_selection_runtime_cli() {
-  local runtime_bin="$RUNTIME_CLI_BUILD_BIN"
-  if [[ ! -x "$runtime_bin" ]]; then
-    runtime_bin="$RUNTIME_CLI_BIN"
+runtime_cli_supports_selection_replay() {
+  local runtime_bin="$1"
+  [[ -x "$runtime_bin" ]] || return 1
+  "$runtime_bin" install --help 2>/dev/null | grep -q "replay-last-selection"
+}
+
+build_selection_replay_runtime_cli() {
+  if [[ "${SKILL_BILL_SKIP_RUNTIME_DISTRIBUTION_BUILD:-}" == "1" ]]; then
+    return 1
   fi
-  if [[ ! -x "$runtime_bin" ]]; then
+
+  local gradlew="$RUNTIME_KOTLIN_DIR/gradlew"
+  if [[ ! -x "$gradlew" ]]; then
+    return 1
+  fi
+
+  info "Preparing source runtime CLI for saved selection replay..."
+  (
+    cd "$RUNTIME_KOTLIN_DIR"
+    ./gradlew -q :runtime-cli:installDist
+  )
+}
+
+run_selection_runtime_cli() {
+  local runtime_bin=""
+  if runtime_cli_supports_selection_replay "$RUNTIME_CLI_BUILD_BIN"; then
+    runtime_bin="$RUNTIME_CLI_BUILD_BIN"
+  elif runtime_cli_supports_selection_replay "$RUNTIME_CLI_BIN"; then
+    runtime_bin="$RUNTIME_CLI_BIN"
+  elif build_selection_replay_runtime_cli && runtime_cli_supports_selection_replay "$RUNTIME_CLI_BUILD_BIN"; then
+    runtime_bin="$RUNTIME_CLI_BUILD_BIN"
+  else
     err "Cannot reuse saved install selections: no Skill Bill runtime CLI is available before cleanup."
+    err "The runtime CLI must support 'install replay-last-selection'."
     err "Run ./install.sh without --reuse-last-selection to choose install options again."
     exit 1
   fi
@@ -1634,22 +1666,31 @@ prompt_for_telemetry_preference() {
 
 replay_last_install_selection() {
   local output
+  local error_output
+  local stderr_file
   local kind
   local value
   local extra
 
+  stderr_file="$(mktemp)"
   if ! output="$(
     run_selection_runtime_cli install replay-last-selection \
       --skills "$SKILLS_DIR" \
-      --platform-packs "$PLATFORM_PACKS_DIR" 2>&1
+      --platform-packs "$PLATFORM_PACKS_DIR" 2>"$stderr_file"
   )"; then
     err "Cannot reuse saved install selections."
     if [[ -n "$(trim_string "$output")" ]]; then
       err "$(trim_string "$output")"
     fi
+    error_output="$(trim_string "$(cat "$stderr_file")")"
+    rm -f "$stderr_file"
+    if [[ -n "$error_output" ]]; then
+      err "$error_output"
+    fi
     err "Run ./install.sh without --reuse-last-selection to choose install options again."
     exit 1
   fi
+  rm -f "$stderr_file"
 
   AGENT_SELECTION_MODE="manual"
   AGENT_NAMES=()

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellReuseLastSelectionTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellReuseLastSelectionTest.kt
@@ -24,6 +24,7 @@ class InstallerShellReuseLastSelectionTest {
     assertEquals(0, run.exitCode, run.output)
     assertContains(run.output, "Reusing latest successful install selections")
     assertContains(run.output, "Selections:     reused latest successful install selection")
+    assertFalse(run.output.contains("Install the optional Skill Bill desktop app"), run.output)
     assertEquals(
       expectedApplyArgs(run) + listOf(
         "--agent",
@@ -131,6 +132,11 @@ class InstallerShellReuseLastSelectionTest {
     |  home="${'$'}2"
     |  shift 2
     |fi
+    |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "--help" ]]; then
+    |  printf '%s\n' "Commands:"
+    |  printf '%s\n' "  replay-last-selection"
+    |  exit 0
+    |fi
     |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "agent-path" ]]; then
     |  printf '%s\n' "${'$'}home/agent-targets/${'$'}3"
     |  exit 0
@@ -140,6 +146,7 @@ class InstallerShellReuseLastSelectionTest {
     |    printf '%s\n' "Install selection record is missing at '${'$'}home/.skill-bill/install-selection.json'."
     |    exit 1
     |  fi
+    |  printf '%s\n' "SLF4J(W): No SLF4J providers were found." >&2
     |  printf 'agent\tcodex\t%s\n' "${'$'}home/agent-targets/codex"
     |  printf 'platform-mode\tselected\nplatform\tkotlin\ntelemetry\tfull\nmcp\tregister\n'
     |  exit 0


### PR DESCRIPTION
## Summary
- verify a runtime CLI supports install replay-last-selection before using it, rebuilding the source CLI when the build artifact is stale
- keep replay stdout separate from runtime stderr so SLF4J warnings are not parsed as replay fields
- add installer shell regression coverage for stderr warnings during replay

## Validation
- bash -n install.sh
- (cd runtime-kotlin && ./gradlew :runtime-core:test --tests 'skillbill.architecture.InstallerShellReuseLastSelectionTest' --tests 'skillbill.architecture.InstallerShellDelegationTest')
- skill-bill validate