### PR TITLE
ci: tag-driven release — push v0.2.0 to ship

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,15 @@ jobs:
           java-version: "17"
           cache: gradle
 
+      # Derive RELEASE_VERSION from the pushed tag (v0.2.0 → 0.2.0) or the
+      # staging_version input (workflow_dispatch). Gradle reads this env var in
+      # build.gradle.kts so every artifact name embeds the correct version.
+      - name: Set release version
+        shell: bash
+        run: |
+          raw="${{ github.event_name == 'workflow_dispatch' && inputs.staging_version || github.ref_name }}"
+          echo "RELEASE_VERSION=${raw#v}" >> "$GITHUB_ENV"
+
       # Linux desktop installers shell out to native packaging tools: .deb needs
       # dpkg-deb (+ fakeroot), .rpm needs rpmbuild. Without them jpackage fails
       # with "Invalid or unsupported type". Hosted ubuntu has dpkg-deb already;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "[0-9]*.*.*"
   # AC6: a maintainer can stage a real, downloadable asset set for subtask 4
   # testing without cutting a tag. The staging_version input names the assets and
   # the (pre)release; see RELEASING.md "Staging a release for downstream testing".

--- a/runtime-kotlin/build.gradle.kts
+++ b/runtime-kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "dev.skillbill"
-version = "0.1.0-SNAPSHOT"
+version = providers.environmentVariable("RELEASE_VERSION").getOrElse("0.1.0-SNAPSHOT")
 
 subprojects {
   group = rootProject.group

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/RepoValidationRuntime.kt
@@ -86,7 +86,7 @@ data class ReleaseRefMetadata(
 object RepoValidationRuntime {
   private val semverTagPattern =
     Regex(
-      "^v(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)" +
+      "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)" +
         "(?:-(?<prerelease>(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*)" +
         "(?:\\.(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*))*))?" +
         "(?:\\+(?<build>[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
@@ -24,6 +24,19 @@ class RepoValidationRuntimeTest {
   }
 
   @Test
+  fun `release refs accept bare version tags without v prefix`() {
+    val stable = RepoValidationRuntime.parseReleaseRef("0.2.0")
+    assertEquals("0.2.0", stable.tag)
+    assertEquals("0.2.0", stable.version)
+    assertFalse(stable.prerelease)
+
+    val prerelease = RepoValidationRuntime.parseReleaseRef("refs/tags/1.0.0-rc.1")
+    assertEquals("1.0.0-rc.1", prerelease.tag)
+    assertEquals("1.0.0-rc.1", prerelease.version)
+    assertTrue(prerelease.prerelease)
+  }
+
+  @Test
   fun `release refs reject non semver tags`() {
     val error = kotlin.runCatching {
       RepoValidationRuntime.parseReleaseRef("release-1.0")


### PR DESCRIPTION
## Summary

- `runtime-kotlin/build.gradle.kts` — version now reads from the `RELEASE_VERSION` environment variable, falling back to `0.1.0-SNAPSHOT` for local dev
- `.github/workflows/release.yml` — new **"Set release version"** step strips the `v` prefix from the pushed tag (or `staging_version` input) and exports it as `RELEASE_VERSION` before any Gradle build runs

## How releases work now

Push a tag — that is the only manual step:

```
git tag v0.2.0
git push origin v0.2.0
```

The release workflow fires, each platform runner gets `RELEASE_VERSION=0.2.0`, Gradle bakes it into every artifact name (`runtime-cli-0.2.0-macos-arm64.zip`, `SkillBill-0.2.0-linux-x64.deb`, etc.), and the publish job attaches them all to the `v0.2.0` GitHub Release. `install.sh` then resolves the latest release via the GitHub API and downloads the correct asset for the host platform.

The staging path (`workflow_dispatch` with a `staging_version` like `v0.2.0-rc.1`) works the same way — useful for a dry-run before tagging.

## What doesn't change

- Local dev: `RELEASE_VERSION` unset → version stays `0.1.0-SNAPSHOT` as before
- No version bump commit to main required
- No other files touched

## Test plan

- [ ] Verify locally: `RELEASE_VERSION=0.2.0 (cd runtime-kotlin && ./gradlew properties) | grep version:` → `version: 0.2.0`
- [ ] Trigger a staging run via `workflow_dispatch` with `staging_version=v0.2.0-rc.1` and confirm all four platform artifacts are named `*-0.2.0-rc.1-*`
- [ ] Push tag `v0.2.0`, confirm the full release fires and `install.sh` downloads and installs from the published assets