### PR TITLE
fix: refuse runtime resume of a foreign-mode (prose) workflow instead of crashing

### DIFF
--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -10,6 +10,7 @@ import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.persistence.WorkflowStateRepository
+import skillbill.ports.persistence.model.FeatureTaskWorkflowMode
 import skillbill.workflow.WorkflowEngine
 import skillbill.workflow.WorkflowSnapshotValidator
 import skillbill.workflow.model.WorkflowStateSnapshot
@@ -261,6 +262,17 @@ class FeatureTaskRuntimePhaseRecorder(
       val record = WorkflowFamily.TASK_RUNTIME.get(unitOfWork.workflowStates, workflowId)
         ?: return@read null
       phaseLedgerFrom(decodeArtifacts(record.artifactsJson))
+    }
+
+  /**
+   * Reads the persisted mode of an existing feature-task workflow row, mode-agnostically. Unlike
+   * [WorkflowFamily.TASK_RUNTIME.get] (which routes through getFeatureTaskWorkflowAsMode and throws
+   * [InvalidWorkflowStateSchemaError] on a foreign-mode row), this never throws — it lets the caller
+   * decide what to do about a mode mismatch. Null when no row exists.
+   */
+  fun existingWorkflowMode(workflowId: String, dbOverride: String? = null): FeatureTaskWorkflowMode? =
+    database.read(dbOverride) { unitOfWork ->
+      unitOfWork.workflowStates.getFeatureTaskWorkflow(workflowId)?.mode
     }
 
   /**

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
@@ -19,6 +19,7 @@ import skillbill.ports.agentrun.model.SkillRunRequest
 import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
 import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
 import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
+import skillbill.ports.persistence.model.FeatureTaskWorkflowMode
 import skillbill.ports.workflow.WorkflowGitOperations
 import skillbill.workflow.FeatureTaskRuntimePhaseOutputValidator
 import skillbill.workflow.model.SpecSource
@@ -66,7 +67,34 @@ class FeatureTaskRuntimeRunner(
   private val specStatusProjector get() = phaseGates.specStatusProjector
   private val specSourceResolver get() = phaseGates.specGate.specSourceResolver
 
+  // A feature-task workflow row is mode-scoped: prose (`wfl-`) and runtime (`wftr-`) persist
+  // different schemas under the same row, so a runtime run cannot resume a workflow created in
+  // prose mode (and vice versa). This happens when a goal subtask is switched from prose to runtime
+  // mid-flight and the runtime resume inherits the prose workflow id. Rather than let the mode guard
+  // (getFeatureTaskWorkflowAsMode) throw uncaught — which exits 1 with no terminal store outcome and
+  // surfaces to the goal supervisor as a cause-agnostic no-terminal-outcome stall — stop loudly with
+  // a durable, actionable Blocked terminal report. We never write to the foreign-mode row.
+  private fun foreignModeWorkflowBlock(request: FeatureTaskRuntimeRunRequest): FeatureTaskRuntimeRunReport.Blocked? {
+    val existingMode = recorder.existingWorkflowMode(request.workflowId, request.dbPathOverride)
+    if (existingMode == null || existingMode == FeatureTaskWorkflowMode.RUNTIME) {
+      return null
+    }
+    return FeatureTaskRuntimeRunReport.Blocked(
+      issueKey = request.issueKey,
+      workflowId = request.workflowId,
+      featureSize = request.runInvariants.featureSize.name,
+      lastIncompletePhase = FeatureTaskRuntimePhaseWorkflowDefinition.definition.defaultInitialStepId,
+      blockedReason = "Cannot resume workflow '${request.workflowId}' in runtime mode: it was created in " +
+        "'${existingMode.wireValue}' mode. A feature-task workflow is mode-scoped — prose and runtime are " +
+        "not interchangeable. Finish this subtask in '${existingMode.wireValue}' mode, or reset the subtask " +
+        "to start a fresh runtime attempt.",
+      completedPhaseIds = emptyList(),
+      resolvedBranch = null,
+    )
+  }
+
   fun run(request: FeatureTaskRuntimeRunRequest): FeatureTaskRuntimeRunReport {
+    foreignModeWorkflowBlock(request)?.let { return it }
     recorder.ensureWorkflowOpen(request.workflowId, request.sessionId, request.dbPathOverride)
     val durableRunInvariants = runInvariantsStore.resolve(
       workflowId = request.workflowId,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunner.kt
@@ -1182,7 +1182,7 @@ private fun skillbill.ports.agentrun.model.AgentRunLaunchOutcome.toGoalRunnerLau
       interrupted = interrupted,
       spawnFailed = spawnFailed,
       exitStatus = exitStatus,
-      stderrTail = stderr.takeLast(GoalRunnerLaunchFacts.STDERR_TAIL_MAX_CHARS).takeIf(String::isNotBlank),
+      stderrExcerpt = stderrExcerpt(stderr, GoalRunnerLaunchFacts.STDERR_EXCERPT_MAX_CHARS),
       liveness = liveness?.let { snapshot ->
         GoalRunnerLivenessSnapshot(
           phase = snapshot.phase,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerObservabilityEmitter.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerObservabilityEmitter.kt
@@ -119,13 +119,11 @@ internal class GoalRunnerObservabilityEmitter(
     progress: GoalRunnerWorkflowProgress?,
     facts: AgentRunLaunchFacts,
   ) {
-    // Persist a bounded stderr tail alongside the counts: a char count alone makes a
+    // Persist a bounded head+tail stderr excerpt alongside the counts: a char count alone makes a
     // no-terminal-outcome stall undiagnosable after the fact (the body is the only signal that
     // distinguishes a crash from a usage limit). The store is local to ~/.skill-bill.
-    val stderrTail = facts.stderr
-      .takeLast(GoalRunnerLaunchFacts.STDERR_TAIL_MAX_CHARS)
-      .takeIf(String::isNotBlank)
-      ?.let { tail -> "; stderr_tail=$tail" }
+    val stderrDetail = stderrExcerpt(facts.stderr, GoalRunnerLaunchFacts.STDERR_EXCERPT_MAX_CHARS)
+      ?.let { excerpt -> "; stderr_excerpt=$excerpt" }
       .orEmpty()
     record(
       subject = subject,
@@ -133,7 +131,7 @@ internal class GoalRunnerObservabilityEmitter(
         workflowPhase = progress?.currentStepId ?: facts.liveness?.workflowStep ?: "goal_runner_supervision",
         livenessClass = "worker_output_summary",
         activitySummary = "stdout_chars=${facts.stdout.length}; stderr_chars=${facts.stderr.length}; " +
-          "exit_status=${facts.exitStatus ?: "none"}$stderrTail",
+          "exit_status=${facts.exitStatus ?: "none"}$stderrDetail",
       ),
     )
   }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStderrExcerpt.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStderrExcerpt.kt
@@ -1,0 +1,26 @@
+package skillbill.application.goalrunner
+
+/**
+ * Produces a bounded head+tail excerpt of child-process [stderr] for diagnosis.
+ *
+ * A plain tail keeps only the bottom of a crash stack trace (`… main()`), discarding the exception
+ * type and message at the top — the most diagnostic part. This splits the [maxChars] budget between
+ * the head (exception + top frames) and the tail (most recent output), with an explicit marker for
+ * the omitted middle. Returns null when there is no captured stderr.
+ */
+internal fun stderrExcerpt(stderr: String, maxChars: Int): String? {
+  val trimmed = stderr.takeIf(String::isNotBlank) ?: return null
+  if (trimmed.length <= maxChars) {
+    return trimmed
+  }
+  val headChars = maxChars / 2
+  val tailChars = maxChars - headChars
+  val omitted = trimmed.length - headChars - tailChars
+  return buildString {
+    append(trimmed.take(headChars))
+    append("\n…[")
+    append(omitted)
+    append(" chars omitted]…\n")
+    append(trimmed.takeLast(tailChars))
+  }
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -104,6 +104,20 @@ class FeatureTaskRuntimeRunnerTest {
   }
 
   @Test
+  fun `runtime run against a prose-mode workflow blocks with an actionable reason and launches nothing`() {
+    val harness = runnerHarness(agentAssignment = phasePerAgentAssignment())
+    harness.seedProseModeWorkflow()
+
+    val report = harness.runner.run(harness.request())
+
+    val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(report)
+    assertContains(blocked.blockedReason, "was created in 'prose' mode")
+    assertContains(blocked.blockedReason, "reset the subtask")
+    // The mode collision is detected before any phase work: no agent is ever launched.
+    assertTrue(harness.launcher.requests.isEmpty())
+  }
+
+  @Test
   fun `blocked phase output stops the run and does not advance to pr`() {
     val harness = runnerHarness(
       launcher = RuntimeRecordingLauncher { request ->
@@ -2694,6 +2708,29 @@ internal class RunnerHarness(
     recorder.recordPhaseStateForTest(phaseId, status, attemptCount, agentId, outputArtifact)
   }
 
+  // Seeds a foreign-mode (prose) feature-task row at WORKFLOW_ID, simulating a goal subtask that was
+  // run in prose mode and is now being resumed in runtime mode — the mode-collision the runtime must
+  // refuse cleanly instead of crashing on the mode guard.
+  fun seedProseModeWorkflow() {
+    repository.saveFeatureTaskWorkflow(
+      WorkflowStateRecord(
+        workflowId = WORKFLOW_ID,
+        sessionId = SESSION_ID,
+        workflowName = "bill-feature-task",
+        contractVersion = "0.1",
+        workflowStatus = "running",
+        currentStepId = "implement",
+        stepsJson = "[]",
+        artifactsJson = "{}",
+        startedAt = null,
+        updatedAt = null,
+        finishedAt = null,
+        mode = skillbill.ports.persistence.model.FeatureTaskWorkflowMode.PROSE,
+      ),
+      skillbill.ports.persistence.model.FeatureTaskWorkflowMode.PROSE,
+    )
+  }
+
   // Seeds the durable run-scoped resolved branch, simulating a prior run that already established it.
   fun seedResolvedBranch(branch: String, baseBranch: String?, created: Boolean) {
     recorder.ensureWorkflowOpen(WORKFLOW_ID, SESSION_ID)
@@ -3657,6 +3694,11 @@ internal class RecordingLifecycleTelemetryRepository : LifecycleTelemetryReposit
 internal class InMemoryRuntimeWorkflowRepository : WorkflowStateRepository {
   private val taskRuntimeRows = linkedMapOf<String, WorkflowStateRecord>()
 
+  // Prose feature-task rows live under the feature-implement family (see WorkflowStateRepository's
+  // mode routing). Storing them faithfully lets the mode-agnostic getFeatureTaskWorkflow find a
+  // prose row, mirroring the production SQLite store where both modes share one table.
+  private val implementRows = linkedMapOf<String, WorkflowStateRecord>()
+
   fun taskRuntimeArtifacts(workflowId: String): Map<String, Any?> {
     val record = requireNotNull(taskRuntimeRows[workflowId]) { "no runtime row for $workflowId" }
     return skillbill.contracts.JsonSupport.parseObjectOrNull(record.artifactsJson)
@@ -3689,11 +3731,13 @@ internal class InMemoryRuntimeWorkflowRepository : WorkflowStateRepository {
   override fun latestFeatureTaskRuntimeWorkflow(): WorkflowStateRecord? =
     listFeatureTaskRuntimeWorkflows(1).firstOrNull()
 
-  override fun saveFeatureImplementWorkflow(row: WorkflowStateRecord) = Unit
+  override fun saveFeatureImplementWorkflow(row: WorkflowStateRecord) {
+    implementRows[row.workflowId] = row
+  }
 
   override fun saveFeatureVerifyWorkflow(row: WorkflowStateRecord) = Unit
 
-  override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? = null
+  override fun getFeatureImplementWorkflow(workflowId: String): WorkflowStateRecord? = implementRows[workflowId]
 
   override fun getFeatureVerifyWorkflow(workflowId: String): WorkflowStateRecord? = null
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
@@ -14,6 +14,7 @@ import skillbill.application.model.GoalRunnerRunRequest
 import skillbill.application.model.GoalRunnerStatusRequest
 import skillbill.application.workflow.repoRoot
 import skillbill.goalrunner.model.GoalAttemptLedgerAction
+import skillbill.goalrunner.model.GoalRunnerLaunchFacts
 import skillbill.goalrunner.model.GoalRunnerRunReport
 import skillbill.goalrunner.model.GoalRunnerStopReason
 import skillbill.goalrunner.model.GoalRunnerStoredOutcome
@@ -745,12 +746,43 @@ class GoalRunnerNoTerminalOutcomeDiagnosisTest {
 
     val stopped = assertIs<GoalRunnerRunReport.Stopped>(report)
     assertEquals(GoalRunnerStopReason.NO_TERMINAL_STORE_OUTCOME, stopped.stop.reason)
-    // A non-zero exit is diagnosed as the child erroring out, with the captured stderr tail.
+    // A non-zero exit is diagnosed as the child erroring out, with the captured stderr excerpt.
     assertContains(stopped.stop.blockedReason, "exited with status 1")
-    assertContains(stopped.stop.blockedReason, "Child stderr tail:")
+    assertContains(stopped.stop.blockedReason, "Child stderr (head+tail):")
     assertContains(stopped.stop.blockedReason, "usage limit reached before persisting terminal outcome")
     // A non-zero exit is not eligible for the no-terminal-outcome retry: exactly one launch.
     assertEquals(1, launcher.requests.size)
+  }
+
+  @Test
+  fun `oversized child stderr keeps exception head and recent tail`() {
+    // A crash stack trace leads with the exception type/message (the diagnostic part) and ends in
+    // framework frames. A plain tail would drop the head; the head+tail excerpt keeps both.
+    val head = "java.lang.IllegalStateException: SQLITE_BUSY: database is locked"
+    val tail = "at skillbill.cli.core.MainKt.main(Main.kt:12)"
+    val stderr = head + "X".repeat(GoalRunnerLaunchFacts.STDERR_EXCERPT_MAX_CHARS * 2) + tail
+    val store = InMemoryGoalManifestStore(manifest = manifest(subtaskCount = 1))
+    val launcher = RecordingSubtaskLauncher { request ->
+      val subtaskId = requireNotNull(request.skillRunRequest.subtaskId)
+      store.mutate { current -> current.withWorkflowId(subtaskId, "wfl-$subtaskId") }
+      AgentRunLaunchFacts(
+        agent = InstallAgent.CLAUDE,
+        exitStatus = 1,
+        stdout = "diagnostic only",
+        stderr = stderr,
+        timedOut = false,
+        interrupted = false,
+        spawnFailed = false,
+      )
+    }
+    val runner = GoalRunner(store, launcher, RecordingOutcomeStore(), RecordingPullRequestPort())
+
+    val report = runner.run(runRequest())
+
+    val stopped = assertIs<GoalRunnerRunReport.Stopped>(report)
+    assertContains(stopped.stop.blockedReason, head)
+    assertContains(stopped.stop.blockedReason, tail)
+    assertContains(stopped.stop.blockedReason, "chars omitted")
   }
 
   private fun runRequest(): GoalRunnerRunRequest = GoalRunnerRunRequest(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalRunnerPolicy.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalRunnerPolicy.kt
@@ -240,9 +240,9 @@ object GoalRunnerOutcomeReconciler {
           "limit or a missed terminal MCP call before persisting."
     }
     val guidance = " Inspect the child workflow and its transcript to confirm, then resume from last_resumable_step."
-    val stderrDetail = launchFacts.stderrTail
+    val stderrDetail = launchFacts.stderrExcerpt
       ?.takeIf(String::isNotBlank)
-      ?.let { tail -> " Child stderr tail:\n$tail" }
+      ?.let { excerpt -> " Child stderr (head+tail):\n$excerpt" }
       .orEmpty()
     return "$lead$guidance$stderrDetail"
   }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
@@ -32,14 +32,16 @@ data class GoalRunnerLaunchFacts(
   val exitStatus: Int? = null,
   val liveness: GoalRunnerLivenessSnapshot? = null,
   /**
-   * Bounded tail of the child process stderr (last [STDERR_TAIL_MAX_CHARS] chars). Carried into
-   * the domain so the no-terminal-outcome diagnosis can report the actual failure cause instead
-   * of a cause-agnostic guess. Null when no stderr was captured.
+   * Bounded head+tail excerpt of the child process stderr (at most [STDERR_EXCERPT_MAX_CHARS]
+   * chars). Carried into the domain so the no-terminal-outcome diagnosis can report the actual
+   * failure cause instead of a cause-agnostic guess. A head+tail excerpt (rather than a plain
+   * tail) preserves the exception type and message at the top of a crash stack trace — the most
+   * diagnostic part — alongside the most recent output. Null when no stderr was captured.
    */
-  val stderrTail: String? = null,
+  val stderrExcerpt: String? = null,
 ) {
   companion object {
-    const val STDERR_TAIL_MAX_CHARS: Int = 2_000
+    const val STDERR_EXCERPT_MAX_CHARS: Int = 3_000
   }
 }
 


### PR DESCRIPTION
## Problem

A feature-task workflow row is **mode-scoped** — prose (`wfl-`) and runtime (`wftr-`) persist different schemas. When a goal subtask is switched from prose to runtime mid-flight, the runtime resume inherits the prose workflow id and `FeatureTaskRuntimeRunner.run → ensureWorkflowOpen`'s mode guard (`getFeatureTaskWorkflowAsMode`, `WorkflowStateStore.kt:65`) throws `InvalidWorkflowStateSchemaError` **uncaught**. The child exits 1 with no terminal store outcome, which the goal supervisor can only surface as a cause-agnostic `no_terminal_store_outcome`.

This was captured live on PS-24 subtask 3 after switching it prose→runtime:

```
skillbill.error.InvalidWorkflowStateSchemaError:
  Feature-task workflow 'wfl-20260620-191528-5540' is mode='prose', not 'runtime'.
    at FeatureTaskWorkflowStateStore.getFeatureTaskWorkflowAsMode (WorkflowStateStore.kt:65)
    at FeatureTaskRuntimePhaseRecorder.ensureWorkflowOpen (…:271)
    at FeatureTaskRuntimeRunner.run (…:70)
```

The mode guard itself is **correct** — a prose row genuinely isn't a runtime workflow, and silently misreading it would be worse. The bug is the *uncaught crash*, not the rejection.

## Fix

- New mode-agnostic read `FeatureTaskRuntimePhaseRecorder.existingWorkflowMode` (uses `getFeatureTaskWorkflow`, which never throws on a foreign mode, unlike `getFeatureTaskWorkflowAsMode`).
- `FeatureTaskRuntimeRunner.run` checks it first and returns a durable `FeatureTaskRuntimeRunReport.Blocked` with an actionable reason when the existing row is not runtime-mode. The foreign-mode row is **never written**.
- The CLI already serializes `Blocked` to a `{"status":"blocked",…}` terminal envelope the goal supervisor recovers as a real terminal outcome — so the operator sees *"workflow was created in 'prose' mode … finish it in prose, or reset the subtask to start a fresh runtime attempt"* instead of a stack trace and a cause-agnostic stall.

### Scope / follow-up
This fixes the **runtime-side** crash (the boundary the failure surfaced at). It does **not** add a goal-supervisor-side guard preventing a runtime resume from being pointed at a prose workflow id in the first place (the "prevent" half) — a reasonable follow-up if mode-switching mid-goal should be blocked earlier.

## Tests / QA
- New `FeatureTaskRuntimeRunnerTest`: a runtime run against a seeded prose-mode workflow blocks with the actionable reason and launches no phase agent.
- Extended the in-memory workflow fake to store feature-implement (prose) rows so the mode-agnostic read mirrors the production SQLite store.
- `:runtime-application:check` passes (detekt, spotless, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)