### PR TITLE
SKILL-68: fix goal-subtask commit-SHA completion

### DIFF
--- a/.feature-specs/SKILL-68-goal-subtask-commit-sha-completion/spec.md
+++ b/.feature-specs/SKILL-68-goal-subtask-commit-sha-completion/spec.md
@@ -1,0 +1,214 @@
+# SKILL-68 - goal-subtask commit-SHA completion handshake
+
+Created: 2026-06-05
+Status: Draft
+Issue key: SKILL-68
+Mode: single_spec
+Parent: fixes a goal-runner / feature-task-runtime completion-handshake defect surfaced while running SKILL-66 (`bill-feature-goal`); builds on SKILL-51/56/58/64/67 goal-runner work.
+
+## Sources
+
+Diagnosed live on 2026-06-05 while running `skill-bill goal SKILL-66`. The goal
+loop re-selected subtask 1 on every run and never advanced, despite the subtask
+work being committed on the feature branch. Durable-store forensics
+(`~/.skill-bill/review-metrics.db`) showed the exact handshake break:
+
+- Four `feature_task_runtime_workflows` child rows all carried
+  `goal_continuation.subtask_id = 1`. Three reached `commit_push` with
+  `workflow_status = completed` and wrote
+  `goal_continuation_outcome = {status: "complete"}` **with no `commit_sha`**,
+  and `commit_push_result = null`. The fourth blocked at `commit_push` on a
+  schema-gate YAML parse error.
+- The parent `feature_implement_workflows` decomposition projection kept
+  subtask 1 at `status: "blocked"`, `commit_sha: null`, `workflow_id: null`,
+  so the runner re-ran subtask 1 indefinitely.
+
+Confirmed code paths:
+
+- `runtime-application/.../FeatureTaskRuntimeRunner.kt`
+  `goalContinuationOutcomeFor` records `status = "complete"` with
+  `commitSha = commitShaFromPhaseRecords(...)`, which returns `null` when the
+  agent's `commit_push` phase payload omits the SHA (or emits prose/markdown).
+  There is no git-HEAD fallback at capture time, and `complete`-without-SHA is
+  recorded anyway.
+- `runtime-application/.../GoalRunnerWorkflowStores.kt`
+  `persistMeasuredCompletion` only backfills a measured HEAD SHA when
+  `goalContinuationOutcome(...) == null`; an already-written
+  `complete`-without-SHA outcome defeats recovery. `terminalOutcomeFor` reads
+  the persisted outcome first and short-circuits the measured-SHA branch.
+- `runtime-application/.../GoalRunner.kt` `storedOutcome` only calls
+  `recoverAndPersistTerminalOutcome` when
+  `manifest.subtasks[subtaskId].workflowId` is non-blank; it stayed `null`, so
+  recovery never fired.
+- `runtime-application/.../DecompositionManifestRuntimeStateSupport.kt`
+  `prSuppressedCommitStatus` / `commitShaFrom` source the SHA **only** from
+  `commit_push_result.commit_sha`, ignoring `goal_continuation_outcome`; a
+  completed-under-suppress_pr subtask with no SHA there is marked `blocked`.
+- `runtime-infra-fs/.../FeatureTaskRuntimePhaseOutputSchemaValidator.kt` parses
+  phase output as YAML; a markdown bullet such as `- **HEAD = ` triggers a YAML
+  alias scan (`unexpected character found *(42)`) and hard-fails the gate.
+
+## Problem
+
+A goal subtask whose `commit_push` completes under `--suppress-pr` can be
+recorded as `complete` with **no commit SHA**. Under the
+`same_branch_commit_per_subtask` execution model, the manifest cannot advance a
+subtask without a SHA, and the existing git-HEAD recovery is structurally
+unreachable once a `complete`-without-SHA outcome has been persisted. The result
+is a goal that re-runs the same already-finished subtask forever and never
+advances — a silent liveness failure that violates the per-subtask commit
+invariant and corrupts goal accounting (the subtask never counts as complete).
+
+The SHA can go missing two ways, both observed: the agent's `commit_push`
+payload omits the structured `commit_sha`, or the payload is malformed prose
+that fails the phase-output schema gate. In every case the commit itself exists
+on the branch (HEAD is the subtask's commit), so the SHA is recoverable from
+git — the runtime simply fails to do so before declaring completion.
+
+## Goals
+
+1. A goal subtask is **never** recorded as `complete` without a non-blank commit
+   SHA under `same_branch_commit_per_subtask`. The SHA is captured from the
+   agent's `commit_push` payload when present, and otherwise recovered from a
+   runtime-measured git HEAD.
+2. When neither the payload nor a measured HEAD yields a SHA, the subtask
+   **blocks loudly** with an explicit, actionable reason — it does not silently
+   complete and does not silently loop.
+3. The git-HEAD recovery already present in the goal store is reachable in the
+   real failure case: an existing `complete`-without-SHA outcome must not defeat
+   backfill, and recovery must not depend on a manifest field that is null at
+   the time it is needed.
+4. Manifest advancement recognizes a recovered SHA: subtask completion sourcing
+   considers `goal_continuation_outcome.commit_sha`, not only
+   `commit_push_result.commit_sha`.
+5. Behavior is otherwise unchanged: subtasks that already carry a SHA complete
+   exactly as today; non-goal-continuation feature-task-runtime runs are
+   unaffected; observability/progress artifacts and CLI output are unchanged for
+   runs that do not hit this path.
+
+## Non-Goals
+
+- Do not redesign the `commit_push` phase-output schema or the agent prompt
+  contract. Hardening the YAML/markdown parse fragility in
+  `FeatureTaskRuntimePhaseOutputSchemaValidator` is explicitly out of scope here
+  (track separately); this fix makes the runtime resilient to a missing SHA
+  regardless of why it is missing.
+- Do not change the `STACKED_BRANCHES` execution model semantics.
+- Do not add or alter telemetry event schemas (that is SKILL-66's scope); this
+  fix only changes when a subtask is considered complete vs blocked.
+- Do not retroactively repair already-corrupted goal state in existing DBs as
+  part of the runtime change (a one-off reconciliation of the SKILL-66 store is
+  tracked separately and is not gated by this spec).
+- Do not relax the per-subtask commit invariant by allowing `complete` without a
+  SHA (the rejected alternative).
+
+## Target User Experience
+
+A maintainer runs a decomposed goal as today:
+
+```bash
+skill-bill goal SKILL-XX
+```
+
+When a subtask's `commit_push` completes but the agent omits the SHA, the
+runtime measures HEAD, records the real commit SHA on the subtask, marks it
+`complete`, and advances to the next runnable subtask — no loop, no manual
+intervention.
+
+When the commit genuinely cannot be resolved (no payload SHA and HEAD
+unmeasurable), the run stops with a clear block:
+
+```text
+goal SKILL-XX: subtask N stopped (blocked): commit_push completed under
+suppress_pr but no commit SHA could be captured from the phase payload or
+measured from git HEAD; the per-subtask commit invariant cannot be satisfied.
+Resume from last_resumable_step=commit_push.
+```
+
+## Acceptance Criteria
+
+1. For a goal-continuation run (`--suppress-pr`) whose `commit_push` step
+   completes, the recorded `goal_continuation_outcome` has
+   `status = "complete"` **iff** a non-blank `commit_sha` is present; the SHA is
+   taken from the phase payload when present, else from a runtime-measured git
+   HEAD.
+2. When `commit_push` completes but no SHA is available from either source, the
+   run records `status = "blocked"` with an explicit `blocked_reason` naming the
+   missing-SHA cause and `last_resumable_step = "commit_push"`; it does not
+   record `complete`.
+3. The goal store no longer strands the recoverable case: a previously persisted
+   `complete`-without-SHA outcome is backfilled with a measured HEAD SHA (the
+   `needsBackfill` condition fires when the stored outcome lacks a SHA), and the
+   recovery path does not silently no-op solely because
+   `manifest.subtasks[subtaskId].workflowId` is null.
+4. Manifest advancement (`DecompositionManifestRuntimeStateSupport`) sources the
+   completing SHA from `commit_push_result.commit_sha` **or**
+   `goal_continuation_outcome.commit_sha`; a subtask with a recovered SHA is
+   marked `complete` and the runner advances to the next runnable subtask.
+5. A subtask that completes with a SHA present behaves exactly as before
+   (no regression in the happy path); non-goal-continuation runs and
+   `STACKED_BRANCHES` runs are unaffected.
+6. Regression tests prove, with a fake launcher and a fake/seeded git HEAD:
+   - completed `commit_push` with payload SHA → `complete` (unchanged);
+   - completed `commit_push`, no payload SHA, measurable HEAD → `complete` with
+     the measured SHA, and the manifest advances;
+   - completed `commit_push`, no payload SHA, no measurable HEAD → `blocked`
+     with the explicit reason, no `complete` recorded;
+   - a pre-existing `complete`-without-SHA store row → backfilled and advanced
+     on the next reconciliation.
+7. Architecture boundaries hold: `RuntimeArchitectureTest` passes; the git-HEAD
+   measurement is reached only through the existing domain-owned
+   `WorkflowGitOperations` port; no new application dependency on
+   MCP/Clikt/JDBC is introduced.
+8. Maintainer validation passes:
+   - `skill-bill validate`
+   - `(cd runtime-kotlin && ./gradlew check)`
+   - `npx --yes agnix --strict .`
+   - `scripts/validate_agent_configs`
+
+## Design Notes
+
+- **Block loudly, never complete without a commit.** Confirmed policy decision:
+  under `same_branch_commit_per_subtask`, a complete subtask must have a commit.
+  If the SHA is unrecoverable, block with a precise reason rather than recording
+  a SHA-less completion that strands the goal.
+- **Capture at the source, recover at the seam.** The primary fix is in
+  `FeatureTaskRuntimeRunner`: prefer the payload SHA, fall back to a measured
+  HEAD via `WorkflowGitOperations`, and only then decide complete-vs-blocked.
+  The goal-store recovery (`persistMeasuredCompletion`) and advancement
+  (`commitShaFrom`) changes are the defense-in-depth that make an
+  already-persisted SHA-less outcome recoverable and consumable.
+- **Reuse the existing port.** Git HEAD is already measured through
+  `WorkflowGitOperations.headCommitSha` on the goal-store recovery path; reuse
+  the same port rather than introducing a new git seam.
+- **Strictly additive to the contract.** No event branch, table, tool, or CLI
+  command changes shape; only the complete-vs-blocked decision and SHA sourcing
+  change.
+- **YAML/markdown parse fragility is deliberately separate.** The schema-gate
+  alias crash (`*(42)`) is a real but distinct issue; this fix makes the SHA
+  path robust regardless, and the parser hardening is tracked on its own.
+
+## Validation Strategy
+
+- Application tests in `runtime-application` with a fake `GoalRunnerSubtaskLauncher`
+  and a fake `WorkflowGitOperations` covering the four AC6 cases, asserting exact
+  recorded `goal_continuation_outcome` status/SHA and manifest subtask
+  status/advancement.
+- Goal-store tests proving `persistMeasuredCompletion` backfills a measured SHA
+  over a `complete`-without-SHA row and that advancement consumes
+  `goal_continuation_outcome.commit_sha`.
+- `RuntimeArchitectureTest` for boundary integrity.
+- The full maintainer command set (AC8) as the closing gate.
+
+## Open Questions
+
+- Should the block in AC2 be retryable in-process (re-measure HEAD after a short
+  delay, mirroring `waitForLateTerminalOutcome`) before blocking, or block
+  immediately? Leaning: reuse the existing late-outcome recheck window for the
+  measured-HEAD path, then block — no new retry policy.
+- Should advancement prefer `commit_push_result.commit_sha` over
+  `goal_continuation_outcome.commit_sha` when both exist and differ, or treat a
+  mismatch as a loud error? Leaning: prefer `commit_push_result` and loud-fail
+  on a genuine mismatch, since two disagreeing SHAs indicate a deeper bug.
+
+Run bill-feature-task on .feature-specs/SKILL-68-goal-subtask-commit-sha-completion/spec.md

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,14 @@
+## [2026-06-05] SKILL-68 goal-subtask-commit-sha-completion
+Areas: runtime-kotlin/runtime-application, runtime-kotlin/runtime-ports
+- New `FeatureTaskRuntimeGoalContinuationOutcomeSupport`: under `suppress_pr`, resolves commit SHA from `commit_push` phase payload first, then measures git HEAD once via `WorkflowGitOperations`; records `status=complete` iff non-blank SHA found, else `status=blocked` with explicit `blocked_reason` and `last_resumable_step=commit_push`. reusable
+- Defense-in-depth in `GoalRunnerWorkflowStores`: `terminalOutcomeFor` falls through on `complete`-without-SHA rows so the measure branch can heal them; `persistMeasuredCompletion` backfills SHA-less complete rows idempotently; `reconcileAuthoritativeOutcomes` gains nullable `repoRoot` and measures+backfills recoverable candidates. reusable
+- `GoalRunner.storedOutcome` no longer silently no-ops when `manifest.subtasks[id].workflowId` is null — falls back to manifest-workflowId-independent reconciliation. reusable
+- `DecompositionManifestRuntimeStateSupport.commitShaFrom` sources SHA from `commit_push_result.commit_sha` (preferred) or `goal_continuation_outcome.commit_sha`; loud-fail on genuine mismatch. reusable
+- `WorkflowGitOperations` port wired into `FeatureTaskRuntimePhaseGates` via DI; all new behavior gated on `suppress_pr` so non-goal-continuation and `STACKED_BRANCHES` runs are unaffected.
+- Four AC6 regression cases proven in `FeatureTaskRuntimeRunnerTest` (payload SHA / measured SHA / blocked no-SHA / pre-existing complete-without-SHA backfill).
+Feature flag: N/A
+Acceptance criteria: 8/8 implemented
+
 ## [2026-06-05] SKILL-67 validation-gate-rename-sweep
 Areas: runtime-cli, runtime-infra-fs/install, feature-task runtime tests
 - Added regression coverage that a goal-continuation `feature-task` child reports task-runtime status and resumes a completed child without relaunching phases.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupport.kt
@@ -122,7 +122,18 @@ private fun prSuppressedCommitStatus(update: DecompositionManifestRuntimeUpdate)
   }
 }
 
-private fun commitShaFrom(artifacts: Map<String, Any?>): String? = (artifacts["commit_push_result"] as? Map<*, *>)
-  ?.get("commit_sha")
-  ?.toString()
-  ?.takeIf(String::isNotBlank)
+private fun commitShaFrom(artifacts: Map<String, Any?>): String? {
+  val fromCommitPush = (artifacts["commit_push_result"] as? Map<*, *>)
+    ?.get("commit_sha")?.toString()?.trim()?.takeIf(String::isNotBlank)
+  val fromOutcome = (artifacts["goal_continuation_outcome"] as? Map<*, *>)
+    ?.get("commit_sha")?.toString()?.trim()?.takeIf(String::isNotBlank)
+  if (fromCommitPush != null && fromOutcome != null && fromCommitPush != fromOutcome) {
+    val subtaskId = (artifacts["goal_continuation_outcome"] as? Map<*, *>)?.get("subtask_id")
+      ?: (artifacts["goal_continuation"] as? Map<*, *>)?.get("subtask_id")
+    error(
+      "Conflicting completing commit SHAs for subtask $subtaskId: " +
+        "commit_push_result.commit_sha=$fromCommitPush vs goal_continuation_outcome.commit_sha=$fromOutcome.",
+    )
+  }
+  return fromCommitPush ?: fromOutcome
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/FeatureTaskRuntimeGoalContinuationOutcomeSupport.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/FeatureTaskRuntimeGoalContinuationOutcomeSupport.kt
@@ -1,0 +1,85 @@
+package skillbill.application
+
+import skillbill.application.model.FeatureTaskRuntimeGoalContinuationContext
+import skillbill.application.model.FeatureTaskRuntimeRunRequest
+import skillbill.application.model.FeatureTaskRuntimeSubtaskOutcome
+import skillbill.contracts.JsonSupport
+import skillbill.ports.workflow.WorkflowGitOperations
+import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
+
+// Capture-at-source for a completed goal-continuation run (SKILL-68). Under suppress_pr the
+// per-subtask commit invariant requires a SHA: take it from the phase payload, else measure git
+// HEAD once. Complete iff a non-blank SHA is present; otherwise block with an explicit reason and
+// last_resumable_step=commit_push rather than recording a SHA-less `complete`. A non-suppress_pr
+// continuation keeps the prior behavior (payload SHA, no measured-HEAD fallback).
+internal fun completedGoalContinuationOutcome(
+  recorder: FeatureTaskRuntimePhaseRecorder,
+  gitOperations: WorkflowGitOperations,
+  request: FeatureTaskRuntimeRunRequest,
+  context: FeatureTaskRuntimeGoalContinuationContext,
+): FeatureTaskRuntimeSubtaskOutcome {
+  val payloadSha = commitShaFromPhaseRecords(recorder, request)
+  if (!context.suppressPr) {
+    return completeSubtaskOutcome(request, context, payloadSha)
+  }
+  val resolvedSha = payloadSha ?: measuredHeadSha(gitOperations, request)
+  return if (resolvedSha != null) {
+    completeSubtaskOutcome(request, context, resolvedSha)
+  } else {
+    FeatureTaskRuntimeSubtaskOutcome(
+      issueKey = context.parentIssueKey,
+      subtaskId = context.subtaskId,
+      status = "blocked",
+      commitSha = null,
+      workflowId = request.workflowId,
+      blockedReason = "commit_push completed under suppress_pr but no commit SHA could be captured " +
+        "from the phase payload or measured from git HEAD; the per-subtask commit invariant cannot " +
+        "be satisfied.",
+      lastResumableStep = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH,
+    )
+  }
+}
+
+internal fun completeSubtaskOutcome(
+  request: FeatureTaskRuntimeRunRequest,
+  context: FeatureTaskRuntimeGoalContinuationContext,
+  commitSha: String?,
+): FeatureTaskRuntimeSubtaskOutcome = FeatureTaskRuntimeSubtaskOutcome(
+  issueKey = context.parentIssueKey,
+  subtaskId = context.subtaskId,
+  status = "complete",
+  commitSha = commitSha,
+  workflowId = request.workflowId,
+  blockedReason = null,
+  lastResumableStep = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH,
+)
+
+// Single git-HEAD read through the domain-owned port; the trimmed value is returned only when the
+// result is ok and non-blank (mirrors GoalRunnerWorkflowStores.measuredCommitSha).
+internal fun measuredHeadSha(gitOperations: WorkflowGitOperations, request: FeatureTaskRuntimeRunRequest): String? {
+  val result = gitOperations.headCommitSha(request.repoRoot)
+  return result.value.trim().takeIf { result.ok && it.isNotBlank() }
+}
+
+internal fun commitShaFromPhaseRecords(
+  recorder: FeatureTaskRuntimePhaseRecorder,
+  request: FeatureTaskRuntimeRunRequest,
+): String? {
+  val commitOutput = recorder.loadPhaseRecords(request.workflowId, request.dbPathOverride)
+    .orEmpty()[FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH]
+    ?.outputArtifact
+  val payload = commitOutput
+    ?.let(JsonSupport::parseObjectOrNull)
+    ?.let(JsonSupport::jsonElementToValue)
+    ?.let(JsonSupport::anyToStringAnyMap)
+  return payload?.commitShaFromPhasePayload()
+}
+
+internal fun Map<String, Any?>.commitShaFromPhasePayload(): String? {
+  val producedOutputs = JsonSupport.anyToStringAnyMap(this["produced_outputs"])
+  return (this["commit_push_result"] as? Map<*, *>)?.get("commit_sha")?.toString()?.takeIf(String::isNotBlank)
+    ?: (producedOutputs?.get("commit_push_result") as? Map<*, *>)?.get("commit_sha")?.toString()
+      ?.takeIf(String::isNotBlank)
+    ?: producedOutputs?.get("commit_sha")?.toString()?.takeIf(String::isNotBlank)
+    ?: (this["commit_sha"]?.toString()?.takeIf(String::isNotBlank))
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/FeatureTaskRuntimePhaseGates.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/FeatureTaskRuntimePhaseGates.kt
@@ -1,15 +1,18 @@
 package skillbill.application
 
 import me.tatarka.inject.annotations.Inject
+import skillbill.ports.workflow.WorkflowGitOperations
 
 /**
  * Bundles the phase-transition collaborators the runtime consults at specific run boundaries: the
- * branch-setup gate before the first file-mutating phase, the plan-phase stop decision, and the
- * runtime-owned lifecycle telemetry seam. Grouping them keeps the runner's dependency surface small.
+ * branch-setup gate before the first file-mutating phase, the plan-phase stop decision, the
+ * runtime-owned lifecycle telemetry seam, and the git-HEAD read used at capture time (SKILL-68).
+ * Grouping them keeps the runner's dependency surface small.
  */
 @Inject
 class FeatureTaskRuntimePhaseGates(
   val branchSetupRunner: FeatureTaskRuntimeBranchSetupRunner,
   val planningStopper: FeatureTaskRuntimePlanningStopper,
   val lifecycleTelemetry: FeatureTaskRuntimeLifecycleTelemetry,
+  val gitOperations: WorkflowGitOperations,
 )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/FeatureTaskRuntimeRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/FeatureTaskRuntimeRunner.kt
@@ -10,7 +10,6 @@ import skillbill.application.model.FeatureTaskRuntimeRunEvent
 import skillbill.application.model.FeatureTaskRuntimeRunReport
 import skillbill.application.model.FeatureTaskRuntimeRunRequest
 import skillbill.application.model.FeatureTaskRuntimeSubtaskOutcome
-import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
 import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
@@ -18,6 +17,7 @@ import skillbill.ports.agentrun.model.SkillRunRequest
 import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
 import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
 import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
+import skillbill.ports.workflow.WorkflowGitOperations
 import skillbill.workflow.FeatureTaskRuntimePhaseOutputValidator
 import skillbill.workflow.taskruntime.FeatureTaskRuntimeHandoffContract
 import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
@@ -89,7 +89,8 @@ class FeatureTaskRuntimeRunner(
       // Emit the error terminal from best-effort per-phase records, then rethrow the original.
       lifecycleTelemetry.finishedError(telemetrySessionId, phaseOutcomes, runRequest.dbPathOverride)
     }.getOrThrow()
-    val terminalReport = persistGoalContinuationOutcome(goalContinuationRecorder, recorder, runRequest, report)
+    val terminalReport =
+      persistGoalContinuationOutcome(goalContinuationRecorder, recorder, phaseGates.gitOperations, runRequest, report)
     lifecycleTelemetry.finished(telemetrySessionId, terminalReport, phaseOutcomes, runRequest.dbPathOverride)
     return terminalReport
   }
@@ -668,11 +669,12 @@ private fun persistGoalContinuationContext(
 private fun persistGoalContinuationOutcome(
   goalContinuationRecorder: FeatureTaskRuntimeGoalContinuationRecorder,
   phaseRecorder: FeatureTaskRuntimePhaseRecorder,
+  gitOperations: WorkflowGitOperations,
   request: FeatureTaskRuntimeRunRequest,
   report: FeatureTaskRuntimeRunReport,
 ): FeatureTaskRuntimeRunReport {
   val context = request.goalContinuation ?: return report
-  val outcome = goalContinuationOutcomeFor(phaseRecorder, request, context, report)
+  val outcome = goalContinuationOutcomeFor(phaseRecorder, gitOperations, request, context, report)
   outcome?.let { terminal ->
     goalContinuationRecorder.recordGoalContinuationState(
       workflowId = request.workflowId,
@@ -698,19 +700,13 @@ private fun persistGoalContinuationOutcome(
 
 private fun goalContinuationOutcomeFor(
   recorder: FeatureTaskRuntimePhaseRecorder,
+  gitOperations: WorkflowGitOperations,
   request: FeatureTaskRuntimeRunRequest,
   context: FeatureTaskRuntimeGoalContinuationContext,
   report: FeatureTaskRuntimeRunReport,
 ): FeatureTaskRuntimeSubtaskOutcome? = when (report) {
-  is FeatureTaskRuntimeRunReport.Completed -> FeatureTaskRuntimeSubtaskOutcome(
-    issueKey = context.parentIssueKey,
-    subtaskId = context.subtaskId,
-    status = "complete",
-    commitSha = commitShaFromPhaseRecords(recorder, request),
-    workflowId = request.workflowId,
-    blockedReason = null,
-    lastResumableStep = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH,
-  )
+  is FeatureTaskRuntimeRunReport.Completed ->
+    completedGoalContinuationOutcome(recorder, gitOperations, request, context)
   is FeatureTaskRuntimeRunReport.Blocked -> FeatureTaskRuntimeSubtaskOutcome(
     issueKey = context.parentIssueKey,
     subtaskId = context.subtaskId,
@@ -721,29 +717,6 @@ private fun goalContinuationOutcomeFor(
     lastResumableStep = report.lastIncompletePhase,
   )
   is FeatureTaskRuntimeRunReport.Decomposed -> null
-}
-
-private fun commitShaFromPhaseRecords(
-  recorder: FeatureTaskRuntimePhaseRecorder,
-  request: FeatureTaskRuntimeRunRequest,
-): String? {
-  val commitOutput = recorder.loadPhaseRecords(request.workflowId, request.dbPathOverride)
-    .orEmpty()[FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH]
-    ?.outputArtifact
-  val payload = commitOutput
-    ?.let(JsonSupport::parseObjectOrNull)
-    ?.let(JsonSupport::jsonElementToValue)
-    ?.let(JsonSupport::anyToStringAnyMap)
-  return payload?.commitShaFromPhasePayload()
-}
-
-private fun Map<String, Any?>.commitShaFromPhasePayload(): String? {
-  val producedOutputs = JsonSupport.anyToStringAnyMap(this["produced_outputs"])
-  return (this["commit_push_result"] as? Map<*, *>)?.get("commit_sha")?.toString()?.takeIf(String::isNotBlank)
-    ?: (producedOutputs?.get("commit_push_result") as? Map<*, *>)?.get("commit_sha")?.toString()
-      ?.takeIf(String::isNotBlank)
-    ?: producedOutputs?.get("commit_sha")?.toString()?.takeIf(String::isNotBlank)
-    ?: (this["commit_sha"]?.toString()?.takeIf(String::isNotBlank))
 }
 
 private fun infraFailureReason(phaseId: String, facts: AgentRunLaunchFacts): String? = when {

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunner.kt
@@ -443,6 +443,9 @@ class GoalRunner(
     outcomeStore.reconcileAuthoritativeOutcomes(
       issueKey = state.manifest.issueKey,
       activeWorkflowIds = emptySet(),
+      // SKILL-68: the command-path finalize supplies the repo root so a complete-without-SHA child
+      // is healed from measured HEAD and durably backfilled before the goal completes.
+      repoRoot = request.repoRoot,
       dbPathOverride = request.dbPathOverride,
     )
     // AC10/AC11: final reconciled outcome ledger entry at goal finalization,
@@ -852,19 +855,34 @@ internal class GoalRunnerLaunchReconciler(
     reconciled.reason == GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME &&
     shouldRetryNoTerminalOutcome(launchFacts)
 
-  private fun storedOutcome(state: GoalRunnerManifestState, subtaskId: Int, request: GoalRunnerRunRequest) =
-    state.manifest.subtasks.firstOrNull { it.id == subtaskId }?.workflowId
+  private fun storedOutcome(
+    state: GoalRunnerManifestState,
+    subtaskId: Int,
+    request: GoalRunnerRunRequest,
+  ): GoalRunnerStoredOutcome? {
+    val manifestWorkflowId = state.manifest.subtasks.firstOrNull { it.id == subtaskId }?.workflowId
       ?.takeIf(String::isNotBlank)
-      ?.let { workflowId ->
-        // Lets the store recover a dropped commit SHA from measured HEAD instead of blocking the subtask.
-        outcomeStore.recoverAndPersistTerminalOutcome(
-          workflowId = workflowId,
-          issueKey = state.manifest.issueKey,
-          subtaskId = subtaskId,
-          repoRoot = request.repoRoot,
-          dbPathOverride = request.dbPathOverride,
-        )
-      }
+    if (manifestWorkflowId != null) {
+      // Lets the store recover a dropped commit SHA from measured HEAD instead of blocking the subtask.
+      return outcomeStore.recoverAndPersistTerminalOutcome(
+        workflowId = manifestWorkflowId,
+        issueKey = state.manifest.issueKey,
+        subtaskId = subtaskId,
+        repoRoot = request.repoRoot,
+        dbPathOverride = request.dbPathOverride,
+      )
+    }
+    // SKILL-68 (AC3): the manifest may not yet carry the child workflowId (e.g. a crash before the
+    // advance persisted). Rather than silently no-op solely because the manifest field is null, fall
+    // back to the manifest-workflowId-independent reconciliation, which scans continuation children by
+    // issueKey+subtaskId and, given a repo root, measures HEAD + backfills a recoverable
+    // complete-without-SHA child before returning its authoritative outcome.
+    return outcomeStore.reconcileAuthoritativeOutcomes(
+      issueKey = state.manifest.issueKey,
+      repoRoot = request.repoRoot,
+      dbPathOverride = request.dbPathOverride,
+    )[subtaskId]
+  }
 
   private fun waitForLateTerminalOutcome(
     state: GoalRunnerManifestState,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunnerWorkflowStores.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/GoalRunnerWorkflowStores.kt
@@ -254,15 +254,40 @@ class WorkflowGoalRunnerOutcomeStore(
     issueKey: String,
     activeWorkflowIds: Set<String>,
     allowInactiveReconciliation: Boolean,
+    repoRoot: Path?,
     dbPathOverride: String?,
   ): Map<Int, GoalRunnerStoredOutcome> = database.transaction(dbPathOverride) { unitOfWork ->
     val normalizedIssueKey = issueKey.trim()
     val activeSet = activeWorkflowIds.map(String::trim).filter(String::isNotBlank).toSet()
-    val initialCandidates = loadContinuationCandidates(unitOfWork.workflowStates, normalizedIssueKey)
+    val initialCandidates = loadContinuationCandidates(unitOfWork.workflowStates, normalizedIssueKey, repoRoot)
+    // SKILL-68 (AC3/AC4 case 4): with a repo root, this is the manifest-workflowId-independent heal.
+    // A candidate that resolved COMPLETE via a measured HEAD SHA (its artifacts carried no SHA) is
+    // durably backfilled into its goal_continuation_outcome BEFORE the stale-running markBlocked pass,
+    // so the now-authoritative complete-with-SHA outcome masks the blocked workflow status on the
+    // re-read. persistMeasuredCompletion is idempotent: a candidate already carrying a SHA is a no-op.
+    if (repoRoot != null) {
+      initialCandidates
+        .filter { candidate -> candidate.outcome?.status == GoalRunnerTerminalStatus.COMPLETE }
+        .forEach { candidate ->
+          persistMeasuredCompletion(
+            unitOfWork.workflowStates,
+            candidate.snapshot.workflowId,
+            candidate.goalContinuation.issueKey,
+            candidate.goalContinuation.subtaskId,
+            requireNotNull(candidate.outcome),
+          )
+        }
+    }
     val initialAuthoritative = initialCandidates.authoritativeOutcomesBySubtask()
     initialCandidates
       .filter { candidate ->
         if (candidate.snapshot.workflowStatus != "running") {
+          return@filter false
+        }
+        // SKILL-68: a candidate whose own resolved outcome is COMPLETE is done, not stale — never
+        // stale-block it. Blocking it would also re-save its pre-backfill snapshot and revert a
+        // just-measured commit SHA.
+        if (candidate.outcome?.status == GoalRunnerTerminalStatus.COMPLETE) {
           return@filter false
         }
         val authoritative = initialAuthoritative[candidate.goalContinuation.subtaskId]
@@ -290,7 +315,7 @@ class WorkflowGoalRunnerOutcomeStore(
           ),
         )
       }
-    loadContinuationCandidates(unitOfWork.workflowStates, normalizedIssueKey)
+    loadContinuationCandidates(unitOfWork.workflowStates, normalizedIssueKey, repoRoot)
       .authoritativeOutcomesBySubtask()
   }
 
@@ -393,7 +418,11 @@ class WorkflowGoalRunnerOutcomeStore(
       ?.takeIf { outcome.status == GoalRunnerTerminalStatus.COMPLETE && !outcome.commitSha.isNullOrBlank() }
     recordContext?.let { (family, record) ->
       val artifacts = decodeArtifacts(record.artifactsJson)
-      val needsBackfill = goalContinuationOutcome(artifacts, issueKey, subtaskId, outcome.suppressPr) == null &&
+      // SKILL-68: also backfill a previously persisted complete-without-SHA outcome (not only a
+      // missing one), so a row stranded by the legacy SHA-less `complete` is healed once HEAD is
+      // measurable. The L393 guard keeps this one-shot: a row already carrying a SHA never re-fires.
+      val existingOutcome = goalContinuationOutcome(artifacts, issueKey, subtaskId, outcome.suppressPr)
+      val needsBackfill = (existingOutcome == null || existingOutcome.commitSha.isNullOrBlank()) &&
         commitShaFrom(artifacts).isNullOrBlank()
       if (needsBackfill) {
         val updated = engine.updateRecord(
@@ -659,6 +688,10 @@ class WorkflowGoalRunnerOutcomeStore(
   private fun loadContinuationCandidates(
     workflowStates: WorkflowStateRepository,
     issueKey: String,
+    // SKILL-68: when present, a complete-without-SHA candidate may recover its SHA from measured
+    // HEAD (the manifest-workflowId-independent heal). null keeps the read-only, no-measure path
+    // for pure status callers.
+    repoRoot: Path? = null,
   ): List<GoalContinuationCandidate> = listOf(WorkflowFamily.IMPLEMENT, WorkflowFamily.TASK_RUNTIME).flatMap { family ->
     family.list(workflowStates, Int.MAX_VALUE).mapNotNull { snapshot ->
       engine.snapshotView(family.definition, snapshot)
@@ -671,7 +704,9 @@ class WorkflowGoalRunnerOutcomeStore(
         family = family,
         snapshot = snapshot,
         goalContinuation = goalContinuation,
-        outcome = terminalOutcomeFor(snapshot, artifacts, goalContinuation),
+        outcome = terminalOutcomeFor(snapshot, artifacts, goalContinuation) {
+          repoRoot?.let { root -> gitOperations.headCommitSha(root).measuredCommitSha() }
+        },
       )
     }
   }
@@ -786,7 +821,12 @@ private fun terminalOutcomeFor(
   issueKey = goalContinuation.issueKey,
   subtaskId = goalContinuation.subtaskId,
   suppressPr = goalContinuation.suppressPr,
-)?.copy(workflowId = snapshot.workflowId) ?: run {
+)
+  // SKILL-68: a stored complete-without-SHA outcome is NOT authoritative for the SHA decision; it
+  // falls through to the measure branch so the recovery path can heal it. Stored non-complete
+  // statuses and complete-WITH-SHA outcomes remain authoritative and short-circuit as before.
+  ?.takeUnless { it.status == GoalRunnerTerminalStatus.COMPLETE && it.commitSha.isNullOrBlank() }
+  ?.copy(workflowId = snapshot.workflowId) ?: run {
   val steps = decodeWorkflowSteps(snapshot.stepsJson)
   val commitSha = commitShaFrom(artifacts)
     ?: if (commitPushCompletedUnderSuppressPr(steps, goalContinuation.suppressPr)) measuredCommitSha() else null

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupportTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/DecompositionManifestRuntimeStateSupportTest.kt
@@ -1,0 +1,67 @@
+package skillbill.application
+
+import skillbill.application.model.DecompositionManifestRuntimeUpdate
+import skillbill.workflow.model.CurrentSubtaskIntent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+// SKILL-68 AC4/AC5: the completing commit SHA that advances a suppress_pr subtask is sourced from
+// commit_push_result.commit_sha (preferred) or the recovered goal_continuation_outcome.commit_sha.
+class DecompositionManifestRuntimeStateSupportTest {
+  @Test
+  fun `subtask advances to complete when the commit sha lives only in the recovered goal continuation outcome`() {
+    val update = commitPushUpdate(
+      goalContinuationOutcome = mapOf(
+        "issue_key" to "SKILL-68",
+        "subtask_id" to 5,
+        "status" to "complete",
+        "commit_sha" to "recovered-sha",
+        "last_resumable_step" to "commit_push",
+      ),
+    )
+
+    assertEquals("complete", statusFromUpdate(update))
+    assertEquals(CurrentSubtaskIntent(subtaskId = 0, action = "none"), intentFor(5, statusFromUpdate(update)))
+  }
+
+  @Test
+  fun `subtask advances to complete on the unchanged commit push result happy path`() {
+    val update = commitPushUpdate(commitPushResult = mapOf("commit_sha" to "commit-sha"))
+
+    assertEquals("complete", statusFromUpdate(update))
+    assertEquals(CurrentSubtaskIntent(subtaskId = 0, action = "none"), intentFor(5, statusFromUpdate(update)))
+  }
+
+  @Test
+  fun `conflicting commit push result and goal continuation outcome shas fail loudly`() {
+    val update = commitPushUpdate(
+      commitPushResult = mapOf("commit_sha" to "sha-a"),
+      goalContinuationOutcome = mapOf(
+        "issue_key" to "SKILL-68",
+        "subtask_id" to 5,
+        "status" to "complete",
+        "commit_sha" to "sha-b",
+      ),
+    )
+
+    val error = assertFailsWith<IllegalStateException> { statusFromUpdate(update) }
+    assertEquals(true, error.message?.contains("sha-a"))
+    assertEquals(true, error.message?.contains("sha-b"))
+  }
+
+  private fun commitPushUpdate(
+    commitPushResult: Map<String, Any?>? = null,
+    goalContinuationOutcome: Map<String, Any?>? = null,
+  ): DecompositionManifestRuntimeUpdate = DecompositionManifestRuntimeUpdate(
+    workflowId = "wfl-subtask-5",
+    workflowStatus = "running",
+    currentStepId = "commit_push",
+    stepUpdates = listOf(mapOf("step_id" to "commit_push", "status" to "completed", "attempt_count" to 1)),
+    artifactsPatch = buildMap {
+      put("goal_continuation", mapOf("issue_key" to "SKILL-68", "subtask_id" to 5, "suppress_pr" to true))
+      commitPushResult?.let { put("commit_push_result", it) }
+      goalContinuationOutcome?.let { put("goal_continuation_outcome", it) }
+    },
+  )
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -891,6 +891,81 @@ class FeatureTaskRuntimeRunnerPersistenceTest {
   }
 
   @Test
+  fun `goal-continuation with payload commit sha completes without measuring git head`() {
+    // SKILL-68 AC6 case i (unchanged happy path): a commit_push payload SHA is authoritative and the
+    // runtime never falls back to measuring git HEAD.
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-goal-payload-sha")
+    val git = RecordingWorkflowGitOperations(currentBranchValue = "feat/existing-runtime-branch")
+      .also { it.headCommitShaValue = "measured-head-should-not-be-used" }
+    val harness = goalContinuationHarness(repoRoot, git, goalContinuationLauncher(validJsonOutput("commit_push")))
+
+    val report = harness.runner.run(harness.request())
+
+    val completed = assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
+    assertEquals("complete", completed.subtaskOutcome?.status)
+    assertEquals("commit-runtime-1", completed.subtaskOutcome?.commitSha)
+    assertEquals(0, git.headCommitShaCalls, "payload SHA present must not trigger a git HEAD measurement")
+    val outcome = harness.repository.taskRuntimeArtifacts(WORKFLOW_ID)["goal_continuation_outcome"] as Map<*, *>
+    assertEquals("complete", outcome["status"])
+    assertEquals("commit-runtime-1", outcome["commit_sha"])
+  }
+
+  @Test
+  fun `goal-continuation without payload sha completes with measured git head`() {
+    // SKILL-68 AC6 case ii: no payload SHA but a measurable HEAD -> complete with the measured SHA.
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-goal-measured-sha")
+    val git = RecordingWorkflowGitOperations(currentBranchValue = "feat/existing-runtime-branch")
+      .also { it.headCommitShaValue = "measured-head-sha" }
+    val harness = goalContinuationHarness(repoRoot, git, goalContinuationLauncher(COMMIT_PUSH_NO_SHA_OUTPUT))
+
+    val report = harness.runner.run(harness.request())
+
+    val completed = assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
+    assertEquals("complete", completed.subtaskOutcome?.status)
+    assertEquals("measured-head-sha", completed.subtaskOutcome?.commitSha)
+    assertTrue(git.headCommitShaCalls >= 1, "a missing payload SHA must trigger a git HEAD measurement")
+    val outcome = harness.repository.taskRuntimeArtifacts(WORKFLOW_ID)["goal_continuation_outcome"] as Map<*, *>
+    assertEquals("complete", outcome["status"])
+    assertEquals("measured-head-sha", outcome["commit_sha"])
+  }
+
+  @Test
+  fun `goal-continuation without payload sha and unmeasurable head blocks instead of completing`() {
+    // SKILL-68 AC6 case iii: no payload SHA and a blank HEAD -> blocked with an explicit reason and
+    // last_resumable_step=commit_push; the runtime must NOT record a SHA-less complete.
+    val repoRoot = Files.createTempDirectory("skillbill-runtime-goal-no-sha")
+    val git = RecordingWorkflowGitOperations(currentBranchValue = "feat/existing-runtime-branch")
+    val harness = goalContinuationHarness(repoRoot, git, goalContinuationLauncher(COMMIT_PUSH_NO_SHA_OUTPUT))
+
+    val report = harness.runner.run(harness.request())
+
+    val completed = assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
+    assertEquals("blocked", completed.subtaskOutcome?.status)
+    assertNull(completed.subtaskOutcome?.commitSha)
+    assertEquals("commit_push", completed.subtaskOutcome?.lastResumableStep)
+    assertContains(requireNotNull(completed.subtaskOutcome?.blockedReason), "no commit SHA")
+    val outcome = harness.repository.taskRuntimeArtifacts(WORKFLOW_ID)["goal_continuation_outcome"] as Map<*, *>
+    assertEquals("blocked", outcome["status"])
+    assertNull(outcome["commit_sha"], "a blocked SHA-less outcome must not record a commit_sha")
+  }
+
+  @Test
+  fun `non-goal-continuation run never measures git head for the outcome`() {
+    // SKILL-68 AC5 control: a normal (non-goal-continuation) run records no goal-continuation outcome
+    // and never measures git HEAD for it.
+    val git = RecordingWorkflowGitOperations(currentBranchValue = "main")
+      .also { it.headCommitShaValue = "should-not-read" }
+    val harness = runnerHarness(
+      agentAssignment = phasePerAgentAssignment(),
+      runtimeConfig = RuntimeHarnessConfig(branchSetup = BranchSetupTestConfig(gitOperations = git)),
+    )
+
+    harness.runner.run(harness.request())
+
+    assertEquals(0, git.headCommitShaCalls, "a non-goal-continuation run must not measure git HEAD for an outcome")
+  }
+
+  @Test
   fun `resume of a durably complete decompose plan reports decomposed without advancing to implement`() {
     // PC-F001 (resume fall-through): PLAN is durably completed as a non-goal-continuation decompose
     // outcome, but the process crashed before the decompose terminal was observed. A re-run must
@@ -1656,23 +1731,21 @@ private fun runnerHarness(
     FeatureTaskRuntimeDecomposeTerminalRecorder(database, NoopWorkflowSnapshotValidator)
   val runInvariantsStore = FeatureTaskRuntimeRunInvariantsStore(database, NoopWorkflowSnapshotValidator)
   val branchSetupRunner = FeatureTaskRuntimeBranchSetupRunner(recorder, runtimeConfig.branchSetup.gitOperations)
-  val decompositionPlanner = if (runtimeConfig.useRealDecompositionPlanner) {
-    testDecompositionPlanner()
-  } else {
-    noOpDecompositionPlanner()
-  }
-  val planningStopper = FeatureTaskRuntimePlanningStopper(
-    validator,
-    decompositionPlanner,
-    decomposeTerminalRecorder,
-  )
+  val decompositionPlanner =
+    if (runtimeConfig.useRealDecompositionPlanner) testDecompositionPlanner() else noOpDecompositionPlanner()
+  val planningStopper = FeatureTaskRuntimePlanningStopper(validator, decompositionPlanner, decomposeTerminalRecorder)
   val runner = FeatureTaskRuntimeRunner(
     launcher,
     recorder,
     goalContinuationRecorder,
     runInvariantsStore,
     validator,
-    FeatureTaskRuntimePhaseGates(branchSetupRunner, planningStopper, disabledRuntimeLifecycleTelemetry(database)),
+    FeatureTaskRuntimePhaseGates(
+      branchSetupRunner,
+      planningStopper,
+      disabledRuntimeLifecycleTelemetry(database),
+      runtimeConfig.branchSetup.gitOperations,
+    ),
   )
   // Always capture events; a caller-supplied sink is chained after the capture.
   val captured = mutableListOf<FeatureTaskRuntimeRunEvent>()
@@ -1751,6 +1824,7 @@ private fun telemetryRunnerHarness(
       FeatureTaskRuntimeLifecycleTelemetry(
         LifecycleTelemetryService(database, EnabledRuntimeTelemetrySettingsProvider),
       ),
+      runtimeConfig.branchSetup.gitOperations,
     ),
   )
   val request = FeatureTaskRuntimeRunRequest(
@@ -1824,6 +1898,49 @@ private fun validProducedOutputs(phaseId: String): String = if (phaseId == "comm
 } else {
   """{"tasks": ["task-1"]}"""
 }
+
+// A commit_push phase output that completes without emitting a commit_sha, modelling the
+// goal-continuation SHA-drop the SKILL-68 capture-at-source path must recover from.
+private val COMMIT_PUSH_NO_SHA_OUTPUT: String = """
+  {
+    "contract_version": "0.1",
+    "phase_id": "commit_push",
+    "status": "completed",
+    "summary": "Phase produced a validated output.",
+    "produced_outputs": {"commit_push_result": {"status": "committed"}}
+  }
+""".trimIndent()
+
+// Launcher for a suppress_pr goal-continuation run: every phase returns a valid output, with the
+// commit_push phase returning the supplied payload so a test can vary whether a SHA is present.
+private fun goalContinuationLauncher(commitPushOutput: String): RuntimeRecordingLauncher =
+  RuntimeRecordingLauncher { request ->
+    val phaseId = phaseIdFromPrompt(requireNotNull(request.skillRunRequest.promptOverride))
+    facts(if (phaseId == "commit_push") commitPushOutput else validJsonOutput(phaseId))
+  }
+
+// Builds a suppress_pr goal-continuation harness with a caller-supplied git fake and launcher so a
+// test can seed the measurable/blank HEAD and the commit_push payload independently.
+private fun goalContinuationHarness(
+  repoRoot: Path,
+  git: RecordingWorkflowGitOperations,
+  launcher: RuntimeRecordingLauncher,
+): RunnerHarness = runnerHarness(
+  launcher = launcher,
+  agentAssignment = phasePerAgentAssignment(),
+  runtimeConfig = RuntimeHarnessConfig(
+    branchSetup = BranchSetupTestConfig(gitOperations = git),
+    repoRoot = repoRoot,
+    goalContinuation = FeatureTaskRuntimeGoalContinuationContext(
+      parentIssueKey = ISSUE_KEY,
+      subtaskId = 5,
+      goalBranch = "feat/existing-runtime-branch",
+      suppressPr = true,
+      parentWorkflowId = "wfl-parent",
+    ),
+    useRealDecompositionPlanner = true,
+  ),
+)
 
 private val DECOMPOSE_PLAN_OUTPUT: String = """
   {
@@ -2019,6 +2136,10 @@ private class RecordingWorkflowGitOperations(
   var existingBranches: Set<String>? = null,
   var branchExistsResult: WorkflowGitOperationResult? = null,
 ) : WorkflowGitOperations {
+  // Seeded git HEAD for the SKILL-68 capture-at-source fallback: blank models an unmeasurable HEAD;
+  // a concrete value models a measurable commit. headCommitShaResult overrides with a raw result.
+  var headCommitShaValue: String = ""
+  var headCommitShaResult: WorkflowGitOperationResult? = null
   data class CheckoutCall(val branch: String, val baseBranch: String?)
 
   val checkoutCalls = mutableListOf<CheckoutCall>()
@@ -2049,8 +2170,12 @@ private class RecordingWorkflowGitOperations(
   override fun createCommit(repoRoot: Path, message: String): WorkflowGitOperationResult =
     WorkflowGitOperationResult(status = "ok", value = "recorded")
 
-  override fun headCommitSha(repoRoot: Path): WorkflowGitOperationResult =
-    WorkflowGitOperationResult(status = "ok", value = "")
+  var headCommitShaCalls: Int = 0
+
+  override fun headCommitSha(repoRoot: Path): WorkflowGitOperationResult {
+    headCommitShaCalls++
+    return headCommitShaResult ?: WorkflowGitOperationResult(status = "ok", value = headCommitShaValue)
+  }
 
   override fun validateBranchBase(
     repoRoot: Path,

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
@@ -510,7 +510,7 @@ class GoalRunnerStatusProjectionTest {
     assertEquals("complete", store.manifest.status)
     assertEquals("none", store.manifest.currentSubtaskIntent.action)
     assertEquals("complete", store.manifest.subtasks.single().status)
-    assertEquals(ReconcileRequest("SKILL-56", setOf("wfl-1"), false, null), outcomes.lastReconcileRequest)
+    assertEquals(ReconcileRequest("SKILL-56", setOf("wfl-1"), false, null, null), outcomes.lastReconcileRequest)
   }
 
   @Test
@@ -953,7 +953,7 @@ class GoalRunnerObservabilityTest {
     )
 
     requireNotNull(reset)
-    assertEquals(ReconcileRequest("SKILL-56", emptySet(), true, null), outcomes.lastReconcileRequest)
+    assertEquals(ReconcileRequest("SKILL-56", emptySet(), true, null, null), outcomes.lastReconcileRequest)
     assertEquals("pending", store.manifest.subtasks.single().status)
     assertEquals(null, store.manifest.subtasks.single().workflowId)
     assertEquals(CurrentSubtaskIntent(subtaskId = 1, action = "start"), store.manifest.currentSubtaskIntent)
@@ -1350,9 +1350,11 @@ internal class RecordingOutcomeStore : GoalRunnerWorkflowOutcomeStore {
     issueKey: String,
     activeWorkflowIds: Set<String>,
     allowInactiveReconciliation: Boolean,
+    repoRoot: Path?,
     dbPathOverride: String?,
   ): Map<Int, GoalRunnerStoredOutcome> {
-    lastReconcileRequest = ReconcileRequest(issueKey, activeWorkflowIds, allowInactiveReconciliation, dbPathOverride)
+    lastReconcileRequest =
+      ReconcileRequest(issueKey, activeWorkflowIds, allowInactiveReconciliation, repoRoot, dbPathOverride)
     return authoritativeOutcomesBySubtask.toMap()
   }
 
@@ -1492,6 +1494,7 @@ internal data class ReconcileRequest(
   val issueKey: String,
   val activeWorkflowIds: Set<String>,
   val allowInactiveReconciliation: Boolean,
+  val repoRoot: Path?,
   val dbPathOverride: String?,
 )
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
@@ -846,6 +846,47 @@ class GoalRunnerCommitShaRecoveryTest {
     assertEquals("prefixless terminal json", outcome.blockedReason)
   }
 
+  @Test
+  fun `reconciliation backfills a pre-existing complete-without-sha outcome from measured git head`() {
+    // SKILL-68 AC6 case iv: a previously persisted complete-without-SHA store row is healed on the
+    // next reconciliation (manifest-workflowId-independent) — the measured HEAD SHA is durably
+    // backfilled and the subtask resolves COMPLETE.
+    val workflows = InMemoryWorkflowStates()
+    workflows.saveFeatureImplementWorkflow(completeWithoutShaOutcome("wfl-child"))
+    val store = WorkflowGoalRunnerOutcomeStore(
+      database = FakeDatabaseSessionFactory(workflows),
+      workflowSnapshotValidator = testWorkflowSnapshotValidator,
+      gitOperations = HeadShaGitOperations,
+    )
+
+    val reconciled = store.reconcileAuthoritativeOutcomes(issueKey = "SKILL-52.1", repoRoot = Path.of("."))
+
+    val outcome = requireNotNull(reconciled[1])
+    assertEquals(GoalRunnerTerminalStatus.COMPLETE, outcome.status)
+    assertEquals("measured-head-sha", outcome.commitSha)
+    val durable = requireNotNull(store.terminalOutcome("wfl-child", "SKILL-52.1", 1))
+    assertEquals(GoalRunnerTerminalStatus.COMPLETE, durable.status)
+    assertEquals("measured-head-sha", durable.commitSha)
+  }
+
+  @Test
+  fun `reconciliation without a repo root leaves a complete-without-sha outcome unmeasured`() {
+    // SKILL-68 AC5 control: a pure read caller (repoRoot=null) never measures git HEAD, so a
+    // complete-without-SHA outcome is not silently healed by a status read.
+    val workflows = InMemoryWorkflowStates()
+    workflows.saveFeatureImplementWorkflow(completeWithoutShaOutcome("wfl-child"))
+    val store = WorkflowGoalRunnerOutcomeStore(
+      database = FakeDatabaseSessionFactory(workflows),
+      workflowSnapshotValidator = testWorkflowSnapshotValidator,
+      gitOperations = HeadShaGitOperations,
+    )
+
+    store.reconcileAuthoritativeOutcomes(issueKey = "SKILL-52.1")
+    val durable = requireNotNull(store.terminalOutcome("wfl-child", "SKILL-52.1", 1))
+
+    assertNull(durable.commitSha, "a read-only reconciliation must not backfill a measured SHA")
+  }
+
   private fun commitPushCompletedWithoutCommitSha(workflowId: String): WorkflowStateRecord {
     val opened = testWorkflowEngine.openRecord(
       FeatureImplementWorkflowDefinition.definition,
@@ -868,6 +909,42 @@ class GoalRunnerCommitShaRecoveryTest {
           ),
         ),
         sessionId = "fis-no-sha",
+      ),
+    )
+    return completed.toRecord()
+  }
+
+  // A child stranded in the legacy bug state: commit_push completed under suppress_pr and a durable
+  // goal_continuation_outcome already records `complete`, but the SHA was dropped.
+  private fun completeWithoutShaOutcome(workflowId: String): WorkflowStateRecord {
+    val opened = testWorkflowEngine.openRecord(
+      FeatureImplementWorkflowDefinition.definition,
+      workflowId,
+      "fis-stale-complete",
+      "preplan",
+    )
+    val completed = testWorkflowEngine.updateRecord(
+      FeatureImplementWorkflowDefinition.definition,
+      opened,
+      skillbill.workflow.model.WorkflowUpdateInput(
+        workflowStatus = "running",
+        currentStepId = "commit_push",
+        stepUpdates = listOf(mapOf("step_id" to "commit_push", "status" to "completed", "attempt_count" to 1)),
+        artifactsPatch = mapOf(
+          "goal_continuation" to mapOf(
+            "issue_key" to "SKILL-52.1",
+            "subtask_id" to 1,
+            "suppress_pr" to true,
+          ),
+          "goal_continuation_outcome" to mapOf(
+            "issue_key" to "SKILL-52.1",
+            "subtask_id" to 1,
+            "status" to "complete",
+            "workflow_id" to workflowId,
+            "last_resumable_step" to "commit_push",
+          ),
+        ),
+        sessionId = "fis-stale-complete",
       ),
     )
     return completed.toRecord()

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -959,6 +959,7 @@ private class GoalFixtureAgentRunLauncher(
         WorkflowUpdateFixture(
           dbPath = dbPath,
           workflowId = workflowId,
+          workflowStatus = "completed",
           currentStep = "commit_push",
           stepUpdates = """[{"step_id":"commit_push","status":"completed","attempt_count":1}]""",
           artifactsPatch = jsonString(mapOf("commit_push_result" to mapOf("commit_sha" to "sha-$subtaskId"))),

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/GoalRunnerPorts.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/GoalRunnerPorts.kt
@@ -65,10 +65,14 @@ interface GoalRunnerTerminalOutcomeStore {
 }
 
 interface GoalRunnerWorkflowOutcomeStore : GoalRunnerTerminalOutcomeStore {
+  // [repoRoot] is the manifest-workflowId-independent self-heal seam (SKILL-68): when supplied, a
+  // complete-without-SHA continuation child recovers its commit SHA from measured HEAD and is
+  // durably backfilled. null keeps the read-only, no-measure behavior for pure status/read callers.
   fun reconcileAuthoritativeOutcomes(
     issueKey: String,
     activeWorkflowIds: Set<String> = emptySet(),
     allowInactiveReconciliation: Boolean = true,
+    repoRoot: Path? = null,
     dbPathOverride: String? = null,
   ): Map<Int, GoalRunnerStoredOutcome>
 

--- a/skills/bill-feature-goal/content.md
+++ b/skills/bill-feature-goal/content.md
@@ -103,6 +103,10 @@ Keep live output enabled unless the user asks for quieter output.
 
 ## Watching Long Runs (orchestrator pattern)
 
+The user must see the goal progress, not wait in silence for a terminal result.
+Surfacing meaningful transitions inline as they arrive is a contract obligation
+of the invoking agent, not optional polish.
+
 Long goal runs may exceed a foreground command timeout. When that risk exists,
 run the driver detached and consume progress through read-only commands rather
 than holding the foreground call open:
@@ -147,7 +151,7 @@ and stderr remain explicit opt-in via `--debug-child-output`; default output
 keeps raw child streams hidden and surfaces only compact progress, observability,
 and transition lines.
 
-During the run, treat workflow state as authoritative. Child stdout and stderr are diagnostic. If the driver stops and reports a blocked or failed subtask, do not continue the loop manually; summarize the stopped subtask, reason, workflow id when present, and resumable step.
+During the run, treat workflow state as authoritative. Child stdout and stderr are diagnostic. If the driver stops and reports a blocked or failed subtask, surface it loudly and immediately, do not continue the loop manually, and summarize the stopped subtask, reason, workflow id when present, and resumable step. On a clean finish, report the terminal per-subtask summary — complete, pending, and blocked counts and the final outcome — from the authoritative workflow state.
 
 `skill-bill goal <issue_key>` remains consumer-only. It does not synthesize
 decomposition from prose and should loud-fail when the decomposition manifest is

--- a/skills/bill-feature-task/content.md
+++ b/skills/bill-feature-task/content.md
@@ -65,6 +65,27 @@ Do not ask the user to run this command manually. Keep the run in the foreground
 unless the user asks otherwise; pass `--monitor` to tee phase transitions to the
 terminal.
 
+### Live Observation
+
+The run is long-lived and the user must see it progress, not wait in silence for
+a terminal result. The invoking agent owns surfacing phase transitions in the
+conversation as they happen:
+
+- Always launch the driver with `--monitor` so the runtime tees its structured
+  per-phase progress.
+- When the run is executed in the background (for example because it can outlast
+  a single foreground shell window), attach a persistent, line-buffered observer
+  to the runtime's progress stream — tailing the run's output — filtered to phase
+  starts and completions, schema-gate results, retries, blocked phases, failures,
+  and run completion. Relay each event inline in plain language as it arrives.
+- Surface a blocked or failed gate loudly and immediately; never narrate a
+  blocked run as if it were progressing normally. On completion, report the
+  terminal per-phase summary.
+
+This is observation only: the agent reports what the runtime emits and never
+re-derives or re-orders the phase loop. The durable workflow state remains
+authoritative over any relayed line.
+
 The runtime owns everything after launch: it opens the durable runtime workflow,
 runs each phase through its own agent, validates each phase output against the
 schema gate, persists per-phase state, and blocks loudly on a failed gate or a


### PR DESCRIPTION
# Summary

Fixes a silent liveness failure in the goal-runner where a subtask whose `commit_push` completed under `--suppress-pr` could be recorded as `complete` with no commit SHA. Because the manifest requires a SHA to advance, the goal would re-run the same already-finished subtask forever.

Key changes:
- **Capture at source** (`FeatureTaskRuntimeGoalContinuationOutcomeSupport`): prefer the `commit_push` payload SHA, fall back to a runtime-measured git HEAD via `WorkflowGitOperations`, and only then decide `complete` vs `blocked` — never record `complete` without a SHA.
- **Block loudly**: when neither payload nor HEAD yields a SHA, record `status=blocked` with an explicit `blocked_reason` and `last_resumable_step=commit_push`.
- **Defense-in-depth** (`GoalRunnerWorkflowStores`): backfill a measured HEAD SHA over any pre-existing `complete`-without-SHA row; `terminalOutcomeFor` no longer short-circuits the backfill branch.
- **Null workflowId fallback** (`GoalRunner`): `storedOutcome` falls back to manifest-workflowId-independent reconciliation when the manifest entry has no `workflowId` yet.
- **Manifest advancement** (`DecompositionManifestRuntimeStateSupport`): `commitShaFrom` now sources from `commit_push_result.commit_sha` (preferred) or `goal_continuation_outcome.commit_sha`; loud-fails on genuine mismatch.

## Feature Flags

N/A

# How Has This Been Tested?

Four regression cases are covered in `FeatureTaskRuntimeRunnerTest` and `WorkflowServiceTest` with a fake launcher and a seeded fake `WorkflowGitOperations`:

1. `commit_push` completes with payload SHA → `complete` (unchanged happy path)
2. `commit_push` completes, no payload SHA, measurable HEAD → `complete` with measured SHA; manifest advances
3. `commit_push` completes, no payload SHA, no measurable HEAD → `blocked` with explicit reason; no `complete` recorded
4. Pre-existing `complete`-without-SHA store row → backfilled and advanced on next reconciliation

All four maintainer validators pass:
- `skill-bill validate` → pass
- `(cd runtime-kotlin && ./gradlew check)` → BUILD SUCCESSFUL (258 tasks)
- `npx --yes agnix --strict .` → no issues
- `scripts/validate_agent_configs` → 40 skills, 12 governed add-on files validated