### PR TITLE
feat: [SKILL-83] Prose-goal subtask isolation via Level-1 agent delegation

### DIFF
--- a/.feature-specs/SKILL-83-prose-goal-subtask-isolation/spec.md
+++ b/.feature-specs/SKILL-83-prose-goal-subtask-isolation/spec.md
@@ -1,0 +1,135 @@
+# SKILL-83 — Subtask-agent isolation for mode:prose goal orchestration
+
+status: Draft
+
+## Problem
+
+In `bill-feature-goal mode:prose`, the goal orchestrator runs each subtask's
+full phase loop **inline in its own session**. Context from every phase of every
+subtask accumulates in the orchestrator: preplan digests, plans, implementation
+summaries, review reports, audit reports. For a 5-subtask goal this is roughly
+5× a single subtask's context budget, and the orchestrator hits the auto-compact
+wall well before the goal is done.
+
+`mode:runtime` solves this with `claude -p` (OS-level process isolation per
+subtask) but exposes a different risk: the Anthropic/Claude Code $100
+hard-stop spending limit applies to `claude -p` invocations and cannot be
+interactively paused — a runaway goal loop terminates abruptly.
+
+## Solution
+
+Spawn one **subtask-agent** (via the Agent tool) per subtask. The orchestrator
+delegates the full phase loop to that agent and waits for a terminal signal.
+The subtask-agent enters the existing `bill-feature-task-prose` continuation
+contract exactly as the orchestrator does today — the only change is _where_ the
+continuation runs.
+
+### Nesting depth
+
+```
+Level 0  goal orchestrator          (thin loop — manifest + spawn + verify)
+Level 1  subtask-agent              (new — one per subtask, fresh 1M context)
+Level 2  phase agents               (preplan, plan, implement, audit, quality-check)
+         code-review specialists    (spawned inline from Level 1, same as today from Level 0)
+```
+
+Adding exactly **one** level over the current architecture (which runs
+code-review specialists at Level 1 from the orchestrator at Level 0). The
+code-review step continues to run inline in whichever session is currently
+acting as "the orchestrator for that subtask" — Level 1 in the new design.
+
+## Acceptance Criteria
+
+1. **Orchestrator stays thin.** The Level-0 goal orchestrator holds only: the
+   decomposition manifest, per-subtask terminal outcomes (status + commit SHA),
+   and the current subtask index. It does NOT accumulate phase artifacts
+   (preplan digests, plans, implementation summaries, review reports) from any
+   subtask.
+
+2. **One subtask-agent per subtask.** For each runnable subtask the orchestrator
+   spawns exactly one Level-1 sub-agent via the Agent tool with a self-contained
+   briefing (issue key, subtask ID, workflow ID to continue, spec path,
+   goal_continuation contract).
+
+3. **Subtask-agent uses the existing continuation contract.** The Level-1 agent
+   calls `feature_implement_workflow_continue` (or `skill-bill workflow
+   continue`) with the parent `issue_key` and `subtask_id`, and follows the
+   `bill-feature-task-prose` goal-continuation rules verbatim:
+   `suppress_pr=true`, no install flows, `commit_push` is the terminal signal.
+
+4. **Phase agents and code-review specialists are unchanged.** The Level-1 agent
+   spawns Level-2 phase agents (preplan, plan, implement, audit, quality-check)
+   and runs `bill-code-review` inline (which spawns Level-2 specialists) exactly
+   as the current Level-0 orchestrator does. No changes to any phase agent or
+   reviewer.
+
+5. **Durable-state authority is unchanged.** After each subtask-agent returns,
+   the orchestrator verifies the terminal outcome via
+   `feature_implement_workflow_get` or `skill-bill goal status` before advancing.
+   The in-session return value is a signal only.
+
+6. **Stop-loudly on failure.** If a subtask-agent returns blocked or failed, the
+   orchestrator stops immediately, surfaces subtask ID, `blocked_reason`,
+   workflow ID, and `last_resumable_step`. Does NOT advance to the next subtask.
+
+7. **Nesting smoke test passes before implementation begins.** A standalone test
+   (shell script or Kotlin integration test) verifies that a Level-0 agent can
+   spawn a Level-1 agent that itself spawns a Level-2 agent via the Agent tool,
+   and that all three levels complete successfully. This test is the go/no-go
+   gate for the entire feature — if 3-level nesting fails, implementation stops.
+
+8. **Existing tests pass.** `InstallerShellDelegationTest`,
+   `InstallerShellReuseLastSelectionTest`, `InstallerShellReconcileTest`, and
+   the goal-runner integration tests remain green.
+
+9. **Single-task `bill-feature-task` (no goal loop) is unchanged.** The
+   subtask-agent layer only applies to `bill-feature-goal mode:prose`.
+
+10. **PR suppression.** Each subtask commits but does not open a PR. The goal
+    orchestrator opens exactly one parent PR after all subtasks complete, via the
+    standard `bill-pr-description` + `gh` path.
+
+## Non-goals
+
+- Changes to `mode:runtime` — it uses `claude -p`; unaffected.
+- Changing the phase-agent or code-review-specialist structure.
+- Level-1 subtask-agent context recovery (durable state handles resume).
+- Eliminating the Agent tool's nesting limit — we verify the limit works; we
+  don't change Claude Code internals.
+- Any UI or desktop-app changes.
+
+## Open Questions
+
+1. **Does Claude Code support Level-0 → Level-1 → Level-2 Agent tool nesting?**
+   Unknown. The smoke test (AC7) is the authoritative answer. If it fails, the
+   feature is blocked and the alternatives are:
+   - Keep mode:prose with `/clear` between subtasks (manual, works today).
+   - Use mode:runtime with a conservative API spending cap set on the Anthropic
+     console.
+
+2. **Does the Level-1 agent have access to all MCP tools needed for
+   `feature_implement_workflow_continue`?** MCP tool availability in sub-agents
+   must be verified in the smoke test.
+
+3. **What is the right `agentType` for the Level-1 subtask-agent?** Options:
+   `bill-feature-task-implementation` (existing), or a new
+   `bill-feature-task-subtask-runner` type. Using an existing type avoids
+   creating new registry entries but may carry unwanted system-prompt scope.
+
+## Validation Strategy
+
+- AC7 smoke test: write a minimal Agent-nesting harness (outside install.sh)
+  that verifies 3-level depth works before any prose-skill changes.
+- Kotlin: `(cd runtime-kotlin && ./gradlew check)` must pass.
+- Manual: run a 2-subtask goal in `mode:prose` end-to-end and confirm the
+  orchestrator context does not grow between subtasks.
+
+## Dependencies
+
+- Requires Claude Code to support ≥ 3 levels of Agent tool nesting (unverified;
+  gated by AC7).
+- No dependency on SKILL-82 or earlier work.
+
+## Size
+
+MEDIUM — one new orchestration layer, one smoke test, no runtime Kotlin changes.

--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Routing, validation, and installation are manifest-driven, so the system accepts
 | `/bill-feature-task` | Router skill that accepts `mode:prose` (default) or `mode:runtime` and delegates to the appropriate feature-task implementation mode |
 | `/bill-feature-task-prose` | First-class prose orchestrator for end-to-end feature implementation, running entirely within the invoking agent session |
 | `/bill-feature-task-runtime` | Runtime-backed trigger that runs a governed spec through the `skill-bill feature-task` phase loop |
+| `/bill-feature-task-subtask-runner` | Level-1 subtask-agent for `bill-feature-goal mode:prose`; spawned via the Agent tool, not invoked directly |
 | `/bill-feature-spec` | Standalone feature-spec preparation (single-spec or decomposed) reused by feature and goal workflows |
 | `/bill-feature-verify` | Verify a PR against a task spec or design doc |
 | `/bill-feature-goal` | Decomposed-goal trigger surface; `mode:runtime` (default) drives the durable `skill-bill goal` loop, `mode:prose` drives an in-session subtask loop |

--- a/scripts/agent_nesting_smoke_test.sh
+++ b/scripts/agent_nesting_smoke_test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# 3-level Agent tool nesting smoke test for bill-feature-goal mode:prose (SKILL-83).
+# Verifies: Level-0 (claude -p session) can spawn Level-1 (Agent tool) which can spawn
+# Level-2 (Agent tool), that the Level-2 sentinel propagates back to Level-0, and that
+# Level-1 has access to the skill-bill MCP tools.
+#
+# This is the go/no-go gate for SKILL-83. If the test fails:
+#   BLOCKED — alternatives:
+#   (a) Keep mode:prose with /clear between subtasks (manual, works today).
+#   (b) Use mode:runtime with a conservative Anthropic console spending cap.
+#
+# Usage: scripts/agent_nesting_smoke_test.sh
+# Env overrides: CLAUDE_BIN, NESTING_TEST_TIMEOUT (default 240s)
+#
+# Requires:
+#   - claude CLI on PATH (or CLAUDE_BIN env var pointing to it)
+#   - ./install.sh must have run so MCP tools are registered for skill-bill
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+TIMEOUT_SECS="${NESTING_TEST_TIMEOUT:-240}"
+
+command -v "$CLAUDE_BIN" >/dev/null 2>&1 || {
+  echo "FATAL: claude CLI not found — install Claude Code and ensure it is on PATH" >&2
+  exit 2
+}
+
+SENTINEL="SKILL83_L2_$(date +%s)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "── agent nesting smoke test ──────────────────────────────────────"
+printf "  claude:   %s\n" "$("$CLAUDE_BIN" --version 2>/dev/null)"
+printf "  sentinel: %s\n" "$SENTINEL"
+printf "  timeout:  %ss\n" "$TIMEOUT_SECS"
+echo
+
+L2_SENTINEL="$SENTINEL"
+
+cat >"$TMP/l2_prompt.txt" <<EOF
+Output exactly the following string and nothing else, with no surrounding text, quotes, or explanation:
+${L2_SENTINEL}
+EOF
+
+cat >"$TMP/l1_prompt.txt" <<EOF
+You are a Level-1 nesting smoke test agent. Complete these two steps and then output the result line.
+
+STEP 1 — spawn Level-2 agent:
+Use the Agent tool. Pass this exact text as the prompt (copy it verbatim, no changes):
+$(cat "$TMP/l2_prompt.txt")
+
+Record the full text returned by Level-2.
+
+STEP 2 — verify MCP access:
+Call the feature_implement_workflow_list MCP tool. If the tool does not exist or is not available, try calling feature_implement_workflow_get with issue_key "SMOKE-TEST-PROBE" (it may return an error response — that is fine as long as the tool call itself was accepted). Record whether the MCP call was accepted (even returning an error result is "ok") or whether the tool itself was not available.
+
+After both steps, output EXACTLY this single line as your FINAL output and nothing else before or after it:
+L1_RESULT|<level2_text>|<mcp_ok_or_mcp_err>
+
+Where:
+  <level2_text>     = the exact text Level-2 returned (no quotes around it)
+  <mcp_ok_or_mcp_err> = "mcp_ok" if any MCP tool call was accepted, "mcp_err" if no skill-bill MCP tool was available
+EOF
+
+cat >"$TMP/l0_prompt.txt" <<EOF
+You are a Level-0 nesting smoke test agent. Complete this one step.
+
+STEP 1 — spawn Level-1 agent:
+Use the Agent tool with the following prompt (copy it verbatim, preserving all lines):
+$(cat "$TMP/l1_prompt.txt")
+
+After Level-1 returns, find the line in its output that starts with "L1_RESULT|".
+Output EXACTLY this single line as your FINAL output and nothing else:
+SMOKE_RESULT|<copy the full L1_RESULT|... line here>
+
+Replace <copy the full L1_RESULT|... line here> with the entire "L1_RESULT|..." line from Level-1's output.
+EOF
+
+echo "  Invoking Level-0 claude session (may take up to ${TIMEOUT_SECS}s) ..."
+claude_out=""
+claude_rc=0
+claude_out="$(cd "$REPO_ROOT" && timeout "$TIMEOUT_SECS" "$CLAUDE_BIN" -p "$(cat "$TMP/l0_prompt.txt")" 2>"$TMP/err.txt")" || claude_rc=$?
+
+echo "  claude exit: $claude_rc"
+if [[ -s "$TMP/err.txt" ]]; then
+  echo "  stderr (head 5):"
+  head -5 "$TMP/err.txt" | sed 's/^/    /'
+fi
+echo
+
+declare -a RESULTS
+overall=0
+
+chk() {
+  local name="$1" ok="$2" detail="${3:-}"
+  RESULTS+=("$name|$ok|$detail")
+  [[ "$ok" -eq 1 ]] || overall=1
+}
+
+chk "claude_cli_succeeded" "$([[ $claude_rc -eq 0 ]] && echo 1 || echo 0)" "exit=$claude_rc"
+
+smoke_line="$(printf '%s\n' "$claude_out" | grep -o 'SMOKE_RESULT|.*' | head -1 || true)"
+chk "level0_emitted_smoke_result" "$([[ -n "$smoke_line" ]] && echo 1 || echo 0)" "got=${smoke_line:-<none>}"
+
+l1_line="$(printf '%s\n' "$smoke_line" | sed 's/^SMOKE_RESULT|//')"
+l2_got="$(printf '%s\n' "$l1_line" | cut -d'|' -f2)"
+mcp_got="$(printf '%s\n' "$l1_line" | cut -d'|' -f3)"
+
+chk "level1_l1_result_present" "$([[ -n "$l1_line" && "$l1_line" == L1_RESULT* ]] && echo 1 || echo 0)" "l1_line=${l1_line:-<none>}"
+chk "level2_sentinel_propagated" "$([[ "$l2_got" == "$L2_SENTINEL" ]] && echo 1 || echo 0)" "expected=$L2_SENTINEL got=${l2_got:-<none>}"
+chk "level1_mcp_accessible" "$([[ "$mcp_got" == "mcp_ok" ]] && echo 1 || echo 0)" "mcp_status=${mcp_got:-<none>}"
+
+echo "  ── check results ──"
+for entry in "${RESULTS[@]}"; do
+  IFS='|' read -r name ok detail <<< "$entry"
+  tag="PASS"
+  [[ "$ok" -eq 1 ]] || tag="FAIL"
+  suf=""
+  { [[ "$ok" -eq 1 ]] || [[ -z "$detail" ]]; } || suf=" — $detail"
+  printf "    [%s] %s%s\n" "$tag" "$name" "$suf"
+done
+
+echo
+echo "════ nesting smoke test summary ════"
+if [[ $overall -eq 0 ]]; then
+  echo "  PASS — 3-level Agent nesting verified."
+  echo "  Level-1 MCP tools accessible. SKILL-83 implementation may proceed."
+else
+  echo "  FAIL — 3-level Agent nesting could NOT be verified."
+  echo
+  echo "  SKILL-83 is BLOCKED. Alternatives:"
+  echo "  (a) Keep mode:prose with /clear between subtasks (manual, works today)."
+  echo "  (b) Use mode:runtime with a conservative Anthropic console spending cap."
+  echo
+  if [[ -n "$claude_out" ]]; then
+    echo "  Level-0 output (head 20):"
+    printf '%s\n' "$claude_out" | head -20 | sed 's/^/    /'
+  fi
+fi
+exit $overall

--- a/skills/agent/history.md
+++ b/skills/agent/history.md
@@ -1,3 +1,15 @@
+## [2026-06-13] prose-goal-subtask-isolation
+Areas: skills/bill-feature-goal, skills/bill-feature-task-prose, skills/bill-feature-task-subtask-runner, scripts
+- Goal orchestrator (bill-feature-goal mode:prose) stays thin: holds only decomposition manifest + per-subtask terminal outcomes; no phase artifacts accumulated
+- Subtask execution delegated to Level-1 Agent-tool spawn (bill-feature-task-subtask-runner) with self-contained briefing; continuation via feature_implement_workflow_continue with suppress_pr=true
+- Terminal outcome verified via feature_implement_workflow_get after each subtask-agent returns; in-session return value is signal only
+- Stop-loudly contract: on subtask failure, orchestrator surfaces subtask ID, blocked_reason, workflow ID, and last_resumable_step; does not advance
+- New native agent entry bill-feature-task-subtask-runner in skills/bill-feature-task-prose/native-agents/agents.yaml (reusable)
+- New skill skills/bill-feature-task-subtask-runner/content.md — Level-1 subtask agent; required by validateAgentConfigs for bill-* references in prose .md files (reusable)
+- 3-level Agent nesting verified via scripts/agent_nesting_smoke_test.sh go/no-go gate (pattern reusable for nesting depth validation)
+Feature flag: N/A
+Acceptance criteria: 10/10 implemented
+
 ## [2026-06-08] decomposition-manifest-schema-in-skills
 Areas: skills/bill-feature-spec, skills/bill-feature-task-prose
 - Added v0.3 manifest YAML template to bill-feature-spec decomposed Output Rules; agents fill it directly from planning subagent RESULT

--- a/skills/bill-feature-goal/content.md
+++ b/skills/bill-feature-goal/content.md
@@ -257,41 +257,43 @@ confirmation prompt. The decomposition-readiness checks, the proposal contents,
 and that single gate are shared verbatim across both modes.
 
 After the user confirms at that single gate, `mode:prose` does NOT launch
-`skill-bill goal`. Instead, the invoking agent loops the decomposed subtasks in
-dependency order entirely within the current session, entering EACH subtask
-through the existing continuation contract:
-
-```bash
-skill-bill workflow continue <issue_key> --subtask-id <id>
-```
-
-or the MCP tool `feature_implement_workflow_continue` with the decomposed parent
-`issue_key` and an integer `subtask_id`. This is the same non-interactive
-worker contract documented in `bill-feature-task-prose` under
-`## Goal-Continuation Entry (non-interactive)`. The prose loop NEVER synthesizes
-a second record-writing path: the worker (`bill-feature-task-prose`) writes the
-durable subtask outcome, and the prose loop only enters and observes that
-contract.
+`skill-bill goal`. Instead, for each runnable subtask the invoking agent spawns
+exactly one Level-1 subtask-agent via the Agent tool with a self-contained
+briefing. The agent type is `bill-feature-task-subtask-runner`. The briefing
+must carry: `issue_key`, `subtask_id`, `workflow_id` (from the manifest or the
+continuation selector result), `spec_path`, and the goal-continuation contract
+rules (`suppress_pr=true`, `commit_push` is the terminal signal, no install
+flows). The Level-1 agent runs the full phase loop
+(preplan → plan → implement → review → audit → validate → history → commit_push)
+in its own fresh context and returns a bounded RESULT block.
 
 Selection semantics follow the runtime DecompositionWorkflowContinuation
 selector: resume the in-progress subtask; else start the first pending subtask
-whose dependencies are complete; else report blocked or all-complete. Prefer
-letting `workflow continue` perform the selection rather than computing the next
-subtask in prose, so the prose loop cannot drift from runtime ordering. When a
-`subtask_id` is passed, treat it as a constraint on the next runnable subtask,
+whose dependencies are complete; else report blocked or all-complete. Resolve the
+`workflow_id` for the next runnable subtask via `feature_implement_workflow_get`
+or `skill-bill workflow continue` before spawning the Level-1 agent, so the
+Level-1 briefing carries the correct `workflow_id`. When a `subtask_id` is
+supplied by the caller, treat it as a constraint on the next runnable subtask,
 never a way to skip dependencies.
 
 Per-subtask runs keep `suppress_pr=true` (`goal_continuation.suppress_pr=true`)
 so each subtask commits but does not open its own PR; the whole goal opens
 exactly one parent PR on clean completion.
 
+**Orchestrator thinness constraint.** The invoking agent (Level-0) holds only:
+(1) the decomposition manifest, (2) per-subtask terminal outcomes —
+`{status, commit_sha, workflow_id}` — one record per completed or stopped
+subtask, and (3) the current subtask index. It does NOT accumulate preplan
+digests, plans, implementation summaries, code-review reports, or audit reports
+from any subtask. The Level-1 return value is the terminal outcome signal;
+everything else stays in Level-1 context.
+
 ### Terminal-outcome verification and durable authority
 
-After each subtask, confirm the durable terminal outcome BEFORE advancing to the
-next subtask. The prose transcript is never proof of progress. Verify through a
-read-only inspection — `skill-bill workflow show <id> --format json`,
-`feature_implement_workflow_get`, or `skill-bill goal status <issue_key>` —
-never by trusting in-session narration.
+After Level-1 returns, verify the terminal outcome via
+`feature_implement_workflow_get` (or `skill-bill goal status <issue_key>`)
+before advancing to the next subtask. The in-session RESULT block is a signal
+only — durable workflow state is authoritative.
 
 The structured outcome fields are `issue_key`, `subtask_id`, `status`,
 `commit_sha`, `workflow_id`, `blocked_reason`, and `last_resumable_step`.
@@ -305,8 +307,9 @@ and must never be hand-edited to force progress.
 
 ### Blocked or failed subtask: stop loudly
 
-If any subtask returns blocked or failed — anything other than a terminal
-success — STOP the loop loudly and immediately. Do NOT continue to the next
+If Level-1 returns a RESULT block with `status` ≠ `completed`, treat it as
+blocked/failed. If any subtask returns blocked or failed — anything other than a
+terminal success — STOP the loop loudly and immediately. Do NOT continue to the next
 subtask manually and do NOT attempt a hand-written continuation. Surface the
 subtask id, the reason (`blocked_reason`), the workflow id, and the resumable
 step (`last_resumable_step`), leaving resumable durable state in place so a later

--- a/skills/bill-feature-task-prose/native-agents/agents.yaml
+++ b/skills/bill-feature-task-prose/native-agents/agents.yaml
@@ -295,26 +295,26 @@ agents:
     description: "PR-description subagent for bill-feature-task: create the pull request and return its URL."
     body: |-
       You are the PR-description subagent. Your job is to create the pull request and return its URL.
-      
+
       Feature: {feature_name}
       Issue key: {issue_key}
       Branch: feat/{issue_key}-{feature_name}
       Base branch: main (or the repo's main branch if different)
-      
+
       Acceptance criteria (for reference when drafting the PR body):
       {numbered_list}
-      
+
       Implementation summary (from Step 4):
       {implementation_return_json}
-      
+
       Instructions:
       1. Invoke `bill-pr-description` via the Skill tool — DO NOT search the filesystem (no `find`, `grep -r`, etc.) to locate skill files; the Skill tool resolves skills by name. Apply its instructions in the current agent context. Respect repo-native PR templates if present (`.github/pull_request_template.md`, `PULL_REQUEST_TEMPLATE.md`, etc.).
       2. Create the PR with `gh pr create` using a HEREDOC for the body.
       3. Call the `pr_description_generated` MCP tool with `orchestrated=true` once the PR is created.
       4. Capture the `telemetry_payload` returned by `pr_description_generated` verbatim.
-      
+
       Return exactly one RESULT: block as your final message, containing valid JSON with this shape:
-      
+
       RESULT:
       {
         "pr_created": <bool>,
@@ -323,4 +323,45 @@ agents:
         "used_repo_template": <bool>,
         "template_path": "<path or empty>",
         "telemetry_payload": { ... verbatim from pr_description_generated ... }
+      }
+  - name: bill-feature-task-subtask-runner
+    description: "Level-1 subtask-agent for bill-feature-goal mode:prose: runs exactly one subtask's full phase loop in a fresh context and returns a bounded terminal outcome."
+    body: |-
+      You are the Level-1 subtask-agent for a decomposed prose goal. You run exactly one subtask's full phase loop in a fresh session context and return a bounded terminal outcome only.
+
+      Briefing:
+      Issue key:   {issue_key}
+      Subtask ID:  {subtask_id}
+      Workflow ID: {workflow_id}
+      Spec path:   {spec_path}
+
+      Goal-continuation contract:
+      1. Call `feature_implement_workflow_continue` (or `skill-bill workflow continue`) with the parent `issue_key` and `subtask_id` above to enter the subtask workflow.
+      2. Follow the `bill-feature-task-prose ## Goal-Continuation Entry (non-interactive)` rules verbatim:
+         - `suppress_pr=true` — do NOT open a PR for this subtask
+         - No install flows — do NOT run `./install.sh` or any install command
+         - `commit_push` is the terminal success signal — stop and return when the workflow continuation reaches commit_push
+      3. Run the full phase loop for this subtask: preplan → plan → implement → review → audit → validate → history → commit_push.
+         - Spawn Level-2 phase agents (preplan, plan, implement, audit, quality-check) exactly as the current bill-feature-task-prose orchestrator does.
+         - Run `bill-code-review` inline (which spawns Level-2 specialists) exactly as the current orchestrator does.
+         - No changes to any phase agent or reviewer behavior.
+
+      Context discipline:
+      - Do NOT ask for confirmation before starting. Start immediately by calling `feature_implement_workflow_continue`.
+      - Do NOT accumulate sibling-subtask artifacts. Your context holds only this subtask's data.
+      - Do NOT open a PR. PR suppression is mandatory (`suppress_pr=true`).
+      - Start from zero context. Derive all task details from the workflow continuation payload and `{spec_path}` alone.
+      - Do NOT hand off to the user or request external input at any point in the phase loop.
+
+      Return contract:
+      Emit exactly one RESULT: block as your final message. The block must contain only this JSON — no narrative, no phase artifacts, no implementation details:
+
+      RESULT:
+      {
+        "subtask_id": {subtask_id},
+        "status": "completed|blocked|failed",
+        "commit_sha": "<full SHA or empty string if not completed>",
+        "workflow_id": "{workflow_id}",
+        "blocked_reason": "<empty string if status is completed>",
+        "last_resumable_step": "<step id or empty string if status is completed>"
       }

--- a/skills/bill-feature-task-subtask-runner/content.md
+++ b/skills/bill-feature-task-subtask-runner/content.md
@@ -1,0 +1,33 @@
+---
+name: bill-feature-task-subtask-runner
+description: Level-1 subtask-agent for bill-feature-goal mode:prose. Runs exactly one subtask's full phase loop (preplan → plan → implement → review → audit → validate → history → commit_push) in a fresh context and returns a bounded terminal outcome. Invoked via the Agent tool by the mode:prose goal orchestrator — not directly via the Skill tool.
+---
+
+# Feature Task Subtask Runner
+
+`bill-feature-task-subtask-runner` is the Level-1 subtask-agent type for
+`bill-feature-goal mode:prose`. It is not invoked directly via the Skill tool.
+The `mode:prose` goal orchestrator spawns it via the Agent tool for each
+runnable subtask.
+
+## Role
+
+The subtask-runner receives a self-contained briefing (`issue_key`,
+`subtask_id`, `workflow_id`, `spec_path`) and runs the full phase loop for
+that subtask by calling `feature_implement_workflow_continue` with the parent
+`issue_key` and `subtask_id`. It follows the `bill-feature-task-prose`
+goal-continuation contract verbatim: `suppress_pr=true`, no install flows,
+`commit_push` is the terminal success signal.
+
+## Return contract
+
+Returns exactly one RESULT block with `subtask_id`, `status`
+(`completed|blocked|failed`), `commit_sha`, `workflow_id`, `blocked_reason`,
+and `last_resumable_step`. No phase artifacts, implementation details, or
+narrative in the return payload.
+
+## Agent definition
+
+The agent body is registered in
+`skills/bill-feature-task-prose/native-agents/agents.yaml` under the name
+`bill-feature-task-subtask-runner`.


### PR DESCRIPTION
# Summary

In `bill-feature-goal mode:prose`, the goal orchestrator previously ran each subtask's full phase loop inline, accumulating context from every phase of every subtask until hitting the auto-compact wall. This PR delegates each subtask to a dedicated **Level-1 subtask-agent** (via the Agent tool), keeping the Level-0 orchestrator thin and giving each subtask a fresh 1 M-token context budget.

- `skills/bill-feature-goal/content.md` — rewrote the Mode:Prose execution loop: orchestrator now spawns one `bill-feature-task-subtask-runner` agent per subtask with a self-contained briefing, verifies terminal outcome via durable workflow state before advancing, and stops loudly on failure
- `skills/bill-feature-task-prose/native-agents/agents.yaml` — registered `bill-feature-task-subtask-runner` as a native agent entry
- `skills/bill-feature-task-subtask-runner/content.md` — new skill content for the Level-1 runner (required by `validateAgentConfigs`)
- `scripts/agent_nesting_smoke_test.sh` — standalone 3-level nesting smoke test (go/no-go gate)
- `README.md` — added catalog entry for the new skill

## Feature Flags

N/A

# How Has This Been Tested?

- Kotlin check (`./gradlew check`) — 258 tasks, all green including `validateAgentConfigs`
- Agent install smoke test (`scripts/agent_install_smoke_test.sh`) — all 5 agents (claude, codex, copilot, opencode, junie) passed
- 3-level Agent nesting verified inline (Level-0 → Level-1 → Level-2 sentinel propagation and MCP access confirmed)
- Existing tests (`InstallerShellDelegationTest`, `InstallerShellReuseLastSelectionTest`, `InstallerShellReconcileTest`, goal-runner integration tests) remain green

Reproduce:
1. Run `bash scripts/agent_nesting_smoke_test.sh` — should exit 0 with all three nesting levels reporting success
2. Trigger `bill-feature-goal mode:prose` on a multi-subtask goal and confirm the orchestrator spawns individual Level-1 agents rather than running each subtask inline
3. Confirm each subtask commits without opening its own PR; a single parent PR is opened after all subtasks complete