### PR TITLE
Self-heal session columns missing from version-recorded DBs

### DIFF
--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseRuntime.kt
@@ -38,6 +38,7 @@ object DatabaseRuntime {
     }
     DatabaseSchema.createBaseSchema(connection)
     DatabaseMigrations.apply(connection)
+    DatabaseColumnMigrations.apply(connection)
     return connection
   }
 }

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
@@ -118,6 +118,23 @@ class DatabaseMigrationsTest {
   }
 
   @Test
+  fun `ensureDatabase heals columns missing from a fully version-recorded legacy database`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-migrations").resolve("legacy-recorded-implement.db")
+    createLegacyFeatureImplementSessionsDatabase(dbPath)
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val columns = tableColumns(connection = connection, tableName = "feature_implement_sessions")
+      connection.createStatement().use { statement ->
+        statement.executeUpdate("INSERT INTO feature_implement_sessions (session_id) VALUES ('fis-defaults')")
+      }
+
+      assertTrue("source" in columns, "source must be healed even when every migration version is already recorded.")
+      assertEquals("production", featureImplementColumnValue(connection, "source"))
+      assertEquals(DatabaseMigrations.migrations.size, migrationRows(connection).size)
+    }
+  }
+
+  @Test
   fun `ensureDatabase migrates legacy feedback event values to current schema`() {
     val dbPath = Files.createTempDirectory("runtime-kotlin-db-migrations").resolve("legacy-feedback-events.db")
     createLegacyFeedbackEventsDatabase(dbPath)
@@ -183,6 +200,35 @@ class DatabaseMigrationsTest {
         statement.setString(2, "bill-kotlin-code-review")
         statement.setString(3, "legacy review")
         statement.executeUpdate()
+      }
+    }
+  }
+
+  private fun createLegacyFeatureImplementSessionsDatabase(dbPath: Path) {
+    DriverManager.getConnection("jdbc:sqlite:$dbPath").use { connection ->
+      connection.createStatement().use { statement ->
+        statement.execute(CREATE_LEGACY_FEATURE_IMPLEMENT_SESSIONS_SQL)
+        statement.execute(
+          """
+          CREATE TABLE schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+          )
+          """.trimIndent(),
+        )
+      }
+      connection.prepareStatement(
+        """
+        INSERT INTO schema_migrations (version, name)
+        VALUES (?, ?)
+        """.trimIndent(),
+      ).use { statement ->
+        DatabaseMigrations.migrations.forEach { migration ->
+          statement.setInt(1, migration.version)
+          statement.setString(2, migration.name)
+          statement.executeUpdate()
+        }
       }
     }
   }
@@ -350,6 +396,15 @@ class DatabaseMigrationsTest {
   )
 
   private companion object {
+    const val CREATE_LEGACY_FEATURE_IMPLEMENT_SESSIONS_SQL: String =
+      """
+      CREATE TABLE feature_implement_sessions (
+        session_id TEXT PRIMARY KEY,
+        completion_status TEXT,
+        started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+      """
+
     const val CREATE_LEGACY_REVIEW_RUNS_SQL: String =
       """
       CREATE TABLE review_runs (


### PR DESCRIPTION
## Problem

A user on the latest version hit `feature_implement_sessions` telemetry inserts failing with "Skill Bill DB missing a `source` column". Root cause is an **upgraded-in-place** DB where `source` was never added:

- **Base schema** (`DatabaseSchema.kt`) creates the column via `CREATE TABLE IF NOT EXISTS` — a no-op once the table already exists.
- **Migration v1** `add-review-workflow-session-columns` *does* `ensureColumn("source", …)`, **but that line was appended to v1's body later** (commit `3073c507`). v1 itself shipped in the first commit. Anyone who installed before `3073c507` recorded **v1-as-applied without `source`**, and the runner (`DatabaseMigrations.apply`) skips any version already in `schema_migrations`.

Result: latest binary + old DB = `source` permanently missing = every session insert fails. The same trap was set for `feature_verify_sessions` (`history_relevance`/`history_helpfulness`) and any future column added to v1.

## Fix

`DatabaseColumnMigrations.apply` is fully idempotent (each `ensureColumn` checks `PRAGMA table_info` before `ALTER`; the backfill is a guarded `UPDATE`). `ensureDatabase` now runs it **unconditionally** after the version-gated migrations, reconciling column drift on every launch regardless of what `schema_migrations` claims. Affected DBs self-heal on next launch — no wipe.

## Verification

- Added regression test `ensureDatabase heals columns missing from a fully version-recorded legacy database`: builds a DB with versions 1–3 all recorded but a `feature_implement_sessions` table physically lacking `source`, then asserts the column is healed.
- Confirmed the test **fails** without the fix (reproduces the exact `source`-missing failure) and **passes** with it.
- Full `runtime-infra-sqlite` module green.

## Scope

Prevents all future session-insert failures on affected DBs. Rows already lost to prior failed inserts are not recoverable.