### PR TITLE
fix: make no-terminal-outcome diagnosis cause-specific with child stderr

### DIFF
--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunner.kt
@@ -1182,6 +1182,7 @@ private fun skillbill.ports.agentrun.model.AgentRunLaunchOutcome.toGoalRunnerLau
       interrupted = interrupted,
       spawnFailed = spawnFailed,
       exitStatus = exitStatus,
+      stderrTail = stderr.takeLast(GoalRunnerLaunchFacts.STDERR_TAIL_MAX_CHARS).takeIf(String::isNotBlank),
       liveness = liveness?.let { snapshot ->
         GoalRunnerLivenessSnapshot(
           phase = snapshot.phase,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerObservabilityEmitter.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerObservabilityEmitter.kt
@@ -1,6 +1,7 @@
 package skillbill.application.goalrunner
 
 import skillbill.application.model.GoalRunnerRunRequest
+import skillbill.goalrunner.model.GoalRunnerLaunchFacts
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
 import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
 import skillbill.ports.goalrunner.GoalRunnerWorkflowOutcomeStore
@@ -118,13 +119,21 @@ internal class GoalRunnerObservabilityEmitter(
     progress: GoalRunnerWorkflowProgress?,
     facts: AgentRunLaunchFacts,
   ) {
+    // Persist a bounded stderr tail alongside the counts: a char count alone makes a
+    // no-terminal-outcome stall undiagnosable after the fact (the body is the only signal that
+    // distinguishes a crash from a usage limit). The store is local to ~/.skill-bill.
+    val stderrTail = facts.stderr
+      .takeLast(GoalRunnerLaunchFacts.STDERR_TAIL_MAX_CHARS)
+      .takeIf(String::isNotBlank)
+      ?.let { tail -> "; stderr_tail=$tail" }
+      .orEmpty()
     record(
       subject = subject,
       signal = GoalRunnerObservabilitySignal(
         workflowPhase = progress?.currentStepId ?: facts.liveness?.workflowStep ?: "goal_runner_supervision",
         livenessClass = "worker_output_summary",
         activitySummary = "stdout_chars=${facts.stdout.length}; stderr_chars=${facts.stderr.length}; " +
-          "exit_status=${facts.exitStatus ?: "none"}",
+          "exit_status=${facts.exitStatus ?: "none"}$stderrTail",
       ),
     )
   }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
@@ -270,7 +270,8 @@ class GoalRunnerTest {
     assertEquals(1, stopped.stop.subtaskId)
     assertEquals("wfl-1", stopped.stop.workflowId)
     assertContains(stopped.stop.blockedReason, "without a terminal workflow-store outcome")
-    assertContains(stopped.stop.blockedReason, "cause-agnostic")
+    // Clean exit (status 0) is diagnosed specifically, not with a cause-agnostic guess.
+    assertContains(stopped.stop.blockedReason, "exited cleanly (status 0)")
     assertContains(stopped.stop.blockedReason, "last_resumable_step")
     assertEquals("blocked", store.manifest.subtasks.single { it.id == 1 }.status)
     assertEquals(listOf("wfl-1"), outcomes.blockedWorkflows.map { it.workflowId })
@@ -714,6 +715,49 @@ class GoalRunnerTest {
     repoRoot = repoRoot,
     invokedAgentId = "claude",
     dbPathOverride = null,
+  )
+}
+
+// Focused coverage for the no-terminal-outcome diagnosis (kept out of GoalRunnerTest to avoid
+// growing that already-large class). Asserts the reason string reflects the child exit status and
+// carries the captured stderr tail instead of a cause-agnostic guess.
+class GoalRunnerNoTerminalOutcomeDiagnosisTest {
+  @Test
+  fun `non-zero child exit reports exit status and stderr tail without retry`() {
+    val store = InMemoryGoalManifestStore(manifest = manifest(subtaskCount = 2))
+    val launcher = RecordingSubtaskLauncher { request ->
+      val subtaskId = requireNotNull(request.skillRunRequest.subtaskId)
+      store.mutate { current -> current.withWorkflowId(subtaskId, "wfl-$subtaskId") }
+      AgentRunLaunchFacts(
+        agent = InstallAgent.CLAUDE,
+        exitStatus = 1,
+        stdout = "diagnostic only",
+        stderr = "Error: usage limit reached before persisting terminal outcome",
+        timedOut = false,
+        interrupted = false,
+        spawnFailed = false,
+      )
+    }
+    val outcomes = RecordingOutcomeStore()
+    val runner = GoalRunner(store, launcher, outcomes, RecordingPullRequestPort())
+
+    val report = runner.run(runRequest())
+
+    val stopped = assertIs<GoalRunnerRunReport.Stopped>(report)
+    assertEquals(GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME, stopped.stop.reason)
+    // A non-zero exit is diagnosed as the child erroring out, with the captured stderr tail.
+    assertContains(stopped.stop.blockedReason, "exited with status 1")
+    assertContains(stopped.stop.blockedReason, "Child stderr tail:")
+    assertContains(stopped.stop.blockedReason, "usage limit reached before persisting terminal outcome")
+    // A non-zero exit is not eligible for the no-terminal-outcome retry: exactly one launch.
+    assertEquals(1, launcher.requests.size)
+  }
+
+  private fun runRequest(): GoalRunnerRunRequest = GoalRunnerRunRequest(
+    issueKey = "SKILL-56",
+    repoRoot = Path.of("/tmp/skillbill-goal-runner"),
+    invokedAgentId = "claude",
+    dbPathOverride = "/tmp/skillbill-goal-runner/metrics.db",
   )
 }
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalRunnerPolicy.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalRunnerPolicy.kt
@@ -152,12 +152,7 @@ object GoalRunnerOutcomeReconciler {
     )
     storedOutcome == null -> GoalRunnerReconciledOutcome.Stop(
       reason = GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME,
-      blockedReason = "Subtask $subtaskId finished without a terminal workflow-store outcome: the child " +
-        "process returned but its workflow row never reached a terminal state (complete or durably " +
-        "blocked). This is cause-agnostic — possible causes include the child process being terminated " +
-        "mid-run (out-of-memory, crash, or an interrupted/declined resume) or hitting a model/usage limit " +
-        "before persisting. Inspect the child workflow and its transcript to confirm the cause, then " +
-        "resume from last_resumable_step.",
+      blockedReason = noTerminalStoreOutcomeReason(subtaskId, launchFacts),
       workflowId = null,
       commitSha = null,
       lastResumableStep = "preplan",
@@ -221,6 +216,35 @@ object GoalRunnerOutcomeReconciler {
         lastResumableStep = storedOutcome.lastResumableStep.orEmpty().ifBlank { "commit_push" },
       )
     }
+  }
+
+  /**
+   * Builds the no-terminal-outcome diagnosis. The child returned but its workflow row never
+   * reached a terminal state. Rather than a cause-agnostic guess, branch on the captured
+   * [GoalRunnerLaunchFacts.exitStatus] and append the captured stderr tail when present, so the
+   * operator sees the actual failure cause (a non-zero exit means the child errored; a clean exit
+   * means it stopped before the terminal store-write — typically a usage/model limit or a missed
+   * terminal MCP call).
+   */
+  private fun noTerminalStoreOutcomeReason(subtaskId: Int, launchFacts: GoalRunnerLaunchFacts): String {
+    val exitStatus = launchFacts.exitStatus
+    val lead = when {
+      exitStatus != null && exitStatus != 0 ->
+        "Subtask $subtaskId finished without a terminal workflow-store outcome: the child process " +
+          "exited with status $exitStatus before its workflow row reached a terminal state (complete " +
+          "or durably blocked). A non-zero exit means the child errored out rather than stopping cleanly."
+      else ->
+        "Subtask $subtaskId finished without a terminal workflow-store outcome: the child process " +
+          "exited cleanly (status ${exitStatus ?: "unknown"}) but its workflow row never reached a " +
+          "terminal state. A clean exit without a terminal store-write usually means a model/usage " +
+          "limit or a missed terminal MCP call before persisting."
+    }
+    val guidance = " Inspect the child workflow and its transcript to confirm, then resume from last_resumable_step."
+    val stderrDetail = launchFacts.stderrTail
+      ?.takeIf(String::isNotBlank)
+      ?.let { tail -> " Child stderr tail:\n$tail" }
+      .orEmpty()
+    return "$lead$guidance$stderrDetail"
   }
 
   private fun stop(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
@@ -31,7 +31,17 @@ data class GoalRunnerLaunchFacts(
   val spawnFailed: Boolean = false,
   val exitStatus: Int? = null,
   val liveness: GoalRunnerLivenessSnapshot? = null,
-)
+  /**
+   * Bounded tail of the child process stderr (last [STDERR_TAIL_MAX_CHARS] chars). Carried into
+   * the domain so the no-terminal-outcome diagnosis can report the actual failure cause instead
+   * of a cause-agnostic guess. Null when no stderr was captured.
+   */
+  val stderrTail: String? = null,
+) {
+  companion object {
+    const val STDERR_TAIL_MAX_CHARS: Int = 2_000
+  }
+}
 
 /**
  * SKILL-64 Subtask 3 (AC23): documented, testable liveness taxonomy derived


### PR DESCRIPTION
## Problem

When a goal subtask child process returns without a terminal workflow-store outcome, the goal runner blocked with a fixed **cause-agnostic** reason ("possible causes include OOM/crash/usage-limit…"), and `worker_output_summary` persisted only `stderr_chars=N` — discarding the stderr body. So a real stall (observed: a child exiting `1` mid-run after the `write_history` phase, leaving `commit_push` unattempted) was **undiagnosable after the fact**: the one signal that distinguishes a crash from a usage limit was already gone.

Root cause was structural: `AgentRunLaunchFacts` (ports) carries the full `stderr`, but `toGoalRunnerLaunchFacts()` copied only `exitStatus` + `liveness` into the domain `GoalRunnerLaunchFacts`, so the classifier that writes the blocked reason never saw stderr. `exitStatus` was consulted *only* to gate retry (which requires `exitStatus == 0`), so a non-zero exit got zero retries **and** a vague reason.

## Fix

- **`GoalRunnerLaunchFacts`** now carries a bounded `stderrTail` (cap 2000 chars); `toGoalRunnerLaunchFacts()` populates it so stderr reaches the domain.
- **`NO_TERMINAL_STORE_OUTCOME` reason** branches on `exitStatus`: a non-zero exit is reported as the child erroring out (`exited with status N`); a clean exit as a likely usage/model limit or missed terminal MCP call. Both append the captured stderr tail.
- **`worker_output_summary`** persists the stderr tail alongside the counts (store is local to `~/.skill-bill`).

This is a **diagnosis** fix — it makes the next stall self-explaining; it does not change why a child exits non-zero.

### Not addressed (flagged)
`lastResumableStep` is still hardcoded to `"preplan"` in the same branch even when liveness knows the real step. Left untouched pending understanding of the goal→child resume handoff.

## Tests / QA
- Updated the clean-exit assertion in `GoalRunnerTest`.
- Added `GoalRunnerNoTerminalOutcomeDiagnosisTest` covering the non-zero-exit + stderr-tail path and the no-retry behavior (kept in a sibling class so the oversized `GoalRunnerTest` stays under detekt `LargeClass`).
- `:runtime-domain:check` + `:runtime-application:check` pass (detekt, spotless, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)