### PR TITLE
chore: make mode:runtime the default and mode:prose opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ Non-negotiable contracts:
 
 ## Product Intent
 
-`bill-feature-task` is the router entry point for feature-task work: it accepts `mode:prose` (default) or `mode:runtime` and delegates to the appropriate implementation mode. `bill-feature-task-prose` is the first-class prose orchestrator that runs the full phase loop in-session. `bill-feature-task-runtime` is the runtime-backed skill that drives the phase loop through the foreground `skill-bill feature-task` driver with durable workflow state, telemetry, platform packs, add-ons, and native subagents.
+`bill-feature-task` is the router entry point for feature-task work: it accepts `mode:runtime` (default) or `mode:prose` and delegates to the appropriate implementation mode. `bill-feature-task-prose` is the first-class prose orchestrator that runs the full phase loop in-session. `bill-feature-task-runtime` is the runtime-backed skill that drives the phase loop through the foreground `skill-bill feature-task` driver with durable workflow state, telemetry, platform packs, add-ons, and native subagents.
 
 Skill catalog status:
 
-- `bill-feature-task`: router that accepts `mode:prose` (default) or `mode:runtime`, presents one confirmation gate, then delegates.
+- `bill-feature-task`: router that accepts `mode:runtime` (default) or `mode:prose`, presents one confirmation gate, then delegates.
 - `bill-feature-task-prose`: first-class prose orchestrator for end-to-end feature implementation running entirely within the invoking agent session.
 - `bill-feature-task-runtime`: runtime-backed skill that launches the `skill-bill feature-task` foreground driver.
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ Skill Bill ships complete Kotlin/KMP and PHP packs — the stack-specific intell
 | `/bill-feature` | Primary feature entry point that prepares a spec, then routes to implementation or the goal loop |
 | `/bill-feature-guard` | Add feature-flag rollout safety to an implementation |
 | `/bill-feature-guard-cleanup` | Remove feature flags and legacy code after rollout |
-| `/bill-feature-task` | Router skill: accepts `mode:prose` (default) or `mode:runtime`, delegates to the appropriate implementation mode |
+| `/bill-feature-task` | Router skill: accepts `mode:runtime` (default) or `mode:prose`, delegates to the appropriate implementation mode |
 | `/bill-feature-task-prose` | First-class prose orchestrator for end-to-end feature implementation within the invoking agent session |
 | `/bill-feature-task-runtime` | Runtime-backed trigger that runs a governed spec through the `skill-bill feature-task` phase loop |
 | `/bill-feature-task-subtask-runner` | Level-1 subtask-agent for `bill-feature-goal mode:prose`; spawned via the Agent tool, not invoked directly |
 | `/bill-feature-spec` | Standalone feature-spec preparation (single-spec or decomposed) reused by feature and goal workflows |
 | `/bill-feature-verify` | Verify a PR against a task spec or design doc |
-| `/bill-feature-goal` | Decomposed-goal trigger: `mode:prose` (default) drives an in-session subtask loop, `mode:runtime` drives the durable `skill-bill goal` loop |
+| `/bill-feature-goal` | Decomposed-goal trigger: `mode:runtime` (default) drives the durable `skill-bill goal` loop, `mode:prose` drives an in-session subtask loop |
 | `/bill-pr-description` | Generate a PR title, description, and QA steps |
 | `/bill-pr-review-fix` | Resolve PR review comments end-to-end with an approval gate and reply automation |
 | `/bill-unit-test-value-check` | Review unit tests for low-value or tautological coverage |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -472,7 +472,7 @@ Primary MCP groups:
 - review and learning tools: `import_review`, `triage_findings`, `resolve_learnings`, `review_stats`
 - telemetry tools: `telemetry_proxy_capabilities`, `telemetry_remote_stats`
 - workflow stats tools: `feature_task_prose_stats`, `feature_verify_stats`
-- feature-task workflow tools (the default `mode:prose` in-session path): `feature_task_prose_started`, `feature_task_prose_workflow_open`, `feature_task_prose_workflow_update`, `feature_task_prose_workflow_list`, `feature_task_prose_workflow_latest`, `feature_task_prose_workflow_get`, `feature_task_prose_workflow_resume`, `feature_task_prose_workflow_continue`, `feature_task_prose_finished`
+- feature-task workflow tools (the `mode:prose` in-session path): `feature_task_prose_started`, `feature_task_prose_workflow_open`, `feature_task_prose_workflow_update`, `feature_task_prose_workflow_list`, `feature_task_prose_workflow_latest`, `feature_task_prose_workflow_get`, `feature_task_prose_workflow_resume`, `feature_task_prose_workflow_continue`, `feature_task_prose_finished`
 - verify workflow tools: `feature_verify_started`, `feature_verify_workflow_open`, `feature_verify_workflow_update`, `feature_verify_workflow_list`, `feature_verify_workflow_latest`, `feature_verify_workflow_get`, `feature_verify_workflow_resume`, `feature_verify_workflow_continue`, `feature_verify_finished`
 - quality and PR tools: `quality_check_started`, `quality_check_finished`, `pr_description_generated`
 - scaffold tool: `new_skill_scaffold`

--- a/skills/bill-feature-goal/content.md
+++ b/skills/bill-feature-goal/content.md
@@ -1,15 +1,15 @@
 ---
 name: bill-feature-goal
-description: Use when a decomposed feature goal is ready to run through one confirmation gate. Accepts `mode:prose` (default), which drives an in-session subtask loop, or `mode:runtime`, which drives the foreground `skill-bill goal` runtime, mirroring bill-feature-task's argument convention.
+description: Use when a decomposed feature goal is ready to run through one confirmation gate. Accepts `mode:runtime` (default), which drives the foreground `skill-bill goal` runtime, or `mode:prose`, which drives an in-session subtask loop, mirroring bill-feature-task's argument convention.
 ---
 
 # Feature Goal Content
 
-`bill-feature-goal` is the interactive front door for a feature goal that needs multiple decomposed implementation subtasks. It verifies decomposition readiness, asks for exactly one confirmation before starting any automated loop, and runs the confirmed decomposition in the selected mode: an in-session subtask loop by default (`mode:prose`), or the foreground `skill-bill goal` driver (`mode:runtime`).
+`bill-feature-goal` is the interactive front door for a feature goal that needs multiple decomposed implementation subtasks. It verifies decomposition readiness, asks for exactly one confirmation before starting any automated loop, and runs the confirmed decomposition in the selected mode: the foreground `skill-bill goal` driver by default (`mode:runtime`), or an in-session subtask loop (`mode:prose`).
 
 `bill-feature-goal` is the trigger surface for decomposed-goal orchestration. In
-`mode:prose` (the default) it loops the subtasks in the current agent session; in
-`mode:runtime` it hands off to the durable `skill-bill goal` runtime driver.
+`mode:runtime` (the default) it hands off to the durable `skill-bill goal` runtime
+driver; in `mode:prose` it loops the subtasks in the current agent session.
 
 `bill-feature-goal` does not own spec-writing logic. When decomposition artifacts are
 missing, it must reuse the shared feature-spec preparation path exposed through
@@ -20,13 +20,14 @@ missing, it must reuse the shared feature-spec preparation path exposed through
 `bill-feature-goal` accepts a `mode:` argument, mirroring `bill-feature-task`'s
 convention:
 
-- `mode:prose` (default) drives the in-session subtask loop documented in the
+- `mode:runtime` (default) drives the foreground `skill-bill goal` runtime
+  documented in the sections below. This is the documented default when no
+  `mode:` argument is supplied.
+- `mode:prose` drives the in-session subtask loop documented in the
   `## Mode: Prose Goal Orchestration (in-session loop)` section near the end of
-  this file. This is the documented default when no `mode:` argument is supplied.
-- `mode:runtime` drives the foreground `skill-bill goal` runtime documented in
-  the sections below.
+  this file.
 
-Resolve the mode to `prose` when no `mode:` argument is supplied.
+Resolve the mode to `runtime` when no `mode:` argument is supplied.
 
 Both modes share the same intake, decomposition-readiness checks, and the single
 confirmation gate defined in `## Decomposition Proposal`. They differ only in how
@@ -71,7 +72,7 @@ Then present a concise proposal that includes:
 - two or more ordered subtasks with dependency notes
 - the expected first runnable subtask
 - the agent that will be used for child runs, including any explicit override
-- the resolved mode: show `prose (default)` when the mode was not specified, `prose` when explicitly set, or `runtime` when `mode:runtime` was passed
+- the resolved mode: show `runtime (default)` when the mode was not specified, `runtime` when explicitly set, or `prose` when `mode:prose` was passed
 
 Ask one confirmation question: whether to proceed with this decomposition and start the goal loop in the resolved mode.
 

--- a/skills/bill-feature-task/content.md
+++ b/skills/bill-feature-task/content.md
@@ -1,14 +1,14 @@
 ---
 name: bill-feature-task
-description: Router skill for feature-task implementation. Accepts `mode:prose` (default) or `mode:runtime` in args and delegates to the appropriate skill. Use when user mentions implement feature, build feature, implement spec, run feature-task, or feature from design doc.
+description: Router skill for feature-task implementation. Accepts `mode:runtime` (default) or `mode:prose` in args and delegates to the appropriate skill. Use when user mentions implement feature, build feature, implement spec, run feature-task, or feature from design doc.
 ---
 
 # Feature Task Router
 
 `bill-feature-task` is the entry point for feature-task implementation. It collects the run context, confirms with the user, and delegates to the appropriate implementation mode:
 
-- **prose** (default) — delegates to `bill-feature-task-prose`, which orchestrates the full phase loop in-session without an external runtime.
-- **runtime** — delegates to `bill-feature-task-runtime`, which launches the `skill-bill feature-task` foreground driver.
+- **runtime** (default) — delegates to `bill-feature-task-runtime`, which launches the `skill-bill feature-task` foreground driver.
+- **prose** — delegates to `bill-feature-task-prose`, which orchestrates the full phase loop in-session without an external runtime.
 
 Both modes persist under the public workflow identity `bill-feature-task` in the
 shared feature-task workflow store: prose records use `mode=prose`, and runtime
@@ -21,12 +21,12 @@ Gather enough to identify and confirm the run:
 - the issue key
 - the governed spec path the run implements
 - the agent currently executing this skill
-- the mode (from args as `mode:prose` or `mode:runtime`; default to `prose` when absent)
+- the mode (from args as `mode:runtime` or `mode:prose`; default to `runtime` when absent)
 - the parallel review agent (from args as `parallel-review:<agent>`; absent when not provided)
 
 If the issue key is missing, stop and ask for it. If the spec path is missing, search `.feature-specs` for exactly one governed `.feature-specs/{ISSUE_KEY}-*/spec.md` match and use it. If there is no match or more than one match, stop and ask for the explicit spec path. Do not invent either value.
 
-Parse the mode and `parallel-review:<agent>` from args before presenting the confirmation gate. If no mode arg is provided, resolve the mode to `prose`.
+Parse the mode and `parallel-review:<agent>` from args before presenting the confirmation gate. If no mode arg is provided, resolve the mode to `runtime`.
 
 ## Single Confirmation Gate
 
@@ -34,7 +34,7 @@ Present one concise confirmation that includes:
 
 - the issue key and spec path
 - the agent that will run each phase, including any explicit override
-- the resolved mode: show `prose (default)` when the mode was not specified, `prose` when explicitly set, or `runtime` when `mode:runtime` was passed
+- the resolved mode: show `runtime (default)` when the mode was not specified, `runtime` when explicitly set, or `prose` when `mode:prose` was passed
 - the parallel review agent when `parallel-review:<agent>` was passed, or `none` otherwise
 
 Ask exactly one confirmation question: whether to proceed with the selected mode.
@@ -45,14 +45,14 @@ Do not launch any downstream skill while the run is unconfirmed. If the user dec
 
 After confirmation, invoke the delegated skill via the Skill tool — do not search the filesystem to locate skill files; the Skill tool resolves skills by name.
 
-When mode is `prose` or unspecified:
-
-- Invoke `bill-feature-task-prose` via the Skill tool.
-- Forward `--agent`, `--agent-override`, `--phase-agent`, and `parallel-review:<agent>` identically from the args received by this router.
-
-When mode is `runtime`:
+When mode is `runtime` or unspecified:
 
 - Invoke `bill-feature-task-runtime` via the Skill tool.
+- Forward `--agent`, `--agent-override`, `--phase-agent`, and `parallel-review:<agent>` identically from the args received by this router.
+
+When mode is `prose`:
+
+- Invoke `bill-feature-task-prose` via the Skill tool.
 - Forward `--agent`, `--agent-override`, `--phase-agent`, and `parallel-review:<agent>` identically from the args received by this router.
 
 Do not add a second confirmation gate on top of the delegated skill's own behavior. Delegate immediately after this router's own gate clears. The delegated skill owns its own intake, confirmation, and execution logic.


### PR DESCRIPTION
## What

Flips the default execution mode for `bill-feature-task` and `bill-feature-goal` from **prose** to **runtime**. When no `mode:` arg is supplied, the routers now resolve to `mode:runtime`; `mode:prose` becomes the opt-in alternative.

## Why

Per updated direction, runtime is the intended default path. This also resolves a pre-existing internal contradiction in `bill-feature-goal/content.md`, whose body already stated "everything above this section is the `mode:runtime` default" while the intake resolved to prose.

## Changes

- `skills/bill-feature-task/content.md` — description, mode list, intake parse rule, mode-resolution rule, confirmation-gate label, confirmed-handoff branch (runtime/unspecified → `bill-feature-task-runtime`)
- `skills/bill-feature-goal/content.md` — description, intro paragraphs, `## Modes` section, resolution rule, proposal label
- `README.md` — router table rows
- `AGENTS.md` — `bill-feature-task` descriptions
- `docs/getting-started.md` — dropped "default" from the `mode:prose` MCP-tools line

## Not touched

- `.feature-specs/` and `skills/agent/history.md` — historical records describing past state
- Runtime/CLI Kotlin layer — mode defaulting is purely a skill-routing concern; the CLI takes explicit parameters

## QA

- `git grep` confirms no remaining "prose is the default" phrasing in source-of-truth files
- Both routers now state runtime as default and prose as opt-in consistently