### PR TITLE
feat: [SKILL-88] PTY-backed stdio spawn for opencode

### DIFF
--- a/.feature-specs/SKILL-88-opencode-pty-stdio/spec.md
+++ b/.feature-specs/SKILL-88-opencode-pty-stdio/spec.md
@@ -1,0 +1,186 @@
+# SKILL-88 — Durable fix for opencode failing under the runtime's JVM-piped stdout spawn
+
+Status: Complete
+
+## Summary
+
+The Bun-compiled `opencode` binary exits with status `1` in ~2-3 seconds, emitting
+non-JSON stdout, **only** when the skill-bill runtime spawns it with its stdout connected
+to a JVM `ProcessBuilder` pipe. The same invocation runs normally when opencode's stdout is
+a regular file. This breaks every `feature-task-runtime` phase that uses `--agent opencode`:
+the phase agent never does real work, the phase schema-gate rejects the non-JSON output
+(`<root> must be an object`), the bounded fix loop burns its retries on the same fast
+failure, and the phase lands in a sticky `blocked` state. Implement a durable runtime fix so
+opencode runs correctly under the runtime's own spawn, and surface the child's stderr in the
+phase failure reason so this class of failure stops being opaque.
+
+## Background — how it surfaced (PS-24)
+
+Subtask 8 of an unrelated decomposed goal (PS-24, "Post revisions + audit log") got stuck in
+a sticky `blocked` state at the preplan phase. The goal loop correctly stopped and refused to
+advance. The failure chain inside the runtime:
+
+1. The goal runner spawns the feature-task child for the subtask (`skill-bill feature-task
+   run …`, via `goalContinuationCommand`).
+2. The feature-task runtime spawns `opencode run --dir <repo> --dangerously-skip-permissions
+   <preplan briefing>` to run the preplan phase (`OpencodeAgentRunCommandBuilder`).
+3. The opencode child exits status `1` in ~2-3s, emitting ~629 chars of non-JSON stdout.
+4. The preplan schema-gate rejects the output (`<root> must be an object`).
+5. The bounded fix loop retries 3× — identical fast failure each time — then marks the phase
+   `blocked`.
+6. `blocked` is sticky: resume will not retry once `attempt_count` exceeds the cap.
+
+PS-24 itself was soft-reset (subtasks 1-7 complete, subtask 8 reverted to pending) and is not
+part of this fix.
+
+## Reproduction & evidence
+
+- The runtime invokes opencode correctly: parent process is `java`, argv is well-formed,
+  `--dir` points at a real existing directory, the prompt positional is non-blank.
+- Connect opencode's stdout to a JVM-owned pipe (the current path) → opencode exits ~2-3s,
+  status 1, non-JSON output → schema-gate failure.
+- Insert an `opencode` wrapper on `PATH` that redirects opencode's stdout to a **file** →
+  opencode runs normally (full LLM execution; hit a 120s harness timeout mid-preplan, no
+  block).
+
+The determining factor is the **type of opencode's stdout fd**: pipe (fails) vs file (works).
+opencode is a Bun-compiled native binary and misbehaves under the runtime's piped-stdio
+spawn specifically.
+
+## Ruled out (with evidence)
+
+- **opencode binary / flags / config** — all valid. `--dir` and
+  `--dangerously-skip-permissions` exist in opencode 1.15.3; `zai-coding/glm-5.2` auth works.
+  The exact builder invocation runs fine from a normal shell (exit 0).
+- **Preplan briefing content** — fed the exact stored ~1520-byte briefing to `opencode run`
+  directly; it ran fine.
+- **`OPENCODE_*` inherited env vars** — stripped them; failure persisted.
+- **Goal-continuation env** — reproduced with all `SKILL_BILL_GOAL_*` vars set; opencode ran
+  fine.
+- **Shell vs no-shell exec** — a direct (no-shell) subprocess spawn with identical argv also
+  succeeded.
+- **Empty/blank prompt, bad `--dir`, bad `--model`** — the three fast opencode exit-1 modes
+  are all excluded: `promptOverride` is validated non-blank
+  (`AgentRunLauncherModels.kt:28`), `--dir` resolves to the real repo dir (goal mode reuses
+  `request.repoRoot`; no per-subtask worktree is created), and the opencode builder never
+  passes `--model`.
+
+## Root cause
+
+The Bun-compiled `opencode` binary does not tolerate having its stdout connected to a JVM
+`ProcessBuilder` pipe and aborts early (status 1) before doing real work. The runtime's
+`JvmAgentRunProcessRunner` currently reads the child's stdout/stderr from
+`process.inputStream` / `process.errorStream` (JVM pipes) via `CappedUtf8Drain`. A file-backed
+stdout avoids the abort but is not a drop-in: a plain file redirect removes the live stdout
+signal the watchdog relies on, which would risk false idle-kills on read-only phases (preplan
+makes no file edits and would emit no pipe output during a multi-minute run).
+
+## Intended outcome
+
+`feature-task-runtime` phases run with `--agent opencode` complete normally under the
+runtime's own spawn — no ~2-3s status-1 abort, no spurious schema-gate failures, no sticky
+`blocked`. When a phase agent does exit non-zero for a real reason, the failure reason names
+the child's actual error instead of a bare exit code.
+
+## Proposed approach
+
+Give the opencode child a **PTY (pseudo-terminal)** for its stdio so its stdout is a TTY-like
+fd it handles correctly, while the runtime still reads output live for capture, output-sink
+streaming, and liveness. This is preferred over a plain file redirect because it preserves the
+live-output signal the idle watchdog depends on, avoiding false idle-kills on read-only phases.
+
+Scope the PTY path to the agents that need it (opencode), carried as a flag on the process
+request so the launcher selects PTY-backed stdio. The JVM has no built-in PTY; add a PTY
+dependency (e.g. `pty4j`) for the runtime-infra-fs module.
+
+Companion fix (independent, related): `infraFailureReason`
+(`FeatureTaskRuntimeRunner.kt:1594`) currently reports only `agent exited with non-zero status
+N` and drops `facts.stderr`, which holds the child's actual error line. Append a bounded
+stderr (and/or stdout) excerpt — reuse the existing `stderrExcerpt` /
+`STDERR_EXCERPT_MAX_CHARS` pattern used by `GoalRunnerObservabilityEmitter` — so the failure
+reason is self-diagnosing.
+
+### Alternatives considered (and why not)
+
+- **File-redirect + `cat` wrapper in the command builder.** Proven to make opencode work, but
+  flushes stdout to the JVM only at exit, removing the live-output signal → risks false
+  idle-kills on read-only phases (preplan). Rejected as the primary fix; the watchdog
+  signal-profile change would have to be reworked anyway.
+- **`opencode run --format json`.** Emits opencode's own event-stream JSON, not the agent's
+  final phase-contract JSON object the schema-gate extracts. Would break extraction.
+- **Switch the default child agent to claude/codex.** They deliver the prompt via stdin and
+  did not show the Bun-pipe symptom, but this is an operational workaround, not a fix, and
+  drops opencode support in runtime mode.
+
+## Acceptance Criteria
+
+1. The runtime spawns the opencode `feature-task-runtime` phase child over a PTY-backed stdio
+   path (not a plain JVM stdout pipe), and a real preplan phase run with `--agent opencode`
+   completes through the phase schema-gate instead of failing with a ~2-3s status-1 non-JSON
+   exit.
+2. Child output from the PTY path is still drained live, capped at the existing output limit,
+   streamed to the output sink, and delivered to the schema-gate identically to the current
+   pipe path — no regression in captured stdout/stderr for any agent.
+3. Liveness/idle-watchdog semantics are preserved: a long-running but live opencode phase is
+   not false-killed by the progress-idle watchdog, and a genuinely hung child is still
+   detected and terminated. No regression to `JvmAgentRunProcessRunner` timeout, idle, or
+   declared-progress behavior.
+4. `infraFailureReason` includes a bounded excerpt of the child's `stderr` (and/or stdout)
+   when a phase agent exits non-zero, so the reason names the child's actual error rather than
+   only `agent exited with non-zero status N`.
+5. The claude, codex, and junie launch paths are unchanged in behavior and continue to pass
+   their existing launcher tests; the PTY path is scoped so it does not regress them.
+6. Tests cover the opencode PTY stdio launch path, the preserved drain/cap/output-sink/
+   liveness behavior, and the `infraFailureReason` stderr surfacing.
+7. `./gradlew check` passes.
+
+## Non-goals
+
+- Changing opencode's prompt delivery (stays the argv positional), model selection, or the
+  `--dir` / `--dangerously-skip-permissions` flags.
+- Fixing the upstream Bun/opencode binary; the runtime adapts to it.
+- Reworking prose-mode (it bypasses the subprocess spawn entirely and is an available
+  workaround, not part of this fix).
+- Migrating claude/codex/junie to PTY-backed stdio (only opencode requires it; any broader
+  rollout is out of scope unless trivially free).
+- Re-running or unblocking PS-24.
+
+## Affected files / anchors
+
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/JvmAgentRunProcessRunner.kt`
+  — PTY-backed stdio spawn + drain (`startProcess`, `CappedUtf8Drain`, the wait/liveness loop).
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/AgentRunProcessRunner.kt`
+  — `AgentRunProcessRequest` model: carry a "needs PTY stdio" flag.
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt`
+  — `OpencodeAgentRunCommandBuilder` (and the `AgentRunCommand` model) to signal the PTY need.
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt`
+  — thread the PTY flag from command into `AgentRunProcessRequest`.
+- `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt:1594`
+  — `infraFailureReason` stderr surfacing.
+- `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerObservabilityEmitter.kt`
+  — reuse `stderrExcerpt` / `STDERR_EXCERPT_MAX_CHARS`.
+- `runtime-kotlin/runtime-infra-fs/build.gradle.kts` (and version catalog) — PTY dependency.
+- Tests: `runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt`
+  and related runtime/launcher tests.
+
+## Validation strategy
+
+- Unit/integration tests for the PTY stdio launch path and the preserved drain/cap/liveness
+  behavior (see Acceptance Criteria 2, 3, 6).
+- A test asserting `infraFailureReason` carries a bounded stderr excerpt on non-zero exit.
+- Manual confirmation: run a real `feature-task-runtime` preplan phase with `--agent opencode`
+  from the runtime and confirm it advances past preplan (no ~2-3s status-1 abort).
+- `./gradlew check` green.
+
+## Risks
+
+- PTY dependency portability across the runtime's target platforms (Linux/macOS); confirm the
+  chosen library covers them.
+- Subtle differences in how a PTY presents EOF/exit vs a pipe could affect the wait/drain loop;
+  covered by Acceptance Criteria 2 and 3.
+
+## Next path
+
+```bash
+Run bill-feature-task on .feature-specs/SKILL-88-opencode-pty-stdio/spec.md
+```

--- a/runtime-kotlin/gradle/libs.versions.toml
+++ b/runtime-kotlin/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 beryxRuntime = "2.0.1"
 detekt = "1.23.8"
+jna = "5.13.0"
 clikt = "5.1.0"
 compose = "1.10.3"
 composeMaterial3 = "1.10.0-alpha05"
@@ -44,6 +45,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 room3-compiler = { module = "androidx.room3:room3-compiler", version.ref = "room3" }
 room3-runtime = { module = "androidx.room3:room3-runtime", version.ref = "room3" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "jsonSchemaValidator" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
@@ -1,6 +1,7 @@
 package skillbill.application.featuretask
 
 import me.tatarka.inject.annotations.Inject
+import skillbill.application.goalrunner.stderrExcerpt
 import skillbill.application.model.FeatureTaskRuntimeFixLoopDecision
 import skillbill.application.model.FeatureTaskRuntimeGoalContinuationContext
 import skillbill.application.model.FeatureTaskRuntimePhaseStateRequest
@@ -13,6 +14,7 @@ import skillbill.application.model.FeatureTaskRuntimeSubtaskOutcome
 import skillbill.application.workflow.repoRoot
 import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
+import skillbill.goalrunner.model.GoalRunnerLaunchFacts
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
 import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
 import skillbill.ports.agentrun.model.SkillRunRequest
@@ -1596,8 +1598,12 @@ private fun infraFailureReason(phaseId: String, facts: AgentRunLaunchFacts): Str
     "Feature-task-runtime phase '$phaseId' failed to launch: the agent process could not be spawned."
   facts.timedOut -> "Feature-task-runtime phase '$phaseId' launch timed out before the agent produced an output."
   facts.interrupted -> "Feature-task-runtime phase '$phaseId' launch was interrupted before completion."
-  facts.exitStatus != null && facts.exitStatus != 0 ->
-    "Feature-task-runtime phase '$phaseId' agent exited with non-zero status ${facts.exitStatus}."
+  facts.exitStatus != null && facts.exitStatus != 0 -> {
+    val base = "Feature-task-runtime phase '$phaseId' agent exited with non-zero status ${facts.exitStatus}."
+    val output = facts.stderr.takeIf(String::isNotBlank) ?: facts.stdout.takeIf(String::isNotBlank)
+    val excerpt = output?.let { stderrExcerpt(it, GoalRunnerLaunchFacts.STDERR_EXCERPT_MAX_CHARS) }
+    if (excerpt != null) "$base\n$excerpt" else base
+  }
   else -> null
 }
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -3748,3 +3748,76 @@ internal class InMemoryRuntimeWorkflowRepository : WorkflowStateRepository {
 
   override fun getFeatureVerifySessionSummary(sessionId: String): FeatureVerifySessionSummary? = null
 }
+
+class InfraFailureReasonStderrSurfacingTest {
+  @Test
+  fun `non-zero exit with non-blank stderr surfaces a bounded stderr excerpt in blocked reason`() {
+    val stderrContent = "Error: something went wrong with the child process"
+    val harness = runnerHarness(
+      launcher = RuntimeRecordingLauncher {
+        AgentRunLaunchFacts(
+          agent = InstallAgent.CLAUDE,
+          exitStatus = 1,
+          stdout = "",
+          stderr = stderrContent,
+          timedOut = false,
+          spawnFailed = false,
+        )
+      },
+    )
+
+    val report = harness.runner.run(harness.request())
+
+    val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(report)
+    assertContains(blocked.blockedReason, "exited with non-zero status 1")
+    assertContains(blocked.blockedReason, stderrContent)
+  }
+
+  @Test
+  fun `non-zero exit with blank stderr and non-blank stdout surfaces stdout excerpt in blocked reason`() {
+    val stdoutContent = "unexpected non-json output from the child"
+    val harness = runnerHarness(
+      launcher = RuntimeRecordingLauncher {
+        AgentRunLaunchFacts(
+          agent = InstallAgent.CLAUDE,
+          exitStatus = 2,
+          stdout = stdoutContent,
+          stderr = "",
+          timedOut = false,
+          spawnFailed = false,
+        )
+      },
+    )
+
+    val report = harness.runner.run(harness.request())
+
+    val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(report)
+    assertContains(blocked.blockedReason, "exited with non-zero status 2")
+    assertContains(blocked.blockedReason, stdoutContent)
+  }
+
+  @Test
+  fun `non-zero exit with both blank stderr and stdout does not append an excerpt to blocked reason`() {
+    val harness = runnerHarness(
+      launcher = RuntimeRecordingLauncher {
+        AgentRunLaunchFacts(
+          agent = InstallAgent.CLAUDE,
+          exitStatus = 1,
+          stdout = "",
+          stderr = "",
+          timedOut = false,
+          spawnFailed = false,
+        )
+      },
+    )
+
+    val report = harness.runner.run(harness.request())
+
+    val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(report)
+    assertContains(blocked.blockedReason, "exited with non-zero status 1")
+    assertFalse(
+      blocked.blockedReason.contains("\n"),
+      "reason must not contain a newline when no output is available: '${blocked.blockedReason}'",
+    )
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/agent/history.md
+++ b/runtime-kotlin/runtime-infra-fs/agent/history.md
@@ -1,5 +1,18 @@
 # Boundary History — runtime-kotlin/runtime-infra-fs
 
+## [2026-06-22] SKILL-88 opencode-pty-stdio
+Areas: runtime-infra-fs/launcher/process, runtime-infra-fs/launcher/agentrun, runtime-application/featuretask
+- PTY-backed stdio spawn path for opencode: `startPtyProcess()` in `JvmAgentRunProcessRunner` allocates a POSIX master fd via JNA (`PosixCLibrary` / `PosixLib`), builds the child process with `redirectInput/Output/Error(File(slavePath))`, and reads output through `PtyMasterInputStream` → `CappedUtf8Drain`. Fixes Bun-compiled opencode aborting status 1 when its stdout is a JVM pipe
+- `ProcessStart.PtyStarted` seals alongside `Started`/`Failed`; `runStartedProcess()` receives `stdoutStream`, `stderrStream`, `ptyMasterCloseable` params; for PTY: stdoutStream=ptyMasterStream, stderrStream=nullInputStream (PTY master fd merges stdout+stderr)
+- Fd lifecycle: `masterCloseable.close()` called BEFORE stdout/stderr drain joins to send EIO and unblock the drain — ordering is critical
+- `usePtyStdio: Boolean = false` threaded through `AgentRunCommand` → `AgentRunProcessRequest` → `JvmAgentRunProcessRunner`; `OpencodeAgentRunCommandBuilder` sets it true; claude/codex/junie unchanged
+- JNA 5.13.0 added to `runtime-infra-fs/build.gradle.kts` (version in `libs.versions.toml`) — provides `Native.load("c", PosixCLibrary::class.java)` without pty4j (unavailable offline)
+- Linux-only guard: `check(os.name.startsWith("linux"))` is the first call in `startPtyProcess()` — macOS lacks `ptsname_r` and has a different `O_NOCTTY` constant
+- `openMasterFd()` wraps `grantpt`/`unlockpt` in try/catch that closes the fd before rethrowing ISE (prevents fd leak on partial PTY init)
+- `infraFailureReason` in `FeatureTaskRuntimeRunner` now appends a bounded stderr/stdout excerpt (reuses `stderrExcerpt` / `GoalRunnerLaunchFacts.STDERR_EXCERPT_MAX_CHARS`) when a phase agent exits non-zero
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented
+
 ## [2026-06-10] SKILL-76 baseline-reconciliation (subtask 2)
 Areas: runtime-infra-fs/install, runtime-domain/install/model, runtime-ports/install, runtime-application/install, runtime-cli, install.sh
 - Reconcile-on-reinstall is dpkg-conffile semantics over installed skills: per-skill compare of three `computeInstallContentHash` values — upstream(staged candidate) / local(`~/.skill-bill` copy) / baseline(last-copied-in) — yielding one of five outcomes. `classifySkill` (`InstallReconcilePolicy.kt`) is the single classifier; `applyReconciliation` (`InstallReconcileApply.kt`) RE-derives the SAME plan from the same inputs rather than carrying it across the process boundary, so compute and apply can never disagree

--- a/runtime-kotlin/runtime-infra-fs/build.gradle.kts
+++ b/runtime-kotlin/runtime-infra-fs/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation(libs.json.schema.validator)
   implementation(libs.jackson.databind)
   implementation(libs.jackson.dataformat.yaml)
+  implementation(libs.jna)
   testImplementation(libs.junit.jupiter)
   testImplementation(libs.kotlin.test)
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
@@ -28,13 +28,12 @@ class ProcessAgentRunAdapter(
         progressIdleTimeout = request.progressIdleTimeout,
         progressProbe = request.progressProbe,
         declaredProgressProbe = request.declaredProgressProbe,
-        // SKILL-64 Subtask 3 (AC21, AC25): thread the supervisor-side declared-
-        // progress emitter into the process-lifecycle wrapper.
         progressEmitter = request.progressEmitter,
         activityProbe = WorktreeActivityProbe(command.workingDirectory),
         environment = command.environment,
         inheritEnvironment = command.inheritEnvironment,
         outputSink = request.outputSink,
+        usePtyStdio = command.usePtyStdio,
       ),
     )
     return AgentRunLaunchFacts(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
@@ -12,6 +12,7 @@ data class AgentRunCommand(
   val stdinText: String? = null,
   val environment: Map<String, String> = emptyMap(),
   val inheritEnvironment: Boolean = true,
+  val usePtyStdio: Boolean = false,
 )
 
 interface AgentRunCommandBuilder {
@@ -105,6 +106,7 @@ class OpencodeAgentRunCommandBuilder : AgentRunCommandBuilder {
       workingDirectory = request.repoRoot,
       timeout = request.timeout,
       environment = goalContinuationEnvironment(request),
+      usePtyStdio = true,
     )
 }
 

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/AgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/AgentRunProcessRunner.kt
@@ -23,16 +23,13 @@ data class AgentRunProcessRequest(
   val statusHeartbeatInterval: Duration = DEFAULT_STATUS_HEARTBEAT_INTERVAL,
   val operationDeadline: Duration? = null,
   val progressProbe: AgentRunProgressProbe = AgentRunProgressProbe.NONE,
-  // SKILL-64 Subtask 3 (AC20): authoritative declared-progress probe; the
-  // legacy progressProbe/activityProbe become non-authoritative hints.
   val declaredProgressProbe: AgentRunDeclaredProgressProbe = AgentRunDeclaredProgressProbe.NONE,
-  // SKILL-64 Subtask 3 (AC21, AC25): supervisor-side declared-progress emitter
-  // driven from the process lifecycle. Defaults to a no-op (AC15).
   val progressEmitter: AgentRunProgressEmitter = AgentRunProgressEmitter.NONE,
   val activityProbe: AgentRunActivityProbe = AgentRunActivityProbe.NONE,
   val environment: Map<String, String> = emptyMap(),
   val inheritEnvironment: Boolean = true,
   val outputSink: AgentRunOutputSink = AgentRunOutputSink.NONE,
+  val usePtyStdio: Boolean = false,
 ) {
   init {
     require(command.isNotEmpty()) { "Agent run command is required." }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/JvmAgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/JvmAgentRunProcessRunner.kt
@@ -2,6 +2,8 @@
 
 package skillbill.launcher.process
 
+import com.sun.jna.Library
+import com.sun.jna.Native
 import me.tatarka.inject.annotations.Inject
 import skillbill.goalrunner.model.GoalRunnerLivenessClassifier
 import skillbill.goalrunner.model.GoalRunnerLivenessDecision
@@ -34,50 +36,56 @@ class JvmAgentRunProcessRunner : AgentRunProcessRunner {
     val processStart = startProcess(request)
     return when (processStart) {
       is ProcessStart.Failed -> spawnFailure(processStart.error)
-      is ProcessStart.Started -> runStartedProcess(processStart.process, request)
+      is ProcessStart.Started -> runStartedProcess(
+        process = processStart.process,
+        stdoutStream = processStart.process.inputStream,
+        stderrStream = processStart.process.errorStream,
+        request = request,
+        ptyMasterCloseable = null,
+      )
+      is ProcessStart.PtyStarted -> runStartedProcess(
+        process = processStart.process,
+        stdoutStream = processStart.ptyMasterStream,
+        stderrStream = InputStream.nullInputStream(),
+        request = request,
+        ptyMasterCloseable = processStart.ptyMasterCloseable,
+      )
     }
   }
 
-  private fun runStartedProcess(process: Process, request: AgentRunProcessRequest): AgentRunProcessResult {
+  private fun runStartedProcess(
+    process: Process,
+    stdoutStream: InputStream,
+    stderrStream: InputStream,
+    request: AgentRunProcessRequest,
+    ptyMasterCloseable: AutoCloseable?,
+  ): AgentRunProcessResult {
     val outputTracker = OutputObservationTracker()
     val lifecycleEmitter = ProcessLifecycleEmitter(request)
     val stdout = CappedUtf8Drain(
-      input = process.inputStream,
+      input = stdoutStream,
       limitBytes = AGENT_RUN_OUTPUT_LIMIT_BYTES,
       outputStream = AgentRunOutputStream.STDOUT,
       outputSink = request.outputSink,
       onChunkRead = { outputTracker.markObserved() },
     ).also { it.start() }
     val stderr = CappedUtf8Drain(
-      input = process.errorStream,
+      input = stderrStream,
       limitBytes = AGENT_RUN_OUTPUT_LIMIT_BYTES,
       outputStream = AgentRunOutputStream.STDERR,
       outputSink = request.outputSink,
       onChunkRead = { outputTracker.markObserved() },
-    ).also { it.start() }
+    ).also { if (stderrStream !== InputStream.nullInputStream()) it.start() }
     writeAndCloseStdin(process, request.stdinText)
-    // SKILL-64 Subtask 3 (AC25, AC21): the process-lifecycle wrapper owns the
-    // declared operation_* lifecycle. operation_started fires once the child is
-    // running; the wait loop fires gated operation_heartbeat ticks; the exit/
-    // timeout/interrupt/kill paths below fire operation_completed.
     lifecycleEmitter.emitStarted(process.isAlive)
-    // Only an interrupt is recovered here (mapped to a CANCELLED terminal event in
-    // finishRun); any other failure propagates unchanged as before.
     val wait = try {
       Result.success(waitForProcess(process, request, outputTracker, lifecycleEmitter))
     } catch (interrupt: InterruptedException) {
       Result.failure(interrupt)
     }
-    return finishRun(process, request, wait, outputTracker, stdout, stderr, lifecycleEmitter)
+    return finishRun(process, request, wait, outputTracker, stdout, stderr, lifecycleEmitter, ptyMasterCloseable)
   }
 
-  // SKILL-64 Subtask 3 (F-NP01): every exit path (normal, wall-clock timeout,
-  // forced kill, and interrupt — whether raised inside the wait loop or by the
-  // guarded post-timeout Process.waitFor) funnels through here so exactly one
-  // operation_completed is always emitted with the right terminal outcome:
-  // SUCCEEDED on a clean exit, TIMED_OUT on a timeout kill, CANCELLED on
-  // interrupt. An interrupt also re-raises the thread interrupt and returns the
-  // interrupted result; heartbeats can never dangle without a terminal event.
   @Suppress("LongParameterList")
   private fun finishRun(
     process: Process,
@@ -87,6 +95,7 @@ class JvmAgentRunProcessRunner : AgentRunProcessRunner {
     stdout: CappedUtf8Drain,
     stderr: CappedUtf8Drain,
     lifecycleEmitter: ProcessLifecycleEmitter,
+    ptyMasterCloseable: AutoCloseable?,
   ): AgentRunProcessResult {
     var interrupted = waitResult.exceptionOrNull() is InterruptedException
     val wait = waitResult.getOrNull()
@@ -96,6 +105,8 @@ class JvmAgentRunProcessRunner : AgentRunProcessRunner {
       runCatching { process.waitFor(DESTROY_WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS) }
         .onFailure { error -> if (error is InterruptedException) interrupted = true }
     }
+    runCatching { ptyMasterCloseable?.close() }
+      .onFailure { System.err.println("skill-bill: failed to close PTY master fd: ${it.message}") }
     stdout.join()
     stderr.join()
     val terminalOutcome = when {
@@ -164,21 +175,49 @@ class JvmAgentRunProcessRunner : AgentRunProcessRunner {
   )
 
   private fun startProcess(request: AgentRunProcessRequest): ProcessStart = try {
-    ProcessStart.Started(
-      ProcessBuilder(request.command)
-        .directory(request.workingDirectory.toFile())
-        .apply {
-          if (!request.inheritEnvironment) {
-            environment().clear()
-          }
-          environment().putAll(request.environment)
-        }
-        .start(),
-    )
+    if (request.usePtyStdio) {
+      startPtyProcess(request)
+    } else {
+      ProcessStart.Started(buildProcess(request).start())
+    }
   } catch (error: IOException) {
     ProcessStart.Failed(error)
   } catch (error: SecurityException) {
     ProcessStart.Failed(error)
+  } catch (error: IllegalStateException) {
+    ProcessStart.Failed(IOException("PTY spawn failed: ${error.message}", error))
+  }
+
+  private fun buildProcess(request: AgentRunProcessRequest): ProcessBuilder = ProcessBuilder(request.command)
+    .directory(request.workingDirectory.toFile())
+    .apply {
+      if (!request.inheritEnvironment) {
+        environment().clear()
+      }
+      environment().putAll(request.environment)
+    }
+
+  private fun startPtyProcess(request: AgentRunProcessRequest): ProcessStart {
+    check(System.getProperty("os.name").lowercase().startsWith("linux")) {
+      "PTY-backed stdio is only supported on Linux; current platform: ${System.getProperty("os.name")}"
+    }
+    val (masterFd, slavePath) = openPtyPair()
+    val process = try {
+      buildProcess(request)
+        .redirectInput(java.io.File(slavePath))
+        .redirectOutput(java.io.File(slavePath))
+        .redirectError(java.io.File(slavePath))
+        .start()
+    } catch (e: IOException) {
+      PosixLib.closeFd(masterFd)
+      throw e
+    } catch (e: SecurityException) {
+      PosixLib.closeFd(masterFd)
+      throw e
+    }
+    val masterStream = PosixLib.masterInputStream(masterFd)
+    val masterCloseable = AutoCloseable { PosixLib.closeFd(masterFd) }
+    return ProcessStart.PtyStarted(process, masterStream, masterCloseable)
   }
 }
 
@@ -652,6 +691,11 @@ private fun AgentRunLivenessSnapshot?.detailsSuffix(): String = this?.let { snap
 
 private sealed interface ProcessStart {
   data class Started(val process: Process) : ProcessStart
+  data class PtyStarted(
+    val process: Process,
+    val ptyMasterStream: InputStream,
+    val ptyMasterCloseable: AutoCloseable,
+  ) : ProcessStart
   data class Failed(val error: Exception) : ProcessStart
 }
 
@@ -727,3 +771,92 @@ private const val MIN_TIMEOUT_MILLIS = 1L
 private const val MIN_TIMEOUT_NANOS = 1L
 private const val PROGRESS_POLL_INTERVAL_MILLIS = 250L
 private const val DESTROY_WAIT_TIMEOUT_MILLIS = 1_000L
+
+@Suppress("FunctionNaming", "ktlint:standard:function-naming")
+private interface PosixCLibrary : Library {
+  fun posix_openpt(flags: Int): Int
+  fun grantpt(fd: Int): Int
+  fun unlockpt(fd: Int): Int
+  fun ptsname_r(fd: Int, buf: ByteArray, buflen: Int): Int
+  fun read(fd: Int, buf: ByteArray, count: Int): Int
+  fun close(fd: Int): Int
+}
+
+private object PosixLib {
+  private const val O_RDWR = 2
+  private const val O_NOCTTY = 0x400
+  val lib: PosixCLibrary by lazy {
+    Native.load("c", PosixCLibrary::class.java)
+  }
+
+  fun openMasterFd(): Int {
+    val fd = lib.posix_openpt(O_RDWR or O_NOCTTY)
+    check(fd >= 0) { "posix_openpt failed" }
+    try {
+      check(lib.grantpt(fd) == 0) { "grantpt failed" }
+      check(lib.unlockpt(fd) == 0) { "unlockpt failed" }
+    } catch (e: IllegalStateException) {
+      lib.close(fd)
+      throw e
+    }
+    return fd
+  }
+
+  fun slavePath(masterFd: Int): String {
+    val buf = ByteArray(PTY_PATH_BUF_SIZE)
+    val result = lib.ptsname_r(masterFd, buf, buf.size)
+    check(result == 0) { "ptsname_r failed" }
+    val nullAt = buf.indexOf(NULL_BYTE)
+    return String(buf, 0, if (nullAt >= 0) nullAt else buf.size, StandardCharsets.US_ASCII)
+  }
+
+  fun masterInputStream(masterFd: Int): InputStream = PtyMasterInputStream(masterFd)
+
+  fun closeFd(fd: Int) {
+    lib.close(fd)
+  }
+}
+
+private class PtyMasterInputStream(private val fd: Int) : InputStream() {
+  @Volatile private var closed = false
+
+  override fun read(): Int {
+    if (closed) return -1
+    val buf = ByteArray(1)
+    val n = PosixLib.lib.read(fd, buf, 1)
+    return if (n <= 0) -1 else buf[0].toInt() and BYTE_MASK
+  }
+
+  override fun read(buf: ByteArray, off: Int, len: Int): Int {
+    if (closed || len == 0) return if (len == 0) 0 else -1
+    return if (off == 0) {
+      val n = PosixLib.lib.read(fd, buf, len)
+      if (n <= 0) -1 else n
+    } else {
+      val tmp = ByteArray(len)
+      val n = PosixLib.lib.read(fd, tmp, len)
+      if (n <= 0) return -1
+      System.arraycopy(tmp, 0, buf, off, n)
+      n
+    }
+  }
+
+  override fun close() {
+    closed = true
+  }
+}
+
+private fun openPtyPair(): Pair<Int, String> {
+  val masterFd = PosixLib.openMasterFd()
+  val slavePath = try {
+    PosixLib.slavePath(masterFd)
+  } catch (e: IllegalStateException) {
+    PosixLib.closeFd(masterFd)
+    throw e
+  }
+  return masterFd to slavePath
+}
+
+private const val PTY_PATH_BUF_SIZE = 256
+private const val NULL_BYTE: Byte = 0
+private const val BYTE_MASK = 0xFF

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/JvmAgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/JvmAgentRunProcessRunner.kt
@@ -105,10 +105,10 @@ class JvmAgentRunProcessRunner : AgentRunProcessRunner {
       runCatching { process.waitFor(DESTROY_WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS) }
         .onFailure { error -> if (error is InterruptedException) interrupted = true }
     }
-    runCatching { ptyMasterCloseable?.close() }
-      .onFailure { System.err.println("skill-bill: failed to close PTY master fd: ${it.message}") }
     stdout.join()
     stderr.join()
+    runCatching { ptyMasterCloseable?.close() }
+      .onFailure { System.err.println("skill-bill: failed to close PTY master fd: ${it.message}") }
     val terminalOutcome = when {
       interrupted -> GoalProgressOutcome.CANCELLED
       finished -> GoalProgressOutcome.SUCCEEDED

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -802,3 +802,155 @@ private class SharedDeclaredProgressStore {
 // start — past the 1s operation deadline measured from process start, but leaving
 // only ~0.5s of run, well under that deadline measured from first observation.
 private const val WITHHELD_POLLS = 6
+
+class OpencodeAgentRunCommandBuilderTest {
+  @Test
+  fun `opencode builder emits usePtyStdio=true`() {
+    val runner = RecordingAgentRunProcessRunner()
+    val request = SkillRunRequest(
+      issueKey = "SKILL-88",
+      repoRoot = Path.of("/tmp/skillbill-agent-run"),
+      subtaskId = 1,
+      timeout = 10.seconds,
+      goalContinuation = null,
+    ).copy(promptOverride = "Phase: preplan")
+
+    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.OPENCODE]).launch(request)
+
+    val captured = runner.requests.single()
+    assertTrue(captured.usePtyStdio, "opencode must request PTY-backed stdio")
+  }
+
+  @Test
+  fun `claude codex and junie builders emit usePtyStdio=false`() {
+    val runner = RecordingAgentRunProcessRunner()
+    val request = SkillRunRequest(
+      issueKey = "SKILL-88",
+      repoRoot = Path.of("/tmp/skillbill-agent-run"),
+      subtaskId = 1,
+      timeout = 10.seconds,
+      goalContinuation = null,
+    ).copy(promptOverride = "Phase: preplan")
+    val adapters = headlessAgentRunAdapters(runner)
+
+    listOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE).forEach { agent ->
+      requireNotNull(adapters[agent]).launch(request)
+    }
+
+    val otherRequests = runner.requests
+    assertTrue(otherRequests.size == 3)
+    otherRequests.forEach { req ->
+      assertFalse(req.usePtyStdio, "non-opencode agent must not request PTY-backed stdio")
+    }
+  }
+
+  @Test
+  fun `process adapter threads usePtyStdio from command into request`() {
+    val runner = RecordingAgentRunProcessRunner()
+    val request = SkillRunRequest(
+      issueKey = "SKILL-88",
+      repoRoot = Path.of("/tmp/skillbill-agent-run"),
+      subtaskId = 1,
+      timeout = 10.seconds,
+      goalContinuation = null,
+    ).copy(promptOverride = "Phase: preplan")
+
+    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.OPENCODE]).launch(request)
+    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.CLAUDE]).launch(request)
+
+    assertEquals(true, runner.requests[0].usePtyStdio, "opencode adapter must thread usePtyStdio=true")
+    assertEquals(false, runner.requests[1].usePtyStdio, "claude adapter must thread usePtyStdio=false")
+  }
+}
+
+class PtyStdioLaunchTest {
+  private fun assumePtyAvailable() {
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+      java.io.File("/dev/ptmx").exists(),
+      "PTY device /dev/ptmx not available; skipping PTY integration test",
+    )
+  }
+
+  @Test
+  fun `jvm process runner spawns child over pty and captures stdout via outputSink`() {
+    assumePtyAvailable()
+    val events = mutableListOf<Pair<AgentRunOutputStream, String>>()
+    val result = JvmAgentRunProcessRunner().run(
+      AgentRunProcessRequest(
+        command = listOf("sh", "-c", "printf hello-pty"),
+        workingDirectory = Path.of(".").toAbsolutePath().normalize(),
+        timeout = 5.seconds,
+        usePtyStdio = true,
+        outputSink = { stream, text -> synchronized(events) { events += stream to text } },
+      ),
+    )
+
+    assertEquals(0, result.exitStatus)
+    assertContains(result.stdout, "hello-pty")
+    assertTrue(
+      events.any { it.first == AgentRunOutputStream.STDOUT && "hello-pty" in it.second },
+      "outputSink must receive PTY stdout chunk",
+    )
+    assertFalse(result.timedOut)
+    assertFalse(result.spawnFailed)
+  }
+
+  @Test
+  fun `jvm process runner pty path does not false-kill a live child under idle watchdog`() {
+    assumePtyAvailable()
+    val sequence = java.util.concurrent.atomic.AtomicInteger(0)
+    val result = JvmAgentRunProcessRunner().run(
+      AgentRunProcessRequest(
+        command = listOf("sh", "-c", "sleep 0.5"),
+        workingDirectory = Path.of(".").toAbsolutePath().normalize(),
+        timeout = 5.seconds,
+        progressIdleTimeout = 100.milliseconds,
+        operationDeadline = 10.seconds,
+        usePtyStdio = true,
+        declaredProgressProbe = AgentRunDeclaredProgressProbe {
+          val seq = sequence.getAndIncrement()
+          AgentRunDeclaredProgressSnapshot(
+            latestEvent = GoalProgressEvent(
+              eventKind = GoalProgressEventKind.OPERATION_STARTED,
+              workflowId = "wfl-child",
+              workflowPhase = "preplan",
+              processAlive = true,
+              sequenceNumber = seq,
+              timestamp = "2026-06-22T10:0$seq:00Z",
+              operationName = "opencode-preplan",
+              expectedLong = true,
+            ),
+            processAlive = true,
+          )
+        },
+      ),
+    )
+
+    assertFalse(result.timedOut, "PTY-backed live child must not be false-killed by idle watchdog")
+    assertEquals(0, result.exitStatus)
+  }
+
+  @Test
+  fun `jvm process runner pty path captures multiline stdout and forwards to outputSink`() {
+    assumePtyAvailable()
+    val events = mutableListOf<Pair<AgentRunOutputStream, String>>()
+    val result = JvmAgentRunProcessRunner().run(
+      AgentRunProcessRequest(
+        command = listOf("sh", "-c", "printf 'line1\nline2\nline3'"),
+        workingDirectory = Path.of(".").toAbsolutePath().normalize(),
+        timeout = 5.seconds,
+        usePtyStdio = true,
+        outputSink = { stream, text -> synchronized(events) { events += stream to text } },
+      ),
+    )
+
+    assertEquals(0, result.exitStatus)
+    assertContains(result.stdout, "line1")
+    assertContains(result.stdout, "line2")
+    assertContains(result.stdout, "line3")
+    assertTrue(
+      events.any { it.first == AgentRunOutputStream.STDOUT && ("line1" in it.second || "line2" in it.second) },
+      "PTY outputSink must receive STDOUT stream events containing expected output lines",
+    )
+  }
+}


### PR DESCRIPTION
# Summary

The Bun-compiled `opencode` binary exits with status 1 in ~2-3 seconds emitting non-JSON stdout whenever its stdout fd is a JVM-owned pipe. This broke every `feature-task-runtime` phase running `--agent opencode`: the schema-gate rejected the non-JSON output, the fix loop exhausted its retries, and phases landed in a sticky `blocked` state.

This PR fixes the root cause by spawning opencode over a PTY-backed stdio path (POSIX `posix_openpt`/`grantpt`/`unlockpt`/`ptsname_r` via JNA), which satisfies opencode's TTY check and lets real preplan runs complete through the phase schema-gate. The `claude`, `codex`, and `junie` launch paths are unchanged.

Key changes:
- JNA 5.13.0 added to `runtime-infra-fs` for POSIX libc PTY bindings
- `usePtyStdio` flag threaded through `AgentRunCommand` → `AgentRunProcessRequest` → `JvmAgentRunProcessRunner`; `OpencodeAgentRunCommandBuilder` sets it `true`; all other builders leave it `false`
- `ProcessStart.PtyStarted` sealed variant alongside `Started`/`Failed`; `startPtyProcess()` opens master fd, spawns child with slave device path, wraps master fd in `PtyMasterInputStream` for `CappedUtf8Drain`
- `infraFailureReason` in `FeatureTaskRuntimeRunner` now appends a bounded stderr/stdout excerpt on non-zero exit, reusing `GoalRunnerLaunchFacts.STDERR_EXCERPT_MAX_CHARS`
- Linux-only guard at top of `startPtyProcess()`; master fd closed before drain joins to send EIO and unblock drain

## Feature Flags

N/A

# How Has This Been Tested?

- `OpencodeAgentRunCommandBuilderTest` (3 tests): verifies `usePtyStdio=true` is set for opencode and `false` for claude/codex/junie
- `PtyStdioLaunchTest` (3 tests, guarded by `/dev/ptmx` availability): covers PTY launch path, drain/cap/output-sink/liveness behavior
- `InfraFailureReasonStderrSurfacingTest` (3 tests): verifies bounded stderr excerpt appears in `infraFailureReason` on non-zero exit
- `./gradlew check` passes

To verify manually:
1. Run a `feature-task-runtime` phase with `--agent opencode` on a real repo
2. Confirm the preplan phase completes through the schema-gate instead of failing with a ~2-3s status-1 non-JSON exit
3. Observe that `infraFailureReason` includes stderr/stdout context when a phase agent does exit non-zero