### PR TITLE
feat: [SKILL-75] Fan out Claude MCP registration across every local profile

### DIFF
--- a/.feature-specs/SKILL-75-claude-mcp-registration-per-profile/spec.md
+++ b/.feature-specs/SKILL-75-claude-mcp-registration-per-profile/spec.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Complete
 ---
 
 # SKILL-75 - claude MCP registration per profile
@@ -113,18 +113,18 @@ Questions).
 
 ## Open Questions
 
-1. **Default-profile config path.** Confirm during planning that the default
-   profile's MCP config is `$HOME/.claude.json` (sibling to `~/.claude/`) and named
-   profiles use `<root>/.claude.json`. Verify against Claude Code's documented
-   resolution and the on-disk evidence (`~/.claude.json` vs
-   `~/.claude-work/.claude.json`). If Claude Code accepts `~/.claude/.claude.json`
-   for the default too, decide which path install should own to match what the agent
-   reads.
-2. **Shell vs runtime fan-out seam.** Prefer the runtime owning the per-profile MCP
-   registration loop (consistent with SKILL-74's apply-internal fan-out) so install
-   and uninstall share one path, rather than looping in `install.sh`/`uninstall.sh`.
-   Confirm whether the existing `install register-mcp` / `unregister-mcp` CLI
-   commands should fan out internally or accept the resolved root list.
+1. **Default-profile config path.** RESOLVED: the default profile root `~/.claude`
+   maps to `$HOME/.claude.json` (sibling to `~/.claude/`, the existing
+   single-profile path), and each named / `CLAUDE_CONFIG_DIR` root maps to
+   `<root>/.claude.json`. `McpRegistrationOperations.claudeProfileConfigPaths`
+   resolves this mapping; the default-only case stays byte-for-byte identical to the
+   prior single-profile behavior.
+2. **Shell vs runtime fan-out seam.** RESOLVED: the runtime owns the per-profile MCP
+   registration loop. `McpRegistrationOperations.register/unregister` fan out
+   internally across `claudeConfigRoots(home, environment)` for the CLAUDE branch;
+   the `install register-mcp` / `unregister-mcp` CLI command surface and the
+   `install.sh` / `uninstall.sh` argv are unchanged. `uninstall.sh` captures the
+   per-profile stdout to report removed paths without a shell-side loop.
 
 ## Validation Strategy
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/InstallCliApplyPayloads.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/InstallCliApplyPayloads.kt
@@ -84,6 +84,12 @@ private fun applyMcpRegistrationPayload(result: InstallApplyResult): Map<String,
       "changed" to outcome.changed,
       "message" to outcome.message,
       "issue" to outcome.issue?.let(::issuePayload),
+      "profiles" to outcome.profiles.map { profile ->
+        mapOf(
+          "config_path" to profile.configPath.toString(),
+          "changed" to profile.changed,
+        )
+      },
     )
   },
 )

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/InstallCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/InstallCliCommands.kt
@@ -15,6 +15,7 @@ import skillbill.application.NativeAgentInstallService
 import skillbill.di.RuntimeComponent
 import skillbill.di.create
 import skillbill.error.SkillBillRuntimeException
+import skillbill.install.model.ClaudeMcpProfileFailure
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallAgentSelection
 import skillbill.install.model.InstallAgentSelectionMode
@@ -24,6 +25,8 @@ import skillbill.install.model.InstallPlan
 import skillbill.install.model.InstallPlanRequest
 import skillbill.install.model.InstallTelemetryLevel
 import skillbill.install.model.InstallationTargetPaths
+import skillbill.install.model.McpMutationResult
+import skillbill.install.model.McpProfileOutcome
 import skillbill.install.model.McpRegistrationChoice
 import skillbill.install.model.PlatformPackSelection
 import skillbill.install.model.PlatformPackSelectionMode
@@ -697,7 +700,7 @@ class InstallRegisterMcpCommand(
       return
     }
     val result = mcpRegistrationService.registerMcp(agent, Path.of(runtimeMcpBin), state.userHome)
-    state.completeText(result.configPath.toString(), mapOf("agent" to agent, "changed" to result.changed))
+    state.completeText(mcpProfilePathsText(result), mcpProfilesMap(agent, result))
   }
 }
 
@@ -712,7 +715,33 @@ class InstallUnregisterMcpCommand(
     if (state.refuseInstallMutationDuringGoalContinuation("unregister-mcp")) {
       return
     }
-    val result = mcpRegistrationService.unregisterMcp(agent, state.userHome)
-    state.completeText(result.configPath.toString(), mapOf("agent" to agent, "changed" to result.changed))
+    val result = try {
+      mcpRegistrationService.unregisterMcp(agent, state.userHome)
+    } catch (error: ClaudeMcpProfileFailure) {
+      val removed = changedProfilePathsText(error.succeeded)
+      if (removed.isNotEmpty()) {
+        state.liveStdout("$removed\n")
+      }
+      throw error
+    }
+    state.completeText(mcpProfilePathsText(result), mcpProfilesMap(agent, result))
   }
 }
+
+private fun mcpProfilePathsText(result: McpMutationResult): String = if (result.profiles.isEmpty()) {
+  result.configPath.toString()
+} else {
+  changedProfilePathsText(result.profiles)
+}
+
+private fun changedProfilePathsText(profiles: List<McpProfileOutcome>): String = profiles
+  .filter { it.changed }
+  .joinToString("\n") { it.configPath.toString() }
+
+private fun mcpProfilesMap(agent: String, result: McpMutationResult): Map<String, Any?> = mapOf(
+  "agent" to agent,
+  "changed" to result.changed,
+  "profiles" to result.profiles.map { profile ->
+    mapOf("config_path" to profile.configPath.toString(), "changed" to profile.changed)
+  },
+)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
@@ -967,6 +967,7 @@ private fun applyMcpRegistrationGoldenPayload(): Map<String, Any?> = mapOf(
       "changed" to false,
       "message" to "MCP registration not requested.",
       "issue" to null,
+      "profiles" to emptyList<Map<String, Any?>>(),
     ),
   ),
 )

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallRuntimeTest.kt
@@ -326,6 +326,121 @@ class CliInstallRuntimeTest {
   }
 
   @Test
+  fun `claude mcp registration fans into every resolved profile and summary reports them`() {
+    val home = Files.createTempDirectory("skillbill-cli-mcp-claude-multi")
+    Files.createDirectories(home.resolve(".claude"))
+    val work = home.resolve(".claude-work")
+    Files.createDirectories(work)
+    Files.writeString(work.resolve(".claude.json"), "{\n  \"theme\": \"work\"\n}\n")
+    val defaultConfig = home.resolve(".claude.json")
+    val workConfig = work.resolve(".claude.json")
+    val context = installCliContext(home)
+
+    val register = CliRuntime.run(
+      listOf("--home", home.toString(), "install", "register-mcp", "claude", "--runtime-mcp-bin", "/tmp/runtime-mcp"),
+      context,
+    )
+
+    assertEquals(0, register.exitCode, register.stdout)
+    assertContains(register.stdout, defaultConfig.toString())
+    assertContains(register.stdout, workConfig.toString())
+    assertEquals(
+      setOf(defaultConfig.toString(), workConfig.toString()),
+      mcpProfileConfigPaths(register).toSet(),
+    )
+    assertTrue(mcpProfileEntries(register).all { entry -> entry["changed"] == true })
+    listOf(defaultConfig, workConfig).forEach { path ->
+      val servers = decodeJsonObject(Files.readString(path))["mcpServers"] as Map<*, *>
+      val skillBill = servers["skill-bill"] as Map<*, *>
+      assertEquals("stdio", skillBill["type"])
+      assertEquals("/tmp/runtime-mcp", skillBill["command"])
+    }
+    assertEquals("work", decodeJsonObject(Files.readString(workConfig))["theme"])
+
+    val unregister = CliRuntime.run(
+      listOf("--home", home.toString(), "install", "unregister-mcp", "claude"),
+      context,
+    )
+
+    assertEquals(0, unregister.exitCode, unregister.stdout)
+    assertContains(unregister.stdout, defaultConfig.toString())
+    assertContains(unregister.stdout, workConfig.toString())
+    assertEquals(
+      setOf(defaultConfig.toString(), workConfig.toString()),
+      mcpProfileConfigPaths(unregister).toSet(),
+    )
+    assertTrue(mcpProfileEntries(unregister).all { entry -> entry["changed"] == true })
+    listOf(defaultConfig, workConfig).forEach { path ->
+      assertFalse(
+        "skill-bill" in (decodeJsonObject(Files.readString(path))["mcpServers"] as? Map<*, *> ?: emptyMap<Any, Any>()),
+      )
+    }
+    assertEquals("work", decodeJsonObject(Files.readString(workConfig))["theme"])
+  }
+
+  @Test
+  fun `claude mcp registration preserves other servers and fails loudly for a malformed profile`() {
+    val home = Files.createTempDirectory("skillbill-cli-mcp-claude-malformed")
+    Files.createDirectories(home.resolve(".claude"))
+    val defaultConfig = home.resolve(".claude.json")
+    Files.writeString(defaultConfig, "{\n  \"mcpServers\": {\"other\": {\"command\": \"other\"}}\n}\n")
+    val work = home.resolve(".claude-work")
+    Files.createDirectories(work)
+    val malformed = work.resolve(".claude.json")
+    Files.writeString(malformed, "{ not valid json")
+    val context = installCliContext(home)
+
+    val register = CliRuntime.run(
+      listOf("--home", home.toString(), "install", "register-mcp", "claude", "--runtime-mcp-bin", "/tmp/runtime-mcp"),
+      context,
+    )
+
+    assertEquals(1, register.exitCode)
+    assertContains(register.stdout, malformed.toString())
+    assertEquals("{ not valid json", Files.readString(malformed))
+    val servers = decodeJsonObject(Files.readString(defaultConfig))["mcpServers"] as Map<*, *>
+    assertTrue("other" in servers)
+    assertTrue("skill-bill" in servers)
+  }
+
+  @Test
+  fun `claude mcp unregister fails loudly yet surfaces profiles it already removed`() {
+    val home = Files.createTempDirectory("skillbill-cli-mcp-claude-partial-unregister")
+    Files.createDirectories(home.resolve(".claude"))
+    val work = home.resolve(".claude-work")
+    Files.createDirectories(work)
+    Files.createFile(work.resolve(".claude.json"))
+    val defaultConfig = home.resolve(".claude.json")
+    val workConfig = work.resolve(".claude.json")
+    val liveStdout = StringBuilder()
+    val context = installCliContext(home).copy(liveStdout = { liveStdout.append(it) })
+
+    val register = CliRuntime.run(
+      listOf("--home", home.toString(), "install", "register-mcp", "claude", "--runtime-mcp-bin", "/tmp/runtime-mcp"),
+      context,
+    )
+    assertEquals(0, register.exitCode, register.stdout)
+
+    Files.writeString(workConfig, "{ not valid json")
+
+    val unregister = CliRuntime.run(
+      listOf("--home", home.toString(), "install", "unregister-mcp", "claude"),
+      context,
+    )
+
+    assertEquals(1, unregister.exitCode)
+    assertContains(liveStdout.toString(), defaultConfig.toString())
+    assertFalse(
+      "skill-bill" in (
+        decodeJsonObject(
+          Files.readString(defaultConfig),
+        )["mcpServers"] as? Map<*, *> ?: emptyMap<Any, Any>()
+        ),
+    )
+    assertEquals("{ not valid json", Files.readString(workConfig))
+  }
+
+  @Test
   fun `cleanup command removes skill bill links and reports user paths as skipped`() {
     val home = Files.createTempDirectory("skillbill-cli-install-cleanup")
     val targetDir = home.resolve("agent-skills")
@@ -699,3 +814,9 @@ private fun mcpJsonCase(
 private fun decodeJsonObject(rawJson: String): Map<String, Any?> =
   JsonSupport.anyToStringAnyMap(JsonSupport.parseObjectOrNull(rawJson)?.let(JsonSupport::jsonElementToValue))
     ?: emptyMap()
+
+private fun mcpProfileEntries(result: CliExecutionResult): List<Map<*, *>> =
+  (result.payload?.get("profiles") as? List<*>).orEmpty().filterIsInstance<Map<*, *>>()
+
+private fun mcpProfileConfigPaths(result: CliExecutionResult): List<String> =
+  mcpProfileEntries(result).mapNotNull { entry -> entry["config_path"] as? String }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
@@ -225,10 +225,18 @@ data class InstallTransaction(
   val createdSymlinks: MutableList<Path> = mutableListOf(),
 )
 
+data class McpProfileOutcome(val configPath: Path, val changed: Boolean)
+
+class ClaudeMcpProfileFailure(
+  message: String,
+  val succeeded: List<McpProfileOutcome>,
+) : IllegalArgumentException(message)
+
 data class McpMutationResult(
   val agent: String,
   val configPath: Path,
   val changed: Boolean,
+  val profiles: List<McpProfileOutcome> = emptyList(),
 )
 
 /**
@@ -409,6 +417,7 @@ data class McpRegistrationApplyOutcome(
   val changed: Boolean = false,
   val message: String = "",
   val issue: InstallApplyIssue? = null,
+  val profiles: List<McpProfileOutcome> = emptyList(),
 )
 
 data class InstallApplyResult(

--- a/runtime-kotlin/runtime-infra-fs/agent/history.md
+++ b/runtime-kotlin/runtime-infra-fs/agent/history.md
@@ -1,5 +1,15 @@
 # Boundary History — runtime-kotlin/runtime-infra-fs
 
+## [2026-06-09] SKILL-75 claude-mcp-registration-per-profile
+Areas: runtime-infra-fs/launcher, runtime-infra-fs/install, runtime-domain/install/model, runtime-cli, uninstall.sh
+- Extends SKILL-74's `claudeConfigRoots(home, environment)` fan-out to MCP registration. `McpRegistrationOperations.register/unregister` fan out across profiles for the CLAUDE branch ONLY; non-claude agents stay single-target via `configPathFor`. No second discovery path — reuses `claudeConfigRoots` and `McpJsonConfig` (no forked JSON merge)
+- Per-profile config-file mapping is asymmetric and lives in `claudeProfileConfigPaths`: default root (`home/.claude`) → `$HOME/.claude.json` (sibling, NOT `~/.claude/.claude.json`); every named/`CLAUDE_CONFIG_DIR` root → `<root>/.claude.json`. Compare against a normalized `home.resolve(".claude")` or the default/named split misclassifies
+- Loud-fail isolation pattern (reusable): `claudeFanOut` is collect-and-surface — attempt every profile, write siblings, collect failures, then throw. The thrown `ClaudeMcpProfileFailure(message, succeeded)` carries already-written profiles so callers report partial state truthfully instead of total failure
+- Pitfall caught in review: a typed exception caught by runtime-cli CANNOT live in runtime-infra-fs (`RuntimeAdapterDependencyAllowlistTest` forbids cli→infra-fs). Put it in runtime-domain (`skillbill.install.model`, exempt from the implementation-import ban) and extend `IllegalArgumentException` so `CliRuntime` still maps it to exit 1
+- AC9 summary: human-facing CLI/uninstall text filters to `changed` profiles; the structured payload (`mcpProfilesMap`, apply `outcomes[].profiles[]`) keeps every profile with its `changed` flag. install.sh/uninstall.sh argv unchanged (no shell-side profile loop); uninstall.sh captures stdout to surface removed + partially-removed paths
+Feature flag: N/A
+Acceptance criteria: 10/10 implemented
+
 ## [2026-06-09] SKILL-74 auto-detect-claude-profiles
 Areas: runtime-infra-fs/install, runtime-infra-fs/nativeagent, runtime-domain/install/policy, runtime-cli, install.sh, uninstall.sh
 - `claudeConfigRoots(home, environment)` in `ClaudeConfigPaths.kt` is the single source of truth for the claude profile set: default `~/.claude` first, then marker-filtered top-level `$HOME/.claude-<name>` dirs (markers `.claude.json`/`.credentials.json`/`commands`/`agents`/`history.jsonl`), then a distinct non-blank `CLAUDE_CONFIG_DIR`; deduped by normalized abs path. The single-root `claudeConfigRoot` stays for AC9 (`agent-path claude`/`claude-agents-path` return only the active root)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/InstallApplySideEffects.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/InstallApplySideEffects.kt
@@ -1,6 +1,7 @@
 package skillbill.install
 
 import skillbill.infrastructure.fs.FileTelemetryConfigStore
+import skillbill.install.model.ClaudeMcpProfileFailure
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallApplyIssue
 import skillbill.install.model.InstallApplyIssueKind
@@ -178,19 +179,31 @@ private fun registerMcpAgent(
     status = McpRegistrationApplyStatus.SUCCESS,
     configPath = result.configPath,
     changed = result.changed,
-    message = if (result.changed) {
-      "MCP registration updated."
-    } else {
-      "MCP registration already up to date."
-    },
+    message = mcpRegistrationMessage(result),
+    profiles = result.profiles,
   )
 }.getOrElse { error ->
+  val succeeded = (error as? ClaudeMcpProfileFailure)?.succeeded.orEmpty()
   failedMcpRegistrationOutcome(
     agent = agent,
-    message = error.message.orEmpty(),
+    message = if (succeeded.isEmpty()) {
+      error.message.orEmpty()
+    } else {
+      "${error.message.orEmpty()}. Already updated: ${succeeded.joinToString(", ") { it.configPath.toString() }}"
+    },
     warnings = warnings,
     error = error,
+    profiles = succeeded,
   )
+}
+
+private fun mcpRegistrationMessage(result: skillbill.install.model.McpMutationResult): String {
+  val base = if (result.changed) "MCP registration updated." else "MCP registration already up to date."
+  if (result.profiles.size <= 1) {
+    return base
+  }
+  val paths = result.profiles.joinToString(", ") { it.configPath.toString() }
+  return "$base Profiles (${result.profiles.size}): $paths"
 }
 
 private fun failedMcpRegistrationOutcome(
@@ -198,6 +211,7 @@ private fun failedMcpRegistrationOutcome(
   message: String,
   warnings: MutableList<InstallApplyIssue>,
   error: Throwable? = null,
+  profiles: List<skillbill.install.model.McpProfileOutcome> = emptyList(),
 ): McpRegistrationApplyOutcome {
   val issue = InstallApplyIssue(
     kind = InstallApplyIssueKind.MCP_REGISTRATION_FAILED,
@@ -209,7 +223,8 @@ private fun failedMcpRegistrationOutcome(
   return McpRegistrationApplyOutcome(
     agent = agent,
     status = McpRegistrationApplyStatus.FAILED,
-    message = "MCP registration failed.",
+    message = if (profiles.isEmpty()) "MCP registration failed." else message,
     issue = issue,
+    profiles = profiles,
   )
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/McpRegistrationOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/McpRegistrationOperations.kt
@@ -1,18 +1,28 @@
 package skillbill.launcher
 
+import skillbill.install.claudeConfigRoots
+import skillbill.install.model.ClaudeMcpProfileFailure
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.McpMutationResult
+import skillbill.install.model.McpProfileOutcome
 import java.nio.file.Path
 
 object McpRegistrationOperations {
-  fun register(agent: String, runtimeMcpBin: Path, home: Path? = null): McpMutationResult {
+  fun register(
+    agent: String,
+    runtimeMcpBin: Path,
+    home: Path? = null,
+    environment: Map<String, String> = System.getenv(),
+  ): McpMutationResult {
     val resolvedHome = home ?: Path.of(System.getProperty("user.home"))
     val command = runtimeMcpBin.toAbsolutePath().normalize().toString()
     if (agent == "glm") {
       return McpJsonConfig.register(agent, resolvedHome.resolve(".glm/mcp-config.json"), command)
     }
     return when (val installAgent = InstallAgent.fromId(agent)) {
-      InstallAgent.CLAUDE -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
+      InstallAgent.CLAUDE -> claudeFanOut(agent, resolvedHome, environment) { perProfilePath ->
+        McpJsonConfig.register(agent, perProfilePath, command)
+      }
       InstallAgent.COPILOT -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
       InstallAgent.CODEX -> McpTomlConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
       InstallAgent.OPENCODE -> McpOpenCodeConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
@@ -20,13 +30,19 @@ object McpRegistrationOperations {
     }
   }
 
-  fun unregister(agent: String, home: Path? = null): McpMutationResult {
+  fun unregister(
+    agent: String,
+    home: Path? = null,
+    environment: Map<String, String> = System.getenv(),
+  ): McpMutationResult {
     val resolvedHome = home ?: Path.of(System.getProperty("user.home"))
     if (agent == "glm") {
       return McpJsonConfig.unregister(agent, resolvedHome.resolve(".glm/mcp-config.json"))
     }
     return when (val installAgent = InstallAgent.fromId(agent)) {
-      InstallAgent.CLAUDE -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+      InstallAgent.CLAUDE -> claudeFanOut(agent, resolvedHome, environment) { perProfilePath ->
+        McpJsonConfig.unregister(agent, perProfilePath)
+      }
       InstallAgent.COPILOT -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
       InstallAgent.CODEX -> McpTomlConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
       InstallAgent.OPENCODE -> McpOpenCodeConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
@@ -40,5 +56,45 @@ object McpRegistrationOperations {
     InstallAgent.CODEX -> home.resolve(".codex/config.toml")
     InstallAgent.OPENCODE -> home.resolve(".config/opencode/opencode.json")
     InstallAgent.JUNIE -> home.resolve(".junie/mcp/mcp.json")
+  }
+
+  private fun claudeProfileConfigPaths(home: Path, environment: Map<String, String>): List<Path> {
+    val defaultRoot = home.resolve(".claude").toAbsolutePath().normalize()
+    return claudeConfigRoots(home, environment).map { root ->
+      if (root == defaultRoot) home.resolve(".claude.json") else root.resolve(".claude.json")
+    }
+  }
+
+  private fun claudeFanOut(
+    agent: String,
+    home: Path,
+    environment: Map<String, String>,
+    mutate: (Path) -> McpMutationResult,
+  ): McpMutationResult {
+    val profilePaths = claudeProfileConfigPaths(home, environment)
+    val representativePath = home.resolve(".claude.json")
+    val outcomes = mutableListOf<McpProfileOutcome>()
+    val failures = mutableListOf<Pair<Path, Throwable>>()
+
+    profilePaths.forEach { perProfilePath ->
+      runCatching { mutate(perProfilePath) }
+        .onSuccess { result -> outcomes.add(McpProfileOutcome(result.configPath, result.changed)) }
+        .onFailure { error -> failures.add(perProfilePath to error) }
+    }
+
+    if (failures.isNotEmpty()) {
+      val names = failures.joinToString("; ") { (path, error) -> "$path: ${error.message}" }
+      throw ClaudeMcpProfileFailure(
+        "Failed to update Claude MCP config for profile(s): $names",
+        succeeded = outcomes.toList(),
+      )
+    }
+
+    return McpMutationResult(
+      agent = agent,
+      configPath = representativePath,
+      changed = outcomes.any { it.changed },
+      profiles = outcomes,
+    )
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyMcpFanOutTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyMcpFanOutTest.kt
@@ -1,0 +1,69 @@
+package skillbill.install
+
+import skillbill.install.model.InstallAgent
+import skillbill.install.model.InstallApplyIssueKind
+import skillbill.install.model.InstallApplyStatus
+import skillbill.install.model.McpRegistrationApplyStatus
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InstallApplyMcpFanOutTest : InstallApplyTestSupport() {
+  @Test
+  fun `apply fans MCP registration across multiple claude profiles`() {
+    val fixture = setupApplyFixture()
+    Files.createDirectories(fixture.home.resolve(".claude"))
+    val work = fixture.home.resolve(".claude-work")
+    Files.createDirectories(work)
+    Files.createFile(work.resolve(".claude.json"))
+    val plan = InstallOperations.planInstall(
+      fixture.request(agents = setOf(InstallAgent.CLAUDE)),
+    )
+
+    val result = InstallOperations.applyInstall(plan)
+
+    assertEquals(InstallApplyStatus.SUCCESS, result.status)
+    val claudeOutcome = result.mcpRegistrationOutcomes.single { outcome -> outcome.agent == InstallAgent.CLAUDE }
+    assertEquals(McpRegistrationApplyStatus.SUCCESS, claudeOutcome.status)
+    assertTrue(claudeOutcome.profiles.size > 1, "expected fan-out across profiles: ${claudeOutcome.profiles}")
+    assertEquals(
+      setOf(fixture.home.resolve(".claude.json"), work.resolve(".claude.json")),
+      claudeOutcome.profiles.map { profile -> profile.configPath }.toSet(),
+    )
+    assertContains(claudeOutcome.message, "Profiles (${claudeOutcome.profiles.size}):")
+    assertContains(claudeOutcome.message, fixture.home.resolve(".claude.json").toString())
+    assertContains(claudeOutcome.message, work.resolve(".claude.json").toString())
+  }
+
+  @Test
+  fun `apply reports claude profiles already written when one profile fails`() {
+    val fixture = setupApplyFixture()
+    Files.createDirectories(fixture.home.resolve(".claude"))
+    val work = fixture.home.resolve(".claude-work")
+    Files.createDirectories(work)
+    val malformed = work.resolve(".claude.json")
+    Files.writeString(malformed, "{ not valid json")
+    val defaultConfig = fixture.home.resolve(".claude.json")
+    val plan = InstallOperations.planInstall(
+      fixture.request(agents = setOf(InstallAgent.CLAUDE)),
+    )
+
+    val result = InstallOperations.applyInstall(plan)
+
+    assertEquals(InstallApplyStatus.WARNING, result.status)
+    val claudeOutcome = result.mcpRegistrationOutcomes.single { outcome -> outcome.agent == InstallAgent.CLAUDE }
+    assertEquals(McpRegistrationApplyStatus.FAILED, claudeOutcome.status)
+    assertEquals(listOf(defaultConfig), claudeOutcome.profiles.map { profile -> profile.configPath })
+    assertContains(claudeOutcome.message, malformed.toString())
+    assertContains(claudeOutcome.message, "Already updated: $defaultConfig")
+    assertTrue(
+      result.warnings.any { warning ->
+        warning.kind == InstallApplyIssueKind.MCP_REGISTRATION_FAILED &&
+          warning.agent == InstallAgent.CLAUDE
+      },
+    )
+    assertEquals("{ not valid json", Files.readString(malformed))
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/McpRegistrationOperationsTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/McpRegistrationOperationsTest.kt
@@ -1,0 +1,209 @@
+package skillbill.launcher
+
+import skillbill.contracts.JsonSupport
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class McpRegistrationOperationsTest {
+  private val runtimeMcpBin = Path.of("/tmp/runtime-mcp")
+
+  private fun decode(path: Path): Map<String, Any?> = JsonSupport.anyToStringAnyMap(
+    JsonSupport.parseObjectOrNull(Files.readString(path))?.let(JsonSupport::jsonElementToValue),
+  ) ?: emptyMap()
+
+  private fun skillBillServer(path: Path): Map<*, *> {
+    val servers = decode(path)["mcpServers"] as Map<*, *>
+    return servers["skill-bill"] as Map<*, *>
+  }
+
+  private fun markedProfile(home: Path, name: String): Path {
+    val root = home.resolve(name)
+    Files.createDirectories(root)
+    Files.createFile(root.resolve(".claude.json"))
+    return root
+  }
+
+  @Test
+  fun `register fans into default and named profile config files`() {
+    val home = Files.createTempDirectory("mcp-fanout")
+    Files.createDirectories(home.resolve(".claude"))
+    val work = markedProfile(home, ".claude-work")
+
+    val result = McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+
+    val defaultConfig = home.resolve(".claude.json")
+    val workConfig = work.resolve(".claude.json")
+    assertEquals(
+      setOf(defaultConfig, workConfig),
+      result.profiles.map { it.configPath }.toSet(),
+    )
+    assertEquals(defaultConfig, result.configPath)
+    assertTrue(result.changed)
+
+    listOf(defaultConfig, workConfig).forEach { path ->
+      val server = skillBillServer(path)
+      assertEquals("stdio", server["type"])
+      assertEquals("/tmp/runtime-mcp", server["command"])
+      assertEquals(emptyList<String>(), server["args"])
+    }
+  }
+
+  @Test
+  fun `unregister removes from every profile leaving other servers and config untouched`() {
+    val home = Files.createTempDirectory("mcp-unregister")
+    Files.createDirectories(home.resolve(".claude"))
+    val work = markedProfile(home, ".claude-work")
+    val defaultConfig = home.resolve(".claude.json")
+    val workConfig = work.resolve(".claude.json")
+    listOf(defaultConfig, workConfig).forEach { path ->
+      Files.writeString(path, "{\n  \"theme\": \"dark\",\n  \"mcpServers\": {\"other\": {\"command\": \"other\"}}\n}\n")
+    }
+
+    McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+    val result = McpRegistrationOperations.unregister("claude", home, environment = emptyMap())
+
+    assertTrue(result.changed)
+    assertEquals(setOf(defaultConfig, workConfig), result.profiles.map { it.configPath }.toSet())
+    listOf(defaultConfig, workConfig).forEach { path ->
+      val settings = decode(path)
+      assertEquals("dark", settings["theme"])
+      val servers = settings["mcpServers"] as Map<*, *>
+      assertTrue("other" in servers)
+      assertFalse("skill-bill" in servers)
+    }
+  }
+
+  @Test
+  fun `default root maps to home claude json and named root maps to its own claude json`() {
+    val home = Files.createTempDirectory("mcp-pathmap")
+    Files.createDirectories(home.resolve(".claude"))
+    val work = markedProfile(home, ".claude-work")
+
+    val result = McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+
+    val paths = result.profiles.map { it.configPath }
+    assertTrue(home.resolve(".claude.json") in paths)
+    assertTrue(work.resolve(".claude.json") in paths)
+    assertFalse(home.resolve(".claude/.claude.json") in paths)
+  }
+
+  @Test
+  fun `register is idempotent per profile and picks up a profile created later`() {
+    val home = Files.createTempDirectory("mcp-idempotent")
+    Files.createDirectories(home.resolve(".claude"))
+
+    McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+    val first = Files.readString(home.resolve(".claude.json"))
+    McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+    assertEquals(first, Files.readString(home.resolve(".claude.json")))
+
+    val work = markedProfile(home, ".claude-work")
+    val result = McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+
+    assertEquals(
+      setOf(home.resolve(".claude.json"), work.resolve(".claude.json")),
+      result.profiles.map {
+        it.configPath
+      }.toSet(),
+    )
+    assertEquals("/tmp/runtime-mcp", skillBillServer(work.resolve(".claude.json"))["command"])
+  }
+
+  @Test
+  fun `default-only writes home claude json identical to single-profile baseline`() {
+    val home = Files.createTempDirectory("mcp-default-only")
+    Files.createDirectories(home.resolve(".claude"))
+
+    val result = McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+    val defaultConfig = home.resolve(".claude.json")
+
+    assertEquals(defaultConfig, result.configPath)
+    assertEquals(listOf(defaultConfig), result.profiles.map { it.configPath })
+
+    val baseline = Files.createTempDirectory("mcp-baseline")
+    val baselinePath = baseline.resolve(".claude.json")
+    val baselineResult = McpJsonConfig.register(
+      "claude",
+      baselinePath,
+      runtimeMcpBin.toAbsolutePath().normalize().toString(),
+    )
+    assertEquals(Files.readString(baselinePath), Files.readString(defaultConfig))
+    assertEquals(baselineResult.changed, result.changed)
+  }
+
+  @Test
+  fun `malformed profile fails loudly naming it while siblings are still written`() {
+    val home = Files.createTempDirectory("mcp-malformed")
+    Files.createDirectories(home.resolve(".claude"))
+    val work = markedProfile(home, ".claude-work")
+    val malformedConfig = work.resolve(".claude.json")
+    Files.writeString(malformedConfig, "{ not valid json")
+
+    val defaultConfig = home.resolve(".claude.json")
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      McpRegistrationOperations.register("claude", runtimeMcpBin, home, environment = emptyMap())
+    }
+    assertContains(error.message.orEmpty(), malformedConfig.toString())
+
+    assertEquals("/tmp/runtime-mcp", skillBillServer(defaultConfig)["command"])
+    assertEquals("{ not valid json", Files.readString(malformedConfig))
+  }
+
+  @Test
+  fun `register honors CLAUDE_CONFIG_DIR env root alongside the default profile`() {
+    val home = Files.createTempDirectory("mcp-config-dir-env")
+    Files.createDirectories(home.resolve(".claude"))
+    val envRoot = Files.createTempDirectory("mcp-config-dir-target")
+    Files.createFile(envRoot.resolve(".claude.json"))
+
+    val result = McpRegistrationOperations.register(
+      "claude",
+      runtimeMcpBin,
+      home,
+      environment = mapOf("CLAUDE_CONFIG_DIR" to envRoot.toString()),
+    )
+
+    val defaultConfig = home.resolve(".claude.json")
+    val envConfig = envRoot.resolve(".claude.json")
+    assertEquals(setOf(defaultConfig, envConfig), result.profiles.map { it.configPath }.toSet())
+    assertFalse(envRoot.resolve(".claude.json/.claude.json") in result.profiles.map { it.configPath })
+    assertFalse(home.resolve("${envRoot.fileName}/.claude.json") in result.profiles.map { it.configPath })
+
+    listOf(defaultConfig, envConfig).forEach { path ->
+      assertEquals("/tmp/runtime-mcp", skillBillServer(path)["command"])
+    }
+  }
+
+  @Test
+  fun `non-claude agents stay single-target`() {
+    val home = Files.createTempDirectory("mcp-single-target")
+
+    val expectedPaths = mapOf(
+      "codex" to home.resolve(".codex/config.toml"),
+      "opencode" to home.resolve(".config/opencode/opencode.json"),
+      "junie" to home.resolve(".junie/mcp/mcp.json"),
+      "copilot" to home.resolve(".copilot/mcp-config.json"),
+      "glm" to home.resolve(".glm/mcp-config.json"),
+    )
+
+    expectedPaths.forEach { (agent, expected) ->
+      val result = McpRegistrationOperations.register(agent, runtimeMcpBin, home, environment = emptyMap())
+      assertEquals(expected, result.configPath, agent)
+      assertTrue(result.profiles.isEmpty(), agent)
+
+      val unregistered = McpRegistrationOperations.unregister(agent, home, environment = emptyMap())
+      assertEquals(expected, unregistered.configPath, agent)
+      assertTrue(unregistered.profiles.isEmpty(), agent)
+    }
+  }
+
+  private fun assertContains(haystack: String, needle: String) {
+    assertTrue(needle in haystack, "Expected '$haystack' to contain '$needle'")
+  }
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -620,8 +620,18 @@ remove_junie_agent_mds
 
 info "Removing MCP server registrations."
 for agent in claude copilot codex glm opencode junie; do
-  if run_runtime_cli install unregister-mcp "$agent" >/dev/null 2>&1; then
+  if mcp_output="$(run_runtime_cli install unregister-mcp "$agent" 2>/dev/null)"; then
     ok "  removed skill-bill MCP server ($agent)"
+    while IFS= read -r profile_path; do
+      [[ -n "$profile_path" ]] || continue
+      info "    $profile_path"
+    done <<< "$mcp_output"
+  elif [[ -n "$mcp_output" ]]; then
+    warn "  partially removed skill-bill MCP server ($agent); manual check may be needed"
+    while IFS= read -r profile_path; do
+      [[ -n "$profile_path" ]] || continue
+      info "    $profile_path"
+    done <<< "$mcp_output"
   else
     warn "  could not remove skill-bill MCP server ($agent)"
   fi


### PR DESCRIPTION
# Summary

Closes SKILL-75. Claude MCP registration now fans out across every local Claude profile instead of only the default `~/.claude`. Previously, work-profile sessions (e.g. `cc work` -> `~/.claude-work`) had zero skill-bill MCP tools, so `bill-feature-task` produced no durable workflow state. This change resolves the profile set from a single discovery path (`claudeConfigRoots(home, environment)`) and registers/unregisters `mcpServers.skill-bill` in each resolved profile's config file in one run.

Key changes:
- `McpRegistrationOperations.kt`: `claudeFanOut` loops `claudeConfigRoots` for the CLAUDE agent only; `claudeProfileConfigPaths` maps the default root to `$HOME/.claude.json` and named / `CLAUDE_CONFIG_DIR` roots to `<root>/.claude.json`. `McpJsonConfig` and `claudeConfigRoots` reused unchanged.
- Loud-fail is collect-and-surface: every profile is attempted and siblings written, then `ClaudeMcpProfileFailure(message, succeeded)` (extends `IllegalArgumentException`, placed in `runtime-domain` so `runtime-cli` can catch it without depending on `runtime-infra-fs`) is thrown carrying the already-written profiles, so install-apply and uninstall report partial state truthfully.
- Install and uninstall summaries report which profiles received / lost registration (multi-profile message + structured `profiles[]` payload with a per-profile `changed` flag).
- Non-claude agents (codex / opencode / junie / copilot / glm) stay single-target via `configPathFor`. `install.sh` / `uninstall.sh` argv unchanged (no shell-side profile loop).
- Default-only case is byte-for-byte identical to today.

## Feature Flags

N/A

# How Has This Been Tested?

- New unit tests: `McpRegistrationOperationsTest.kt` (per-profile path mapping, idempotency, JSON preservation, malformed-profile loud-fail without corruption, late-created profile pickup) and `InstallApplyMcpFanOutTest.kt` (multi-profile apply side effects + summary payload).
- Updated `CliInstallRuntimeTest.kt` and `CliInstallPlanApplyRuntimeTest.kt` for the multi-profile summary output.
- `(cd runtime-kotlin && ./gradlew check)` -> BUILD SUCCESSFUL.
- `skill-bill validate` pass; `scripts/validate_agent_configs` passed.

Manual QA steps:
1. Have a default profile (`~/.claude`) and a named work profile (`~/.claude-work`, e.g. via `cc work`).
2. Run `./install.sh --mcp register`.
3. Confirm `mcpServers.skill-bill` is present in **both** `$HOME/.claude.json` and `~/.claude-work/.claude.json`, pointing at the freshly installed `runtime-mcp` binary.
4. Confirm any pre-existing servers / config in those files are untouched.
5. Run `./uninstall.sh`.
6. Confirm `mcpServers.skill-bill` is **removed** from both `$HOME/.claude.json` and `~/.claude-work/.claude.json`, with all other config intact.
7. Confirm the install/uninstall summary lists each profile that received / lost registration.