### PR TITLE
feat: [SKILL-90] propagate boundary history signal to goal_subtask_finished event

### DIFF
--- a/.feature-specs/SKILL-90-goal-subtask-history-usefulness/spec.md
+++ b/.feature-specs/SKILL-90-goal-subtask-history-usefulness/spec.md
@@ -1,0 +1,162 @@
+# SKILL-90 — Per-subtask history-usefulness telemetry on `goal_subtask_finished`
+
+Status: Ready for implementation
+Issue key: SKILL-90
+Mode: single_spec
+
+## Context & Motivation
+
+The goal-decomposition architecture's core claim is that running each subtask in a
+fresh context window — with a curated `history.md` / `decisions.md` handoff instead of a
+dragged-along transcript — keeps a long, decomposed goal "clean": a 20-subtask, 10-hour
+goal reasons as clearly at subtask 20 as at subtask 1. Today that claim is **inferred, not
+measured at the subtask grain.**
+
+Live PostHog analysis (project SkillBill, 90 days) established the current instrumentation gap:
+
+- `skillbill_feature_verify_finished` carries a **two-axis** rating: `history_relevance` +
+  `history_helpfulness` (enum `none|irrelevant|low|medium|high`). At 90d the axes provably
+  diverge (largest signal bucket: `relevance=low / helpfulness=medium`), so the second axis
+  carries independent signal.
+- `skillbill_feature_implement_finished` (and `feature_task_prose_finished`) carry a
+  **single-axis** rating: `boundary_history_value` (same enum) plus a boolean
+  `boundary_history_written`. Implement-side data is strong and well-powered (n≈706 rated
+  reads, ~96% medium-or-high, ~0.4% irrelevant).
+- `skillbill_goal_subtask_finished` carries **no history-usefulness property at all.**
+
+Because a decomposed-goal subtask runs a full feature-task phase loop, the subtask's own
+implement/prose run already produces a `boundary_history_value` for the `history.md` it read
+on entry — but that rating is not surfaced on the goal subtask event, so it cannot be sliced
+per subtask, per goal, or across a goal's subtask sequence. This spec closes that gap.
+
+## Intended Outcome
+
+`skillbill_goal_subtask_finished` emits the history-usefulness rating the subtask produced for
+the boundary `history.md` it read at the start of its phase loop, so the decomposition
+context-handoff claim can be measured **directly, per subtask**, across an entire goal —
+including degradation-over-sequence questions (does usefulness fall as a goal gets longer?).
+
+## Design Decision — single-axis now, two-axis follow-up
+
+The subtask runner (`bill-feature-task-subtask-runner`) executes a feature-task/implement
+loop, which already scores **one** axis (`boundary_history_value`). Producing the verify-style
+**two** axes (`history_relevance` + `history_helpfulness`) would require teaching the
+implement/subtask path to score a second axis — a separate, larger change to scoring behavior,
+which Requirement "reuse the existing implement mechanism, do not invent new scoring"
+explicitly excludes.
+
+Resolution: this spec **reuses the already-produced `boundary_history_value` (+
+`boundary_history_written`)** and surfaces them on `goal_subtask_finished`. Property names
+mirror the implement event exactly for cross-event comparability. Adding the second
+(`helpfulness`) axis to the implement/subtask path — and thereby to this event — is recorded
+as an explicit **follow-up** (see Non-Goals), not part of this pass.
+
+## Scope
+
+1. **Schema contract** (`orchestration/contracts/telemetry-event-schema.yaml`): add two
+   **optional** properties to the `goalSubtaskFinishedEvent` branch — `boundary_history_value`
+   (`$ref` the shared `historySignalEnum`) and `boundary_history_written` (boolean). Do not add
+   them to the `required` array. Decide and apply whether this backward-compatible addition
+   warrants a `contract_version` minor bump (`1.1.0` → `1.2.0`); if bumped, update the schema
+   const(s), the `TELEMETRY_EVENT_CONTRACT_VERSION` Kotlin constant
+   (`runtime-mcp/.../telemetry/TelemetryEventSchemaPaths.kt`), and the contract-version test in
+   lockstep.
+2. **Capture / persistence**: persist the subtask's `boundary_history_value` +
+   `boundary_history_written` onto the goal subtask events row that
+   `goalSubtaskFinishedPayload` reads from. Source the values from the subtask's own
+   feature-task run (joined by `workflow_id`) at subtask-finish reconciliation
+   (`GoalRunnerOutcomeReconciler` / goal telemetry emit path) — reuse the existing
+   implement-path values; do not re-score. Add the backing column(s) via the goal telemetry
+   migration (`GoalTelemetryMigration.kt`), following the self-healing column-ensure pattern
+   so existing DBs gain the column on startup.
+3. **Payload builder** (`GoalTelemetryPayloadSupport.kt#goalSubtaskFinishedPayload`): emit the
+   two new keys, mirroring `featureImplementFinishedPayload` semantics — `boundary_history_value`
+   defaults to `"none"` when blank/absent; `boundary_history_written` is a boolean. Place them
+   consistently with the event's existing telemetry-level gating (the non-`full` payload must
+   remain valid; if these are treated as `full`-level detail, gate them accordingly).
+4. **Parity guards stay green**: `goal_subtask_finished` is a runtime-internal emission event
+   (in the `runtimeInternalEmissionEvents` allowlist in `TelemetryEventInputSchemaParityTest`),
+   so **no MCP input-schema entry is added**. The schema branch and emitted payload must stay
+   structurally consistent so the parity and contract-version tests pass.
+
+## Acceptance Criteria
+
+1. The `goalSubtaskFinishedEvent` branch in `telemetry-event-schema.yaml` declares
+   `boundary_history_value` (referencing the shared `historySignalEnum`:
+   `none|irrelevant|low|medium|high`) and `boundary_history_written` (boolean) as **optional**
+   properties (absent from `required`).
+2. When a decomposed-goal subtask finishes, `skillbill_goal_subtask_finished` is emitted with
+   `boundary_history_value` and `boundary_history_written` reflecting the `history.md` the
+   subtask read at the start of its phase loop, sourced from that subtask's own feature-task
+   run (no new scoring logic introduced).
+3. The values match what the same subtask run reports on its
+   `skillbill_feature_implement_finished` / `feature_task_prose_finished` event for the same
+   `workflow_id` (cross-event consistency).
+4. The behavior is backward compatible: a subtask that read no boundary history emits
+   `boundary_history_value = "none"` and `boundary_history_written = false`; existing dashboards
+   and the telemetry proxy continue to ingest the event without error.
+5. Existing DBs gain the backing column(s) on startup via the self-healing column-ensure
+   migration path (no manual migration step, no data loss).
+6. `TelemetryEventInputSchemaParityTest` and `TelemetryEventSchemaContractVersionTest` pass;
+   `goal_subtask_finished` remains in the runtime-internal-emission allowlist (no MCP tool
+   added). If `contract_version` is bumped, the schema const and
+   `TELEMETRY_EVENT_CONTRACT_VERSION` are updated together and the contract-version test
+   reflects the new value.
+7. A test asserts the emitted `goal_subtask_finished` payload includes the two new properties
+   with correct values for both the history-read and no-history-read cases.
+
+## Non-Goals / Follow-ups
+
+- **Two-axis on the subtask/goal path.** Adding `history_helpfulness` as an independent second
+  axis to the implement/subtask scoring (and thus to this event) is a deliberate follow-up,
+  not part of SKILL-90. This spec ships single-axis parity with the implement event.
+- **Changing how usefulness is scored** on any existing event (`verify`, `implement`,
+  `prose`). Reuse only.
+- **Backfilling** historical `goal_subtask_finished` events.
+- **Telemetry proxy stats-endpoint aggregation** of the new properties (e.g. exposing a
+  per-goal usefulness rollup via `telemetry_remote_stats`) — separate follow-up.
+- **Dashboards / insights** in PostHog consuming the new property — out of scope here.
+
+## Constraints
+
+- Reuse the shared `historySignalEnum`; do not define a new enum.
+- New properties optional/nullable; absence reads as "no history read".
+- Keep schema ↔ Kotlin-constant ↔ payload structurally in parity (locked by tests).
+- Follow the self-healing migration convention (column-ensure runs unconditionally at startup;
+  appending to an already-applied migration body is a no-op for existing DBs).
+- No unnecessary comments in changed code.
+
+## Validation Strategy
+
+- Unit test on `goalSubtaskFinishedPayload` covering history-read and no-history-read cases
+  (criterion 7).
+- Run the telemetry parity + contract-version tests (criterion 6).
+- Schema-validate a sample `goal_subtask_finished` envelope (with and without the new
+  properties) against the updated contract.
+- `./gradlew check` green.
+- Post-merge confirmation via PostHog: `skillbill_goal_subtask_finished` events begin carrying
+  `boundary_history_value`, and a per-goal slice (`group by workflow_id`, ordered by
+  `subtask_id`) is queryable — the measurement this spec exists to enable.
+
+## Affected Files (map)
+
+- `orchestration/contracts/telemetry-event-schema.yaml` — `goalSubtaskFinishedEvent` branch
+  (~L1281–1336); shared `historySignalEnum` (~L154–161).
+- `runtime-kotlin/runtime-infra-sqlite/.../telemetry/GoalTelemetryPayloadSupport.kt` —
+  `goalSubtaskFinishedPayload`.
+- `runtime-kotlin/runtime-infra-sqlite/.../telemetry/GoalTelemetryEmitSupport.kt` —
+  `emitGoalSubtaskFinished` / `goalSubtaskEventRow` (row source).
+- `runtime-kotlin/runtime-infra-sqlite/.../telemetry/GoalTelemetryMigration.kt` — backing
+  column(s).
+- `runtime-kotlin/runtime-domain/.../goalrunner/GoalRunnerPolicy.kt` —
+  `GoalRunnerOutcomeReconciler` (capture point at subtask-finish).
+- `runtime-kotlin/runtime-mcp/.../telemetry/TelemetryEventSchemaPaths.kt` —
+  `TELEMETRY_EVENT_CONTRACT_VERSION` (only if version bumped).
+- Tests: `runtime-mcp/.../TelemetryEventInputSchemaParityTest.kt`,
+  `TelemetryEventSchemaContractVersionTest.kt`, plus a new/extended payload test.
+
+## Next
+
+```bash
+Run bill-feature-task on .feature-specs/SKILL-90-goal-subtask-history-usefulness/spec.md
+```

--- a/orchestration/contracts/telemetry-event-schema.yaml
+++ b/orchestration/contracts/telemetry-event-schema.yaml
@@ -1350,6 +1350,16 @@ $defs:
           Order-stable distinct resolved agents that executed a phase of the subtask. Enables
           per-agent finalized vs handoff-participant aggregation. Additive-optional: legacy
           payloads omit the key.
+      boundary_history_value:
+        $ref: "#/$defs/historySignalEnum"
+        description: >
+          History-usefulness rating the subtask's feature-task run produced for the
+          boundary history.md it read on entry. Additive-optional: legacy payloads omit the key.
+      boundary_history_written:
+        type: boolean
+        description: >
+          Whether the subtask's feature-task run wrote a boundary history.md entry.
+          Additive-optional: legacy payloads omit the key.
 
   goalFinishedEvent:
     type: object

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-06-23] SKILL-90 per-subtask history-usefulness telemetry on goal_subtask_finished
+Areas: runtime-kotlin/runtime-infra-sqlite, runtime-kotlin/runtime-mcp, orchestration/contracts
+- Schema: `boundary_history_value` ($ref historySignalEnum `none|irrelevant|low|medium|high`) and `boundary_history_written` (boolean) added as optional properties to `goalSubtaskFinishedEvent`; not in `required[]`; `contract_version` stays `1.1.0` (backward-compatible addition).
+- Two-hop JOIN UPDATE in `saveGoalSubtaskFinished`: after INSERT, UPDATE `goal_subtask_events` via `feature_task_workflows → feature_implement_sessions` to copy the subtask's own implement-run ratings; COALESCE fallbacks handle nullable `boundary_history_written` on legacy rows. reusable PATTERN: pull implement-side ratings onto a goal-layer event without new scoring logic — JOIN on `workflow_id`, no dual-write, no drift.
+- Self-heal: two `ensureColumn` calls inside the `goalSubtaskEventsExists` guard in `DatabaseColumnMigrations` — defaults `'none'`/`0` mean existing subtask rows read as "no history" on upgrade, no data loss. reusable
+- Payload emission in `GoalTelemetryPayloadSupport.goalSubtaskFinishedPayload` inside `if (level == "full")` block, mirroring `LifecycleTelemetryPayloadSupport` pattern.
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented
+
 ## [2026-06-22] SKILL-89 per-subtask agent attribution rollup
 Areas: runtime-kotlin/runtime-application, runtime-kotlin/runtime-domain, runtime-kotlin/runtime-infra-sqlite, runtime-kotlin/runtime-infra-fs, runtime-kotlin/runtime-ports, orchestration/contracts, skills/bill-feature-task-prose
 - Seam A (child→goal rollup): `FeatureTaskRuntimeGoalContinuationOutcome` gains `finalizingAgentId`/`participatingAgentIds` derived from the child's existing phase ledger — first-seen distinct `resolvedAgentId` values, record fallback when the ledger is pruned. Effect-free `agentAttributionFromPhaseState` helper reads ledger+records; no new ledger entries, no agent-identity branching. reusable

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
@@ -23,6 +23,8 @@ internal object DatabaseColumnMigrations {
     if (goalSubtaskEventsExists) {
       ensureColumn(connection, "goal_subtask_events", "finalizing_agent_id", "TEXT")
       ensureColumn(connection, "goal_subtask_events", "participating_agent_ids", "TEXT NOT NULL DEFAULT '[]'")
+      ensureColumn(connection, "goal_subtask_events", "boundary_history_value", "TEXT NOT NULL DEFAULT 'none'")
+      ensureColumn(connection, "goal_subtask_events", "boundary_history_written", "INTEGER NOT NULL DEFAULT 0")
     }
   }
 

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/GoalTelemetryPayloadSupport.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/GoalTelemetryPayloadSupport.kt
@@ -68,5 +68,7 @@ fun goalSubtaskFinishedPayload(row: Map<String, Any?>, level: String): Map<Strin
       "participating_agent_ids",
       parseAgentIdArray(row.stringOrEmpty("participating_agent_ids"), row.stringOrEmpty("workflow_id")),
     )
+    put("boundary_history_written", row.booleanFromInt("boundary_history_written"))
+    put("boundary_history_value", row.stringOrEmpty("boundary_history_value").ifBlank { "none" })
   }
 }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/GoalTelemetrySaveSupport.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/GoalTelemetrySaveSupport.kt
@@ -116,8 +116,8 @@ private fun insertGoalFinished(connection: Connection, record: GoalFinishedRecor
   }
 }
 
-fun saveGoalSubtaskFinished(connection: Connection, record: GoalSubtaskFinishedRecord): Boolean =
-  connection.prepareStatement(
+fun saveGoalSubtaskFinished(connection: Connection, record: GoalSubtaskFinishedRecord): Boolean {
+  val inserted = connection.prepareStatement(
     """
     INSERT INTO goal_subtask_events (
       issue_key, workflow_id, subtask_id, subtask_name, status,
@@ -143,6 +143,38 @@ fun saveGoalSubtaskFinished(connection: Connection, record: GoalSubtaskFinishedR
     )
     statement.executeUpdate() > 0
   }
+  connection.prepareStatement(
+    """
+    UPDATE goal_subtask_events
+    SET
+      boundary_history_value = COALESCE(
+        (SELECT fis.boundary_history_value
+         FROM feature_task_workflows ftw
+         JOIN feature_implement_sessions fis ON fis.session_id = ftw.session_id
+         WHERE ftw.workflow_id = ?),
+        'none'
+      ),
+      boundary_history_written = COALESCE(
+        (SELECT fis.boundary_history_written
+         FROM feature_task_workflows ftw
+         JOIN feature_implement_sessions fis ON fis.session_id = ftw.session_id
+         WHERE ftw.workflow_id = ?),
+        0
+      )
+    WHERE issue_key = ? AND subtask_id = ? AND workflow_id = ?
+    """.trimIndent(),
+  ).use { statement ->
+    statement.bind(
+      record.workflowId,
+      record.workflowId,
+      record.issueKey,
+      record.subtaskId,
+      record.workflowId,
+    )
+    statement.executeUpdate()
+  }
+  return inserted
+}
 
 private fun goalRunSessionExists(connection: Connection, workflowId: String): Boolean =
   connection.prepareStatement("SELECT 1 FROM goal_run_sessions WHERE workflow_id = ?").use { statement ->

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/GoalTelemetryStoreTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/GoalTelemetryStoreTest.kt
@@ -259,6 +259,56 @@ class GoalTelemetryStoreTest {
     }
   }
 
+  @Test
+  fun `goal_subtask_finished payload carries boundary_history fields when workflow and session rows exist`() {
+    withConnection { connection ->
+      connection.prepareStatement(
+        "INSERT INTO feature_task_workflows " +
+          "(workflow_id, session_id, mode, contract_version) VALUES (?, ?, 'prose', '1.1.0')",
+      ).use {
+        it.setString(1, "wfl-history")
+        it.setString(2, "fis-history")
+        it.executeUpdate()
+      }
+      connection.prepareStatement(
+        "INSERT INTO feature_implement_sessions " +
+          "(session_id, boundary_history_value, boundary_history_written) VALUES (?, 'high', 1)",
+      ).use {
+        it.setString(1, "fis-history")
+        it.executeUpdate()
+      }
+
+      val store = LifecycleTelemetryStore(connection)
+      store.goalSubtaskFinished(
+        subtask(id = 1, status = "complete", durationMs = 60_000, attempts = 1).copy(workflowId = "wfl-history"),
+        "full",
+      )
+
+      val payload = parsePayload(
+        pendingOutbox(connection).single { it.eventName == "skillbill_goal_subtask_finished" }.payloadJson,
+      )
+      assertEquals("high", payload["boundary_history_value"])
+      assertEquals(true, payload["boundary_history_written"])
+    }
+  }
+
+  @Test
+  fun `goal_subtask_finished payload defaults boundary_history fields when no feature_task_workflows row exists`() {
+    withConnection { connection ->
+      val store = LifecycleTelemetryStore(connection)
+      store.goalSubtaskFinished(
+        subtask(id = 1, status = "complete", durationMs = 60_000, attempts = 1).copy(workflowId = "wfl-unknown"),
+        "full",
+      )
+
+      val payload = parsePayload(
+        pendingOutbox(connection).single { it.eventName == "skillbill_goal_subtask_finished" }.payloadJson,
+      )
+      assertEquals("none", payload["boundary_history_value"])
+      assertEquals(false, payload["boundary_history_written"])
+    }
+  }
+
   private fun seedBlockedRunWithMixedSubtasks(store: LifecycleTelemetryStore) {
     store.goalStarted(startedRecord("wf-1", subtaskTotal = 3, resumed = false), level = "full")
     store.goalSubtaskFinished(subtask(id = 1, status = "complete", durationMs = 60_000, attempts = 1), "full")

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/GoalTelemetryEmissionEventParityTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/GoalTelemetryEmissionEventParityTest.kt
@@ -99,7 +99,7 @@ class GoalTelemetryEmissionEventParityTest {
   }
 
   @Test
-  fun `representative emission envelopes validate clean including blocked_reason null and string`() {
+  fun `goal_started and goal_finished representative envelopes validate clean`() {
     TelemetryEventSchemaValidator.validate(
       envelope = linkedMapOf(
         "event_name" to "goal_started",
@@ -112,35 +112,6 @@ class GoalTelemetryEmissionEventParityTest {
         "started_at" to "2026-06-04T10:15:30Z",
       ),
       eventName = "goal_started",
-    )
-
-    val subtaskFinishedBase = linkedMapOf<String, Any?>(
-      "event_name" to "goal_subtask_finished",
-      "contract_version" to TELEMETRY_EVENT_CONTRACT_VERSION,
-      "issue_key" to "SKILL-66",
-      "workflow_id" to "wfl-goal-1",
-      "subtask_id" to 1,
-      "subtask_name" to "goal-telemetry-contract-and-schema",
-      "status" to "complete",
-      "started_at" to "2026-06-04T10:15:30Z",
-      "finished_at" to "2026-06-04T10:42:05Z",
-      "duration_ms" to 1_595_000,
-      "attempt_count" to 1,
-    )
-
-    // blocked_reason as null (the `complete` case).
-    TelemetryEventSchemaValidator.validate(
-      envelope = LinkedHashMap(subtaskFinishedBase).apply { put("blocked_reason", null) },
-      eventName = "goal_subtask_finished",
-    )
-
-    // blocked_reason as a string (the `blocked` case).
-    TelemetryEventSchemaValidator.validate(
-      envelope = LinkedHashMap(subtaskFinishedBase).apply {
-        put("status", "blocked")
-        put("blocked_reason", "validation gate failed twice")
-      },
-      eventName = "goal_subtask_finished",
     )
 
     TelemetryEventSchemaValidator.validate(
@@ -158,6 +129,45 @@ class GoalTelemetryEmissionEventParityTest {
         "subtasks_skipped" to 0,
       ),
       eventName = "goal_finished",
+    )
+  }
+
+  @Test
+  fun `goal_subtask_finished envelopes validate clean including blocked_reason and history fields`() {
+    val subtaskFinishedBase = linkedMapOf<String, Any?>(
+      "event_name" to "goal_subtask_finished",
+      "contract_version" to TELEMETRY_EVENT_CONTRACT_VERSION,
+      "issue_key" to "SKILL-66",
+      "workflow_id" to "wfl-goal-1",
+      "subtask_id" to 1,
+      "subtask_name" to "goal-telemetry-contract-and-schema",
+      "status" to "complete",
+      "started_at" to "2026-06-04T10:15:30Z",
+      "finished_at" to "2026-06-04T10:42:05Z",
+      "duration_ms" to 1_595_000,
+      "attempt_count" to 1,
+    )
+
+    TelemetryEventSchemaValidator.validate(
+      envelope = LinkedHashMap(subtaskFinishedBase).apply { put("blocked_reason", null) },
+      eventName = "goal_subtask_finished",
+    )
+
+    TelemetryEventSchemaValidator.validate(
+      envelope = LinkedHashMap(subtaskFinishedBase).apply {
+        put("status", "blocked")
+        put("blocked_reason", "validation gate failed twice")
+      },
+      eventName = "goal_subtask_finished",
+    )
+
+    TelemetryEventSchemaValidator.validate(
+      envelope = LinkedHashMap(subtaskFinishedBase).apply {
+        put("blocked_reason", null)
+        put("boundary_history_value", "high")
+        put("boundary_history_written", true)
+      },
+      eventName = "goal_subtask_finished",
     )
   }
 


### PR DESCRIPTION
# Summary

`skillbill_goal_subtask_finished` now carries the same history-usefulness signal (`boundary_history_value` + `boundary_history_written`) that the subtask's own feature-task run already produces — closing an instrumentation gap that prevented slicing history quality per subtask, per goal, or across a goal's subtask sequence. The values are sourced directly from the subtask's `feature_implement_sessions` row (joined via `feature_task_workflows.workflow_id`) at subtask-finish time; no new scoring logic is introduced.

Key changes:
- **Schema** (`telemetry-event-schema.yaml`): two optional properties added to `goalSubtaskFinishedEvent` — `boundary_history_value` ($ref `historySignalEnum`) and `boundary_history_written` (boolean). Neither is in `required[]`; `contract_version` stays `1.1.0`.
- **Column migration** (`DatabaseColumnMigrations.kt`): two self-healing `ensureColumn` calls added inside the `goalSubtaskEventsExists` guard — existing DBs gain the columns on startup with safe defaults (`'none'` / `0`).
- **Save path** (`GoalTelemetrySaveSupport.kt`): after the INSERT, a two-hop JOIN UPDATE (`goal_subtask_events → feature_task_workflows → feature_implement_sessions`) backfills the new columns; `COALESCE` handles rows that predate the column.
- **Payload builder** (`GoalTelemetryPayloadSupport.kt`): the two keys are emitted inside the `if (level == "full")` block, mirroring `featureImplementFinishedPayload`.
- **Tests**: `GoalTelemetryStoreTest` gains two new cases (history-read and no-history-read paths); `GoalTelemetryEmissionEventParityTest` gains a third `validate` call confirming the schema accepts the optional fields.

## Feature Flags

N/A

# How Has This Been Tested?

- `GoalTelemetryStoreTest` — history-read case asserts `boundary_history_value="high"` and `boundary_history_written=true`; no-history case asserts `"none"`/`false` defaults. All 12 test cases pass.
- `GoalTelemetryEmissionEventParityTest` — parity and contract-version tests pass with the new optional properties present in the schema.
- Full `./gradlew test` suite green.

Reproduce:
1. Run a decomposed goal so at least one subtask completes.
2. Query `goal_subtask_events` — `boundary_history_value` and `boundary_history_written` columns should reflect the subtask's implement-session values.
3. Trigger `skillbill_goal_subtask_finished` telemetry emission and confirm the payload includes both new fields at `full` telemetry level.