### PR TITLE
ci: build macOS releases on Apple Silicon Mac mini, drop Intel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,12 +1,10 @@
 # actionlint configuration.
 #
 # self-hosted-runner.labels registers runner labels that actionlint's bundled
-# runner-label database does not yet know about. "macos-15-intel" is a real,
-# current GitHub-HOSTED runner label (the x64 macOS 15 image that replaced the
-# retired macos-13 Intel host); see actions/runner-images. Without this entry
-# actionlint reports a false-positive "label is unknown" error for the Intel
-# build matrix leg in release.yml. This is not a self-hosted runner — the key is
-# simply actionlint's documented mechanism for teaching it valid labels.
+# runner-label database does not know about. "macmini" is the custom label of the
+# self-hosted Apple Silicon runner that builds the macos-arm64 release leg and
+# runs the main-CI workflows. Without this entry actionlint reports a
+# false-positive "label is unknown" error wherever the label is referenced.
 self-hosted-runner:
   labels:
-    - macos-15-intel
+    - macmini

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,28 +35,27 @@ jobs:
   # resolves by host (resolveHostRuntimeToken).
   build:
     name: Build ${{ matrix.host_token }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ fromJSON(matrix.runner) }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # macOS arm64 (Apple Silicon hosted runner).
-          - runner: macos-14
+          # macOS arm64 (Apple Silicon) — built natively on the self-hosted Mac
+          # mini. Apple Silicon is the only supported macOS target; the Intel
+          # (macos-x64) leg was dropped. The mini must be online when a release
+          # tag is pushed, or this leg queues until it is (fail-fast:false lets
+          # the hosted legs publish regardless). runner is a JSON array so a
+          # self-hosted label set and the hosted single-label legs share one
+          # `runs-on: ${{ fromJSON(matrix.runner) }}` expression.
+          - runner: '["self-hosted", "macmini"]'
             host_token: macos-arm64
             installer_tasks: ":runtime-desktop:canonicalRenameDmgInstaller"
-          # macOS x64 (Intel hosted runner). GitHub retired the bare macos-13
-          # Intel image; the current Intel hosted label is macos-15-intel. If
-          # GitHub later retires the -intel images too, drop this leg (fail-fast is
-          # off, so the other hosts still publish) and note the gap in the release.
-          - runner: macos-15-intel
-            host_token: macos-x64
-            installer_tasks: ":runtime-desktop:canonicalRenameDmgInstaller"
           # Windows x64.
-          - runner: windows-latest
+          - runner: '["windows-latest"]'
             host_token: windows-x64
             installer_tasks: ":runtime-desktop:canonicalRenameMsiInstaller"
           # Linux x64 (produces both .deb and .rpm).
-          - runner: ubuntu-latest
+          - runner: '["ubuntu-latest"]'
             host_token: linux-x64
             installer_tasks: >-
               :runtime-desktop:canonicalRenameDebInstaller

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,21 +21,23 @@ archive plus its `.sha256` sidecar to the GitHub Release for that tag:
 - desktop installers (`SkillBill-<version>-<os>-<arch>.<ext>`):
   `.dmg` on macOS, `.msi` on Windows, `.deb` + `.rpm` on Linux
 
-The `<os>-<arch>` token is the canonical set `macos-arm64` / `macos-x64` /
-`windows-x64` / `linux-x64`, so downstream installers can resolve the correct
-asset by host. Each artifact ships with a matching `<name>.sha256` file. The
-build toolchain is pinned to JDK 17 (temurin) on every runner.
+The `<os>-<arch>` token is the canonical set `macos-arm64` / `windows-x64` /
+`linux-x64`, so downstream installers can resolve the correct asset by host. Each
+artifact ships with a matching `<name>.sha256` file. The build toolchain is
+pinned to JDK 17 (temurin) on every runner.
 
 Builds run on host-matched runners because jlink and jpackage cannot
-cross-compile: macOS arm64 on `macos-14`, macOS x64 on `macos-15-intel` (the
-current Intel hosted image), Windows x64 on `windows-latest`, Linux x64 on
-`ubuntu-latest`. Installers ship **unsigned for v1** (see
+cross-compile: macOS arm64 on the **self-hosted Apple Silicon Mac mini**
+(label `macmini`), Windows x64 on `windows-latest`, Linux x64 on `ubuntu-latest`.
+Apple Silicon is the only supported macOS target — the Intel (`macos-x64`) leg
+was dropped. Installers ship **unsigned for v1** (see
 `runtime-kotlin/agent/decisions.md`).
 
-> **macOS x64 note.** If the Intel-based hosted runner (`macos-15-intel`) becomes
-> unavailable, drop that matrix leg; the workflow's `fail-fast: false` strategy
-> lets the remaining hosts still publish, and the macOS x64 asset is simply
-> absent for that release rather than silently mislabeled.
+> **Self-hosted macOS leg.** The `macos-arm64` build runs on the self-hosted Mac
+> mini, so it must be online when a release tag is pushed. If it is offline that
+> leg queues until it comes back; the workflow's `fail-fast: false` strategy lets
+> the hosted Windows/Linux legs publish regardless, with the macOS asset filled
+> in once the mini runs.
 
 ## Staging a release for downstream testing
 


### PR DESCRIPTION
Apple Silicon is now the only supported macOS release target.

- `macos-arm64` build leg moves from hosted `macos-14` → self-hosted Mac mini (`macmini`), built natively.
- Intel `macos-x64` leg removed entirely.
- Windows/Linux release legs unchanged (GitHub-hosted).
- `matrix.runner` is now a JSON array consumed via `fromJSON` so self-hosted + hosted legs share one `runs-on`.
- `actionlint.yaml` registers `macmini`; RELEASING.md updated.

**Caveat:** the mini must be online when a release tag is pushed, or the macOS leg queues (others still publish via `fail-fast: false`).

**Follow-up (separate, via /bill-feature):** drop `macos-x64` from the installer `host_token` and `RuntimeTargets.kt` so Intel hosts get a clean unsupported-host path instead of fetching a missing asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)