### PR TITLE
feat: [SKILL-95] make opencode prose-only; refuse runtime mode

### DIFF
--- a/.feature-specs/SKILL-95-opencode-prose-only/spec.md
+++ b/.feature-specs/SKILL-95-opencode-prose-only/spec.md
@@ -1,0 +1,69 @@
+# SKILL-95 — opencode is prose-only (runtime mode refuses on opencode)
+
+status: complete
+
+## Summary
+
+Make opencode a **prose-only** agent in skill-bill. On opencode, **prose is the implicit default** — no `mode:prose` argument is required — and an **explicit** `mode:runtime` (or any runtime invocation whose agent resolves to opencode) must **fail fast with a clear, actionable message**, instead of attempting a run that wedges. All opencode install, scaffold, MCP, prose orchestration, and telemetry support stay exactly as they are.
+
+> Scope note: this changes the default **only when the host/invoking agent is opencode**. It does NOT change the framework-wide default (which `#197` set to `mode:runtime`) for other agents. Flipping the global default to prose is a separate decision tracked outside this spec unless explicitly folded in.
+
+## Background
+
+A real run (NEWS-141, workflow `wftr-20260626-193556-a4lk`) proved runtime mode is non-viable under opencode, for two independent reasons:
+
+- **A — 120 s harness kill.** The Kotlin runtime driver runs the whole phase loop synchronously in one foreground process, but opencode's Bash tool hard-kills foreground commands at 120 000 ms. A single phase (preplan) took ~241 s, so the driver is guillotined before even one phase completes.
+- **B — per-phase output cannot be harvested.** Even given a longer timeout, the nested `opencode run` produced a valid contract JSON but the runtime never captured it back (the opencode builder uses `usePtyStdio=true` + opencode's default formatted/TUI output, so the phase-output JSON can't be parsed out of the ANSI stream). The phase stays `running` and the loop wedges.
+
+These are not worth fixing: opencode is the highest-churn, lowest-usage runtime target, and prose mode runs the identical governed loop in-session with none of these problems. The decision is to **stop supporting runtime on opencode and fail loudly so the user is told to use prose**, rather than silently degrade or wedge.
+
+## Intended Outcome
+
+A user invoking runtime mode on opencode gets an immediate, legible failure that names the supported path (prose). No opencode runtime workflow is opened, no branch is created, and no opencode per-phase subprocess is spawned. opencode remains fully usable in prose mode.
+
+## Acceptance Criteria
+
+1. On opencode, prose is the implicit default: invoking `bill-feature-task` or `bill-feature-goal` with **no mode argument** while the host/invoking agent is opencode runs in prose, with no need to pass `mode:prose`.
+2. Invoking `bill-feature-task mode:runtime` while the host/invoking agent is opencode fails fast with a clear message stating opencode does not support runtime mode and to use prose; the router refuses before launching the runtime driver.
+3. The runtime CLI refuses whenever the resolved runtime agent is opencode by any route — host-agent detection, `SKILL_BILL_AGENT=opencode`, `--agent opencode`, or `--phase-agent <phase>=opencode` — exiting non-zero before opening a workflow, resolving a branch, or spawning any phase.
+4. `bill-feature-goal mode:runtime` under opencode (and the goal runtime continuation `--agent opencode` path) refuses identically; no opencode runtime subprocess is ever spawned.
+5. The opencode runtime execution path is disabled at the source: the opencode agent-run command builder / launcher adapter no longer offers a runtime launch for opencode and yields the unsupported-launch outcome, so no code path can spawn opencode for a runtime phase even if a guard is bypassed.
+6. The refusal message is actionable and names the supported alternative explicitly (`bill-feature-task-prose` / `bill-feature-goal mode:prose`).
+7. opencode prose support is unchanged: install/scaffold (skills, generated opencode agents, MCP registration into `~/.config/opencode`), in-session prose orchestration, and telemetry all continue to work.
+8. Runtime support for the other agents (claude, codex, junie, glm) is unchanged; they still run runtime mode as before.
+9. Tests are updated: assertions that opencode is an accepted runtime agent become fast-refusal assertions, and a test covers opencode-host detection refusing runtime; opencode prose/install tests stay green; `./gradlew check` passes.
+10. The decision and its rationale are recorded in the relevant module's `agent/decisions.md`.
+
+## Non-Goals
+
+- Removing opencode from install/scaffold or from prose mode.
+- Fixing the opencode runtime bugs (A/B above) — explicitly declined.
+- Changing runtime support for claude, codex, junie, or glm.
+- Removing or changing the `--agent` / `--phase-agent` flags for other agents.
+- Any change to the GLM-in-Claude-Code workflow.
+
+## Constraints
+
+- Fail loud at the boundary (preflight): refuse before opening a workflow, creating/reusing a branch, or spawning any subprocess.
+- Leave the prose execution path byte-for-byte unaffected.
+- The guard must cover implicit resolution (host is opencode, no explicit flag), not only the explicit `--agent opencode` flag.
+
+## Affected Areas (implementation guidance, not binding)
+
+- `runtime-kotlin/runtime-infra-fs/.../launcher/agentrun/AgentRunCommandBuilders.kt` — `OpencodeAgentRunCommandBuilder` and its registration in the headless agent-run adapters / `FileSystemAgentRunLauncher`.
+- `runtime-kotlin/runtime-cli/.../featuretask/FeatureTaskRuntimeCliCommands.kt` — runtime agent resolution (`resolveInvokedRuntimeAgentId`, `parsePhaseAgents`); add the fast-refusal preflight for an opencode-resolved runtime agent.
+- Goal runtime agent-resolution / `goalContinuationCommand` `--agent opencode` path.
+- The `bill-feature-task-runtime` / goal runtime skill confirmation step (surface the refusal at the skill layer too).
+- Tests under `runtime-kotlin/runtime-cli/src/test` and `runtime-kotlin/runtime-application/src/test` that currently assert opencode runtime acceptance.
+
+## Validation Strategy
+
+- `./gradlew check` is green.
+- Negative path: a runtime invocation resolving the agent to opencode (each of: host detection, `SKILL_BILL_AGENT`, `--agent`, `--phase-agent`) exits non-zero with the refusal message and opens no workflow.
+- Positive path: opencode prose (`bill-feature-task-prose`) and a runtime invocation on a non-opencode agent both still succeed.
+
+## Next
+
+```bash
+Run bill-feature-task on .feature-specs/SKILL-95-opencode-prose-only/spec.md
+```

--- a/runtime-kotlin/agent/decisions.md
+++ b/runtime-kotlin/agent/decisions.md
@@ -24,18 +24,24 @@ detection, `SKILL_BILL_AGENT=opencode`, `--agent opencode`, `--phase-agent
 <phase>=opencode`, `--agent-override opencode`, and `--parallel-review-agent
 opencode` on the feature-task CLI, plus the invoked agent and `--agent-override`
 on the goal CLI — failing fast before opening a workflow, resolving a branch, or
-spawning a phase. Enforcement is defense-in-depth over two layers sharing one
-centralized predicate and message (`skillbill.install.model.isOpencodeAgent` +
-`OPENCODE_RUNTIME_REFUSAL_MESSAGE`): (L1) the runtime CLI preflights throw a
-`UsageError` with the actionable message naming both prose alternatives
-(`bill-feature-task-prose` / `bill-feature-goal mode:prose`); (L2) the launcher
-source-disablement — `OpencodeAgentRunCommandBuilder` is removed and opencode is
-intentionally not registered in `headlessAgentRunAdapters`, so
-`FileSystemAgentRunLauncher` yields `UnsupportedAgentRunLaunch` for it (mirroring
-copilot) as an unbypassable backstop even if a CLI guard is bypassed. The
-refusal message is centralized in `runtime-domain` (a plain const is inert data,
-allowed by the 2026-05-24 boundary decision) so both CLI layers emit byte-identical
-wording; the launcher keeps its generic backstop reason.
+spawning a phase. The single source of truth is one domain set,
+`skillbill.install.model.RUNTIME_REFUSED_AGENTS` (`{OPENCODE}`), with the predicate
+`isRuntimeRefusedAgent` and `OPENCODE_RUNTIME_REFUSAL_MESSAGE` derived from it; every
+layer consumes that set so re-enabling an agent's runtime path is a one-line change
+rather than scattered edits that drift. Enforcement is defense-in-depth over two
+layers: (L1) the runtime CLI preflights — feature-task, goal, and
+`code-review-parallel` — all funnel their reachable agent ids through one shared gate
+`skillbill.cli.core.refuseRuntimeRefusedAgents`, which throws a `UsageError` with the
+actionable message naming both prose alternatives (`bill-feature-task-prose` /
+`bill-feature-goal mode:prose`); (L2) the launcher source-disablement —
+`OpencodeAgentRunCommandBuilder` is removed and `headlessAgentRunAdapters` filters out
+`RUNTIME_REFUSED_AGENTS`, so `FileSystemAgentRunLauncher` yields
+`UnsupportedAgentRunLaunch` for opencode (mirroring copilot) as an unbypassable
+backstop even if a CLI guard is bypassed, and that deep path carries the same
+actionable `OPENCODE_RUNTIME_REFUSAL_MESSAGE` (not a generic reason) so it is as
+legible as the preflight. The message is centralized in `runtime-domain` (a plain
+const is inert data, allowed by the 2026-05-24 boundary decision) and consumed by
+both the CLI and the launcher, so every refusal emits byte-identical wording.
 
 Reason: opencode stays fully usable in prose mode, which runs the identical
 governed phase loop in-session with none of the 120s-kill / PTY-harvest problems.
@@ -47,10 +53,11 @@ retained: opencode must stay detectable (to refuse) and installable/scaffoldable
 LAUNCH path is disabled. No app-layer guard is added (`AgentRunService` /
 `FeatureTaskRuntimeRunner` / `GoalRunner` are unguarded) so their
 resolution/recording tests stay green and the launcher backstop remains the single
-spawner chokepoint. As an intended consequence of the global registry removal,
-opencode is also disabled for `bill-code-review-parallel` runtime (a parallel-review
-subprocess hits the same 120s-kill/PTY-harvest wall); it relies on the launcher
-backstop's generic message only.
+spawner chokepoint. `bill-code-review-parallel` runtime is disabled for opencode the
+same way (a parallel-review subprocess hits the same 120s-kill/PTY-harvest wall): its
+command now runs the shared preflight on both resolved lanes, so an opencode lane
+refuses upfront with the actionable message instead of degrading to a silent one-lane
+review.
 
 Non-goals: no change to opencode install/scaffold/MCP, prose orchestration, or
 telemetry (all byte-for-byte unchanged); no change to runtime support for claude,

--- a/runtime-kotlin/agent/decisions.md
+++ b/runtime-kotlin/agent/decisions.md
@@ -4,6 +4,63 @@ This file records architectural and implementation decisions that span the
 `runtime-kotlin/` boundary. Each entry is dated and explains the trade-off,
 not the implementation detail.
 
+## 2026-06-27 — opencode is prose-only: runtime mode refuses whenever the resolved agent is opencode
+
+Context: A real run (NEWS-141, workflow `wftr-20260626-193556-a4lk`) proved the
+runtime-driven phase loop is non-viable under opencode for two independent
+reasons: (A) the Kotlin runtime driver runs the whole phase loop synchronously in
+one foreground process, but opencode's Bash tool hard-kills foreground commands
+at 120 000 ms — a single phase (preplan) took ~241 s, so the driver is guillotined
+before even one phase completes; and (B) even with a longer budget, the nested
+`opencode run` emits valid contract JSON that the runtime never captures back (the
+opencode builder used `usePtyStdio=true` + opencode's formatted/TUI output, so the
+phase-output JSON cannot be parsed out of the ANSI stream), leaving the phase
+`running` and wedging the loop. opencode is the highest-churn, lowest-usage
+runtime target, so fixing either bug is not worth it.
+
+Decision: opencode is prose-only. Runtime mode refuses, loudly and at the
+boundary, whenever the resolved runtime agent is opencode by ANY route — host-agent
+detection, `SKILL_BILL_AGENT=opencode`, `--agent opencode`, `--phase-agent
+<phase>=opencode`, `--agent-override opencode`, and `--parallel-review-agent
+opencode` on the feature-task CLI, plus the invoked agent and `--agent-override`
+on the goal CLI — failing fast before opening a workflow, resolving a branch, or
+spawning a phase. Enforcement is defense-in-depth over two layers sharing one
+centralized predicate and message (`skillbill.install.model.isOpencodeAgent` +
+`OPENCODE_RUNTIME_REFUSAL_MESSAGE`): (L1) the runtime CLI preflights throw a
+`UsageError` with the actionable message naming both prose alternatives
+(`bill-feature-task-prose` / `bill-feature-goal mode:prose`); (L2) the launcher
+source-disablement — `OpencodeAgentRunCommandBuilder` is removed and opencode is
+intentionally not registered in `headlessAgentRunAdapters`, so
+`FileSystemAgentRunLauncher` yields `UnsupportedAgentRunLaunch` for it (mirroring
+copilot) as an unbypassable backstop even if a CLI guard is bypassed. The
+refusal message is centralized in `runtime-domain` (a plain const is inert data,
+allowed by the 2026-05-24 boundary decision) so both CLI layers emit byte-identical
+wording; the launcher keeps its generic backstop reason.
+
+Reason: opencode stays fully usable in prose mode, which runs the identical
+governed phase loop in-session with none of the 120s-kill / PTY-harvest problems.
+Failing loudly with an actionable message (instead of silently degrading or
+wedging) tells the user exactly which path to take. The host-agent DETECTION
+(`InvokingAgentContextResolver`) and the `InstallAgent` enum are intentionally
+retained: opencode must stay detectable (to refuse) and installable/scaffoldable
+(MCP into `~/.config/opencode`, generated opencode agents); only the runtime
+LAUNCH path is disabled. No app-layer guard is added (`AgentRunService` /
+`FeatureTaskRuntimeRunner` / `GoalRunner` are unguarded) so their
+resolution/recording tests stay green and the launcher backstop remains the single
+spawner chokepoint. As an intended consequence of the global registry removal,
+opencode is also disabled for `bill-code-review-parallel` runtime (a parallel-review
+subprocess hits the same 120s-kill/PTY-harvest wall); it relies on the launcher
+backstop's generic message only.
+
+Non-goals: no change to opencode install/scaffold/MCP, prose orchestration, or
+telemetry (all byte-for-byte unchanged); no change to runtime support for claude,
+codex, or junie; no removal of opencode from detection or the install enum; no
+schema/data migration and no feature flag (refusal-only).
+
+Revisit when: opencode gains a non-TTY harvestable headless mode and a foreground
+budget longer than 120s, at which point re-registering an opencode runtime adapter
+and dropping the preflights becomes viable.
+
 ## 2026-06-26 — SQLite runs in WAL with a busy_timeout for concurrent runs
 
 Context: All runtimes share one global SQLite file (`~/.skill-bill/review-metrics.db`),

--- a/runtime-kotlin/agent/decisions.md
+++ b/runtime-kotlin/agent/decisions.md
@@ -20,9 +20,9 @@ runtime target, so fixing either bug is not worth it.
 
 Decision: opencode is prose-only. Runtime mode refuses, loudly and at the
 boundary, whenever the resolved runtime agent is opencode by ANY route — host-agent
-detection, `SKILL_BILL_AGENT=opencode`, `--agent opencode`, `--phase-agent
-<phase>=opencode`, `--agent-override opencode`, and `--parallel-review-agent
-opencode` on the feature-task CLI, plus the invoked agent and `--agent-override`
+detection, `SKILL_BILL_AGENT=opencode`, `--agent opencode`,
+`--phase-agent plan=opencode`, `--agent-override opencode`, and
+`--parallel-review-agent opencode` on the feature-task CLI, plus the invoked agent and `--agent-override`
 on the goal CLI — failing fast before opening a workflow, resolving a branch, or
 spawning a phase. The single source of truth is one domain set,
 `skillbill.install.model.RUNTIME_REFUSED_AGENTS` (`{OPENCODE}`), with the predicate

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-06-27] SKILL-95 opencode prose-only (refuse runtime mode)
+Areas: runtime-kotlin/runtime-domain, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-infra-fs, skills/bill-feature-task, skills/bill-feature-goal, skills/bill-feature-task-runtime
+- Shared predicate+message in `InstallModels.kt`: `isOpencodeAgent(agentId)` trims+lowercases vs `InstallAgent.OPENCODE.id`; `OPENCODE_RUNTIME_REFUSAL_MESSAGE` names the supported alternatives (`bill-feature-task-prose` / `bill-feature-goal mode:prose`). reusable PATTERN: one domain-level predicate+message, consumed by every layer, keeps refusal wording from drifting.
+- Feature-task CLI preflight: `refuseUnsupportedRuntimeAgent()` in `FeatureTaskRuntimeCliCommands.kt` aggregates ALL agent routes (invoked/host agent, `--agent`, every `--phase-agent`, `--parallel-review-agent`) and throws `UsageError` first in all 6 run bodies — refuses before opening a workflow, resolving a branch, or spawning a phase. reusable
+- Goal CLI: `GoalRunCommand.run()` refuses invoked-agent and `--agent` override before presenter/child spawn (covers the `--agent opencode` continuation path).
+- Source-level backstop: `OpencodeAgentRunCommandBuilder` deleted and unregistered from `headlessAgentRunAdapters()` — opencode now yields `UnsupportedAgentRunLaunch`, so no code path can spawn opencode for a runtime phase even if a guard is bypassed. reusable PATTERN: de-register the launcher builder as the single spawner chokepoint rather than scattering app-layer guards.
+- Skill router docs: no-mode resolves to prose on opencode; explicit `mode:runtime` refuses at the skill layer quoting the shared message. opencode prose/install/telemetry unchanged; claude/codex/junie/glm runtime unchanged.
+Feature flag: N/A
+Acceptance criteria: 10/10 implemented
+
 ## [2026-06-23] SKILL-94 release-tooling (update-check release notes)
 Areas: runtime-kotlin/runtime-application, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-mcp
 - `UpdateCheckResult.releaseNotes: String?` added as trailing nullable field (default null); `candidateFromEntry` in `UpdateCheckService` extracts `body` from the GitHub Releases API JSON response via `entry["body"] as? String`; null/absent body → `releaseNotes = null`, no visible change to existing output. reusable PATTERN: nullable trailing fields on result data classes are backward-compatible — callers that don't consume the field are unaffected.

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/codereview/CodeReviewParallelCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/codereview/CodeReviewParallelCommand.kt
@@ -15,6 +15,7 @@ import skillbill.application.model.UsageValidationException
 import skillbill.application.review.ParallelCodeReviewRunner
 import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
+import skillbill.cli.core.refuseRuntimeRefusedAgents
 import skillbill.cli.model.CliExecutionResult
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InvokingAgentContextResolver
@@ -61,6 +62,11 @@ class CodeReviewParallelCommand(
       ?: throw UsageError(
         "Option --agent2 is required. Supported agents: ${InstallAgent.supportedIds.joinToString()}.",
       )
+
+    // A lane that resolves to a runtime-refused agent (opencode) would otherwise fall through to the
+    // launcher and fail with a generic message while the other lane still ran — a silently degraded
+    // one-lane review. Refuse upfront with the actionable prose guidance instead.
+    refuseRuntimeRefusedAgents(listOf(resolvedAgent1, resolvedAgent2))
 
     val resolvedScope = when (scope) {
       "staged" -> ParallelReviewScope.STAGED

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/RuntimeAgentRefusal.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/RuntimeAgentRefusal.kt
@@ -1,0 +1,15 @@
+package skillbill.cli.core
+
+import com.github.ajalt.clikt.core.UsageError
+import skillbill.install.model.OPENCODE_RUNTIME_REFUSAL_MESSAGE
+import skillbill.install.model.isRuntimeRefusedAgent
+
+// Shared runtime-refusal gate for every CLI entry point that can resolve a runtime agent
+// (feature-task, goal, code-review-parallel). Callers collect the agent ids reachable on their own
+// command surface and pass them here, so the predicate and the actionable message stay in one place
+// instead of being re-derived per command. Refuses before any workflow, branch, or subprocess.
+fun refuseRuntimeRefusedAgents(candidateAgentIds: List<String?>) {
+  if (candidateAgentIds.any(::isRuntimeRefusedAgent)) {
+    throw UsageError(OPENCODE_RUNTIME_REFUSAL_MESSAGE)
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
@@ -28,10 +28,9 @@ import skillbill.application.model.WorkflowOpenResult
 import skillbill.application.workflow.WorkflowService
 import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
+import skillbill.cli.core.refuseRuntimeRefusedAgents
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InvokingAgentContextResolver
-import skillbill.install.model.OPENCODE_RUNTIME_REFUSAL_MESSAGE
-import skillbill.install.model.isOpencodeAgent
 import skillbill.ports.featurespec.FeatureSpecPathResolverPort
 import skillbill.ports.featurespec.model.FeatureSpecPathResolveInput
 import skillbill.ports.featurespec.model.FeatureSpecPathResolveResult
@@ -119,17 +118,17 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
 
   // Refuses before a workflow is opened, a branch resolved, or a phase spawned: opencode is
   // prose-only because its foreground Bash tool is hard-killed at 120s and per-phase output
-  // cannot be harvested back. Covers every route the runtime agent can resolve from.
+  // cannot be harvested back. Enumerates every route the runtime agent can resolve from and
+  // defers the predicate + message to the shared gate.
   protected fun refuseUnsupportedRuntimeAgent(environment: Map<String, String>) {
-    val candidateAgentIds = buildList {
-      add(resolveInvokedRuntimeAgentId(agent, environment))
-      agentOverride?.takeIf(String::isNotBlank)?.let { add(it) }
-      addAll(parsePhaseAgents(phaseAgents).values)
-      parallelReviewAgent?.takeIf(String::isNotBlank)?.let { add(it) }
-    }
-    if (candidateAgentIds.any { isOpencodeAgent(it) }) {
-      throw UsageError(OPENCODE_RUNTIME_REFUSAL_MESSAGE)
-    }
+    refuseRuntimeRefusedAgents(
+      buildList {
+        add(resolveInvokedRuntimeAgentId(agent, environment))
+        agentOverride?.takeIf(String::isNotBlank)?.let { add(it) }
+        addAll(parsePhaseAgents(phaseAgents).values)
+        parallelReviewAgent?.takeIf(String::isNotBlank)?.let { add(it) }
+      },
+    )
   }
 
   protected fun executeRuntimeRun(

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
@@ -30,6 +30,8 @@ import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InvokingAgentContextResolver
+import skillbill.install.model.OPENCODE_RUNTIME_REFUSAL_MESSAGE
+import skillbill.install.model.isOpencodeAgent
 import skillbill.ports.featurespec.FeatureSpecPathResolverPort
 import skillbill.ports.featurespec.model.FeatureSpecPathResolveInput
 import skillbill.ports.featurespec.model.FeatureSpecPathResolveResult
@@ -114,6 +116,21 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
 
   protected fun resolveRunWorkflowId(workflowService: WorkflowService, state: CliRunState): String =
     explicitWorkflowId?.takeIf(String::isNotBlank) ?: openRuntimeWorkflowId(workflowService, state)
+
+  // Refuses before a workflow is opened, a branch resolved, or a phase spawned: opencode is
+  // prose-only because its foreground Bash tool is hard-killed at 120s and per-phase output
+  // cannot be harvested back. Covers every route the runtime agent can resolve from.
+  protected fun refuseUnsupportedRuntimeAgent(environment: Map<String, String>) {
+    val candidateAgentIds = buildList {
+      add(resolveInvokedRuntimeAgentId(agent, environment))
+      agentOverride?.takeIf(String::isNotBlank)?.let { add(it) }
+      addAll(parsePhaseAgents(phaseAgents).values)
+      parallelReviewAgent?.takeIf(String::isNotBlank)?.let { add(it) }
+    }
+    if (candidateAgentIds.any { isOpencodeAgent(it) }) {
+      throw UsageError(OPENCODE_RUNTIME_REFUSAL_MESSAGE)
+    }
+  }
 
   protected fun executeRuntimeRun(
     deps: FeatureTaskRuntimeRunDependencies,
@@ -224,6 +241,7 @@ class FeatureTaskRuntimeRunCommand(
     if (currentContext.invokedSubcommand != null) {
       return
     }
+    refuseUnsupportedRuntimeAgent(deps.state.environment)
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for feature-task run.")
     val runSpecPath = resolveSpecPath(deps, runIssueKey, specPath)
     executeRuntimeRun(
@@ -252,6 +270,7 @@ class FeatureTaskRuntimeExplicitRunCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.").optional()
 
   override fun run() {
+    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
@@ -289,6 +308,7 @@ class FeatureTaskRuntimeResumeCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.")
 
   override fun run() {
+    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
@@ -340,6 +360,7 @@ class FeatureTaskRuntimeDeprecatedRunCommand(
     if (currentContext.invokedSubcommand != null) {
       return
     }
+    refuseUnsupportedRuntimeAgent(deps.state.environment)
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for feature-task run.")
     val runSpecPath = resolveSpecPath(deps, runIssueKey, specPath)
     executeRuntimeRun(
@@ -363,6 +384,7 @@ class FeatureTaskRuntimeDeprecatedExplicitRunCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.").optional()
 
   override fun run() {
+    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
@@ -400,6 +422,7 @@ class FeatureTaskRuntimeDeprecatedResumeCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.")
 
   override fun run() {
+    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
@@ -23,12 +23,11 @@ import skillbill.application.model.GoalRunnerStatusRequest
 import skillbill.application.system.RuntimeProvenanceService
 import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
+import skillbill.cli.core.refuseRuntimeRefusedAgents
 import skillbill.contracts.system.RuntimeProvenanceContract
 import skillbill.goalrunner.model.GoalRunnerRunReport
 import skillbill.goalrunner.model.GoalRunnerStatusProjection
 import skillbill.install.model.InvokingAgentContextResolver
-import skillbill.install.model.OPENCODE_RUNTIME_REFUSAL_MESSAGE
-import skillbill.install.model.isOpencodeAgent
 import skillbill.ports.agentrun.model.AgentRunOutputSink
 import skillbill.ports.agentrun.model.AgentRunOutputStream
 import skillbill.ports.workflow.model.DEFAULT_SELECTED_DIFF_MAX_BYTES
@@ -86,11 +85,11 @@ class GoalRunCommand(
     if (currentContext.invokedSubcommand != null) {
       return
     }
+    // opencode is prose-only: refuse before any child subprocess is spawned, and before the
+    // issue_key check so the actionable refusal wins over a generic argument error (mirrors
+    // feature-task, where the preflight is the first statement in every run body).
+    refuseRuntimeRefusedAgents(listOf(resolveInvokedAgentId(agent, state.environment), agentOverride))
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for goal run.")
-    // opencode is prose-only: refuse before any child subprocess is spawned.
-    if (listOf(resolveInvokedAgentId(agent, state.environment), agentOverride).any { isOpencodeAgent(it) }) {
-      throw UsageError(OPENCODE_RUNTIME_REFUSAL_MESSAGE)
-    }
     val presenter = GoalRunPresenter(
       issueKey = runIssueKey,
       state = state,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
@@ -27,6 +27,8 @@ import skillbill.contracts.system.RuntimeProvenanceContract
 import skillbill.goalrunner.model.GoalRunnerRunReport
 import skillbill.goalrunner.model.GoalRunnerStatusProjection
 import skillbill.install.model.InvokingAgentContextResolver
+import skillbill.install.model.OPENCODE_RUNTIME_REFUSAL_MESSAGE
+import skillbill.install.model.isOpencodeAgent
 import skillbill.ports.agentrun.model.AgentRunOutputSink
 import skillbill.ports.agentrun.model.AgentRunOutputStream
 import skillbill.ports.workflow.model.DEFAULT_SELECTED_DIFF_MAX_BYTES
@@ -85,6 +87,10 @@ class GoalRunCommand(
       return
     }
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for goal run.")
+    // opencode is prose-only: refuse before any child subprocess is spawned.
+    if (listOf(resolveInvokedAgentId(agent, state.environment), agentOverride).any { isOpencodeAgent(it) }) {
+      throw UsageError(OPENCODE_RUNTIME_REFUSAL_MESSAGE)
+    }
     val presenter = GoalRunPresenter(
       issueKey = runIssueKey,
       state = state,

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCodeReviewParallelRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCodeReviewParallelRuntimeTest.kt
@@ -224,6 +224,43 @@ class CliCodeReviewParallelRuntimeTest {
   }
 
   @Test
+  fun `code-review-parallel refuses upfront when a resolved lane agent is opencode`() {
+    // SKILL-95: opencode is prose-only. A lane resolving to opencode (agent1 via SKILL_BILL_AGENT, or
+    // agent2 explicitly) must fail fast with the actionable message — not degrade to a one-lane review
+    // — and spawn no lane.
+    val tempDir = createGitRepo()
+    createStagedFile(tempDir)
+    val launcher = RecordingParallelLauncher()
+
+    val viaAgent1 = CliRuntime.run(
+      listOf("code-review-parallel", "--agent2", "claude", "--scope", "staged", "--repo-root", tempDir.toString()),
+      CliRuntimeContext(environment = mapOf("SKILL_BILL_AGENT" to "opencode"), agentRunLauncher = launcher),
+    )
+    assertEquals(1, viaAgent1.exitCode, viaAgent1.stdout)
+    assertContains(viaAgent1.stdout, "Runtime mode is not supported on opencode")
+    assertContains(viaAgent1.stdout, "bill-feature-task-prose")
+
+    val viaAgent2 = CliRuntime.run(
+      listOf(
+        "code-review-parallel",
+        "--agent1",
+        "claude",
+        "--agent2",
+        "opencode",
+        "--scope",
+        "staged",
+        "--repo-root",
+        tempDir.toString(),
+      ),
+      CliRuntimeContext(environment = emptyMap(), agentRunLauncher = launcher),
+    )
+    assertEquals(1, viaAgent2.exitCode, viaAgent2.stdout)
+    assertContains(viaAgent2.stdout, "Runtime mode is not supported on opencode")
+    // Refused before either lane runs.
+    assertEquals(emptyList(), launcher.agentIds, viaAgent2.stdout)
+  }
+
+  @Test
   fun `code-review-parallel defaults agent1 to codex when nothing resolves`() {
     val tempDir = createGitRepo()
     createStagedFile(tempDir)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCodeReviewParallelRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCodeReviewParallelRuntimeTest.kt
@@ -212,12 +212,13 @@ class CliCodeReviewParallelRuntimeTest {
         tempDir.toString(),
       ),
       CliRuntimeContext(
-        environment = System.getenv() + mapOf("SKILL_BILL_AGENT" to "opencode"),
+        environment = System.getenv() + mapOf("SKILL_BILL_AGENT" to "junie"),
         agentRunLauncher = launcher,
       ),
     )
 
-    // agent1 resolves to opencode, but agent2 is claude so no duplicate error
+    // SKILL-95: opencode is prose-only, so agent1 now resolves to junie (a supported runtime agent);
+    // agent2 is claude so no duplicate error.
     assertEquals(0, result.exitCode, result.stdout)
     assertFalse(launcher.agentIds.isEmpty())
   }

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -287,6 +287,34 @@ class CliFeatureTaskRuntimeRuntimeTest {
   }
 
   @Test
+  fun `feature-task-runtime resume refuses when the resolved agent is opencode`() {
+    // SKILL-95 AC9: the resume entry point — the cross-mode resume hazard — must refuse opencode too,
+    // before touching the durable workflow. Driven directly with a placeholder workflow id since the
+    // preflight fires before any DB read.
+    val fixture = runtimeFixture()
+    val launcher = RecordingPhaseLauncher()
+
+    val result = CliRuntime.run(
+      listOf(
+        "--db",
+        fixture.dbPath.toString(),
+        "feature-task",
+        "resume",
+        "wftr-nonexistent",
+        "SKILL-650",
+        fixture.specPath.toString(),
+        "--agent",
+        "opencode",
+      ),
+      fixture.context(launcher),
+    )
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Runtime mode is not supported on opencode")
+    assertEquals(emptyList(), launcher.requests, result.stdout)
+  }
+
+  @Test
   fun `feature-task-runtime run falls back to the documented codex default when nothing resolves`() {
     val fixture = runtimeFixture()
     val launcher = RecordingPhaseLauncher()

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -222,7 +222,10 @@ class CliFeatureTaskRuntimeRuntimeTest {
   }
 
   @Test
-  fun `feature-task-runtime run SKILL_BILL_AGENT wins over detected invoking context`() {
+  fun `feature-task-runtime run refuses when the resolved agent is opencode via SKILL_BILL_AGENT`() {
+    // SKILL-95 AC3/AC9: opencode is prose-only. A runtime run whose agent resolves to opencode
+    // (here SKILL_BILL_AGENT over the detected invoking context) must fail fast with the actionable
+    // refusal message, opening no workflow and spawning no phase.
     val fixture = runtimeFixture()
     val launcher = RecordingPhaseLauncher()
 
@@ -231,8 +234,56 @@ class CliFeatureTaskRuntimeRuntimeTest {
       fixture.context(launcher, environment = mapOf("CLAUDECODE" to "1", "SKILL_BILL_AGENT" to "opencode")),
     )
 
-    assertEquals(0, result.exitCode, result.stdout)
-    assertEquals(listOf("opencode"), launcher.requests.map { it.agentId }.distinct())
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Runtime mode is not supported on opencode")
+    assertContains(result.stdout, "bill-feature-task-prose")
+    assertContains(result.stdout, "bill-feature-goal mode:prose")
+    // No phase is launched and no workflow is opened before the refusal.
+    assertEquals(emptyList(), launcher.requests, result.stdout)
+    assertFalse(result.stdout.contains("workflow_id:"), result.stdout)
+  }
+
+  @Test
+  fun `feature-task-runtime run refuses when the host invoking agent is detected as opencode`() {
+    // SKILL-95 AC3/AC9: implicit resolution must also refuse — when opencode is detected as the
+    // invoking host (no --agent / SKILL_BILL_AGENT), runtime still fails fast with the message.
+    val fixture = runtimeFixture()
+    val launcher = RecordingPhaseLauncher()
+
+    val result = CliRuntime.run(
+      fixture.runCommand(),
+      fixture.context(launcher, environment = mapOf("OPENCODE" to "1")),
+    )
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Runtime mode is not supported on opencode")
+    assertEquals(emptyList(), launcher.requests, result.stdout)
+    assertFalse(result.stdout.contains("workflow_id:"), result.stdout)
+  }
+
+  @Test
+  fun `feature-task-runtime run refuses opencode from agent-override phase-agent and parallel-review routes`() {
+    // SKILL-95 AC5/AC9: opencode reaching a runtime phase by ANY route must refuse at the preflight,
+    // and the predicate is case- and whitespace-insensitive (`OpenCode`, ` opencode `).
+    listOf(
+      listOf("--agent", "codex", "--agent-override", "opencode"),
+      listOf("--agent", "codex", "--phase-agent", "plan=opencode"),
+      listOf("--agent", "codex", "--parallel-review-agent", "opencode"),
+      listOf("--agent", "OpenCode"),
+      listOf("--agent", " opencode "),
+    ).forEach { extra ->
+      val fixture = runtimeFixture()
+      val launcher = RecordingPhaseLauncher()
+
+      val result = CliRuntime.run(
+        fixture.runCommand(extra = extra),
+        fixture.context(launcher),
+      )
+
+      assertEquals(1, result.exitCode, "expected refusal for $extra: ${result.stdout}")
+      assertContains(result.stdout, "Runtime mode is not supported on opencode")
+      assertEquals(emptyList(), launcher.requests, "no phase should spawn for $extra: ${result.stdout}")
+    }
   }
 
   @Test

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -799,6 +799,37 @@ class CliGoalOpencodeRefusalTest {
     assertContains(result.stdout, "Runtime mode is not supported on opencode")
     assertEquals(emptyList(), launcher.requests, result.stdout)
   }
+
+  @Test
+  fun `goal runtime run refuses when the host invoking agent is detected as opencode`() {
+    // SKILL-95 AC4: implicit host resolution (no --agent, no SKILL_BILL_AGENT) must refuse identically,
+    // since the goal guard resolves through the same invoking-agent detection as the explicit routes.
+    val fixture = goalFixture(subtaskCount = 1)
+    val launcher = GoalFixtureAgentRunLauncher(fixture)
+    val command = buildList {
+      add("--db")
+      add(fixture.dbPath.toString())
+      add("goal")
+      add("SKILL-901")
+      add("--repo-root")
+      add(fixture.tempDir.toString())
+    }
+
+    val result = CliRuntime.run(
+      command,
+      CliRuntimeContext(
+        userHome = fixture.tempDir,
+        workflowGitOperations = GoalTestWorkflowGitOperations,
+        agentRunLauncher = launcher,
+        goalPullRequestPort = fixture.pullRequests,
+        environment = mapOf("OPENCODE" to "1"),
+      ),
+    )
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Runtime mode is not supported on opencode")
+    assertEquals(emptyList(), launcher.requests, result.stdout)
+  }
 }
 
 private fun startRunningGoalChild(fixture: GoalCliFixture): String = runGoalJson(

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -752,6 +752,55 @@ class CliGoalTransitionMonitoringTest {
   }
 }
 
+/**
+ * SKILL-95 (AC4, AC9): opencode is prose-only. Kept in its own class so it does not push the broad
+ * [CliGoalRuntimeTest] over the detekt LargeClass threshold (the file's established convention).
+ */
+class CliGoalOpencodeRefusalTest {
+  @Test
+  fun `goal runtime run refuses when the resolved agent is opencode`() {
+    // A goal runtime run that resolves the agent to opencode must refuse before spawning any child
+    // feature-task subprocess, with the actionable message naming prose.
+    val fixture = goalFixture(subtaskCount = 1)
+    val launcher = GoalFixtureAgentRunLauncher(fixture)
+    val command = listOf(
+      "--db",
+      fixture.dbPath.toString(),
+      "goal",
+      "SKILL-901",
+      "--agent",
+      "opencode",
+      "--repo-root",
+      fixture.tempDir.toString(),
+    )
+
+    val result = CliRuntime.run(command, fixture.context(launcher = launcher))
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Runtime mode is not supported on opencode")
+    assertContains(result.stdout, "bill-feature-task-prose")
+    assertContains(result.stdout, "bill-feature-goal mode:prose")
+    // No opencode child subprocess is spawned.
+    assertEquals(emptyList(), launcher.requests, result.stdout)
+  }
+
+  @Test
+  fun `goal runtime run refuses when the agent override is opencode`() {
+    // The --agent-override route must also refuse before spawning a child.
+    val fixture = goalFixture(subtaskCount = 1)
+    val launcher = GoalFixtureAgentRunLauncher(fixture)
+
+    val result = CliRuntime.run(
+      fixture.goalCommand(extra = listOf("--agent-override", "opencode")),
+      fixture.context(launcher = launcher),
+    )
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "Runtime mode is not supported on opencode")
+    assertEquals(emptyList(), launcher.requests, result.stdout)
+  }
+}
+
 private fun startRunningGoalChild(fixture: GoalCliFixture): String = runGoalJson(
   listOf(
     "--db",

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
@@ -31,8 +31,16 @@ enum class InstallAgent(
   }
 }
 
-fun isOpencodeAgent(agentId: String?): Boolean =
-  agentId != null && agentId.trim().lowercase() == InstallAgent.OPENCODE.id
+// Single source of truth for agents skill-bill refuses to run in runtime mode. Every layer derives
+// from this set: the CLI preflights, the launcher backstop, and the headless adapter registry, so
+// re-enabling an agent's runtime path is a one-line change here rather than scattered edits that drift.
+val RUNTIME_REFUSED_AGENTS: Set<InstallAgent> = setOf(InstallAgent.OPENCODE)
+
+fun isRuntimeRefusedAgent(agentId: String?): Boolean {
+  if (agentId == null) return false
+  val normalized = agentId.trim().lowercase()
+  return RUNTIME_REFUSED_AGENTS.any { refused -> refused.id == normalized }
+}
 
 const val OPENCODE_RUNTIME_REFUSAL_MESSAGE: String =
   "Runtime mode is not supported on opencode: its foreground Bash tool is hard-killed at 120s before " +

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
@@ -31,6 +31,14 @@ enum class InstallAgent(
   }
 }
 
+fun isOpencodeAgent(agentId: String?): Boolean =
+  agentId != null && agentId.trim().lowercase() == InstallAgent.OPENCODE.id
+
+const val OPENCODE_RUNTIME_REFUSAL_MESSAGE: String =
+  "Runtime mode is not supported on opencode: its foreground Bash tool is hard-killed at 120s before " +
+    "a phase can finish, and per-phase output cannot be harvested back. Use prose instead — run " +
+    "bill-feature-task-prose for a single feature task, or bill-feature-goal mode:prose for a decomposed goal."
+
 /**
  * SKILL-64 Subtask 3 (AC18): pure, effect-free mapping from an already-read
  * execution-context environment map to the [InstallAgent] that most likely

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
@@ -1,6 +1,7 @@
 package skillbill.launcher.agentrun
 
 import skillbill.install.model.InstallAgent
+import skillbill.install.model.RUNTIME_REFUSED_AGENTS
 import skillbill.launcher.process.AgentRunProcessRequest
 import skillbill.launcher.process.AgentRunProcessRunner
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
@@ -76,10 +77,11 @@ fun headlessAgentRunAdapters(processRunner: AgentRunProcessRunner): Map<InstallA
   // opencode is prose-only and intentionally NOT registered, so the launcher yields
   // UnsupportedAgentRunLaunch for it (mirroring copilot) — no runtime phase can spawn it.
   JunieAgentRunCommandBuilder(),
-).associate { builder ->
-  builder.agent to ProcessAgentRunAdapter(
-    agent = builder.agent,
-    commandBuilder = builder,
-    processRunner = processRunner,
-  )
-}
+).filterNot { builder -> RUNTIME_REFUSED_AGENTS.contains(builder.agent) }
+  .associate { builder ->
+    builder.agent to ProcessAgentRunAdapter(
+      agent = builder.agent,
+      commandBuilder = builder,
+      processRunner = processRunner,
+    )
+  }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
@@ -73,7 +73,8 @@ class ProcessAgentRunAdapter(
 fun headlessAgentRunAdapters(processRunner: AgentRunProcessRunner): Map<InstallAgent, AgentRunAdapter> = listOf(
   ClaudeAgentRunCommandBuilder(),
   CodexAgentRunCommandBuilder(),
-  OpencodeAgentRunCommandBuilder(),
+  // opencode is prose-only and intentionally NOT registered, so the launcher yields
+  // UnsupportedAgentRunLaunch for it (mirroring copilot) — no runtime phase can spawn it.
   JunieAgentRunCommandBuilder(),
 ).associate { builder ->
   builder.agent to ProcessAgentRunAdapter(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
@@ -92,27 +92,6 @@ class CodexAgentRunCommandBuilder : AgentRunCommandBuilder {
     )
 }
 
-class OpencodeAgentRunCommandBuilder : AgentRunCommandBuilder {
-  override val agent: InstallAgent = InstallAgent.OPENCODE
-
-  override fun build(request: SkillRunRequest): AgentRunCommand =
-    goalContinuationCommand(request, agent) ?: AgentRunCommand(
-      command = listOf(
-        "opencode",
-        "run",
-        "--dir",
-        request.repoRoot.toString(),
-        "--dangerously-skip-permissions",
-        launchPrompt(request),
-      ),
-      workingDirectory = request.repoRoot,
-      timeout = request.timeout,
-      environment = goalContinuationEnvironment(request),
-      usePtyStdio = true,
-      idlePolicy = AgentRunIdlePolicy.HEARTBEAT_EXTENDED,
-    )
-}
-
 class JunieAgentRunCommandBuilder : AgentRunCommandBuilder {
   override val agent: InstallAgent = InstallAgent.JUNIE
 

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/FileSystemAgentRunLauncher.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/FileSystemAgentRunLauncher.kt
@@ -2,6 +2,8 @@ package skillbill.launcher.agentrun
 
 import me.tatarka.inject.annotations.Inject
 import skillbill.install.model.InstallAgent
+import skillbill.install.model.OPENCODE_RUNTIME_REFUSAL_MESSAGE
+import skillbill.install.model.isRuntimeRefusedAgent
 import skillbill.launcher.process.JvmAgentRunProcessRunner
 import skillbill.ports.agentrun.AgentRunLauncher
 import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
@@ -19,7 +21,14 @@ class FileSystemAgentRunLauncher(
     val adapter = adapters[agent]
       ?: return UnsupportedAgentRunLaunch(
         agent = agent,
-        reason = "Agent '${agent.id}' does not have a supported headless bill-feature-task launch path.",
+        // A runtime-refused agent (opencode) reaching this deep path — e.g. a future caller that
+        // resolves an agent past the CLI preflight — gets the same actionable prose guidance as the
+        // preflight, not a generic "no launch path" line.
+        reason = if (isRuntimeRefusedAgent(agent.id)) {
+          OPENCODE_RUNTIME_REFUSAL_MESSAGE
+        } else {
+          "Agent '${agent.id}' does not have a supported headless bill-feature-task launch path."
+        },
       )
     return adapter.launch(request.skillRunRequest)
   }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunGoalContinuationCommandTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunGoalContinuationCommandTest.kt
@@ -115,11 +115,13 @@ class AgentRunGoalContinuationCommandTest {
   @Test
   fun `every agent goal-continuation child spawns skill-bill feature-task and never the skill`() {
     val runner = RecordingAgentRunProcessRunner()
-    listOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.OPENCODE, InstallAgent.JUNIE).forEach { agent ->
+    // SKILL-95: opencode is prose-only and excluded from the headless runtime adapters, so the
+    // remaining runtime agents (claude, codex, junie) each spawn skill-bill feature-task directly.
+    listOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE).forEach { agent ->
       requireNotNull(headlessAgentRunAdapters(runner)[agent]).launch(skillRunRequest())
     }
 
-    assertEquals(4, runner.requests.size)
+    assertEquals(3, runner.requests.size)
     runner.requests.forEach { request ->
       assertEquals(
         listOf("skill-bill", "--db", "/tmp/skillbill-agent-run/metrics.db", "feature-task"),
@@ -132,7 +134,7 @@ class AgentRunGoalContinuationCommandTest {
       assertFalse(request.command.any { value -> "workflow continue" in value })
       assertFalse(request.command.any { value -> "use the" in value.lowercase() && "skill" in value.lowercase() })
     }
-    val perAgent = listOf("claude", "codex", "opencode", "junie")
+    val perAgent = listOf("claude", "codex", "junie")
     runner.requests.forEachIndexed { index, request ->
       assertEquals(perAgent[index], request.command.last())
       assertEquals("--agent", request.command[request.command.size - 2])

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -2,7 +2,11 @@ package skillbill.launcher
 
 import skillbill.goalrunner.model.GoalRunnerLivenessState
 import skillbill.install.model.InstallAgent
+import skillbill.install.model.RUNTIME_REFUSED_AGENTS
+import skillbill.launcher.agentrun.AgentRunCommand
+import skillbill.launcher.agentrun.AgentRunCommandBuilder
 import skillbill.launcher.agentrun.FileSystemAgentRunLauncher
+import skillbill.launcher.agentrun.ProcessAgentRunAdapter
 import skillbill.launcher.agentrun.WorktreeActivityProbe
 import skillbill.launcher.agentrun.headlessAgentRunAdapters
 import skillbill.launcher.process.AgentRunActivityProbe
@@ -86,9 +90,11 @@ class AgentRunLauncherTest {
   }
 
   @Test
-  fun `opencode returns the unsupported headless launch outcome`() {
+  fun `opencode returns the unsupported headless launch outcome with the actionable prose message`() {
     // SKILL-95 AC5: opencode is prose-only and must not have a runtime launch adapter, so the
-    // launcher yields the unsupported outcome (mirroring copilot) for opencode by any route.
+    // launcher yields the unsupported outcome. Unlike a generically-unsupported agent (copilot),
+    // a runtime-refused agent carries the actionable refusal message so the deep path is as legible
+    // as the CLI preflight.
     val launcher = FileSystemAgentRunLauncher(JvmAgentRunProcessRunner())
 
     val outcome = launcher.launch(
@@ -100,7 +106,8 @@ class AgentRunLauncherTest {
 
     assertIs<UnsupportedAgentRunLaunch>(outcome)
     assertEquals(InstallAgent.OPENCODE, outcome.agent)
-    assertContains(outcome.reason, "does not have a supported headless")
+    assertContains(outcome.reason, "Runtime mode is not supported on opencode")
+    assertContains(outcome.reason, "bill-feature-task-prose")
   }
 
   @Test
@@ -839,8 +846,32 @@ class HeadlessAgentRunAdapterTest {
     // no code path can spawn it for a runtime phase even if a CLI guard is bypassed.
     val adapters = headlessAgentRunAdapters(RecordingAgentRunProcessRunner())
 
-    assertFalse(adapters.keys.contains(InstallAgent.OPENCODE))
-    assertEquals(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE), adapters.keys)
+    // Every runtime-refused agent is absent (the AC), while the known runtime agents stay registered.
+    // Asserting a subset rather than exact-set equality keeps this robust to unrelated future agents.
+    RUNTIME_REFUSED_AGENTS.forEach { refused -> assertFalse(adapters.keys.contains(refused)) }
+    assertTrue(adapters.keys.containsAll(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE)))
+  }
+
+  @Test
+  fun `process adapter threads usePtyStdio from the built command rather than a constant`() {
+    // After opencode (the only PTY-backed builder) was removed, no real builder sets usePtyStdio=true,
+    // so prove threading directly: a builder requesting PTY stdio must surface usePtyStdio=true in the
+    // process request. Guards against the flag being hardcoded to false.
+    val runner = RecordingAgentRunProcessRunner()
+    val ptyBuilder = object : AgentRunCommandBuilder {
+      override val agent: InstallAgent = InstallAgent.CLAUDE
+      override fun build(request: SkillRunRequest): AgentRunCommand = AgentRunCommand(
+        command = listOf("true"),
+        workingDirectory = request.repoRoot,
+        timeout = request.timeout,
+        usePtyStdio = true,
+      )
+    }
+
+    ProcessAgentRunAdapter(InstallAgent.CLAUDE, ptyBuilder, runner).launch(phaseRunRequest())
+
+    assertEquals(1, runner.requests.size)
+    assertTrue(runner.requests.single().usePtyStdio, "adapter must thread usePtyStdio=true from the builder")
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -60,10 +60,12 @@ class AgentRunLauncherTest {
     val runner = RecordingAgentRunProcessRunner()
     val request = skillRunRequest(goalContinuation = null).copy(promptOverride = PHASE_PROMPT)
 
-    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.OPENCODE]).launch(request)
+    // SKILL-95: opencode is no longer a runtime adapter; junie is the other argv-delivered agent
+    // (the prompt rides as a trailing argv token, never via stdin).
+    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.JUNIE]).launch(request)
 
     val captured = runner.requests.single()
-    assertEquals(listOf("opencode", "run"), captured.command.take(2))
+    assertEquals("junie", captured.command.first())
     assertEquals(PHASE_PROMPT, captured.command.last())
   }
 
@@ -80,6 +82,24 @@ class AgentRunLauncherTest {
 
     assertIs<UnsupportedAgentRunLaunch>(outcome)
     assertEquals(InstallAgent.COPILOT, outcome.agent)
+    assertContains(outcome.reason, "does not have a supported headless")
+  }
+
+  @Test
+  fun `opencode returns the unsupported headless launch outcome`() {
+    // SKILL-95 AC5: opencode is prose-only and must not have a runtime launch adapter, so the
+    // launcher yields the unsupported outcome (mirroring copilot) for opencode by any route.
+    val launcher = FileSystemAgentRunLauncher(JvmAgentRunProcessRunner())
+
+    val outcome = launcher.launch(
+      AgentRunLaunchRequest(
+        agentId = "opencode",
+        skillRunRequest = skillRunRequest(),
+      ),
+    )
+
+    assertIs<UnsupportedAgentRunLaunch>(outcome)
+    assertEquals(InstallAgent.OPENCODE, outcome.agent)
     assertContains(outcome.reason, "does not have a supported headless")
   }
 
@@ -610,7 +630,8 @@ class AgentRunLauncherTest {
     // consulted.
     val runner = RecordingAgentRunProcessRunner()
     val adapters = headlessAgentRunAdapters(runner)
-    listOf(InstallAgent.CODEX, InstallAgent.CLAUDE, InstallAgent.OPENCODE, InstallAgent.JUNIE).forEach { agent ->
+    // SKILL-95: opencode is prose-only and excluded from the headless runtime adapters.
+    listOf(InstallAgent.CODEX, InstallAgent.CLAUDE, InstallAgent.JUNIE).forEach { agent ->
       val facts = requireNotNull(adapters[agent]).launch(skillRunRequest())
       assertEquals("/tmp/skillbill-agent-run", facts.childSessionPath, "session path for $agent")
       val sessionId = requireNotNull(facts.childSessionId) { "session id for $agent" }
@@ -803,34 +824,29 @@ private class SharedDeclaredProgressStore {
 // only ~0.5s of run, well under that deadline measured from first observation.
 private const val WITHHELD_POLLS = 6
 
-class OpencodeAgentRunCommandBuilderTest {
+class HeadlessAgentRunAdapterTest {
+  private fun phaseRunRequest(): SkillRunRequest = SkillRunRequest(
+    issueKey = "SKILL-88",
+    repoRoot = Path.of("/tmp/skillbill-agent-run"),
+    subtaskId = 1,
+    timeout = 10.seconds,
+    goalContinuation = null,
+  ).copy(promptOverride = "Phase: preplan")
+
   @Test
-  fun `opencode builder emits usePtyStdio=true`() {
-    val runner = RecordingAgentRunProcessRunner()
-    val request = SkillRunRequest(
-      issueKey = "SKILL-88",
-      repoRoot = Path.of("/tmp/skillbill-agent-run"),
-      subtaskId = 1,
-      timeout = 10.seconds,
-      goalContinuation = null,
-    ).copy(promptOverride = "Phase: preplan")
+  fun `opencode is not registered as a headless runtime adapter`() {
+    // SKILL-95 AC5: opencode is prose-only. It must not appear in the headless adapter registry, so
+    // no code path can spawn it for a runtime phase even if a CLI guard is bypassed.
+    val adapters = headlessAgentRunAdapters(RecordingAgentRunProcessRunner())
 
-    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.OPENCODE]).launch(request)
-
-    val captured = runner.requests.single()
-    assertTrue(captured.usePtyStdio, "opencode must request PTY-backed stdio")
+    assertFalse(adapters.keys.contains(InstallAgent.OPENCODE))
+    assertEquals(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE), adapters.keys)
   }
 
   @Test
   fun `claude codex and junie builders emit usePtyStdio=false`() {
     val runner = RecordingAgentRunProcessRunner()
-    val request = SkillRunRequest(
-      issueKey = "SKILL-88",
-      repoRoot = Path.of("/tmp/skillbill-agent-run"),
-      subtaskId = 1,
-      timeout = 10.seconds,
-      goalContinuation = null,
-    ).copy(promptOverride = "Phase: preplan")
+    val request = phaseRunRequest()
     val adapters = headlessAgentRunAdapters(runner)
 
     listOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE).forEach { agent ->
@@ -845,21 +861,17 @@ class OpencodeAgentRunCommandBuilderTest {
   }
 
   @Test
-  fun `process adapter threads usePtyStdio from command into request`() {
+  fun `process adapter threads usePtyStdio=false into the process request for supported agents`() {
     val runner = RecordingAgentRunProcessRunner()
-    val request = SkillRunRequest(
-      issueKey = "SKILL-88",
-      repoRoot = Path.of("/tmp/skillbill-agent-run"),
-      subtaskId = 1,
-      timeout = 10.seconds,
-      goalContinuation = null,
-    ).copy(promptOverride = "Phase: preplan")
+    val request = phaseRunRequest()
+    val adapters = headlessAgentRunAdapters(runner)
 
-    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.OPENCODE]).launch(request)
-    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.CLAUDE]).launch(request)
+    requireNotNull(adapters[InstallAgent.CLAUDE]).launch(request)
+    requireNotNull(adapters[InstallAgent.CODEX]).launch(request)
 
-    assertEquals(true, runner.requests[0].usePtyStdio, "opencode adapter must thread usePtyStdio=true")
-    assertEquals(false, runner.requests[1].usePtyStdio, "claude adapter must thread usePtyStdio=false")
+    runner.requests.forEach { req ->
+      assertEquals(false, req.usePtyStdio, "supported adapter must thread usePtyStdio=false")
+    }
   }
 }
 

--- a/skills/bill-feature-goal/content.md
+++ b/skills/bill-feature-goal/content.md
@@ -29,6 +29,12 @@ convention:
 
 Resolve the mode to `runtime` when no `mode:` argument is supplied.
 
+**opencode is prose-only.** When the agent currently executing this skill is opencode, prose is the implicit default and runtime mode is unsupported: its foreground Bash tool is hard-killed at 120s before a phase can finish, and per-phase output cannot be harvested back. On opencode: with no mode arg, resolve to `prose` (no need to pass `mode:prose`); with an explicit `mode:runtime`, stop and emit the actionable refusal and do NOT hand off to the `skill-bill goal` runtime:
+
+> Runtime mode is not supported on opencode: its foreground Bash tool is hard-killed at 120s before a phase can finish, and per-phase output cannot be harvested back. Use prose instead — run bill-feature-task-prose for a single feature task, or bill-feature-goal mode:prose for a decomposed goal.
+
+The `skill-bill goal` CLI refuses the same way whenever the resolved runtime agent is opencode (invoked agent or `--agent-override`), so this skill gate and the CLI agree.
+
 Both modes share the same intake, decomposition-readiness checks, and the single
 confirmation gate defined in `## Decomposition Proposal`. They differ only in how
 confirmed subtasks are executed: `mode:runtime` hands off to the foreground

--- a/skills/bill-feature-task-runtime/content.md
+++ b/skills/bill-feature-task-runtime/content.md
@@ -35,6 +35,19 @@ either one. The runtime sources the run-invariants (spec reference, acceptance
 criteria, mandates and overrides) directly from the spec at launch — this skill
 does not parse or restate them.
 
+**opencode is prose-only; refuse before launch.** This skill can be invoked
+directly (bypassing the `bill-feature-task` router), so it must refuse on its own
+when the agent currently executing it is opencode: stop before the Single
+Confirmation Gate and the foreground launch and emit the actionable refusal
+pointing to `bill-feature-task-prose`:
+
+> Runtime mode is not supported on opencode: its foreground Bash tool is hard-killed at 120s before a phase can finish, and per-phase output cannot be harvested back. Use prose instead — run bill-feature-task-prose for a single feature task, or bill-feature-goal mode:prose for a decomposed goal.
+
+Do not launch `skill-bill feature-task` on opencode — the runtime CLI refuses the
+same way whenever the resolved runtime agent is opencode, and runtime mode is
+non-viable there (the 120s foreground kill and the un-harvestable PTY output).
+For a prose run instead, use `bill-feature-task-prose`.
+
 ## Single Confirmation Gate
 
 Present one concise confirmation that includes:

--- a/skills/bill-feature-task/content.md
+++ b/skills/bill-feature-task/content.md
@@ -21,12 +21,18 @@ Gather enough to identify and confirm the run:
 - the issue key
 - the governed spec path the run implements
 - the agent currently executing this skill
-- the mode (from args as `mode:runtime` or `mode:prose`; default to `runtime` when absent)
+- the mode (from args as `mode:runtime` or `mode:prose`; default to `runtime` when absent — except on opencode, where prose is the implicit default; see the opencode rule below)
 - the parallel review agent (from args as `parallel-review:<agent>`; absent when not provided)
 
 If the issue key is missing, stop and ask for it. If the spec path is missing, search `.feature-specs` for exactly one governed `.feature-specs/{ISSUE_KEY}-*/spec.md` match and use it. If there is no match or more than one match, stop and ask for the explicit spec path. Do not invent either value.
 
 Parse the mode and `parallel-review:<agent>` from args before presenting the confirmation gate. If no mode arg is provided, resolve the mode to `runtime`.
+
+**opencode is prose-only.** When the agent currently executing this skill is opencode, prose is the implicit default and runtime mode is unsupported: its foreground Bash tool is hard-killed at 120s before a phase can finish, and per-phase output cannot be harvested back. So on opencode: with no mode arg, resolve to `prose` (no need to pass `mode:prose`); with an explicit `mode:runtime`, stop and emit the actionable refusal and do NOT delegate to `bill-feature-task-runtime`:
+
+> Runtime mode is not supported on opencode: its foreground Bash tool is hard-killed at 120s before a phase can finish, and per-phase output cannot be harvested back. Use prose instead — run bill-feature-task-prose for a single feature task, or bill-feature-goal mode:prose for a decomposed goal.
+
+This skill gate and the runtime CLI agree: the CLI refuses the same way whenever the resolved runtime agent is opencode by any route.
 
 ## Single Confirmation Gate
 
@@ -45,7 +51,7 @@ Do not launch any downstream skill while the run is unconfirmed. If the user dec
 
 After confirmation, invoke the delegated skill via the Skill tool — do not search the filesystem to locate skill files; the Skill tool resolves skills by name.
 
-When mode is `runtime` or unspecified:
+When mode is `runtime` or unspecified (on opencode the mode resolves to `prose`, or an explicit `mode:runtime` already refused per the opencode rule above, so this runtime branch is never taken on opencode):
 
 - Invoke `bill-feature-task-runtime` via the Skill tool.
 - Forward `--agent`, `--agent-override`, `--phase-agent`, and `parallel-review:<agent>` identically from the args received by this router.

--- a/skills/bill-feature-verify/content.md
+++ b/skills/bill-feature-verify/content.md
@@ -7,6 +7,8 @@ description: Verify a PR against a task spec — extract acceptance criteria, de
 
 This file is the author-owned execution body for `bill-feature-verify`. It carries the workflow-state contract, continuation contract, stable step ids, stable artifact names, telemetry ownership rules, and the per-step orchestration prose.
 
+**Agent-agnostic; opencode-safe.** `bill-feature-verify` has no runtime-vs-prose mode: it runs entirely in-session as an orchestrator (Skill-tool-driven code review, unit-test checks, completeness audit) with no foreground `skill-bill` runtime driver and no per-phase agent subprocess. It therefore runs identically on opencode, Claude Code, codex, junie, or glm — the opencode runtime refusal that applies to `bill-feature-task` / `bill-feature-goal` does not apply here because there is no runtime launch to refuse.
+
 ## Workflow State
 
 `bill-feature-verify` adopts the workflow contract as a durable top-level workflow. In addition to the existing telemetry tools, the orchestrator must persist workflow state with:


### PR DESCRIPTION
## Summary

Makes **opencode a prose-only agent**. On opencode, prose is the implicit default (no `mode:prose` needed), and an explicit `mode:runtime` — or any runtime invocation whose agent resolves to opencode — **fails fast with an actionable message** instead of wedging.

A real run (NEWS-141, `wftr-20260626-193556-a4lk`) proved opencode runtime is non-viable for two independent reasons:
- **120s harness kill** — the synchronous foreground driver is guillotined mid-phase (preplan alone took ~241s).
- **Un-harvestable per-phase output** — opencode's `usePtyStdio=true` + TUI output means the contract JSON can't be parsed back out of the ANSI stream, so the phase stays `running` and the loop wedges.

These aren't worth fixing: opencode is the highest-churn, lowest-usage runtime target, and prose runs the identical governed loop in-session without either problem. The decision is to **refuse loudly toward prose**.

## Changes

- Shared, case-insensitive `isOpencodeAgent` + `OPENCODE_RUNTIME_REFUSAL_MESSAGE` source.
- feature-task **and** goal runtime CLIs refuse before opening a workflow, resolving a branch, or spawning a phase — covering every agent-resolution route: host detection, `SKILL_BILL_AGENT`, `--agent`, `--phase-agent`, `--agent-override`, `--parallel-review-agent`.
- `OpencodeAgentRunCommandBuilder` removed and unregistered from the headless adapters, so `FileSystemAgentRunLauncher` yields `UnsupportedAgentRunLaunch` for opencode at the source — no code path can spawn it for a runtime phase even if a guard is bypassed.
- Skills (`bill-feature-task`, `bill-feature-task-runtime`, `bill-feature-goal`): opencode resolves to prose implicitly and refuses an explicit `mode:runtime`.
- Decision + rationale recorded in `runtime-kotlin/agent/decisions.md`.

## Unchanged
- opencode prose, install/scaffold, MCP registration, telemetry.
- Runtime support for claude, codex, junie, glm.

## Validation
- `./gradlew check` green (incl. agent-config validation of the skill edits).
- Tests: opencode-runtime-acceptance assertions converted to fast-refusal assertions; new coverage for opencode-host detection and each `--agent`/`--phase-agent`/override/parallel-review route; opencode prose/install tests stay green.

Spec: `.feature-specs/SKILL-95-opencode-prose-only/spec.md`