### PR TITLE
feat: [SKILL-93] add update_check MCP tool and bill-feature gate

### DIFF
--- a/orchestration/contracts/telemetry-event-schema.yaml
+++ b/orchestration/contracts/telemetry-event-schema.yaml
@@ -148,6 +148,7 @@ oneOf:
   - $ref: "#/$defs/telemetryProxyCapabilitiesEvent"
   - $ref: "#/$defs/telemetryRemoteStatsEvent"
   - $ref: "#/$defs/triageFindingsEvent"
+  - $ref: "#/$defs/updateCheckEvent"
 
 $defs:
   # ---------------------------------------------------------------------
@@ -468,6 +469,18 @@ $defs:
     properties:
       event_name:
         const: doctor
+      contract_version:
+        const: "1.3.0"
+
+  updateCheckEvent:
+    type: object
+    additionalProperties: true
+    required:
+      - event_name
+      - contract_version
+    properties:
+      event_name:
+        const: update_check
       contract_version:
         const: "1.3.0"
 

--- a/runtime-kotlin/runtime-mcp/agent/history.md
+++ b/runtime-kotlin/runtime-mcp/agent/history.md
@@ -1,0 +1,9 @@
+## [2026-06-23] SKILL-93 update-check-on-bill-feature
+Areas: runtime-kotlin/runtime-mcp, orchestration/contracts, skills/bill-feature
+- New `update_check` MCP tool: registered in `McpToolRegistry.toolNames`, `McpToolDispatcher.nativeHandlers`, and backed by `McpRuntime.updateCheck()`
+- `UpdateCheckService` added as last param of `McpRuntimeServices`; kotlin-inject resolves it automatically — no `RuntimeComponent` changes needed (reusable pattern for adding services to the DI graph)
+- `updateCheck()` is a pure-query tool (no `withAutoSync`); returns 5-key map: `status`, `installed_version`, `latest_version`, `recommended_install_command`, `reason`
+- `updateCheckEvent` open-object `$defs` block added to telemetry schema after `doctorEvent`; `oneOf` ref added at matching position (reusable pattern for future open-object events)
+- Zero-input tools have no `inputSchemas` entry and fall through to `openObjectSchema()` in `McpToolRegistry` (established pattern)
+Feature flag: N/A
+Acceptance criteria: 12/12 implemented

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpComponent.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpComponent.kt
@@ -19,6 +19,7 @@ abstract class McpComponent(
 }
 
 @Inject
+@Suppress("LongParameterList") // DI aggregate: one cohesive bundle for all MCP runtime services
 class McpRuntimeServices(
   val learningService: LearningService,
   val lifecycleTelemetryService: LifecycleTelemetryService,

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpComponent.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpComponent.kt
@@ -7,6 +7,7 @@ import skillbill.application.review.ReviewService
 import skillbill.application.system.SystemService
 import skillbill.application.telemetry.LifecycleTelemetryService
 import skillbill.application.telemetry.TelemetryService
+import skillbill.application.updatecheck.UpdateCheckService
 import skillbill.application.workflow.WorkflowService
 import skillbill.di.RuntimeComponent
 
@@ -25,4 +26,5 @@ class McpRuntimeServices(
   val systemService: SystemService,
   val telemetryService: TelemetryService,
   val workflowService: WorkflowService,
+  val updateCheckService: UpdateCheckService,
 )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpRuntime.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpRuntime.kt
@@ -256,6 +256,17 @@ object McpRuntime {
   fun doctor(context: McpRuntimeContext = McpRuntimeContext()): Map<String, Any?> =
     services(context).systemService.doctor(dbOverride = null).toPayload()
 
+  fun updateCheck(context: McpRuntimeContext = McpRuntimeContext()): Map<String, Any?> {
+    val result = services(context).updateCheckService.check(includePrereleases = false)
+    return mapOf(
+      "status" to result.status.wireName,
+      "installed_version" to result.installedVersion,
+      "latest_version" to result.latestVersion,
+      "recommended_install_command" to result.recommendedInstallCommand,
+      "reason" to result.reason,
+    )
+  }
+
   fun newSkillScaffold(
     payload: Map<String, Any?>,
     dryRun: Boolean = false,

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolDispatcher.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolDispatcher.kt
@@ -123,6 +123,7 @@ object McpToolDispatcher {
       "telemetry_proxy_capabilities" to { _, context -> McpRuntime.telemetryProxyCapabilities(context) },
       "telemetry_remote_stats" to ::telemetryRemoteStats,
       "triage_findings" to ::triageFindings,
+      "update_check" to { _, context -> McpRuntime.updateCheck(context) },
     )
 
   internal val legacyToolAliases: Map<String, String> =

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolRegistry.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolRegistry.kt
@@ -86,6 +86,7 @@ object McpToolRegistry {
       "telemetry_proxy_capabilities",
       "telemetry_remote_stats",
       "triage_findings",
+      "update_check",
     )
 
   private val descriptions: Map<String, String> =
@@ -149,6 +150,7 @@ object McpToolRegistry {
       "telemetry_proxy_capabilities" to "Show configured telemetry proxy capabilities.",
       "telemetry_remote_stats" to "Fetch aggregate org-wide workflow metrics.",
       "triage_findings" to "Record triage decisions for imported review findings.",
+      "update_check" to "Check whether the installed skill-bill runtime is up to date.",
     )
 
   private val inputSchemas: Map<String, Map<String, Any?>> =

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt
@@ -754,6 +754,7 @@ private val expectedToolInventory =
     "telemetry_proxy_capabilities",
     "telemetry_remote_stats",
     "triage_findings",
+    "update_check",
   )
 
 private val priorityStrictToolNames =

--- a/skills/agent/history.md
+++ b/skills/agent/history.md
@@ -1,3 +1,11 @@
+## [2026-06-23] SKILL-93 update-check-on-bill-feature (bill-feature gate)
+Areas: skills/bill-feature
+- `bill-feature` now calls `mcp__skill-bill__update_check` as the **first** action before any intake or spec-prep work
+- Gates on `update_available`: surfaces installed vs latest version, asks update-now-or-continue; stops with `recommended_install_command` if user chooses update
+- All other statuses (up-to-date, ahead, unknown) proceed to intake silently — no user prompt (reusable gate pattern for skill entry-point version checks)
+Feature flag: N/A
+Acceptance criteria: 12/12 implemented
+
 ## [2026-06-23] SKILL-92 bill-feature-goal prose lifecycle telemetry wiring
 Areas: skills/bill-feature-goal
 - `bill-feature-goal mode:prose` now emits goal lifecycle telemetry: calls `goal_prose_started` at goal start, `goal_prose_subtask_finished` after each subtask, and `goal_prose_finished` at goal completion/termination.

--- a/skills/bill-feature/content.md
+++ b/skills/bill-feature/content.md
@@ -13,6 +13,18 @@ It does not replace `bill-feature-spec`, `bill-feature-task`, or `bill-feature-g
 - `bill-feature-task` owns one implementation unit.
 - `bill-feature-goal` owns decomposed goal-loop execution with durable state.
 
+## Update Check
+
+Call `mcp__skill-bill__update_check` before any other action.
+
+When the tool returns `status: "update_available"`:
+- Show the user: installed version (`installed_version`) → latest version (`latest_version`).
+- Ask: **Update now or continue with the current version?**
+  - If the user chooses to update: stop and show the `recommended_install_command`. Do not proceed to Intake.
+  - If the user chooses to continue: proceed to Intake unchanged.
+
+When the tool returns any other status (`up_to_date`, `ahead_of_release`, or `unknown`): silently proceed to Intake with no prompt.
+
 ## Intake
 
 Clarify the user's feature request enough to identify:


### PR DESCRIPTION
# Summary

Adds a new `update_check` MCP tool backed by the existing `UpdateCheckService` and wires it as the first action in `bill-feature`. When a newer stable release is available the skill soft-blocks: it shows the version gap (installed vs latest) and asks the user whether to update or continue. For any other status (up to date, ahead of release, or unknown) the skill proceeds silently with no user-visible overhead.

Key changes:
- `McpComponent` / `McpRuntime` / `McpToolDispatcher` / `McpToolRegistry` — register and expose `update_check` as a native MCP tool, delegating to `UpdateCheckService.check(includePrereleases = false)`
- `McpRuntimeServices` — adds `UpdateCheckService` as a DI constructor param (no `RuntimeComponent` changes needed)
- `telemetry-event-schema.yaml` — adds `updateCheckEvent` to `oneOf` and `$defs` with open-object shape (matching `doctorEvent` pattern)
- `skills/bill-feature/content.md` — prepends an **Update Check** section that calls `mcp__skill-bill__update_check` and gates on `update_available` status

## Feature Flags

N/A — the update check runs on every `bill-feature` invocation; there is no flag to enable or disable it separately.

# How Has This Been Tested?

- All existing test suites pass unchanged: `McpRuntimeTest`, `TelemetryEventInputSchemaParityTest`, `TelemetryEventSchemaValidatesAllEventsTest`, `TelemetryEventSchemaContractVersionTest`, `McpStdioArgumentShapeUnifiedContractTest`.
- Skill content logic verified by inspection against AC5–AC11 (first-action placement, `update_available` branch, silent pass-through for all other statuses).

Manual verification:
1. Install a slightly older `skill-bill` runtime binary locally.
2. Invoke `/bill-feature` in Claude Code.
3. Confirm the skill calls `mcp__skill-bill__update_check` first and surfaces the version gap prompt.
4. Choose "update" — confirm execution stops and the install command is displayed.
5. Repeat step 2–3; choose "continue" — confirm normal `bill-feature` intake proceeds unmodified.
6. Install the latest version and invoke `/bill-feature` again — confirm the check passes silently with no prompt.