### PR TITLE
ci: run main CI on self-hosted Mac mini, keep releases on GitHub

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -7,8 +7,12 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Self-hosted Mac mini for trusted runs (push, same-repo PRs); fork PRs fall
+    # back to a GitHub-hosted runner so untrusted code never executes on the
+    # self-hosted host (this is a public repo). Running under macOS bash 3.2 also
+    # makes this the ideal regression environment for the curl-piped installer.
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted","macmini"]') }}
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository

--- a/.github/workflows/validate-agent-configs.yml
+++ b/.github/workflows/validate-agent-configs.yml
@@ -5,11 +5,33 @@ on:
   push:
 
 jobs:
+  # Compute the runner matrix. Trusted events (push, same-repo PRs) validate on
+  # BOTH hosted ubuntu (full Linux coverage) and the self-hosted Apple Silicon Mac
+  # mini (macOS-native coverage). Fork PRs from a public repo run on ubuntu ONLY,
+  # so untrusted code never executes on the self-hosted host even if a maintainer
+  # approves the run. A static matrix cannot drop a leg conditionally, hence this
+  # setup job.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{ steps.pick.outputs.runners }}
+    steps:
+      - id: pick
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo 'runners=[["ubuntu-latest"]]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runners=[["ubuntu-latest"],["self-hosted","macmini"]]' >> "$GITHUB_OUTPUT"
+          fi
+
   validate:
-    # Self-hosted Mac mini for trusted runs (push, same-repo PRs); fork PRs fall
-    # back to a GitHub-hosted runner so untrusted code never executes on the
-    # self-hosted host (this is a public repo).
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted","macmini"]') }}
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(needs.setup.outputs.runners) }}
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/validate-agent-configs.yml
+++ b/.github/workflows/validate-agent-configs.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    # Self-hosted Mac mini for trusted runs (push, same-repo PRs); fork PRs fall
+    # back to a GitHub-hosted runner so untrusted code never executes on the
+    # self-hosted host (this is a public repo).
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && fromJSON('["ubuntu-latest"]') || fromJSON('["self-hosted","macmini"]') }}
 
     steps:
       - name: Check out repository
@@ -16,6 +19,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      # Pin JDK 17 explicitly: the self-hosted host's default java is newer, and
+      # the project targets 17. setup-java provisions it into the runner tool cache.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
 
       - name: Run Kotlin runtime checks
         run: (cd runtime-kotlin && ./gradlew check)

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -9,6 +9,20 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class InstallerShellDelegationTest {
+  // This suite drives install.sh end-to-end and asserts the Linux installer flow
+  // (headless $DISPLAY/$WAYLAND_DISPLAY desktop gating, no-desktop prebuilt/from-source
+  // paths, .deb extraction, the util-linux `script` PTY harness). macOS/Windows
+  // install.sh legitimately diverges (desktop defaults to yes, BSD `script`), so the
+  // suite runs on the Linux CI leg and skips elsewhere; macOS install behavior is
+  // covered by scripts/install_smoke_test.sh.
+  @org.junit.jupiter.api.BeforeEach
+  fun assumeLinuxHost() {
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+      System.getProperty("os.name").lowercase().startsWith("linux"),
+      "installer-shell suite assumes Linux host behavior; skipping on ${System.getProperty("os.name")}",
+    )
+  }
+
   private val runtimeRoot: Path =
     Path.of("").toAbsolutePath().normalize().let { workingDir ->
       if (workingDir.fileName.toString().startsWith("runtime-")) {
@@ -255,7 +269,6 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `prebuilt default installs runtime from staged release without gradle`() {
-    assumeLinuxHost()
     val run = runPrebuiltInstaller(releaseValid = true)
 
     assertEquals(0, run.exitCode, run.output)
@@ -293,7 +306,6 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `from-source keeps gradle skip-build install behavior`() {
-    assumeLinuxHost()
     // --from-source with the SKILL_BILL_SKIP_RUNTIME_DISTRIBUTION_BUILD escape hatch
     // must still route through the durable copy path, never the prebuilt fetch.
     val run = runInstallerShell(input = "1\ncopilot\nbase only\noff\nskip\n", fromSource = true)
@@ -304,7 +316,6 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `prebuilt auto-falls back to source when host token has no matching asset`() {
-    assumeLinuxHost()
     // A staged release dir with NO assets for this host forces the explicit
     // auto-fallback message and the source build path.
     val run = runPrebuiltInstaller(releaseValid = true, options = PrebuiltOptions(omitRuntimeAssets = true))
@@ -315,7 +326,6 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `display gating defaults headless to no and explicit flag forces install`() {
-    assumeLinuxHost()
     // Headless (no DISPLAY/WAYLAND_DISPLAY), non-interactive → desktop default no.
     val headless = runPrebuiltInstaller(releaseValid = true)
     assertEquals(0, headless.exitCode, headless.output)
@@ -329,7 +339,6 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `interactive headless empty input defaults desktop app to no`() {
-    assumeLinuxHost()
     // A TTY-attached but headless session (no DISPLAY/WAYLAND_DISPLAY): pressing
     // Enter at the desktop prompt must resolve to the gated default (skip), not the
     // old hardcoded install. Driven under a real PTY via `script`.
@@ -361,7 +370,6 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `install plan summary is printed before any mutation`() {
-    assumeLinuxHost()
     // Do NOT set SKILL_BILL_SKIP_PREINSTALL_UNINSTALL: the plan must print before
     // the pre-install uninstall mutates anything.
     val run = runPrebuiltInstaller(releaseValid = true, options = PrebuiltOptions(skipPreinstallUninstall = false))
@@ -719,17 +727,6 @@ class InstallerShellDelegationTest {
     org.junit.jupiter.api.Assumptions.assumeTrue(
       hostTokenForTests() == "linux-x64",
       "desktop-extract assertions require a linux-x64 host with ar/tar",
-    )
-  }
-
-  // These scenarios assert the Linux installer flow: headless $DISPLAY/$WAYLAND_DISPLAY
-  // desktop gating (macOS/Windows always default desktop=yes) and the no-desktop
-  // prebuilt/from-source paths. They run on the Linux CI leg and skip on other OSes,
-  // where install.sh legitimately behaves differently.
-  private fun assumeLinuxHost() {
-    org.junit.jupiter.api.Assumptions.assumeTrue(
-      System.getProperty("os.name").lowercase().startsWith("linux"),
-      "installer flow assertions assume Linux host behavior; skipping on ${System.getProperty("os.name")}",
     )
   }
 

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -255,6 +255,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `prebuilt default installs runtime from staged release without gradle`() {
+    assumeLinuxHost()
     val run = runPrebuiltInstaller(releaseValid = true)
 
     assertEquals(0, run.exitCode, run.output)
@@ -292,6 +293,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `from-source keeps gradle skip-build install behavior`() {
+    assumeLinuxHost()
     // --from-source with the SKILL_BILL_SKIP_RUNTIME_DISTRIBUTION_BUILD escape hatch
     // must still route through the durable copy path, never the prebuilt fetch.
     val run = runInstallerShell(input = "1\ncopilot\nbase only\noff\nskip\n", fromSource = true)
@@ -302,6 +304,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `prebuilt auto-falls back to source when host token has no matching asset`() {
+    assumeLinuxHost()
     // A staged release dir with NO assets for this host forces the explicit
     // auto-fallback message and the source build path.
     val run = runPrebuiltInstaller(releaseValid = true, options = PrebuiltOptions(omitRuntimeAssets = true))
@@ -312,6 +315,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `display gating defaults headless to no and explicit flag forces install`() {
+    assumeLinuxHost()
     // Headless (no DISPLAY/WAYLAND_DISPLAY), non-interactive → desktop default no.
     val headless = runPrebuiltInstaller(releaseValid = true)
     assertEquals(0, headless.exitCode, headless.output)
@@ -325,6 +329,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `interactive headless empty input defaults desktop app to no`() {
+    assumeLinuxHost()
     // A TTY-attached but headless session (no DISPLAY/WAYLAND_DISPLAY): pressing
     // Enter at the desktop prompt must resolve to the gated default (skip), not the
     // old hardcoded install. Driven under a real PTY via `script`.
@@ -356,6 +361,7 @@ class InstallerShellDelegationTest {
 
   @Test
   fun `install plan summary is printed before any mutation`() {
+    assumeLinuxHost()
     // Do NOT set SKILL_BILL_SKIP_PREINSTALL_UNINSTALL: the plan must print before
     // the pre-install uninstall mutates anything.
     val run = runPrebuiltInstaller(releaseValid = true, options = PrebuiltOptions(skipPreinstallUninstall = false))
@@ -713,6 +719,17 @@ class InstallerShellDelegationTest {
     org.junit.jupiter.api.Assumptions.assumeTrue(
       hostTokenForTests() == "linux-x64",
       "desktop-extract assertions require a linux-x64 host with ar/tar",
+    )
+  }
+
+  // These scenarios assert the Linux installer flow: headless $DISPLAY/$WAYLAND_DISPLAY
+  // desktop gating (macOS/Windows always default desktop=yes) and the no-desktop
+  // prebuilt/from-source paths. They run on the Linux CI leg and skip on other OSes,
+  // where install.sh legitimately behaves differently.
+  private fun assumeLinuxHost() {
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+      System.getProperty("os.name").lowercase().startsWith("linux"),
+      "installer flow assertions assume Linux host behavior; skipping on ${System.getProperty("os.name")}",
     )
   }
 

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellReconcileTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellReconcileTest.kt
@@ -26,6 +26,16 @@ class InstallerShellReconcileTest {
       }
     }
 
+  // The TTY-bypass accept scenario drives install.sh's desktop-install summary, which
+  // defaults differently per OS; it asserts the Linux flow, so it runs on the Linux CI
+  // leg and skips elsewhere.
+  private fun assumeLinuxHost() {
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+      System.getProperty("os.name").lowercase().startsWith("linux"),
+      "installer flow assertions assume Linux host behavior; skipping on ${System.getProperty("os.name")}",
+    )
+  }
+
   @Test
   fun `reinstall with no upstream-local change is idempotent and commits the apply`() {
     // SKILL-76 AC-9: a no-conflict reconcile report drives the runtime per-skill apply to
@@ -105,6 +115,7 @@ class InstallerShellReconcileTest {
 
   @Test
   fun `TTY-bypass accept overwrites the conflicting skill and reports it in the summary (AC-7 accept)`() {
+    assumeLinuxHost()
     // SKILL-76 AC-7 y branch: a both-changed conflict driven through the TEST-ONLY
     // SKILL_BILL_RECONCILE_CONFLICT_CHOICE=y seam must overwrite the live skill with
     // upstream, refresh the baseline, and report the overwritten conflict path in the

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperationsTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperationsTest.kt
@@ -332,12 +332,21 @@ class GitWorkflowGitOperationsTest {
   }
 
   private fun git(repoRoot: Path, vararg args: String): String {
-    // Force-disable signing so a host's global commit.gpgsign=true (common on dev
-    // machines and self-hosted CI runners) does not fail these throwaway-repo
-    // commits when gpg is unavailable in the process environment.
-    val process = ProcessBuilder(
-      listOf("git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "-C", repoRoot.toString()) + args,
-    )
+    val output = runGit(repoRoot, *args)
+    // Persist signing-off into the repo's own config right after init so that BOTH
+    // these helper commits AND the production GitWorkflow commits under test (which
+    // run their own `git commit` in this repo) skip signing. A host global
+    // commit.gpgsign=true would otherwise fail every commit when gpg is absent from
+    // the process environment (common on dev machines and self-hosted CI runners).
+    if (args.firstOrNull() == "init") {
+      runGit(repoRoot, "config", "commit.gpgsign", "false")
+      runGit(repoRoot, "config", "tag.gpgsign", "false")
+    }
+    return output
+  }
+
+  private fun runGit(repoRoot: Path, vararg args: String): String {
+    val process = ProcessBuilder(listOf("git", "-C", repoRoot.toString()) + args)
       .redirectErrorStream(true)
       .start()
     val output = process.inputStream.bufferedReader().readText().trim()

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperationsTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/GitWorkflowGitOperationsTest.kt
@@ -332,7 +332,12 @@ class GitWorkflowGitOperationsTest {
   }
 
   private fun git(repoRoot: Path, vararg args: String): String {
-    val process = ProcessBuilder(listOf("git", "-C", repoRoot.toString()) + args)
+    // Force-disable signing so a host's global commit.gpgsign=true (common on dev
+    // machines and self-hosted CI runners) does not fail these throwaway-repo
+    // commits when gpg is unavailable in the process environment.
+    val process = ProcessBuilder(
+      listOf("git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "-C", repoRoot.toString()) + args,
+    )
       .redirectErrorStream(true)
       .start()
     val output = process.inputStream.bufferedReader().readText().trim()

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -908,6 +908,14 @@ class HeadlessAgentRunAdapterTest {
 
 class PtyStdioLaunchTest {
   private fun assumePtyAvailable() {
+    // PTY-backed stdio is a Linux-only production feature (JvmAgentRunProcessRunner
+    // hard-guards `os.name startsWith "linux"`). macOS ships /dev/ptmx too, so gate
+    // on the OS — not just the device — or these tests run into that guard and the
+    // spawn fails with a null exit status on non-Linux CI hosts.
+    org.junit.jupiter.api.Assumptions.assumeTrue(
+      System.getProperty("os.name").lowercase().startsWith("linux"),
+      "PTY-backed stdio is only supported on Linux; skipping on ${System.getProperty("os.name")}",
+    )
     org.junit.jupiter.api.Assumptions.assumeTrue(
       java.io.File("/dev/ptmx").exists(),
       "PTY device /dev/ptmx not available; skipping PTY integration test",


### PR DESCRIPTION
Moves `validate-agent-configs` and `install-smoke-test` to the self-hosted Mac mini runner for trusted events (push + same-repo PRs). Fork PRs fall back to `ubuntu-latest` so untrusted public-fork code never runs on the self-hosted host. `release.yml` is untouched — Windows/Linux/macOS release builds stay on GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)