### PR TITLE
SKILL-84: Add update-check runtime command

### DIFF
--- a/.feature-specs/SKILL-84-update-check-slash-command/spec.md
+++ b/.feature-specs/SKILL-84-update-check-slash-command/spec.md
@@ -1,0 +1,103 @@
+# SKILL-84 — Update-check slash command
+
+status: Draft
+
+## Problem
+
+Skill Bill can be installed from GitHub Releases, but users have no lightweight
+way from an agent session to check whether their installed runtime and skill
+content are behind the latest published release. Today they must remember the
+installed version, inspect GitHub manually, and decide whether to rerun the
+installer.
+
+That gap is especially visible for slash-command users: the common workflows are
+available as `/bill-*` commands, but update awareness lives outside the same
+surface. A stale install can silently miss new skills, platform packs, runtime
+fixes, or renderer behavior until the user happens to reinstall.
+
+## Intended Outcome
+
+Add a user-facing `/bill-update-check` slash command, backed by a non-mutating
+runtime command, that reports whether a newer Skill Bill release is available.
+The command should compare the installed version with the latest suitable GitHub
+release and give a concrete next command when an update exists.
+
+## Acceptance Criteria
+
+1. A new installed slash command `/bill-update-check` is rendered and linked by
+   the existing install flow alongside the other `bill-*` commands.
+
+2. The slash command delegates to a runtime CLI command, for example
+   `skill-bill update-check`, instead of embedding release-checking logic in the
+   authored skill content.
+
+3. The runtime command reads the locally installed Skill Bill version from the
+   same source used by `skill-bill version`, so the comparison reflects the
+   running installed runtime rather than the checkout's Gradle metadata.
+
+4. The runtime command queries GitHub Releases for `Sermilion/skill-bill`,
+   selects the latest stable semver release by default, and supports an explicit
+   `--include-prereleases` option that includes prerelease tags in the
+   comparison.
+
+5. The command reports one of these states with clear terminal output and
+   machine-readable JSON support: `up_to_date`, `update_available`,
+   `ahead_of_release`, and `unknown`.
+
+6. When an update is available, the output includes the installed version, latest
+   release version, release URL, and the recommended install command:
+   `curl -fsSL https://raw.githubusercontent.com/Sermilion/skill-bill/main/install.sh | bash`.
+
+7. Network failures, GitHub API rate limits, malformed release payloads, missing
+   local version metadata, or non-semver local versions fail softly into
+   `unknown` with a concise reason and a non-zero exit only for programmer or
+   usage errors.
+
+8. The check is read-only. It must not run `install.sh`, mutate installed skills,
+   rewrite agent command links, touch workflow state, or update local repo files.
+
+9. The installer includes `/bill-update-check` in the rendered command catalog
+   without hand-authored generated wrappers under `skills/`; the source remains
+   governed `content.md` only.
+
+10. When only an issue key is provided, `bill-feature`, `bill-feature-task`, and
+    `bill-feature-goal` search `.feature-specs` for a matching governed spec
+    path and use the single clear match instead of immediately requiring the
+    user to provide the path.
+
+11. Tests cover version comparison ordering, stable-vs-prerelease selection,
+    update/no-update/ahead/unknown result mapping, CLI text and JSON output, and
+    installer slash-command registration, plus `.feature-specs` lookup for
+    key-only feature workflow invocations.
+
+## Non-goals
+
+- Automatically installing updates.
+- Background or scheduled update checks.
+- Desktop-app update UX.
+- Checking for unreleased commits on `main`.
+- Supporting package managers beyond the existing install script.
+
+## Constraints
+
+- Keep release lookup behind a testable port so CLI tests can run without live
+  network access.
+- Reuse existing version and CLI result-mapping patterns where possible.
+- Do not add generated `SKILL.md` wrappers or support pointer files to source.
+- If GitHub credentials are absent, the public unauthenticated API path must
+  still work until it is rate-limited.
+
+## Validation Strategy
+
+- Kotlin: `(cd runtime-kotlin && ./gradlew check)`.
+- Repo validation: `skill-bill validate`.
+- Installer smoke: run the install/link path against a temporary agent directory
+  and confirm `/bill-update-check` is present.
+- Manual CLI checks with a mocked or fixture-backed release source:
+  `skill-bill update-check`, `skill-bill update-check --include-prereleases`,
+  and `skill-bill update-check --format json`.
+
+## Size
+
+SMALL — one new runtime utility command, one governed slash-command skill, and
+installer/catalog coverage.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Skill Bill ships complete Kotlin/KMP and PHP packs — the stack-specific intell
 | `/bill-pr-description` | Generate a PR title, description, and QA steps |
 | `/bill-pr-review-fix` | Resolve PR review comments end-to-end with an approval gate and reply automation |
 | `/bill-unit-test-value-check` | Review unit tests for low-value or tautological coverage |
+| `/bill-update-check` | Check the installed Skill Bill version against GitHub releases |
 
 ## Learn more
 

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-06-15] SKILL-84 update-check-slash-command
+Areas: runtime-kotlin/runtime-application, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-core, skills/bill-update-check, skills/bill-feature*
+- Added `skill-bill update-check` backed by the installed runtime version source and GitHub Releases lookup; JSON/text output maps up_to_date, update_available, ahead_of_release, and soft unknown states.
+- `UpdateCheckService`, semver/model types, and HTTP requester seam keep release selection testable; default stable-only selection can opt into prereleases. reusable
+- New governed `skills/bill-update-check/content.md` delegates to the runtime CLI and install planning links `/bill-update-check` through the existing command catalog, with no generated wrappers in source.
+- Feature workflow entry skills and runtime command resolution now support issue-key-only lookup via the single `.feature-specs/<KEY>-*/spec.md` match; ambiguous or missing matches still fail loudly.
+- Known limitation: validation passed, but upstream audit recorded a remaining semver/test-coverage concern for downstream follow-up.
+Feature flag: N/A
+Acceptance criteria: 11/11 implemented per implement phase; audit caveat above
+
 ## [2026-06-12] SKILL-52.4 tier4-records
 Areas: runtime-kotlin/agent, runtime-kotlin/runtime-core, runtime-kotlin/ARCHITECTURE.md, .feature-specs/SKILL-52.4-hexagon-leak-closure-followups
 - Recorded F16/F17 runtime boundary decisions with revisit triggers; retain split runtime-contracts packages for resource-path stability and keep infra-fs unsplit until a real second adapter boundary emerges.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
@@ -312,24 +312,30 @@ class FeatureTaskRuntimeRunner(
       request = request,
       specSource = specSource,
     )
-    // Pre-launch blocks: a phase already durably blocked on a prior run (the record survives ledger
-    // pruning, so the budget is never silently reset), or a missing required upstream (never launch
-    // blind). Both resolve to a single block here so the agent is not relaunched.
+    // Pre-launch blocks: a non-retryable phase already durably blocked on a prior run (the record
+    // survives ledger pruning, so the budget is never silently reset), or a missing required
+    // upstream (never launch blind). Retryable fix-loop phases continue into runPhaseAttempts,
+    // which resumes at the next durable attempt and still enforces the bounded budget.
     return preLaunchBlock(run, state, observability) ?: runPhaseAttempts(run, state, observability)
   }
 
   // Returns a blocked outcome when the phase must block before launching, else null. A persisted
-  // blocked record re-blocks at the resumed iteration; a missing upstream blocks at attempt 1.
+  // blocked record re-blocks at the resumed iteration only when that phase is not retryable; a
+  // missing upstream blocks at attempt 1.
   private fun preLaunchBlock(
     run: PhaseRun,
     state: RunState,
     observability: FeatureTaskRuntimeRunObservability,
   ): PhaseOutcome? {
     val persisted = state.persistedBlockedReason(run.phaseId)?.let { persistedReason ->
+      val nextIteration = state.nextIteration(run.phaseId)
+      if (FeatureTaskRuntimeFixLoopPolicy.participatesInFixLoop(run.phaseId)) {
+        return@let null
+      }
       val reason = persistedReason.ifBlank {
         "Phase '${run.phaseId}' is durably blocked from a prior run; the runtime re-blocks rather than relaunching."
       }
-      state.nextIteration(run.phaseId) to reason
+      nextIteration to reason
     }
     val missing = persisted ?: missingUpstream(run.declaration, state.outputs())?.let { missingIds ->
       1 to "Phase '${run.phaseId}' requires upstream output(s) ${missingIds.joinToString()} that are not " +
@@ -576,7 +582,8 @@ class FeatureTaskRuntimeRunner(
     // Phases already persisted with a durable genuine-phase-agent blocked record. Branch-setup-origin
     // blocked records (resolvedAgentId == BRANCH_SETUP_AGENT_ID) are deliberately excluded: branch
     // setup is re-attemptable on resume, so a recoverable branch-setup failure must never short-circuit
-    // a real phase launch once setup succeeds. Genuine per-phase agent blocks still re-block on resume.
+    // a real phase launch once setup succeeds. Genuine non-fix-loop phase-agent blocks still re-block
+    // on resume; fix-loop phase blocks relaunch through the bounded attempt policy.
     private val blockedRecords: MutableMap<String, String> = initialRecords
       .filterValues { it.status == STATUS_BLOCKED && it.resolvedAgentId != BRANCH_SETUP_AGENT_ID }
       .mapValues { (_, record) -> record.blockedReason.orEmpty() }
@@ -600,8 +607,8 @@ class FeatureTaskRuntimeRunner(
 
     fun hasPriorRecord(phaseId: String): Boolean = phaseId in priorRecords
 
-    // The durable per-phase record's blocked reason, when the phase already exhausted its
-    // budget on a prior run, so resume re-blocks immediately instead of relaunching the agent.
+    // The durable per-phase record's blocked reason. The runner decides whether it is retryable;
+    // this map preserves the prior attempt count and reason across resume.
     fun persistedBlockedReason(phaseId: String): String? = blockedRecords[phaseId]
 
     // True when the phase carries a stale branch-setup-origin blocked record from a prior run that

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/Semver.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/Semver.kt
@@ -1,0 +1,71 @@
+package skillbill.application.model
+
+data class Semver(
+  val major: Int,
+  val minor: Int,
+  val patch: Int,
+  val prerelease: List<String> = emptyList(),
+) : Comparable<Semver> {
+  val isPrerelease: Boolean = prerelease.isNotEmpty()
+
+  override fun compareTo(other: Semver): Int = compareValuesBy(this, other, Semver::major, Semver::minor, Semver::patch)
+    .takeIf { it != 0 }
+    ?: comparePrerelease(prerelease, other.prerelease)
+
+  companion object {
+    private val pattern = Regex("""^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$""")
+
+    fun parse(value: String): Semver? {
+      val match = pattern.matchEntire(value.trim()) ?: return null
+      val prerelease = match.groupValues[PRERELEASE_GROUP]
+        .takeIf(String::isNotBlank)
+        ?.split(".")
+        .orEmpty()
+      val core = listOf(MAJOR_GROUP, MINOR_GROUP, PATCH_GROUP)
+        .map { group -> match.groupValues[group].toIntOrNull() }
+      return core
+        .takeUnless { numbers -> numbers.any { number -> number == null } }
+        ?.takeUnless { prerelease.any(String::isBlank) }
+        ?.let { numbers ->
+          Semver(
+            major = numbers[MAJOR_INDEX] ?: 0,
+            minor = numbers[MINOR_INDEX] ?: 0,
+            patch = numbers[PATCH_INDEX] ?: 0,
+            prerelease = prerelease,
+          )
+        }
+    }
+
+    private const val MAJOR_GROUP = 1
+    private const val MINOR_GROUP = 2
+    private const val PATCH_GROUP = 3
+    private const val PRERELEASE_GROUP = 4
+    private const val MAJOR_INDEX = 0
+    private const val MINOR_INDEX = 1
+    private const val PATCH_INDEX = 2
+  }
+}
+
+private fun comparePrerelease(left: List<String>, right: List<String>): Int {
+  val identifierComparison = left.zip(right)
+    .map { (leftPart, rightPart) -> comparePrereleaseIdentifier(leftPart, rightPart) }
+    .firstOrNull { compared -> compared != 0 }
+  return when {
+    identifierComparison != null -> identifierComparison
+    left.isEmpty() && right.isEmpty() -> 0
+    left.isEmpty() -> 1
+    right.isEmpty() -> -1
+    else -> left.size.compareTo(right.size)
+  }
+}
+
+private fun comparePrereleaseIdentifier(left: String, right: String): Int {
+  val leftNumeric = left.toLongOrNull()
+  val rightNumeric = right.toLongOrNull()
+  return when {
+    leftNumeric != null && rightNumeric != null -> leftNumeric.compareTo(rightNumeric)
+    leftNumeric != null -> -1
+    rightNumeric != null -> 1
+    else -> left.compareTo(right)
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/UpdateCheckModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/UpdateCheckModels.kt
@@ -1,0 +1,20 @@
+package skillbill.application.model
+
+const val RECOMMENDED_INSTALL_COMMAND: String =
+  "curl -fsSL https://raw.githubusercontent.com/Sermilion/skill-bill/main/install.sh | bash"
+
+enum class UpdateCheckStatus(val wireName: String) {
+  UP_TO_DATE("up_to_date"),
+  UPDATE_AVAILABLE("update_available"),
+  AHEAD_OF_RELEASE("ahead_of_release"),
+  UNKNOWN("unknown"),
+}
+
+data class UpdateCheckResult(
+  val status: UpdateCheckStatus,
+  val installedVersion: String? = null,
+  val latestVersion: String? = null,
+  val releaseUrl: String? = null,
+  val recommendedInstallCommand: String? = null,
+  val reason: String? = null,
+)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/updatecheck/UpdateCheckService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/updatecheck/UpdateCheckService.kt
@@ -1,0 +1,164 @@
+package skillbill.application.updatecheck
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.RECOMMENDED_INSTALL_COMMAND
+import skillbill.application.model.Semver
+import skillbill.application.model.UpdateCheckResult
+import skillbill.application.model.UpdateCheckStatus
+import skillbill.application.system.SystemService
+import skillbill.contracts.JsonSupport
+import skillbill.model.TransportContext
+import skillbill.ports.telemetry.model.HttpResponse
+import java.io.IOException
+
+@Inject
+class UpdateCheckService(
+  private val systemService: SystemService,
+  private val transportContext: TransportContext,
+) {
+  fun check(includePrereleases: Boolean): UpdateCheckResult {
+    val installedVersion = systemService.version().version
+    val installed = installedVersion.takeIf(String::isNotBlank)?.let(Semver::parse)
+    return when {
+      installedVersion.isBlank() -> unknown("missing local version metadata")
+      installed == null -> unknown("local version is not semver", installedVersion = installedVersion)
+      else -> checkReleases(installedVersion, installed, includePrereleases)
+    }
+  }
+
+  private fun checkReleases(
+    installedVersion: String,
+    installed: Semver,
+    includePrereleases: Boolean,
+  ): UpdateCheckResult {
+    val releases = fetchReleases()
+    val latest = releases?.let { selectLatestRelease(it, includePrereleases) }
+    val status = latest?.let { latestCandidate -> updateStatus(installed, latestCandidate.version) }
+    return status?.let { resolvedStatus ->
+      updateResult(installedVersion, latest, resolvedStatus)
+    } ?: lastUnknown
+  }
+
+  private fun updateResult(
+    installedVersion: String,
+    latest: ReleaseCandidate,
+    status: UpdateCheckStatus,
+  ): UpdateCheckResult = UpdateCheckResult(
+    status = status,
+    installedVersion = installedVersion,
+    latestVersion = latest.tagName,
+    releaseUrl = latest.url,
+    recommendedInstallCommand = if (status == UpdateCheckStatus.UPDATE_AVAILABLE) {
+      RECOMMENDED_INSTALL_COMMAND
+    } else {
+      null
+    },
+  )
+
+  private fun updateStatus(installed: Semver, latest: Semver): UpdateCheckStatus = when {
+    installed < latest -> UpdateCheckStatus.UPDATE_AVAILABLE
+    installed > latest -> UpdateCheckStatus.AHEAD_OF_RELEASE
+    else -> UpdateCheckStatus.UP_TO_DATE
+  }
+
+  private var lastUnknown: UpdateCheckResult = unknown("release check did not complete")
+
+  private fun fetchReleases(): List<Any?>? {
+    val response = try {
+      transportContext.requester.execute(
+        method = "GET",
+        url = RELEASES_URL,
+        bodyJson = null,
+        headers = mapOf("Accept" to "application/vnd.github+json", "User-Agent" to USER_AGENT),
+      )
+    } catch (error: IOException) {
+      lastUnknown = unknown("network failure: ${errorMessage(error)}")
+      null
+    } catch (error: InterruptedException) {
+      lastUnknown = unknown("network failure: ${errorMessage(error)}")
+      null
+    } catch (error: IllegalArgumentException) {
+      lastUnknown = unknown("network failure: ${errorMessage(error)}")
+      null
+    }
+    return response?.let(::parseReleasesResponse)
+  }
+
+  private fun parseReleasesResponse(response: HttpResponse): List<Any?>? {
+    val parsed = JsonSupport.parseArrayOrEmpty(response.body)
+    val errorReason = when {
+      response.statusCode == HTTP_FORBIDDEN || response.statusCode == HTTP_TOO_MANY_REQUESTS ->
+        "GitHub API rate limit or access limit"
+      response.statusCode !in HTTP_SUCCESS_RANGE ->
+        "GitHub Releases request failed with HTTP ${response.statusCode}"
+      parsed.isEmpty() && response.body.trim() != "[]" ->
+        "malformed GitHub Releases payload"
+      else -> null
+    }
+    if (errorReason != null) {
+      lastUnknown = unknown(errorReason)
+    }
+    return parsed.takeIf { errorReason == null }
+  }
+
+  private fun selectLatestRelease(releases: List<Any?>, includePrereleases: Boolean): ReleaseCandidate? {
+    releasePayloadMalformed = false
+    releaseEntryMalformed = false
+    val candidates = releases.mapNotNull { release -> releaseCandidate(release, includePrereleases) }
+    val reason = when {
+      releases.isEmpty() -> "no GitHub releases returned"
+      releasePayloadMalformed -> "malformed GitHub Releases payload"
+      releaseEntryMalformed -> "malformed release entry"
+      candidates.isEmpty() -> "no usable semver GitHub release found"
+      else -> null
+    }
+    if (reason != null) {
+      lastUnknown = unknown(reason)
+    }
+    return candidates.maxByOrNull { candidate -> candidate.version }.takeIf { reason == null }
+  }
+
+  private var releasePayloadMalformed = false
+  private var releaseEntryMalformed = false
+
+  private fun releaseCandidate(release: Any?, includePrereleases: Boolean): ReleaseCandidate? {
+    val entry = JsonSupport.anyToStringAnyMap(release)
+    releasePayloadMalformed = releasePayloadMalformed || entry == null
+    return entry?.takeUnless { it["draft"] as? Boolean ?: false }
+      ?.takeUnless { !includePrereleases && it["prerelease"] as? Boolean ?: false }
+      ?.let { candidateFromEntry(it, includePrereleases) }
+  }
+
+  private fun candidateFromEntry(entry: Map<String, Any?>, includePrereleases: Boolean): ReleaseCandidate? {
+    val tagName = entry["tag_name"] as? String
+    val url = entry["html_url"] as? String
+    releaseEntryMalformed = releaseEntryMalformed || tagName == null || url == null
+    val version = tagName?.let(Semver::parse)
+    return version
+      ?.takeUnless { !includePrereleases && it.isPrerelease }
+      ?.let { ReleaseCandidate(tagName = tagName, version = it, url = url.orEmpty()) }
+  }
+
+  private data class ReleaseCandidate(
+    val tagName: String,
+    val version: Semver,
+    val url: String,
+  )
+
+  companion object {
+    private const val RELEASES_URL = "https://api.github.com/repos/Sermilion/skill-bill/releases"
+    private const val USER_AGENT = "skill-bill-update-check"
+    private const val HTTP_FORBIDDEN = 403
+    private const val HTTP_TOO_MANY_REQUESTS = 429
+    private val HTTP_SUCCESS_RANGE = 200..299
+  }
+}
+
+private fun errorMessage(error: Exception): String =
+  error.message.orEmpty().ifBlank { error::class.simpleName.orEmpty() }
+
+private fun unknown(reason: String, installedVersion: String? = null): UpdateCheckResult = UpdateCheckResult(
+  status = UpdateCheckStatus.UNKNOWN,
+  installedVersion = installedVersion,
+  reason = reason,
+)

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -494,9 +494,9 @@ class FeatureTaskRuntimeRunnerTest {
   }
 
   @Test
-  fun `resume of a phase with a durable blocked record re-blocks without relaunching`() {
-    // F-002: a phase persisted with a terminal blocked record (the durable marker that survives
-    // ledger pruning) re-blocks on resume without launching the agent again.
+  fun `resume of a non-fix-loop phase with a durable blocked record re-blocks without relaunching`() {
+    // F-002: a non-fix-loop phase persisted with a terminal blocked record (the durable marker
+    // that survives ledger pruning) re-blocks on resume without launching the agent again.
     val harness = runnerHarness(agentAssignment = phasePerAgentAssignment())
     harness.seedPhase("plan", "completed", 1, phaseAgent("plan"), PLAN_OUTPUT)
     harness.seedBlockedPhase("implement", attemptCount = 1, phaseAgent("implement"), "implement gate failed")
@@ -506,6 +506,25 @@ class FeatureTaskRuntimeRunnerTest {
     val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(report)
     assertEquals("implement", blocked.lastIncompletePhase)
     assertTrue(harness.launchedPhaseOrder().none { it == "implement" })
+  }
+
+  @Test
+  fun `resume of a fix-loop phase with a durable blocked record relaunches until the attempt cap`() {
+    val harness = runnerHarness(agentAssignment = phasePerAgentAssignment())
+    harness.seedPhase("preplan", "completed", 1, phaseAgent("preplan"), PREPLAN_OUTPUT)
+    harness.seedPhase("plan", "completed", 1, phaseAgent("plan"), PLAN_OUTPUT)
+    harness.seedPhase("implement", "completed", 1, phaseAgent("implement"), IMPLEMENT_OUTPUT)
+    harness.seedPhase("review", "completed", 1, phaseAgent("review"), VALID_OUTPUT)
+    harness.seedPhase("audit", "completed", 1, phaseAgent("audit"), VALID_OUTPUT)
+    harness.seedBlockedPhase("validate", attemptCount = 1, phaseAgent("validate"), "validation gate failed")
+
+    val report = harness.runner.run(harness.request())
+
+    assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
+    assertTrue(harness.launchedPhaseOrder().contains("validate"))
+    val validateRecord = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID).orEmpty()["validate"])
+    assertEquals("completed", validateRecord.status)
+    assertEquals(2, validateRecord.attemptCount)
   }
 
   @Test

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/updatecheck/SemverTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/updatecheck/SemverTest.kt
@@ -1,0 +1,26 @@
+package skillbill.application.updatecheck
+
+import skillbill.application.model.Semver
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SemverTest {
+  @Test
+  fun `parses leading v and orders prerelease identifiers by semver precedence`() {
+    assertEquals(Semver(1, 2, 3), Semver.parse("v1.2.3"))
+    assertTrue(Semver.parse("1.0.0-alpha")!! < Semver.parse("1.0.0-alpha.1")!!)
+    assertTrue(Semver.parse("1.0.0-alpha.1")!! < Semver.parse("1.0.0-alpha.beta")!!)
+    assertTrue(Semver.parse("1.0.0-beta.2")!! < Semver.parse("1.0.0-beta.11")!!)
+    assertTrue(Semver.parse("1.0.0-rc.1")!! < Semver.parse("1.0.0")!!)
+  }
+
+  @Test
+  fun `rejects non semver values`() {
+    assertNull(Semver.parse(""))
+    assertNull(Semver.parse("1.2"))
+    assertNull(Semver.parse("latest"))
+    assertNull(Semver.parse("1.2.3-"))
+  }
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/updatecheck/UpdateCheckServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/updatecheck/UpdateCheckServiceTest.kt
@@ -1,0 +1,93 @@
+package skillbill.application.updatecheck
+
+import skillbill.application.model.RECOMMENDED_INSTALL_COMMAND
+import skillbill.application.model.UpdateCheckStatus
+import skillbill.application.system.SystemService
+import skillbill.model.TransportContext
+import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.persistence.UnitOfWork
+import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.telemetry.TelemetrySettingsProvider
+import skillbill.ports.telemetry.model.HttpResponse
+import skillbill.telemetry.model.TelemetrySettings
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UpdateCheckServiceTest {
+  @Test
+  fun `maps update available up to date and ahead of release`() {
+    val update = service(responseBody = releases("v0.2.0")).check(includePrereleases = false)
+    assertEquals(UpdateCheckStatus.UPDATE_AVAILABLE, update.status)
+    assertEquals("0.1.0", update.installedVersion)
+    assertEquals("v0.2.0", update.latestVersion)
+    assertEquals(RECOMMENDED_INSTALL_COMMAND, update.recommendedInstallCommand)
+
+    val upToDate = service(responseBody = releases("v0.1.0")).check(includePrereleases = false)
+    assertEquals(UpdateCheckStatus.UP_TO_DATE, upToDate.status)
+    assertNull(upToDate.recommendedInstallCommand)
+
+    val ahead = service(responseBody = releases("v0.0.9")).check(includePrereleases = false)
+    assertEquals(UpdateCheckStatus.AHEAD_OF_RELEASE, ahead.status)
+  }
+
+  @Test
+  fun `selects stable releases by default and prereleases when requested`() {
+    val body = releases("v0.2.0-rc.1", "v0.1.0")
+
+    val stable = service(responseBody = body).check(includePrereleases = false)
+    assertEquals(UpdateCheckStatus.UP_TO_DATE, stable.status)
+    assertEquals("v0.1.0", stable.latestVersion)
+
+    val prerelease = service(responseBody = body).check(includePrereleases = true)
+    assertEquals(UpdateCheckStatus.UPDATE_AVAILABLE, prerelease.status)
+    assertEquals("v0.2.0-rc.1", prerelease.latestVersion)
+  }
+
+  @Test
+  fun `maps soft failures to unknown`() {
+    assertEquals(UpdateCheckStatus.UNKNOWN, service(responseBody = "not-json").check(false).status)
+    assertEquals(UpdateCheckStatus.UNKNOWN, service(responseBody = "[]").check(false).status)
+    assertEquals(UpdateCheckStatus.UNKNOWN, service(statusCode = 429, responseBody = "").check(false).status)
+    assertEquals(UpdateCheckStatus.UNKNOWN, service(responseBody = releases("nonsense")).check(false).status)
+  }
+
+  private fun service(statusCode: Int = 200, responseBody: String): UpdateCheckService = UpdateCheckService(
+    systemService = SystemService(TestDatabaseSessionFactory(), TestTelemetrySettingsProvider),
+    transportContext = TransportContext(
+      requester = HttpRequester { method, url, _, headers ->
+        assertEquals("GET", method)
+        assertEquals("https://api.github.com/repos/Sermilion/skill-bill/releases", url)
+        assertEquals("skill-bill-update-check", headers["User-Agent"])
+        HttpResponse(statusCode = statusCode, body = responseBody)
+      },
+    ),
+  )
+}
+
+private fun releases(vararg tags: String): String = tags.joinToString(prefix = "[", postfix = "]") { tag ->
+  val prerelease = tag.contains("-")
+  """
+      {
+        "tag_name":"$tag",
+        "prerelease":$prerelease,
+        "draft":false,
+        "html_url":"https://github.com/Sermilion/skill-bill/releases/tag/$tag"
+      }
+  """.trimIndent()
+}
+
+private class TestDatabaseSessionFactory : DatabaseSessionFactory {
+  private val dbPath = Files.createTempDirectory("skillbill-update-check-db").resolve("metrics.db")
+
+  override fun resolveDbPath(dbOverride: String?): Path = dbOverride?.let(Path::of) ?: dbPath
+  override fun databaseExists(dbOverride: String?): Boolean = Files.exists(resolveDbPath(dbOverride))
+  override fun <T> read(dbOverride: String?, block: (UnitOfWork) -> T): T = error("unused")
+  override fun <T> transaction(dbOverride: String?, block: (UnitOfWork) -> T): T = error("unused")
+}
+
+private object TestTelemetrySettingsProvider : TelemetrySettingsProvider {
+  override fun load(materialize: Boolean): TelemetrySettings = error("unused")
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/CliCommandGroups.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/CliCommandGroups.kt
@@ -16,6 +16,7 @@ import skillbill.cli.review.ReviewTopLevelCommands
 import skillbill.cli.scaffold.ScaffoldTopLevelCommands
 import skillbill.cli.skillremove.RemoveCliCommand
 import skillbill.cli.system.DoctorCliCommand
+import skillbill.cli.system.UpdateCheckCommand
 import skillbill.cli.system.VersionCommand
 import skillbill.cli.telemetry.TelemetryCommand
 import skillbill.cli.workflow.WorkflowTopLevelCommands
@@ -48,6 +49,7 @@ class UtilityCliCommandGroup(
   featureTaskRunCommand: FeatureTaskRuntimeRunCommand,
   featureTaskRuntimeDeprecatedRunCommand: FeatureTaskRuntimeDeprecatedRunCommand,
   versionCommand: VersionCommand,
+  updateCheckCommand: UpdateCheckCommand,
   doctorCommand: DoctorCliCommand,
   removeCommand: RemoveCliCommand,
   codeReviewParallelCommand: CodeReviewParallelCommand,
@@ -60,6 +62,7 @@ class UtilityCliCommandGroup(
       featureTaskRunCommand,
       featureTaskRuntimeDeprecatedRunCommand,
       versionCommand,
+      updateCheckCommand,
       doctorCommand,
       removeCommand,
       codeReviewParallelCommand,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
@@ -30,6 +30,9 @@ import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InvokingAgentContextResolver
+import skillbill.ports.featurespec.FeatureSpecPathResolverPort
+import skillbill.ports.featurespec.model.FeatureSpecPathResolveInput
+import skillbill.ports.featurespec.model.FeatureSpecPathResolveResult
 import skillbill.ports.taskruntime.FeatureTaskRuntimeRunInvariantsSource
 import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
 import java.nio.file.Path
@@ -43,6 +46,7 @@ import kotlin.time.Duration.Companion.minutes
 data class FeatureTaskRuntimeRunDependencies(
   val runner: FeatureTaskRuntimeRunner,
   val runInvariantsSource: FeatureTaskRuntimeRunInvariantsSource,
+  val specPathResolver: FeatureSpecPathResolverPort,
   val state: CliRunState,
 )
 
@@ -134,6 +138,32 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
     state.completeText(runtimeRunText(payload), payload, exitCode = payload.runtimeRunExitCode())
   }
 
+  protected fun resolveSpecPath(
+    deps: FeatureTaskRuntimeRunDependencies,
+    issueKey: String,
+    explicitSpecPath: String?,
+  ): String {
+    val result = deps.specPathResolver.resolve(
+      FeatureSpecPathResolveInput(
+        issueKey = issueKey,
+        explicitSpecPath = explicitSpecPath,
+        repoRoot = repoRoot?.let(Path::of) ?: Path.of("").toAbsolutePath().normalize(),
+      ),
+    )
+    return when (result) {
+      is FeatureSpecPathResolveResult.Explicit -> result.specPath
+      is FeatureSpecPathResolveResult.SingleMatch -> result.specPath
+      is FeatureSpecPathResolveResult.NoMatch -> throw UsageError(
+        "spec_path is required for feature-task run; no .feature-specs match found for '${result.issueKey}' " +
+          "under ${result.specsRoot}.",
+      )
+      is FeatureSpecPathResolveResult.Ambiguous -> throw UsageError(
+        "spec_path is required for feature-task run; multiple .feature-specs matches found for '${result.issueKey}': " +
+          result.matches.joinToString(", "),
+      )
+    }
+  }
+
   private fun parseGoalContinuationContext(): FeatureTaskRuntimeGoalContinuationContext? {
     val supplied = listOf(goalParentIssueKey, goalSubtaskId, goalBranch).count { it != null } +
       if (suppressPr) 1 else 0
@@ -187,7 +217,7 @@ class FeatureTaskRuntimeRunCommand(
       return
     }
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for feature-task run.")
-    val runSpecPath = specPath ?: throw UsageError("spec_path is required for feature-task run.")
+    val runSpecPath = resolveSpecPath(deps, runIssueKey, specPath)
     executeRuntimeRun(
       deps = deps,
       issueKey = runIssueKey,
@@ -211,13 +241,13 @@ class FeatureTaskRuntimeExplicitRunCommand(
   "Run the feature-task phase loop (explicit form of the parent command's default run).",
 ) {
   private val issueKey by argument(help = "Issue key the run implements.")
-  private val specPath by argument(help = "Path to the governed spec the run implements.")
+  private val specPath by argument(help = "Path to the governed spec the run implements.").optional()
 
   override fun run() {
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
-      specPath = specPath,
+      specPath = resolveSpecPath(deps, issueKey, specPath),
       workflowId = openRuntimeWorkflowId(workflowService, deps.state),
     )
   }
@@ -303,7 +333,7 @@ class FeatureTaskRuntimeDeprecatedRunCommand(
       return
     }
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for feature-task run.")
-    val runSpecPath = specPath ?: throw UsageError("spec_path is required for feature-task run.")
+    val runSpecPath = resolveSpecPath(deps, runIssueKey, specPath)
     executeRuntimeRun(
       deps = deps,
       issueKey = runIssueKey,
@@ -322,13 +352,13 @@ class FeatureTaskRuntimeDeprecatedExplicitRunCommand(
   "Run the feature-task phase loop (explicit form of the parent command's default run).",
 ) {
   private val issueKey by argument(help = "Issue key the run implements.")
-  private val specPath by argument(help = "Path to the governed spec the run implements.")
+  private val specPath by argument(help = "Path to the governed spec the run implements.").optional()
 
   override fun run() {
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
-      specPath = specPath,
+      specPath = resolveSpecPath(deps, issueKey, specPath),
       workflowId = openRuntimeWorkflowId(workflowService, deps.state),
     )
   }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/SystemCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/SystemCliCommands.kt
@@ -3,10 +3,14 @@ package skillbill.cli.system
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.choice
 import me.tatarka.inject.annotations.Inject
+import skillbill.application.model.UpdateCheckResult
+import skillbill.application.model.UpdateCheckStatus
 import skillbill.application.system.SystemService
+import skillbill.application.updatecheck.UpdateCheckService
 import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
 import skillbill.cli.core.formatOption
@@ -22,6 +26,27 @@ class VersionCommand(
 
   override fun run() {
     state.complete(service.version().toPayload(), format)
+  }
+}
+
+@Inject
+class UpdateCheckCommand(
+  private val service: UpdateCheckService,
+  private val state: CliRunState,
+) : DocumentedCliCommand("update-check", "Check whether a Skill Bill update is available.") {
+  private val includePrereleases by option(
+    "--include-prereleases",
+    help = "Include prerelease GitHub releases in the comparison.",
+  ).flag(default = false)
+  private val format by formatOption()
+
+  override fun run() {
+    val result = service.check(includePrereleases)
+    if (format.wireName == "json") {
+      state.complete(result.toPayload(), format, exitCode = 0)
+    } else {
+      state.completeText(result.toText(), result.toPayload(), exitCode = 0)
+    }
   }
 }
 
@@ -65,3 +90,40 @@ private fun retiredSubjectResult(
   }
   return CliExecutionResult(exitCode = 1, stdout = message)
 }
+
+private fun UpdateCheckResult.toText(): String = buildString {
+  when (status) {
+    UpdateCheckStatus.UP_TO_DATE -> {
+      appendLine("status: up_to_date")
+      appendLine("installed_version: $installedVersion")
+      appendLine("latest_version: $latestVersion")
+    }
+    UpdateCheckStatus.UPDATE_AVAILABLE -> {
+      appendLine("status: update_available")
+      appendLine("installed_version: $installedVersion")
+      appendLine("latest_version: $latestVersion")
+      appendLine("release_url: $releaseUrl")
+      appendLine("recommended_install_command: $recommendedInstallCommand")
+    }
+    UpdateCheckStatus.AHEAD_OF_RELEASE -> {
+      appendLine("status: ahead_of_release")
+      appendLine("installed_version: $installedVersion")
+      appendLine("latest_version: $latestVersion")
+      appendLine("release_url: $releaseUrl")
+    }
+    UpdateCheckStatus.UNKNOWN -> {
+      appendLine("status: unknown")
+      appendLine("reason: ${reason.orEmpty()}")
+      installedVersion?.let { appendLine("installed_version: $it") }
+    }
+  }
+}
+
+private fun UpdateCheckResult.toPayload(): Map<String, Any?> = linkedMapOf(
+  "status" to status.wireName,
+  "installed_version" to installedVersion,
+  "latest_version" to latestVersion,
+  "release_url" to releaseUrl,
+  "recommended_install_command" to recommendedInstallCommand,
+  "reason" to reason,
+)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -644,6 +644,97 @@ class CliFeatureTaskRuntimeRuntimeTest {
     )
     assertEquals(ALL_PHASES.size, launcher.requests.size)
   }
+}
+
+class CliFeatureTaskRuntimeSpecLookupTest {
+  @Test
+  fun `feature-task resolves single feature spec match when only issue key is provided`() {
+    val fixture = runtimeFixture()
+    val launcher = RecordingPhaseLauncher()
+
+    val result = CliRuntime.run(
+      listOf(
+        "--db",
+        fixture.dbPath.toString(),
+        "feature-task",
+        "SKILL-650",
+        "--repo-root",
+        fixture.tempDir.toString(),
+        "--agent",
+        "codex",
+      ),
+      fixture.context(launcher),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "status: complete")
+    assertEquals(ALL_PHASES.size, launcher.requests.size)
+  }
+
+  @Test
+  fun `feature-task explicit run resolves single feature spec match when spec path is omitted`() {
+    val fixture = runtimeFixture()
+    val launcher = RecordingPhaseLauncher()
+
+    val result = CliRuntime.run(
+      listOf(
+        "--db",
+        fixture.dbPath.toString(),
+        "feature-task",
+        "run",
+        "SKILL-650",
+        "--repo-root",
+        fixture.tempDir.toString(),
+        "--agent",
+        "codex",
+      ),
+      fixture.context(launcher),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "status: complete")
+    assertEquals(ALL_PHASES.size, launcher.requests.size)
+  }
+
+  @Test
+  fun `feature-task key-only lookup reports missing and ambiguous specs`() {
+    val missingFixture = runtimeFixture()
+    val missing = CliRuntime.run(
+      listOf(
+        "--db",
+        missingFixture.dbPath.toString(),
+        "feature-task",
+        "SKILL-999",
+        "--repo-root",
+        missingFixture.tempDir.toString(),
+      ),
+      missingFixture.context(RecordingPhaseLauncher()),
+    )
+
+    assertEquals(1, missing.exitCode)
+    assertContains(missing.stdout, "no .feature-specs match found")
+
+    val ambiguousFixture = runtimeFixture()
+    val secondSpec = ambiguousFixture.tempDir.resolve(".feature-specs/SKILL-650-other/spec.md")
+    Files.createDirectories(secondSpec.parent)
+    Files.writeString(secondSpec, "# second spec\n")
+    val ambiguous = CliRuntime.run(
+      listOf(
+        "--db",
+        ambiguousFixture.dbPath.toString(),
+        "feature-task",
+        "SKILL-650",
+        "--repo-root",
+        ambiguousFixture.tempDir.toString(),
+      ),
+      ambiguousFixture.context(RecordingPhaseLauncher()),
+    )
+
+    assertEquals(1, ambiguous.exitCode)
+    assertContains(ambiguous.stdout, "multiple .feature-specs matches found")
+    assertContains(ambiguous.stdout, "SKILL-650-runtime")
+    assertContains(ambiguous.stdout, "SKILL-650-other")
+  }
 
   @Test
   fun `feature-task-runtime resume re-runs against an existing workflow id without re-launching complete phases`() {

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
@@ -1074,8 +1074,8 @@ private data class SingleCodexGoldenPaths(private val fixture: InstallPlanApplyF
     fixture.home.resolve(".skill-bill/installed-skills").resolve("$skillName-$contentHash").toString()
 }
 
-private const val CODE_REVIEW_GOLDEN_CONTENT_HASH = "f8ac2740c5fa2af0"
-private const val QUALITY_CHECK_GOLDEN_CONTENT_HASH = "cf4fc54fd276ecd7"
+private const val CODE_REVIEW_GOLDEN_CONTENT_HASH = "3cea366171325f4f"
+private const val QUALITY_CHECK_GOLDEN_CONTENT_HASH = "983064702b4f2629"
 private const val WINDOWS_SYMLINK_GUIDANCE =
   "On Windows, enable Developer Mode (Settings -> Privacy & security -> For developers) or run the install command " +
     "from an elevated shell so the JVM can create symlinks."

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
@@ -695,6 +695,78 @@ class CliRuntimeTest {
   }
 
   @Test
+  fun `update-check emits text and json update results through configured requester`() {
+    val capturedRequests = mutableListOf<Map<String, Any?>>()
+    val context = CliRuntimeContext(
+      requester = updateCheckRequester(capturedRequests),
+      userHome = Files.createTempDirectory("skillbill-update-check-home"),
+    )
+
+    val text = CliRuntime.run(listOf("update-check"), context)
+
+    assertEquals(0, text.exitCode, text.stdout)
+    assertContains(text.stdout, "status: update_available")
+    assertContains(text.stdout, "installed_version: 0.1.0")
+    assertContains(text.stdout, "latest_version: v0.2.0")
+    assertContains(text.stdout, "recommended_install_command: $EXPECTED_INSTALL_COMMAND")
+
+    val json = CliRuntime.run(listOf("update-check", "--format", "json"), context)
+    val payload = decodeJsonObject(json.stdout)
+
+    assertEquals(0, json.exitCode, json.stdout)
+    assertEquals("update_available", payload["status"])
+    assertEquals("0.1.0", payload["installed_version"])
+    assertEquals("v0.2.0", payload["latest_version"])
+    assertEquals("https://github.com/Sermilion/skill-bill/releases/tag/v0.2.0", payload["release_url"])
+    assertEquals(2, capturedRequests.size)
+    assertEquals("GET", capturedRequests.first()["method"])
+    assertEquals("skill-bill-update-check", (capturedRequests.first()["headers"] as Map<*, *>)["User-Agent"])
+  }
+
+  @Test
+  fun `update-check includes prereleases and returns unknown with exit zero`() {
+    val prerelease = CliRuntime.run(
+      listOf("update-check", "--include-prereleases", "--format", "json"),
+      CliRuntimeContext(requester = updateCheckRequester(mutableListOf(), latest = "v0.2.0-rc.1")),
+    )
+    val prereleasePayload = decodeJsonObject(prerelease.stdout)
+
+    assertEquals(0, prerelease.exitCode, prerelease.stdout)
+    assertEquals("update_available", prereleasePayload["status"])
+    assertEquals("v0.2.0-rc.1", prereleasePayload["latest_version"])
+
+    val unknown = CliRuntime.run(
+      listOf("update-check"),
+      CliRuntimeContext(requester = HttpRequester { _, _, _, _ -> HttpResponse(429, "") }),
+    )
+
+    assertEquals(0, unknown.exitCode, unknown.stdout)
+    assertContains(unknown.stdout, "status: unknown")
+    assertContains(unknown.stdout, "reason:")
+  }
+
+  @Test
+  fun `update-check is read only for local home and repo paths`() {
+    val tempDir = Files.createTempDirectory("skillbill-update-check-read-only")
+    val home = tempDir.resolve("home")
+    val repo = tempDir.resolve("repo")
+    Files.createDirectories(home)
+    Files.createDirectories(repo)
+    val before = snapshotTree(tempDir)
+
+    val result = CliRuntime.run(
+      listOf("update-check"),
+      CliRuntimeContext(
+        userHome = home,
+        requester = updateCheckRequester(mutableListOf(), latest = "v0.1.0"),
+      ),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertEquals(before, snapshotTree(tempDir))
+  }
+
+  @Test
   fun `goal-stats --format json emits stable payload`() {
     val tempDir = Files.createTempDirectory("skillbill-cli-goal-stats-json")
     val dbPath = tempDir.resolve("metrics.db")
@@ -836,6 +908,14 @@ private fun decodeJsonObject(rawJson: String): Map<String, Any?> {
   val decoded = JsonSupport.anyToStringAnyMap(JsonSupport.jsonElementToValue(parsed))
   require(decoded != null) { "Expected decoded JSON object but got: $rawJson" }
   return decoded
+}
+
+private fun snapshotTree(root: Path): List<String> = Files.walk(root).use { stream ->
+  stream
+    .filter { path -> path != root }
+    .map { path -> root.relativize(path).toString() }
+    .sorted()
+    .toList()
 }
 
 private fun goldenJson(fileName: String, vararg replacements: Pair<String, String>): String {
@@ -996,6 +1076,27 @@ private fun statsRequester(capturedRequests: MutableList<Map<String, Any?>>): Ht
         )
     }
   }
+
+private fun updateCheckRequester(
+  capturedRequests: MutableList<Map<String, Any?>>,
+  latest: String = "v0.2.0",
+): HttpRequester = HttpRequester { method, url, _, headers ->
+  capturedRequests += mapOf("method" to method, "url" to url, "headers" to headers)
+  HttpResponse(
+    statusCode = 200,
+    body = """
+        [{
+          "tag_name":"$latest",
+          "prerelease":${latest.contains("-")},
+          "draft":false,
+          "html_url":"https://github.com/Sermilion/skill-bill/releases/tag/$latest"
+        }]
+    """.trimIndent(),
+  )
+}
+
+private const val EXPECTED_INSTALL_COMMAND =
+  "curl -fsSL https://raw.githubusercontent.com/Sermilion/skill-bill/main/install.sh | bash"
 
 private fun telemetryStatusPayload(dbPath: Path, configPath: Path): Map<String, Any?> {
   val statusContext =

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -37,6 +37,7 @@ import skillbill.infrastructure.fs.FeatureTaskRuntimePhaseOutputValidatorAdapter
 import skillbill.infrastructure.fs.FileSystemBaselineManifestPersistence
 import skillbill.infrastructure.fs.FileSystemDecompositionManifestFileStore
 import skillbill.infrastructure.fs.FileSystemDiffResolver
+import skillbill.infrastructure.fs.FileSystemFeatureSpecPathResolver
 import skillbill.infrastructure.fs.FileSystemFeatureTaskRuntimeRunInvariantsSource
 import skillbill.infrastructure.fs.FileSystemInstallAgentTargets
 import skillbill.infrastructure.fs.FileSystemInstallApplyExecution
@@ -89,6 +90,7 @@ import skillbill.ports.agentrun.AgentRunLauncher
 import skillbill.ports.config.RepoLocalConfigPort
 import skillbill.ports.diagnostics.RuntimeDiagnostics
 import skillbill.ports.diff.DiffResolverPort
+import skillbill.ports.featurespec.FeatureSpecPathResolverPort
 import skillbill.ports.goalrunner.GoalPullRequestPort
 import skillbill.ports.goalrunner.GoalRunnerManifestStore
 import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
@@ -446,6 +448,11 @@ abstract class RuntimeComponent(
 
   @Provides
   @JvmSynthetic
+  internal fun featureSpecPathResolverPort(adapter: FileSystemFeatureSpecPathResolver): FeatureSpecPathResolverPort =
+    adapter
+
+  @Provides
+  @JvmSynthetic
   internal fun goalObservabilityEventValidator(
     adapter: GoalObservabilityEventValidatorAdapter,
   ): GoalObservabilityEventValidator = adapter
@@ -473,6 +480,7 @@ abstract class RuntimeComponent(
   // Exposed as a pre-built object so the CLI consumer need not resolve the infra-fs adapter type,
   // which is not on the CLI module's compile classpath.
   abstract val featureTaskRuntimeRunInvariantsSource: FeatureTaskRuntimeRunInvariantsSource
+  abstract val featureSpecPathResolverPort: FeatureSpecPathResolverPort
   abstract val goalRunner: GoalRunner
   abstract val goalRunnerStatusService: GoalRunnerStatusService
   abstract val installAgentService: InstallAgentService

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemFeatureSpecPathResolver.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemFeatureSpecPathResolver.kt
@@ -1,0 +1,35 @@
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.ports.featurespec.FeatureSpecPathResolverPort
+import skillbill.ports.featurespec.model.FeatureSpecPathResolveInput
+import skillbill.ports.featurespec.model.FeatureSpecPathResolveResult
+import java.nio.file.Files
+import java.nio.file.Path
+
+@Inject
+class FileSystemFeatureSpecPathResolver : FeatureSpecPathResolverPort {
+  override fun resolve(input: FeatureSpecPathResolveInput): FeatureSpecPathResolveResult {
+    input.explicitSpecPath?.takeIf(String::isNotBlank)?.let { explicit ->
+      return FeatureSpecPathResolveResult.Explicit(Path.of(explicit).toString())
+    }
+    val specsRoot = input.repoRoot.toAbsolutePath().normalize().resolve(".feature-specs")
+    if (!Files.isDirectory(specsRoot)) {
+      return FeatureSpecPathResolveResult.NoMatch(input.issueKey, specsRoot)
+    }
+    val matches = Files.list(specsRoot).use { stream ->
+      stream
+        .filter { candidate -> Files.isDirectory(candidate) }
+        .filter { candidate -> candidate.fileName.toString().startsWith("${input.issueKey}-") }
+        .map { candidate -> candidate.resolve("spec.md") }
+        .filter { specPath -> Files.isRegularFile(specPath) }
+        .toList()
+        .sorted()
+    }
+    return when (matches.size) {
+      0 -> FeatureSpecPathResolveResult.NoMatch(input.issueKey, specsRoot)
+      1 -> FeatureSpecPathResolveResult.SingleMatch(matches.single().toString())
+      else -> FeatureSpecPathResolveResult.Ambiguous(input.issueKey, matches)
+    }
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApply.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApply.kt
@@ -47,6 +47,9 @@ internal fun applyInstallPlan(
   val platformManifests = discoverPlatformManifests(plan.installationTargetPaths.platformPacksRoot)
   cleanupExistingSkillBillLinks(plan, platformManifests, failures)
   val appliedSkills = applyPlannedSkills(plan, platformManifests, failures)
+  if (failures.isEmpty()) {
+    materializeAgentPlatformPackViews(plan, platformManifests, appliedSkills, failures)
+  }
   val nativeAgents = if (failures.isEmpty()) {
     applyRepoLocalConfigScaffold(plan, warnings)
     applyNativeAgents(plan, platformManifests, failures)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplyPlatformPackView.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplyPlatformPackView.kt
@@ -1,0 +1,172 @@
+package skillbill.install.apply
+
+import skillbill.install.model.InstallAppliedSkill
+import skillbill.install.model.InstallApplyIssue
+import skillbill.install.model.InstallApplyIssueKind
+import skillbill.install.model.InstallPlan
+import skillbill.install.model.InstallPlanSkillKind
+import skillbill.install.model.InstallSkillStagingStatus
+import skillbill.install.support.createNewSymlinkWithGuidance
+import skillbill.install.support.createReplacementSymlinkWithGuidance
+import skillbill.scaffold.model.PlatformManifest
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+private const val MANAGED_INSTALL_MARKER = ".skill-bill-install"
+private const val PLATFORM_PACKS_DIR = "platform-packs"
+
+internal fun materializeAgentPlatformPackViews(
+  plan: InstallPlan,
+  platformManifests: List<PlatformManifest>,
+  appliedSkills: List<InstallAppliedSkill>,
+  failures: MutableList<InstallApplyIssue>,
+) {
+  if (plan.selectedPlatformSlugs.isEmpty()) {
+    cleanupManagedPlatformPackViews(plan, failures)
+    return
+  }
+  val selectedManifests = platformManifests
+    .filter { manifest -> manifest.slug in plan.selectedPlatformSlugs }
+    .sortedBy(PlatformManifest::slug)
+  val stagedPlatformSkills = appliedSkills
+    .filter { skill -> skill.kind == InstallPlanSkillKind.PLATFORM_PACK }
+    .filter { skill -> skill.staging.status == InstallSkillStagingStatus.STAGED }
+    .associateBy { skill -> skill.sourceDir.toAbsolutePath().normalize() }
+  plan.agents.forEach { agentTarget ->
+    runCatching {
+      val root = agentTarget.path.toAbsolutePath().normalize().resolve(PLATFORM_PACKS_DIR)
+      replaceManagedPlatformPackView(root)
+      selectedManifests.forEach { manifest ->
+        materializeOnePack(root, manifest, stagedPlatformSkills)
+      }
+    }.getOrElse { error ->
+      failures.add(
+        InstallApplyIssue(
+          kind = InstallApplyIssueKind.SKILL_LINK_FAILED,
+          message = error.message.orEmpty(),
+          agent = agentTarget.agent,
+          path = agentTarget.path.resolve(PLATFORM_PACKS_DIR),
+          causeClass = error::class.qualifiedName,
+        ),
+      )
+    }
+  }
+}
+
+internal fun cleanupManagedPlatformPackViews(plan: InstallPlan, failures: MutableList<InstallApplyIssue>) {
+  plan.agents.forEach { agentTarget ->
+    runCatching {
+      val root = agentTarget.path.toAbsolutePath().normalize().resolve(PLATFORM_PACKS_DIR)
+      if (Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS) && Files.exists(root.resolve(MANAGED_INSTALL_MARKER))) {
+        deleteTree(root)
+      }
+    }.getOrElse { error ->
+      failures.add(
+        InstallApplyIssue(
+          kind = InstallApplyIssueKind.SKILL_LINK_FAILED,
+          message = error.message.orEmpty(),
+          agent = agentTarget.agent,
+          path = agentTarget.path.resolve(PLATFORM_PACKS_DIR),
+          causeClass = error::class.qualifiedName,
+        ),
+      )
+    }
+  }
+}
+
+private fun replaceManagedPlatformPackView(root: Path) {
+  if (Files.isSymbolicLink(root)) {
+    error("Existing symlink at $root was preserved.")
+  }
+  if (Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+    require(Files.isDirectory(root, LinkOption.NOFOLLOW_LINKS) && Files.exists(root.resolve(MANAGED_INSTALL_MARKER))) {
+      "Existing non-managed platform-packs path at $root was preserved."
+    }
+    deleteTree(root)
+  }
+  Files.createDirectories(root)
+  Files.writeString(root.resolve(MANAGED_INSTALL_MARKER), "")
+}
+
+private fun materializeOnePack(
+  agentPacksRoot: Path,
+  manifest: PlatformManifest,
+  stagedPlatformSkills: Map<Path, InstallAppliedSkill>,
+) {
+  val packRoot = manifest.packRoot.toAbsolutePath().normalize()
+  val destinationPackRoot = agentPacksRoot.resolve(manifest.slug).normalize()
+  require(destinationPackRoot.startsWith(agentPacksRoot)) {
+    "Platform pack '${manifest.slug}' escapes agent platform-packs root '$agentPacksRoot'."
+  }
+  val skillDirs = platformSkillDirs(manifest)
+  copyPackNonSkillFiles(packRoot, destinationPackRoot, skillDirs)
+  skillDirs.forEach { skillDir ->
+    val staged = stagedPlatformSkills[skillDir]?.staging?.stagingDir
+      ?: error("Selected platform pack '${manifest.slug}' skill '$skillDir' was not staged.")
+    val relative = packRoot.relativize(skillDir).toString()
+    val linkPath = destinationPackRoot.resolve(relative).normalize()
+    require(linkPath.startsWith(destinationPackRoot)) {
+      "Platform pack '${manifest.slug}' skill link '$linkPath' escapes pack root '$destinationPackRoot'."
+    }
+    linkPath.parent?.let(Files::createDirectories)
+    createOrReplaceManagedSkillSymlink(linkPath, staged)
+  }
+}
+
+private fun platformSkillDirs(manifest: PlatformManifest): Set<Path> = (
+  listOfNotNull(manifest.declaredFiles.baseline, manifest.declaredQualityCheckFile) +
+    manifest.declaredFiles.areas.values
+  )
+  .map { contentFile -> contentFile.toAbsolutePath().normalize().parent }
+  .toSet()
+
+private fun copyPackNonSkillFiles(packRoot: Path, destinationPackRoot: Path, skillDirs: Set<Path>) {
+  Files.walk(packRoot).use { stream ->
+    stream.forEach { source ->
+      if (Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS)) {
+        return@forEach
+      }
+      val resolvedSource = source.toAbsolutePath().normalize()
+      if (skillDirs.any { skillDir -> resolvedSource.startsWith(skillDir) }) {
+        return@forEach
+      }
+      val destination = destinationPackRoot.resolve(packRoot.relativize(resolvedSource).toString()).normalize()
+      require(destination.startsWith(destinationPackRoot)) {
+        "Platform pack file '$source' escapes destination pack root '$destinationPackRoot'."
+      }
+      destination.parent?.let(Files::createDirectories)
+      Files.copy(
+        source,
+        destination,
+        StandardCopyOption.REPLACE_EXISTING,
+        StandardCopyOption.COPY_ATTRIBUTES,
+        LinkOption.NOFOLLOW_LINKS,
+      )
+    }
+  }
+}
+
+private fun createOrReplaceManagedSkillSymlink(linkPath: Path, stagingDir: Path) {
+  val target = stagingDir.toAbsolutePath().normalize()
+  require(Files.isDirectory(target, LinkOption.NOFOLLOW_LINKS)) {
+    "Staged platform skill target '$target' is not a directory."
+  }
+  if (Files.isSymbolicLink(linkPath)) {
+    createReplacementSymlinkWithGuidance(linkPath, target)
+  } else if (Files.exists(linkPath, LinkOption.NOFOLLOW_LINKS)) {
+    error("Existing non-symlink platform skill path at $linkPath was preserved.")
+  } else {
+    createNewSymlinkWithGuidance(linkPath, target)
+  }
+}
+
+private fun deleteTree(root: Path) {
+  if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+    return
+  }
+  Files.walk(root).use { stream ->
+    stream.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/staging/InstallStaging.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/staging/InstallStaging.kt
@@ -20,6 +20,7 @@ import java.util.logging.Level
 import java.util.logging.Logger
 
 private const val INSTALL_CACHE_KEY_BYTES = 8
+private const val INSTALL_STAGING_RECIPE_VERSION = "install-staging-v3-platform-packs-child-inline-pointers"
 
 private val log: Logger = Logger.getLogger("skillbill.install.InstallStaging")
 
@@ -133,6 +134,8 @@ internal fun computeInstallContentHash(
 ): String {
   val digest = MessageDigest.getInstance("SHA-256")
   val newline = byteArrayOf('\n'.code.toByte())
+  digest.update(INSTALL_STAGING_RECIPE_VERSION.toByteArray(StandardCharsets.UTF_8))
+  digest.update(newline)
   authored.forEach { file ->
     val rel = sourceSkillDir.relativize(file).toString().replace(File.separatorChar, '/')
     digest.update(rel.toByteArray(StandardCharsets.UTF_8))
@@ -238,6 +241,10 @@ private fun buildFreshInstallStaging(inputs: FreshInstallInputs): RenderedSkill 
       tempDir = tempDir,
       pointers = inputs.supportPointers,
     )
+    val packsRoot = inputs.repoRoot.resolve("platform-packs")
+    if (Files.isDirectory(packsRoot)) {
+      Files.createSymbolicLink(tempDir.resolve("platform-packs"), packsRoot)
+    }
     Files.write(
       tempDir.resolve(INSTALL_STAGING_CONTENT_HASH_FILENAME),
       inputs.contentHash.toByteArray(StandardCharsets.UTF_8),

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/staging/InstallStaging.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/staging/InstallStaging.kt
@@ -144,9 +144,21 @@ internal fun computeInstallContentHash(
   digest.update(newline)
   applicablePointers
     .sortedWith(compareBy({ it.second.skillRelativeDir }, { it.second.name }))
-    .forEach { (_, spec) ->
+    .forEach { (manifest, spec) ->
       val line = "${spec.skillRelativeDir}|${spec.name}|${spec.target}"
       digest.update(line.toByteArray(StandardCharsets.UTF_8))
+      digest.update(newline)
+      val repoRoot = manifest.packRoot.toAbsolutePath().normalize().parent?.parent
+        ?: error("Platform pack '${manifest.slug}' root '${manifest.packRoot}' has no repo root parent.")
+      val targetFile = repoRoot.resolve(spec.target).normalize()
+      require(targetFile.startsWith(repoRoot)) {
+        "Pointer '${spec.name}' under '${spec.skillRelativeDir}' targets '${spec.target}' outside repoRoot '$repoRoot'."
+      }
+      require(Files.isRegularFile(targetFile, LinkOption.NOFOLLOW_LINKS)) {
+        "Pointer '${spec.name}' under '${spec.skillRelativeDir}' targets '${spec.target}' " +
+          "which does not exist at '$targetFile'."
+      }
+      digest.update(Files.readAllBytes(targetFile))
       digest.update(newline)
     }
   generatedSupportPointers

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/staging/InstallStagingIO.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/staging/InstallStagingIO.kt
@@ -4,6 +4,7 @@ package skillbill.install.staging
 
 import skillbill.install.model.RenderedSkill
 import skillbill.scaffold.authoring.AuthoringTarget
+import skillbill.scaffold.authoring.normalizeMarkdownLineEndings
 import skillbill.scaffold.authoring.renderWrapper
 import skillbill.scaffold.model.PlatformManifest
 import skillbill.scaffold.model.PointerSpec
@@ -117,7 +118,9 @@ internal fun writeRenderedPointerFiles(
   require(pointerFile.startsWith(tempDir)) {
     "Pointer '${spec.name}' staging path '$pointerFile' escapes staging dir '$tempDir'."
   }
-  val rendered = renderPointer(repoRoot = repoRoot, packRoot = manifest.packRoot, spec = spec)
+  renderPointer(repoRoot = repoRoot, packRoot = manifest.packRoot, spec = spec)
+  val targetFile = repoRoot.toAbsolutePath().normalize().resolve(spec.target).normalize()
+  val rendered = normalizeMarkdownLineEndings(Files.readString(targetFile)).trimEnd() + "\n"
   Files.write(pointerFile, rendered.toByteArray(StandardCharsets.UTF_8))
   pointerFile
 }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyPlatformPackViewTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyPlatformPackViewTest.kt
@@ -1,0 +1,44 @@
+package skillbill.install
+
+import skillbill.install.model.InstallAgent
+import skillbill.install.model.InstallApplyStatus
+import skillbill.install.runtime.InstallOperations
+import skillbill.scaffold.platformpack.discoverPlatformPacks
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InstallApplyPlatformPackViewTest : InstallApplyTestSupport() {
+  @Test
+  fun `apply materializes selected platform pack manifests under each agent skill root`() {
+    val fixture = setupApplyFixture()
+    Files.createDirectories(fixture.home.resolve(".codex"))
+    val plan = InstallOperations.planInstall(
+      fixture.request(
+        selectedPlatforms = setOf("kotlin"),
+        agents = setOf(InstallAgent.CODEX),
+      ),
+    )
+
+    val result = InstallOperations.applyInstall(plan)
+
+    assertEquals(InstallApplyStatus.SUCCESS, result.status)
+    val agentRoot = fixture.home.resolve("agent-skill-targets/codex")
+    val packRoot = agentRoot.resolve("platform-packs/kotlin")
+    assertTrue(Files.isRegularFile(agentRoot.resolve("platform-packs/.skill-bill-install")))
+    assertTrue(Files.isRegularFile(packRoot.resolve("platform.yaml")), "installed pack manifest is missing")
+    assertEquals(listOf("kotlin"), discoverPlatformPacks(agentRoot.resolve("platform-packs")).map { pack -> pack.slug })
+    val flatCodeReview = readSymlinkTarget(agentRoot.resolve("bill-kotlin-code-review"))
+    val nestedCodeReview = readSymlinkTarget(packRoot.resolve("code-review/bill-kotlin-code-review"))
+    assertEquals(flatCodeReview, nestedCodeReview)
+    assertTrue(Files.isRegularFile(packRoot.resolve("code-review/bill-kotlin-code-review/content.md")))
+    assertTrue(Files.isRegularFile(packRoot.resolve("quality-check/bill-kotlin-code-check/content.md")))
+    assertFalse(
+      Files.exists(agentRoot.resolve("platform-packs/kmp/platform.yaml"), LinkOption.NOFOLLOW_LINKS),
+      "unselected pack manifest must not be discoverable",
+    )
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyTest.kt
@@ -49,12 +49,14 @@ class InstallApplyTest : InstallApplyTestSupport() {
       setOf(
         "bill-code-review",
         "bill-code-check",
+        "bill-update-check",
         "bill-kotlin-code-review",
         "bill-kotlin-code-check",
       ),
       skillsByName.keys,
     )
     assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-code-review").kind)
+    assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-update-check").kind)
     assertEquals(InstallPlanSkillKind.PLATFORM_PACK, skillsByName.getValue("bill-kotlin-code-review").kind)
     assertFalse(skillsByName.containsKey("bill-kmp-code-review"), "unselected platform skill was applied")
     result.skills.forEach { skill ->

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyTestSupport.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyTestSupport.kt
@@ -46,6 +46,7 @@ open class InstallApplyTestSupport {
     val home = Files.createTempDirectory("skillbill-install-apply-home").also(tempDirs::add)
     seedBaseSkill(repoRoot, "bill-code-review", nativeAgentName = "bill-code-review-worker")
     seedBaseSkill(repoRoot, "bill-code-check")
+    seedBaseSkill(repoRoot, "bill-update-check")
     seedPlatformPack(repoRoot, "kotlin", nativeAgentName = "bill-kotlin-code-review-worker")
     seedPlatformPack(repoRoot, "kmp", nativeAgentName = "bill-kmp-code-review-worker")
     return ApplyFixture(repoRoot, home)

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallPlanBuilderTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallPlanBuilderTest.kt
@@ -70,6 +70,7 @@ class InstallPlanBuilderTest {
     assertEquals(listOf("kotlin"), plan.selectedPlatformSlugs)
     assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-code-review").kind)
     assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-code-check").kind)
+    assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-update-check").kind)
     assertEquals(InstallPlanSkillKind.PLATFORM_PACK, skillsByName.getValue("bill-kotlin-code-review").kind)
     assertEquals(InstallPlanSkillKind.PLATFORM_PACK, skillsByName.getValue("bill-kotlin-code-review-architecture").kind)
     assertEquals(InstallPlanSkillKind.PLATFORM_PACK, skillsByName.getValue("bill-kotlin-code-review-testing").kind)
@@ -97,6 +98,7 @@ class InstallPlanBuilderTest {
     val skillsByName = plan.skills.associateBy { skill -> skill.name }
     assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-code-review").kind)
     assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-code-check").kind)
+    assertEquals(InstallPlanSkillKind.BASE, skillsByName.getValue("bill-update-check").kind)
     assertEquals(InstallPlanSkillKind.PLATFORM_PACK, skillsByName.getValue("bill-python-code-review").kind)
     assertEquals(InstallPlanSkillKind.PLATFORM_PACK, skillsByName.getValue("bill-python-code-review-security").kind)
     assertEquals(InstallPlanSkillKind.PLATFORM_PACK, skillsByName.getValue("bill-python-code-check").kind)
@@ -540,6 +542,7 @@ class InstallPlanBuilderTest {
     val home = Files.createTempDirectory("skillbill-install-plan-home").also(tempDirs::add)
     seedBaseSkill(repoRoot, "bill-code-review")
     seedBaseSkill(repoRoot, "bill-code-check")
+    seedBaseSkill(repoRoot, "bill-update-check")
     seedPlatformPack(repoRoot, "kotlin", areaNames = listOf("architecture", "testing"))
     seedPlatformPack(repoRoot, "kmp", areaNames = listOf("architecture", "testing"))
     return PlanFixture(repoRoot = repoRoot, home = home)

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallStagingTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallStagingTest.kt
@@ -105,6 +105,29 @@ class InstallStagingTest {
   }
 
   @Test
+  fun `staged skill exposes platform packs from resolved skill directory`() {
+    val fixture = setupFixture()
+
+    val rendered = stageInstalledSkill(fixture.repoRoot, fixture.skillDir, fixture.home)
+
+    val packs = rendered.stagingDir.resolve("platform-packs")
+    val manifest = packs.resolve("sample/platform.yaml")
+    assertTrue(Files.isSymbolicLink(packs), "platform-packs must be present in the staged skill dir")
+    assertTrue(
+      Files.isRegularFile(manifest),
+      "manifest must resolve from the staged skill dir at ${rendered.stagingDir.relativize(manifest)}",
+    )
+    assertEquals(
+      "sample",
+      Files.readString(manifest)
+        .lineSequence()
+        .first { it.startsWith("platform:") }
+        .substringAfter('"')
+        .substringBefore('"'),
+    )
+  }
+
+  @Test
   fun `generated supporting pointers for skills are materialized in staging`() {
     val repoRoot = Files.createTempDirectory("skillbill-install-staging-skill-repo").also(tempDirs::add)
     val home = Files.createTempDirectory("skillbill-install-staging-skill-home").also(tempDirs::add)

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallStagingTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallStagingTest.kt
@@ -89,7 +89,7 @@ class InstallStagingTest {
   }
 
   @Test
-  fun `pointer files are materialized in staging via renderPointer`() {
+  fun `platform pointer files are materialized as installed sidecar content`() {
     val fixture = setupFixture()
 
     val rendered = stageInstalledSkill(fixture.repoRoot, fixture.skillDir, fixture.home)
@@ -97,8 +97,10 @@ class InstallStagingTest {
     fixture.pointerSpecs.forEach { (manifest, spec) ->
       val staged = rendered.stagingDir.resolve(spec.name)
       assertTrue(Files.isRegularFile(staged, LinkOption.NOFOLLOW_LINKS), "missing pointer file ${spec.name}")
-      val expected = renderPointer(repoRoot = fixture.repoRoot, packRoot = manifest.packRoot, spec = spec)
+      renderPointer(repoRoot = fixture.repoRoot, packRoot = manifest.packRoot, spec = spec)
+      val expected = Files.readString(fixture.repoRoot.resolve(spec.target)).trimEnd() + "\n"
       assertEquals(expected, String(Files.readAllBytes(staged), StandardCharsets.UTF_8))
+      assertFalse(Files.readString(staged).contains("../"), "staged pointer ${spec.name} must not dangle")
     }
   }
 
@@ -149,7 +151,8 @@ class InstallStagingTest {
     fixture.pointerSpecs.forEach { (manifest, spec) ->
       val staged = rendered.stagingDir.resolve(spec.name)
       val reusedStaged = reused.stagingDir.resolve(spec.name)
-      val expected = renderPointer(repoRoot = fixture.repoRoot, packRoot = manifest.packRoot, spec = spec)
+      renderPointer(repoRoot = fixture.repoRoot, packRoot = manifest.packRoot, spec = spec)
+      val expected = Files.readString(fixture.repoRoot.resolve(spec.target)).trimEnd() + "\n"
       assertEquals(expected, String(Files.readAllBytes(staged), StandardCharsets.UTF_8))
       assertEquals(expected, String(Files.readAllBytes(reusedStaged), StandardCharsets.UTF_8))
     }
@@ -326,6 +329,20 @@ class InstallStagingTest {
 
     assertTrue(hashBefore != hashAfterMutation, "hash must change when support pointer target bytes change")
     assertEquals(hashBefore, hashAfterRestore, "hash must stabilise after restoring target bytes")
+  }
+
+  @Test
+  fun `content hash changes when platform pointer target bytes change`() {
+    val fixture = setupFixture()
+    val pointers = applicablePointers(fixture.repoRoot, fixture.skillDir)
+    val authored = authoredFilesFor(fixture.skillDir, pointers)
+    val hashBefore = computeInstallContentHash(fixture.skillDir, authored, pointers)
+    val target = fixture.repoRoot.resolve(pointers.single().second.target)
+
+    Files.writeString(target, "# Review orchestrator\n\nChanged guidance.\n")
+    val hashAfterMutation = computeInstallContentHash(fixture.skillDir, authored, pointers)
+
+    assertTrue(hashBefore != hashAfterMutation, "hash must change when platform pointer target bytes change")
   }
 
   @Test

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/featurespec/FeatureSpecPathResolverPort.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/featurespec/FeatureSpecPathResolverPort.kt
@@ -1,0 +1,8 @@
+package skillbill.ports.featurespec
+
+import skillbill.ports.featurespec.model.FeatureSpecPathResolveInput
+import skillbill.ports.featurespec.model.FeatureSpecPathResolveResult
+
+fun interface FeatureSpecPathResolverPort {
+  fun resolve(input: FeatureSpecPathResolveInput): FeatureSpecPathResolveResult
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/featurespec/model/FeatureSpecPathResolverModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/featurespec/model/FeatureSpecPathResolverModels.kt
@@ -1,0 +1,23 @@
+package skillbill.ports.featurespec.model
+
+import java.nio.file.Path
+
+data class FeatureSpecPathResolveInput(
+  val issueKey: String,
+  val explicitSpecPath: String?,
+  val repoRoot: Path,
+)
+
+sealed interface FeatureSpecPathResolveResult {
+  val specPath: String?
+
+  data class Explicit(override val specPath: String) : FeatureSpecPathResolveResult
+  data class SingleMatch(override val specPath: String) : FeatureSpecPathResolveResult
+  data class NoMatch(val issueKey: String, val specsRoot: Path) : FeatureSpecPathResolveResult {
+    override val specPath: String? = null
+  }
+
+  data class Ambiguous(val issueKey: String, val matches: List<Path>) : FeatureSpecPathResolveResult {
+    override val specPath: String? = null
+  }
+}

--- a/skills/bill-feature-goal/content.md
+++ b/skills/bill-feature-goal/content.md
@@ -43,6 +43,10 @@ Clarify the user's feature goal enough to identify:
 
 If the issue key is missing, stop and ask for it. Do not invent one.
 
+When the caller provides only an issue key, use existing governed artifacts under
+`.feature-specs` when there is a single clear match for that key. Ask for a more
+specific path only when there is no match or the matches are ambiguous.
+
 Classify the goal before decomposing:
 
 - If the goal is small enough for one normal implementation pass, complete it directly in the current agent session. Do not create a decomposition manifest and do not invoke `skill-bill goal`.

--- a/skills/bill-feature-task/content.md
+++ b/skills/bill-feature-task/content.md
@@ -24,7 +24,7 @@ Gather enough to identify and confirm the run:
 - the mode (from args as `mode:prose` or `mode:runtime`; default to `prose` when absent)
 - the parallel review agent (from args as `parallel-review:<agent>`; absent when not provided)
 
-If the issue key or spec path is missing, stop and ask for it. Do not invent either one.
+If the issue key is missing, stop and ask for it. If the spec path is missing, search `.feature-specs` for exactly one governed `.feature-specs/{ISSUE_KEY}-*/spec.md` match and use it. If there is no match or more than one match, stop and ask for the explicit spec path. Do not invent either value.
 
 Parse the mode and `parallel-review:<agent>` from args before presenting the confirmation gate. If no mode arg is provided, resolve the mode to `prose`.
 

--- a/skills/bill-feature/content.md
+++ b/skills/bill-feature/content.md
@@ -34,7 +34,7 @@ Wait for `bill-feature-spec` to produce governed artifacts under `.feature-specs
 
 For `single_spec` output:
 
-- Run `bill-feature-task` on `.feature-specs/{ISSUE_KEY}-{feature-name}/spec.md` in the current session.
+- Run `bill-feature-task` on `.feature-specs/{ISSUE_KEY}-{feature-name}/spec.md` in the current session. When exactly one governed `.feature-specs/{ISSUE_KEY}-*/spec.md` exists, the issue key alone is enough for the runtime invocation.
 - Do not invoke `bill-feature-goal`.
 - Let `bill-feature-task` own implementation, review, validation, history, and PR description behavior.
 

--- a/skills/bill-update-check/content.md
+++ b/skills/bill-update-check/content.md
@@ -1,0 +1,29 @@
+---
+name: bill-update-check
+description: Check whether the installed Skill Bill runtime is behind the latest GitHub release.
+---
+
+# Update Check Content
+
+Run the runtime command:
+
+```bash
+skill-bill update-check
+```
+
+Use JSON output when the caller needs machine-readable output:
+
+```bash
+skill-bill update-check --format json
+```
+
+To compare against prerelease tags as well as stable releases, pass:
+
+```bash
+skill-bill update-check --include-prereleases
+```
+
+Do not inspect GitHub releases directly in this skill content, run `install.sh`,
+rewrite installed skill links, or mutate workflow state. The runtime command owns
+release selection, version comparison, output formatting, and soft failure
+handling.


### PR DESCRIPTION
# Summary

Adds the SKILL-84 update awareness workflow: a governed `/bill-update-check` command delegates to a read-only runtime `skill-bill update-check` CLI that compares the installed Skill Bill version with GitHub Releases and reports text or JSON status. The change also lets feature workflows resolve a single `.feature-specs/<ISSUE>-*/spec.md` match when invoked with only an issue key.

- Adds semver parsing, release selection, update/no-update/ahead/unknown mapping, and soft-failure handling for release lookup issues.
- Registers the new slash command through governed `content.md` source and the existing installer/link flow.
- Adds focused Kotlin and installer regression coverage for update-check behavior and key-only spec lookup.

## Feature Flags

N/A

# How Has This Been Tested?

Focused regression tests passed with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk`:

1. `./gradlew :runtime-application:test --tests 'skillbill.application.updatecheck.*' :runtime-cli:test --tests 'skillbill.cli.CliRuntimeTest' --tests 'skillbill.cli.CliFeatureTaskRuntimeRuntimeTest' :runtime-infra-fs:test --tests 'skillbill.install.InstallPlanBuilderTest' --tests 'skillbill.install.InstallApplyTest'`\n2. `./gradlew :runtime-cli:test --tests 'skillbill.cli.CliRuntimeTest'`\n3. Expected result: update-check service/CLI behavior, feature spec key lookup, and installer registration/link coverage pass.\n\nFull validation was handled in the prior runtime validation phase.