### PR TITLE
SKILL-98: ios-platform-pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 docs/cloudflare-telemetry-proxy/.wrangler/
 _migration_backup/
 /.skill-bill/
+
+# SKILL-98 specs describe a private external app — keep local, not public
+.feature-specs/SKILL-98-ios-platform-pack/

--- a/platform-packs/ios/addons/offline-background-reliability.md
+++ b/platform-packs/ios/addons/offline-background-reliability.md
@@ -1,0 +1,25 @@
+# Background Sync Reliability
+
+Cues: background-sync engine, sync queue, retry/backoff, sync-vs-migration interplay, lifecycle-driven sync triggers, interceptor/chain composition.
+
+## Migration-vs-sync ordering
+
+A schema migration that adds a column a sync path immediately reads, or a sync that runs before a migration completes, produces missing-column errors or empty results on the first launch after update.
+
+- Confirm a newly-added column is available to every read/write site before sync consumes it, and that migrations run to completion before the first sync that depends on them.
+- Migrations must stay frozen and additive: reference **frozen string literals** for table/column names, never a live model symbol whose value can change later and retroactively alter an already-shipped migration. When a table has been renamed, the migration must handle the legacy name (an `alterRenamedTable`-style helper), not assume the current name exists on un-migrated devices.
+
+## Retries, backoff, and cancellation
+
+- A long-running or repeatable sync effect must carry an effect-identity (`cancellableId`) so a superseding trigger cancels the in-flight one; otherwise overlapping syncs race and a slower older run can overwrite newer results.
+- Check that a removed `.retry`/backoff wasn't silently dropped in a refactor — trace whether it moved into the new request path or vanished.
+- Errors on a background path must be observable (logged/metered), not swallowed. A `do { … }` block with no `catch` propagates (fine); an empty `catch {}` or `.catch { _ in Empty() }` hides failures — flag the latter.
+
+## Lifecycle-driven triggers
+
+- Sync/refresh sent unconditionally on every view appearance re-fires on modal present/dismiss and foreground/background cycles. Confirm it is idempotent or guarded, and that a same-key guard actually disambiguates two concurrent runs (comparing the same id-set does not).
+- Sync that only triggers from one screen's lifecycle silently stops for flows that never open that screen — verify the trigger lives at the right level.
+
+## Per-item work inside the sync loop
+
+Moving a single end-of-sync maintenance pass into per-item processing multiplies DB/network round-trips by N. Flag per-item trims/queries/fetches that a single batched pass previously handled, unless the batching is preserved.

--- a/platform-packs/ios/addons/offline-conflict-resolution.md
+++ b/platform-packs/ios/addons/offline-conflict-resolution.md
@@ -1,0 +1,28 @@
+# Offline Write Reconciliation & Optimistic UI
+
+Cues: last-write-wins, versioned/merge records, optimistic local updates, `isDeleted`/status flags flipped before an async write, save-on-navigation.
+
+## Premature local state flip before the async write confirms
+
+Setting a success/deleted/completed flag synchronously, before the effect that performs the write completes, corrupts state when the write later fails.
+
+- Flag `state.isDeleted = true` / `state.saved = true` set in the reducer ahead of the delete/save effect's completion. On failure the UI shows the item gone or saved while the store still holds it (or vice versa). Drive the flag from the effect's success, not its dispatch.
+
+## Optimistic update with no rollback path
+
+An optimistic local mutation applied before the server confirms must have a defined revert if the write fails.
+
+- If the diff applies a local change and fires a fire-and-forget write whose failure is swallowed (`.catch { _ in Empty() }`, no error surfaced, no rollback), a failed sync leaves local state diverged from the server with no user-visible signal. Flag the swallow; require the error to either surface or roll back.
+
+## Save/sync on navigation without a dirty check
+
+Auto-saving on back/disappear whenever the record "validates," with no comparison against the initial value, schedules a redundant write and sync job for unchanged records.
+
+- Flag `willDisappear`/back handlers that unconditionally `saveChanges` in view mode. Require a `state.initialItem != state.item`-style dirty check so open-and-back on an unedited record is a no-op.
+
+## Write-semantics changes on a synced table
+
+Changing how a sync-participating table is written (last-write-wins vs versioned, which fields are authoritative, whether a field is backfilled) can desync clients that haven't migrated.
+
+- When a new persisted field is added by migration but no deep sync / backfill is triggered, pre-existing rows stay `NULL` until each is independently re-fetched — flag the missing backfill story, or confirm the field is nullable-and-tolerated by all readers.
+- A deleted item re-saved during pop/navigation (delete effect maps to a "back" action that then re-persists) resurrects it — check delete-then-navigate ordering.

--- a/platform-packs/ios/addons/offline-first-review.md
+++ b/platform-packs/ios/addons/offline-first-review.md
@@ -1,0 +1,32 @@
+# iOS Offline-First Review Add-On
+
+Use this governed add-on only after stack routing has already selected `ios` and the review scope touches an offline-first surface — a local store (GRDB/SQLite, Core Data, Realm) plus a sync layer that reconciles local and remote state.
+
+This file is a review index for `bill-ios-code-review` and its `persistence`/`reliability`/`platform-correctness` specialists. It is not a standalone review command. The guidance is generic to offline-first iOS apps; it encodes recurring failure modes, not any single project's internals.
+
+## Activation signals
+
+Activate `offline-first` when the diff shows any of:
+
+- a local persistent store (GRDB/SQLite statements or migrations, Core Data, Realm) **and** a network/sync path that writes into or reads around it
+- a cache-trim/eviction, prefetch, or "download for offline" flow
+- a background-sync engine, sync queue, or interceptor/chain-of-responsibility sync composition
+- conflict handling: last-write-wins, versioned records, merge functions, optimistic UI with rollback
+
+If the diff only touches UI or pure in-memory state with no local store or sync, do **not** activate this add-on.
+
+## Section index
+
+Scan this file first. Then open only the linked topic files whose cues match the diff instead of loading all offline-first guidance by default.
+
+- `[offline-sync-consistency.md](offline-sync-consistency.md)`
+  Read when the diff touches cache trimming/eviction, prefetch/download-for-offline, the ordering of delete-vs-download, or a query whose join/filter can hide un-synced rows.
+- `[offline-conflict-resolution.md](offline-conflict-resolution.md)`
+  Read when the diff touches write reconciliation: last-write-wins, versioned/merge records, optimistic UI updates, or premature local state flips before an async write confirms.
+- `[offline-background-reliability.md](offline-background-reliability.md)`
+  Read when the diff touches background sync, retries/backoff, sync-vs-migration interplay, or lifecycle-driven sync triggers.
+
+## How to use it
+
+- Treat findings from this add-on as `persistence`/`reliability`/`platform-correctness` findings — fold them into those specialists' registers, do not create a parallel lane.
+- Every finding must name a concrete, reachable failure (data a user loses, a row that disappears, a write that silently drops). Offline-first bugs are high-severity precisely because they surface only on a device that is offline, mid-sync, or freshly installed — states a quick manual test misses. Describe that state explicitly.

--- a/platform-packs/ios/addons/offline-sync-consistency.md
+++ b/platform-packs/ios/addons/offline-sync-consistency.md
@@ -1,0 +1,29 @@
+# Offline Sync & Cache Consistency
+
+Cues: cache trim/eviction, prefetch or "download for offline", delete-then-refetch flows, queries that join or filter on sync state.
+
+## Delete-before-download loses the only offline copy
+
+When a flow clears or trims a cached artifact **before** its replacement has been confirmed downloaded, an offline or failed fetch leaves the user with neither the old nor the new copy.
+
+- Flag any `clear`/`trim`/`evict` that runs ahead of the `fetch`/`download` whose result is meant to replace it. The safe order is fetch-then-swap: only delete the old artifact once the new one is durably stored.
+- A "keep latest version" rule that selects by version number **without checking the item is actually cached** can purge the one copy present on-device. Keep-selection for eviction must be cache-aware.
+
+## Cache-only reads that dropped a fetch fallback
+
+A read path refactored from "return cached, else fetch-and-cache" to "return cached, else fail" silently breaks first-view / cache-miss / post-eviction cases.
+
+- On any load path, check the `-` side of the diff: did a `fetchIfMissing`/`returnCacheDataElseFetch` fallback get replaced by a cache-only read that errors on `nil`? That plan/image/document then never loads on a fresh install or after eviction.
+
+## Queries that hide un-synced rows
+
+A local query that `INNER JOIN`s (or filters) on a related row that is populated only by sync will silently omit entities whose related rows haven't synced yet.
+
+- Flag a join changed from outer/`LEFT` to `INNER` (or a new `WHERE` on a sync-populated column) on a list/enumeration/lookup query: mid-sync or on a fresh install the entity disappears from lists, is skipped by offline-caching enumeration, and resolves `nil` in detail/relationship lookups.
+
+## Trim/eviction driven by the wrong lifecycle
+
+Cache maintenance wired to a screen's lifecycle (view appear/disappear, a specific store instance) instead of the sync pipeline runs too often, not at all, or concurrently with the sync it should follow.
+
+- Watch for eviction moved into a per-screen store: multiple live instances each subscribe and trim (duplicate work), and flows that never open that screen never trim (unbounded growth).
+- Eviction that runs on every `syncCompleted` emission — including `.offline`/`.errored`/replayed initial values — trims after failed or non-events. Gate it on a genuine successful completion.

--- a/platform-packs/ios/agent/history.md
+++ b/platform-packs/ios/agent/history.md
@@ -1,0 +1,49 @@
+## [2026-07-01] ios-platform-pack (dry-run-validation)
+Areas: platform-packs/ios/code-review
+- Read-only dry-run of `bill-ios-code-review` vs two real stuck iOS-app PRs:
+  routing matched changed-file signals; 32 findings accurate/non-noisy
+  (incl. a genuine Blocker); zero GitHub posting.
+- Reusable acquisition trick: shallow clone at PR head loads repo-local
+  `AGENTS.md`/`CLAUDE.md` + `references/*.md`, so repo-local-knowledge
+  specialists read real project rules (no `gh pr diff` fallback needed).
+- Known gaps (report-only, NOT fixed): iOS specialists in
+  `native-agents/agents.yaml` are unregistered in `~/.claude/agents`, so the
+  documented Agent-tool spawn path can't resolve on Claude (validated rubric
+  + routing, not installed spawn wiring); overlap needs merge-layer dedup;
+  installed skill dir lacks sidecar ceremony files.
+Feature flag: N/A
+Acceptance criteria: 1/1 implemented
+
+## [2026-07-01] ios-platform-pack (revise-validate-install)
+Areas: platform-packs/ios/code-review
+- Frequency-weighted revision of 5 specialist rubrics from mined patterns:
+  reliability +6, architecture +5, testing +3, platform-correctness +3
+  (sharpened, breadth kept), performance -3. Trimming rule: never empty a
+  declared area — keep frontmatter/Focus/Ignore/Applicability + >=1
+  Project-Specific rule so `show` stays `complete`.
+- Reusable: add depth as generalized house-voice bullets only (no verbatim
+  mined PR text, no proprietary internals) so the public tree stays free of
+  proprietary content.
+- Router + 5 low-signal specialists unchanged; routing verified via synthetic
+  diffs (background-sync-engine paths -> reliability, *.graphql -> api-contracts).
+- `validate-agent-configs` pass/[] across all 11 + render clean; `./install.sh`
+  blocked only by goal-continuation guard (install.sh:67) — run post-goal.
+Feature flag: N/A
+Acceptance criteria: 4/4 implemented
+
+## [2026-07-01] ios-platform-pack (pack-foundation)
+Areas: platform-packs/ios, platform-packs/ios/code-review
+- Added `ios` platform pack: `platform.yaml` routing signals (`.xcodeproj`,
+  `.xcworkspace`, `import SwiftUI`, `import UIKit`, `iOSApplicationExtension`)
+  with no overlap vs KMP's iosMain/androidMain/commonMain signals.
+- Added `bill-ios-code-review` router + 10 area specialists (architecture,
+  performance, platform-correctness, security, testing, api-contracts,
+  persistence, reliability, ui, ux-accessibility) mirroring the PHP pack's
+  router/specialist shape and min-2/max-10 bounds pattern.
+- Reusable: `architecture`/`persistence`/`platform-correctness`/`reliability`
+  specialists each add a "Repo-Local Knowledge" section pointing the reviewer
+  at the target repo's own `.agents/skills/*/references/*.md` and root
+  `AGENTS.md`/`CLAUDE.md` — keeps proprietary knowledge out of
+  skill-bill's public repo while still informing review.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented

--- a/platform-packs/ios/code-review/bill-ios-code-review-api-contracts/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-api-contracts/content.md
@@ -1,0 +1,34 @@
+---
+name: bill-ios-code-review-api-contracts
+description: Use when reviewing iOS GraphQL/Apollo API-contract risks including generated code drift, cache/field-policy correctness, and schema/codegen alignment.
+---
+
+# API Contracts Review Specialist
+
+Review only high-signal API-contract issues.
+
+## Focus
+
+- Generated GraphQL client code staying in sync with schema/operation changes
+- Apollo cache and field-policy correctness
+- `.graphql` operation changes that alter response shape or nullability
+- Codegen regeneration discipline
+
+## Ignore
+
+- Non-networking code with no GraphQL/Apollo surface
+- Cosmetic differences in generated code that codegen would reproduce identically
+
+## Applicability
+
+Use this specialist for the GraphQL/Apollo-consuming client surface: `.graphql` operation/fragment files, the generated API client code, and Apollo cache configuration. This is a client consuming a GraphQL API, so the contract risk is codegen and cache correctness, not server-side request validation.
+
+## Project-Specific Rules
+
+- Never hand-edit generated API client code (e.g. a generated `API.swift`); any change to server contract behavior must originate from a `.graphql` operation/schema change followed by codegen regeneration
+- Every `.graphql` operation or fragment change must be accompanied by regenerated client code in the same diff; a schema/operation change without a matching codegen diff is a contract-drift risk
+- Cache and field policies (type policies, merge functions, cache key resolution) must be reviewed whenever a `.graphql` change alters an identifying field, a list field's merge behavior, or a type's cache key
+- Nullability changes in `.graphql` operations must be checked against all call sites that unwrap the generated response type; a field going from non-null to nullable (or vice versa) is a breaking client-side change even though the client compiles
+- Query/mutation naming and fragment reuse should stay consistent with existing operations touching the same types, to avoid duplicate or conflicting cache entries for the same underlying object
+- Optimistic responses and cache writes for mutations must match the shape codegen will regenerate; hand-shaped optimistic payloads that drift from the real response type are a correctness risk
+- For Major or Critical findings, describe the concrete stale-cache, crash-on-unwrap, or data-integrity consequence

--- a/platform-packs/ios/code-review/bill-ios-code-review-architecture/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-architecture/content.md
@@ -1,0 +1,46 @@
+---
+name: bill-ios-code-review-architecture
+description: Use when reviewing iOS architecture, dependency-injection scopes, composition-root wiring, and SPM package-boundary respect.
+---
+
+# Architecture Review Specialist
+
+Review only high-signal architectural issues.
+
+## Focus
+
+- Dependency-injection scope and lifetime correctness
+- Composition-root wiring and registration hygiene
+- Local Swift Package Manager package-boundary respect
+- Module ownership and source-of-truth consistency
+- Cross-module coupling introduced by new dependencies
+
+## Ignore
+
+- Formatting, style, and framework-idiom differences without architectural impact
+- Naming or pattern preferences without concrete risk
+
+## Applicability
+
+Use this specialist across app targets and local SPM packages when changed code can affect dependency wiring, module boundaries, or architectural consistency. First infer the architecture established in the changed area and adjacent modules; treat coherent local architecture as the contract for consistency. Where the local architecture is absent, weak, inconsistent, or accidental, guide changes toward established iOS/Swift practices through concrete risk-based findings, not terminology preference.
+
+## Project-Specific Rules
+
+- Dependency injection should use the project's established DI container rather than ad-hoc singletons, global statics, or hidden service locators
+- Respect the container's declared scopes (for example: singleton/app-lifetime, per-flow/session-scoped, and transient/per-use scopes); a dependency registered at one scope must not be resolved or cached in a way that outlives or leaks across that scope
+- New dependencies must be registered through the project's composition-root registration surface (e.g. a `DependencyContainer+Registrations.swift`-style extension), not constructed inline at call sites
+- Never bypass the DI container to reach a concrete implementation directly when a declared protocol/provider exists for that dependency
+- Local SPM packages must only be consumed through their declared public API; reaching into another package's internal types, or importing implementation details across a package boundary, is an architecture violation
+- A new local SPM package or new cross-package dependency must have a clear, documented reason it does not already fit an existing package boundary
+- New cross-boundary consumers should depend on a `Provider`-style protocol rather than a concrete type, so the composition root remains the single place that wires concrete implementations to their consumers
+- Business workflows and invariants should stay independent of transport, rendering, and persistence details when complexity warrants that separation or the project architecture already requires it
+- Dead or unused code (parameters, variables, functions, properties, imports, whole files) left behind after a refactor should be removed rather than committed as noise that hides an incomplete refactor
+- Duplicated or competing logic (retry wrappers, validation, effects, business rules) copy-pasted across layers or stores invites divergent behavior; extract it into a shared helper rather than maintaining parallel copies
+- State mutated directly inside a Combine operator (`sink`/`map`/`flatMap`) or otherwise outside the reducer breaks unidirectional flow; state changes should be routed through the store's send/reduce path
+- UI-adjacent or utility code placed in the wrong module/package layer (UI leaking into a core/light package, or code pushed too low-level) breaks the intended dependency direction and grows the build graph unnecessarily
+- Legacy Combine/callback-based store patterns (cancellables held in state, delay chains) used in place of the current Effect-driven architecture mix thread-safety concerns into the store and should migrate to the established pattern
+- Report architecture issues only when the change creates or worsens concrete risk: maintainability loss, duplicated ownership, unclear scope lifetime, testability loss, or coupling that makes the package graph harder to reason about
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. an explicitly frozen composition-root convention or DI-scope rule) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-performance/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-performance/content.md
@@ -1,0 +1,31 @@
+---
+name: bill-ios-code-review-performance
+description: Use when reviewing iOS performance risks on hot reducer paths, main-thread work, and image/PDF-heavy processing.
+---
+
+# Performance Review Specialist
+
+Review only performance issues with real, demonstrable production impact.
+
+## Focus
+
+- Hot reducer/store paths that run on every state update
+- Main-thread work that can cause dropped frames or UI stalls
+- Image, PDF, and media-processing hot paths
+- Large sync/import loops with unbounded or repeated work
+
+## Ignore
+
+- Micro-optimizations with no measurable or plausible production impact
+- Premature optimization of cold paths
+
+## Applicability
+
+Use this specialist for reducer/store code that runs on frequent state updates, any code executing on the main thread that affects UI responsiveness, and image/PDF/media-processing code paths (for example, gallery, editor, or camera-adjacent features).
+
+## Project-Specific Rules
+
+- Reducer logic invoked on every action dispatch must avoid expensive synchronous work (large collection copies, repeated filtering/sorting, synchronous I/O); move expensive computation into an effect off the hot reducer path
+- Image and PDF decoding, downscaling, and rendering must not run synchronously on the main thread for anything larger than trivial thumbnail-sized content
+- Large sync/import loops must avoid O(n²) patterns (e.g. repeated linear scans per item) when a single pass or indexed lookup is available
+- For Major or Critical findings, describe the concrete user-visible stall, dropped-frame, or memory-pressure consequence

--- a/platform-packs/ios/code-review/bill-ios-code-review-persistence/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-persistence/content.md
@@ -1,0 +1,39 @@
+---
+name: bill-ios-code-review-persistence
+description: Use when reviewing iOS GRDB/SQLite persistence risks including migration safety, schema changes, and offline-sync data consistency.
+---
+
+# Persistence Review Specialist
+
+Review only persistence issues that can corrupt data, break consistency, or create high-risk operational regressions.
+
+## Focus
+
+- Migration safety and forward compatibility
+- Schema-change discipline for local SQLite/GRDB storage
+- 1:1 coverage between SQL statements and their statement tests
+- Blast radius of changes touching deep/offline sync
+
+## Ignore
+
+- Harmless query-style preferences
+- Micro-optimizations with no correctness or sync-consistency impact
+
+## Applicability
+
+Use this specialist for the local persistence layer: GRDB (or equivalent SQLite wrapper) migrations, schema definitions, statement-level SQL, and code paths that participate in offline-first sync of persisted data.
+
+## Project-Specific Rules
+
+- A migration that has already shipped is frozen: never edit an already-applied migration's body to add or change behavior, even to fix a bug — ship a new, additive migration instead
+- Migrations are additive-only; do not drop columns/tables or narrow types in a way that breaks a device that has not yet migrated forward, unless the project has an explicit deprecation/backfill path for that
+- Any schema change (new table, new column, index change, constraint change) must ship with a corresponding migration in the same diff — schema drift between code and the applied migration history is a correctness risk
+- Statement tests (e.g. a `{Statement}SQLStatementTests.swift`-style 1:1 test) are a recommended convention, not a universal hard rule — confirm the repo actually applies it broadly before treating its absence as a violation (in practice only a subset of statements carry one). A new or changed hand-written SQL statement without a matching test is a real but at-most-Minor coverage gap; reserve higher severity for a statement whose correctness is genuinely load-bearing (migration-affecting, sync-driving, or complex enough that a silent regression would corrupt or drop data)
+- A SQL statement assembled by regex/string substitution against another statement's raw text (e.g. stripping a join by pattern-matching the `.sql` file) is fragile: its correctness is coupled to the exact formatting of the source SQL. Flag it, and note that a test which only asserts substring presence/absence does not prove the produced statement is valid runnable SQL
+- Changes that touch deep/offline sync of persisted data must be evaluated for blast radius: what happens to already-synced records, in-flight sync operations, and conflict resolution when this change ships to a device mid-sync
+- Reads and writes that participate in sync must preserve whatever consistency guarantee the existing sync design relies on (e.g. last-write-wins, versioned records, or conflict markers) — do not silently change write semantics for a table that sync depends on
+- For Major or Critical findings, explain the data-loss, migration-failure, or sync-inconsistency consequence explicitly
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. an explicitly frozen-migration rule or a documented sync-consistency invariant) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-platform-correctness/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-platform-correctness/content.md
@@ -1,0 +1,43 @@
+---
+name: bill-ios-code-review-platform-correctness
+description: Use when reviewing iOS unidirectional-data-flow correctness, main-thread discipline, Combine effect lifecycles, and reducer purity.
+---
+
+# Platform Correctness Review Specialist
+
+Review only high-signal platform-correctness issues.
+
+## Focus
+
+- Store/Action/Environment (unidirectional data flow) correctness
+- Main-thread discipline for state mutation and UI-facing output
+- Combine effect cancellation and lifecycle discipline
+- Reducer purity and side-effect placement
+- Lifecycle-unsafe state capture across async boundaries
+
+## Ignore
+
+- Style preferences for effect composition with no correctness impact
+- Micro-optimizations to reducer code with no behavior change
+
+## Applicability
+
+Use this specialist wherever the project's unidirectional-data-flow pattern (a `{Feature}Store`/`Action`/`Environment`-shaped store, or equivalent) drives feature state, and wherever Combine (or an equivalent reactive pipeline) issues effects that ultimately mutate state or update the UI.
+
+## Project-Specific Rules
+
+- Reducers (the `Action`-handling function of a `Store`) should generally stay pure: given the current state and an action, they compute the next state and describe effects to run. But first infer whether this project's `Store` actually enforces reducer purity — some custom (non-TCA) stores deliberately allow synchronous state or view-model mutation inside `reduce`, and when that is the established, pervasive house pattern it is not a defect. Flag in-reduce side effects only when they cause a concrete, reachable problem (an ordering/reentrancy bug, a main-thread violation, unmanaged async work that leaks or races, or real external I/O) — and describe that consequence. A purity deviation that merely conforms to the codebase's intentional pattern with no wrong outcome is at most a Minor/Nit, not a Major "purity violation"
+- Effects that update state or drive UI must be delivered back to the store on the main thread (e.g. via a `.receive(on: mainScheduler)`-style operator); do not update `@Published`/store state from a background queue or an arbitrary Combine scheduler
+- Every long-running or cancellable effect must be registered under an explicit `cancellableId` (or equivalent effect-identity token); effects without an identity cannot be cancelled and can leak or race with a later effect for the same logical operation
+- Starting a new effect for an id that already has one in flight must explicitly cancel the prior effect first, unless the store intentionally allows concurrent effects for that id
+- Effects must not capture stale state by value across an async boundary when the store's state can change before the effect resumes; re-read current state through the store/environment rather than trusting a closure-captured snapshot
+- Side effects (networking, persistence, timers, notifications) belong in the `Environment`, invoked from effects the reducer returns — not called directly from views or from the reducer body
+- Cancellation on view disappearance, feature teardown, or navigation-away must actually cancel in-flight effects tied to that feature's cancellable ids
+- Coordinate or unit values conflated between normalized (0–1) and raw/pixel ranges — including omitted axis offsets — produce visibly wrong placement and are a correctness bug, not a rounding detail
+- Inverted, redundant, or always-true/always-false guard and boolean logic makes a conditional behave opposite to its intent or go permanently dead; scrutinize refactored conditionals for this
+- Force-unwrap or `.require()` applied to state that can legitimately be nil at runtime crashes the app instead of gracefully guarding the expected absent-state case
+- For Major or Critical findings, describe the concrete race, stale-state, or main-thread-violation scenario a user or crash report would surface
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. an explicitly required main-thread or cancellation discipline) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-reliability/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-reliability/content.md
@@ -1,0 +1,44 @@
+---
+name: bill-ios-code-review-reliability
+description: Use when reviewing iOS background-sync reliability risks including chained interceptor composition, error-logging discipline, and permission-check completeness.
+---
+
+# Reliability Review Specialist
+
+Review only issues that affect production reliability of background and sync-critical work.
+
+## Focus
+
+- Chained-interceptor/chain-of-responsibility composition for background sync (read, write, permission, and utility stages)
+- Mandatory error logging on background sync failures
+- Permission-check completeness before privileged sync operations
+- Retry, backoff, and failure-visibility behavior for background work
+
+## Ignore
+
+- Style preferences in interceptor ordering with no behavioral effect
+- Logging verbosity preferences that do not affect failure visibility
+
+## Applicability
+
+Use this specialist for background sync and any interceptor/chain-of-responsibility-style composition that wraps sync operations with cross-cutting stages (e.g. read, write, permission-checking, and utility/logging stages).
+
+## Project-Specific Rules
+
+- Background sync chains composed from Read/Write/Permissions/Utility-style stages must run every applicable stage for a given operation; skipping a stage (especially a permission-check stage) to save time is a reliability and correctness risk, not just a performance shortcut
+- Every background sync failure path must produce an error log with enough context (operation, entity, and failure reason) to diagnose the failure after the fact; a swallowed or silently-dropped background sync error is a reliability regression
+- Permission checks in a sync chain must run before the corresponding read/write stage executes, not after or in parallel with it; a permission check that runs too late does not actually prevent the unauthorized operation
+- New stages added to an existing chain must preserve the chain's existing ordering guarantees unless the change explicitly and visibly redefines that order
+- Retries for background sync operations must be bounded and must not silently retry an operation that has already permanently failed (e.g. due to a permission denial) as if it were a transient failure
+- Utility/cross-cutting stages (logging, metrics, cleanup) must not swallow or mask an error raised by the read/write/permission stage they wrap
+- The swallowed-error rule is not limited to sync chains: on any async path, an error caught and dropped (empty `catch`, mapped to a default, ignored via `_`, or turned into an empty result) rather than logged or propagated to its caller, the UI, or store state is a reliability regression
+- A dependent async action (UI transition, save, reload, navigation) that proceeds before the awaited operation it depends on has actually completed is a race: the follow-up can act on stale or partial data
+- Concurrent or duplicate async operations (overlapping network fetches, store effects, repeated form submissions) that run without cancelling superseded work or guarding against re-entry let a stale response overwrite newer state, or let a rapidly repeated trigger cause duplicate writes, navigations, or sync jobs
+- Extracting or rewriting a view/component that silently drops previously-present functionality (buttons, fallback labels, forwarded callbacks, wired services) is a regression unless the removal is explicitly flagged as intentional
+- Debug `print`/logging statements or debug-only code paths left in shipped code are a reliability and information-leak risk, not just noise
+- `[weak self]` captured but the closure still reaches `self`/outer state directly instead of through the safely-unwrapped self — or omitted entirely on a long-lived subscription — risks crashes, stale reads, or retain-cycle leaks
+- For Major or Critical findings, describe the concrete data-loss, unauthorized-access, or silent-failure scenario in production
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. a required error-logging or permission-check-ordering rule for background sync) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-security/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-security/content.md
@@ -1,0 +1,35 @@
+---
+name: bill-ios-code-review-security
+description: Use when reviewing iOS security risks including Keychain-only token storage, credential logging, and auth/session handling.
+---
+
+# Security Review Specialist
+
+Review only exploitable or compliance-relevant issues.
+
+## Focus
+
+- Secret and credential leakage
+- Auth/session token storage and handling
+- Sensitive logging
+- Insecure local storage or transport assumptions
+
+## Ignore
+
+- Non-security style comments
+
+## Applicability
+
+Use this specialist for iOS code at trust boundaries: auth/session handling, token storage, network clients, and any code that reads or writes credentials or sensitive user data.
+
+## Project-Specific Rules
+
+- Auth/session tokens must be stored in the Keychain (or an equivalent OS-backed secure store), never in `UserDefaults`, plain files, or in-memory-only globals that could be trivially dumped
+- Tokens, passwords, and other credentials must never appear in log output, including debug-only logging that can ship in a release build by accident
+- Do not log full request/response bodies or headers for authenticated endpoints by default; redact or omit auth headers and any field known to carry sensitive user data
+- New network clients must use TLS and must not disable certificate validation, even temporarily, outside of an explicit and reviewed debug-only build configuration
+- Biometric-gated or Keychain-protected data must not be duplicated into a less-protected store as a convenience cache
+- Deep links, universal links, and pasteboard access must not leak sensitive tokens or personal data to other apps
+- Temporary debug bypasses, hardcoded test credentials, or relaxed certificate/auth checks must not ship in production code paths
+- SQL built by string interpolation is worth flagging, but rate it by the trust of the interpolated value: interpolating a DB-sourced or upstream-validated UUID (no untrusted-input path reaching it) is a defense-in-depth/consistency nit, not a Major injection vulnerability. Reserve a security severity for a real path where attacker- or user-controlled text reaches the query unescaped. Inconsistency with a sibling `.sqlEscaped`-style helper is a code-quality point better owned by architecture/persistence than a security Major
+- For Major or Critical findings, describe the concrete exposure or exploit scenario explicitly — including how untrusted input actually reaches the sink

--- a/platform-packs/ios/code-review/bill-ios-code-review-testing/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-testing/content.md
@@ -1,0 +1,35 @@
+---
+name: bill-ios-code-review-testing
+description: Use when reviewing iOS test coverage quality, XCTest/snapshot-testing conventions, and the 1:1 SQL-statement-test cross-reference.
+---
+
+# Testing Review Specialist
+
+Review only test-coverage and test-quality issues with real regression-protection impact.
+
+## Focus
+
+- Missing or weak test coverage for new views, stores, and SQL statements
+- XCTest and snapshot-testing convention consistency
+- 1:1 coverage between hand-written SQL statements and their statement tests
+- Tautological or coverage-padding tests that do not validate real behavior
+
+## Ignore
+
+- Style-only test-naming preferences with no coverage impact
+
+## Applicability
+
+Use this specialist wherever test files change, or wherever new views, stores, or SQL statements ship without an accompanying test.
+
+## Project-Specific Rules
+
+- New or changed views should have a snapshot test (e.g. via `assertSnapshotsOf` or an equivalent snapshot-testing convention) covering their meaningful visual states, unless the project explicitly excludes that view type
+- New or changed stores/reducers should have XCTest coverage for their action-handling behavior, not just their initial state
+- A `{Statement}SQLStatementTests.swift`-style test per hand-written SQL statement is a recommended convention, not a universal hard rule — verify the repo applies it broadly before treating its absence as a violation (only a subset of statements carry one in practice). Flag a missing statement test as an at-most-Minor coverage gap, reserving higher severity for statements whose correctness is load-bearing; do not frame it as a mandatory "1:1" requirement the change breaks
+- Snapshot baselines committed alongside a UI change must correspond to an intentional, reviewed visual change — a snapshot update with no visible reason in the diff is a red flag worth calling out
+- Flag tests that assert only on mocks calling through to other mocks, or that would pass unchanged if the underlying behavior were broken (tautological or coverage-padding tests)
+- Coverage disabled, weakened, or commented out (removed assertions, `isRecording = true` left on, tautological checks) without a stated justification silently drops regression protection and should be flagged
+- Assertions that have gone stale after a behavior change — asserting a string, parameter, or mock value that no longer matches the implementation — let a test pass without validating the real behavior
+- Flaky UI/E2E coverage that leaves the app in a navigation/state the next step does not expect, or relies on fragile or colliding element identifiers, produces false passes and failures unrelated to the behavior under test
+- Missing tests for new views, stores, or SQL statements should be reported even when the rest of the diff is otherwise low-risk, since these are the project's designated regression-protection surfaces

--- a/platform-packs/ios/code-review/bill-ios-code-review-ui/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-ui/content.md
@@ -1,0 +1,30 @@
+---
+name: bill-ios-code-review-ui
+description: Use when reviewing iOS UI correctness for feature views, shared theming/design-system usage, navigation wiring, and snapshot baselines.
+---
+
+# UI Review Specialist
+
+Review only UI correctness and framework-usage issues that can break the rendered experience or make the app behave inconsistently.
+
+## Focus
+
+- Feature view correctness and composition
+- Shared design-system/theme usage consistency
+- Navigation wiring correctness
+- Snapshot baseline changes matching intentional visual changes
+
+## Ignore
+
+- Pure visual taste feedback
+- Accessibility-only findings that belong to `bill-ios-code-review-ux-accessibility`
+
+## Project-Specific Rules
+
+- Feature views (e.g. a `{Feature}View.swift`-style SwiftUI view) should compose from the project's shared UI component library and theme module rather than reimplementing styling, spacing, or common components locally
+- Navigation changes (e.g. a `Scene+{Feature}.swift`-style navigation wiring file) must keep the declared navigation graph consistent — no dangling routes, no duplicate destinations for the same scene, no navigation state that can desync from the store driving it
+- View state must have a single clear source of truth; do not split ownership of the same visual state across a store, local `@State`, and a child view without an explicit synchronization model
+- Conditional rendering must preserve state-machine correctness across loading, success, empty, and error states
+- Snapshot baseline updates committed with a UI change must correspond to an intentional, reviewed visual change described in the diff — an unexplained snapshot update alongside unrelated logic changes is a red flag
+- Reusable components should be added to or reused from the shared component library rather than duplicated per-feature when the same visual pattern already exists elsewhere
+- In findings, explain the rendered or interactive behavior a user would actually experience

--- a/platform-packs/ios/code-review/bill-ios-code-review-ux-accessibility/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-ux-accessibility/content.md
@@ -1,0 +1,31 @@
+---
+name: bill-ios-code-review-ux-accessibility
+description: Use when reviewing iOS UX and accessibility risks including localization-string completeness and VoiceOver label coverage.
+---
+
+# UX & Accessibility Review Specialist
+
+Review only UX correctness and accessibility issues that can make the app harder to understand, harder to operate, or inaccessible to assistive-technology users.
+
+## Focus
+
+- Localization-string completeness across supported languages
+- VoiceOver and other accessibility-label coverage
+- Validation feedback clarity and error-state discoverability
+- Interaction patterns where the UI technically renders but is confusing or inaccessible
+
+## Ignore
+
+- Pure visual design preference
+- Security-only findings that belong to `bill-ios-code-review-security`
+
+## Project-Specific Rules
+
+- New or changed user-facing strings must be added through the project's centralized strings surface (e.g. a `Strings.swift`-style accessor) rather than hardcoded inline, and must have translations present across all supported `.lproj` locales
+- A new string added to one locale without corresponding entries in the other supported locales is a localization-completeness gap, not just a nice-to-have
+- Every new interactive control (button, tappable element, custom control) must have a VoiceOver-accessible label that matches the control's actual action, not a generic or missing label
+- Images and icons that convey meaning (not purely decorative) must have accessibility labels or be explicitly marked decorative so VoiceOver does not announce them incorrectly
+- Focus order for VoiceOver navigation should follow the visual/logical reading order; custom layouts that reorder visual elements must not scramble the accessibility traversal order
+- Validation errors and status changes must be both visually distinguishable and announced or discoverable via VoiceOver, not conveyed by color alone
+- Dynamic Type and larger accessibility text sizes should not clip, truncate, or overlap critical content in new or changed views
+- In findings, make the user-visible UX or accessibility consequence explicit

--- a/platform-packs/ios/code-review/bill-ios-code-review/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review/content.md
@@ -1,0 +1,78 @@
+---
+name: bill-ios-code-review
+description: Use when reviewing native iOS/Swift changes (UIKit/SwiftUI, Xcode projects, local SPM packages).
+---
+
+# Adaptive iOS PR Review
+
+You are an experienced iOS architect conducting a code review.
+
+This skill owns the baseline native iOS review layer. It covers UIKit/SwiftUI app code, local Swift Package Manager modules, and the specialist-selection logic that the iOS review lanes build on top of.
+
+## Project Guidance
+
+Treat coherent local project standards and established architecture as the consistency target. Do not preserve local patterns that are inconsistent, accidental, or harmful; use this iOS pack to flag concrete maintainability, correctness, security, scalability, or testability risks and guide changes toward established iOS/Swift practices.
+
+## Finding Discipline
+
+These rules apply to every specialist lane. They exist to keep precision high — a plausible-sounding finding that cannot actually fire, or that is rated far above its real impact, erodes trust in the whole review.
+
+- **Verify the triggering precondition before asserting a consequence.** Before reporting "this crashes / hangs / shows the wrong screen / gets requested," confirm the state or configuration that would trigger it can actually occur. Examples of premises to check first: that a SwiftUI/WidgetKit family or lifecycle case can actually be requested given the declared `supportedFamilies`/guards; that an interactive-pop (swipe-back) gesture is still enabled given `navigationBarBackButtonHidden` + custom leading items; that a "spinner never resets" path is reachable when both success and failure branches reset it; that a value can actually be `nil`. If the guarding config contradicts the premise, do not report it.
+- **Scan removed (`-`) lines, not just additions.** Dropped call sites, deleted effects, removed guards/tracking, and commented-out flows are as important as added code — a refactor that silently drops a data-loading call, a network-fetch fallback, or an analytics event is a real regression that only shows up on the `-` side of the diff. On refactor-heavy or deletion-heavy diffs, explicitly diff what behavior the removals drop.
+- **Get Swift semantics right.** Do not report a finding that depends on a misreading of the language. Common traps:
+  - A `do { … }` block **without** a `catch` does not swallow errors — `try` inside it propagates to the enclosing throwing scope. It is only "swallowed" if there is an actual empty/`catch {}` handler.
+  - An `enum` with **no associated values**, or whose associated values are all `Equatable`/`Hashable`, gets `Equatable`/`Hashable` synthesized automatically — a nested payload-less enum does not break the outer type's synthesis.
+  - A computed `URL?` (or any optional) that coalesces to a **non-optional** value (`optional ?? nonOptional`) can never be `nil`; a `guard let` on it is dead, but that is a dead-code Nit, not a crash.
+  - `[weak self]`/`[weak store]` on an `ObservedObject`/store that outlives the closure is a robustness/consistency nit, not a leak or crash.
+- **Calibrate severity to demonstrated impact.** Reserve Blocker/Major for a concrete, reachable failure (data loss, crash, wrong result a user or crash report would see). A finding that flags conformance to (or deviation from) an intentional, pervasive house pattern with no demonstrated wrong outcome is at most Minor — and often a Nit. When a rule below says "should," a violation is not automatically Major.
+
+## iOS Review Heuristics
+
+Always include:
+
+- `bill-ios-code-review-architecture`
+- `bill-ios-code-review-platform-correctness`
+
+Add other specialists only when the changed files justify them.
+
+| Signal in the diff | Specialist review to run |
+|---|---|
+| `DependencyContainer+Registrations.swift`, new `Provider` protocol, new SPM package, package-boundary crossing | `bill-ios-code-review-architecture` |
+| `{Feature}Store/Action/Environment`, Combine effect chains, `.receive(on: mainScheduler)`, `cancellableId` | `bill-ios-code-review-platform-correctness` |
+| GraphQL/Apollo client package, `*.graphql` operations, generated GraphQL API code, Apollo cache/field policies | `bill-ios-code-review-api-contracts` |
+| `Database` package, GRDB migrations, `createTable`/schema changes, `{Statement}SQLStatementTests.swift`, deep sync | `bill-ios-code-review-persistence` |
+| Background-sync engine (interceptor/chain-of-responsibility Read/Write/Permissions/Utility stages), background sync, error logging | `bill-ios-code-review-reliability` |
+| Auth/session/Keychain, token storage, sensitive log content | `bill-ios-code-review-security` |
+| Hot Store reducers, large sync/import loops, image/PDF/camera work (photo-gallery, PDF-editor, camera modules) | `bill-ios-code-review-performance` |
+| Test files, `assertSnapshotsOf`, `{Statement}SQLStatementTests.swift`, missing tests for new views/stores | `bill-ios-code-review-testing` |
+| `{Feature}View.swift`, shared UI-component/theme module, navigation (`Scene+{Feature}.swift`), snapshot baselines | `bill-ios-code-review-ui` |
+| `Strings.swift`, `*.lproj` (5 languages), VoiceOver/accessibility labels | `bill-ios-code-review-ux-accessibility` |
+
+`api-contracts` is reframed, not dropped: for a GraphQL/Apollo-consuming client the contract risk is codegen regeneration, `.graphql` changes, and cache/field-policy correctness — not request validation.
+
+## Mixed Diffs
+
+If different parts of the diff touch different review surfaces:
+
+- inspect those changed areas separately
+- keep the baseline specialists for the whole review
+- add only the specialists needed for the relevant areas
+- do not force every file through every specialist
+
+## Specialist Selection Bounds
+
+- Minimum 2 specialist reviews: `architecture` plus one other
+- If no additional triggers match, include `bill-ios-code-review-platform-correctness` as the default second specialist
+- If tests changed materially, include `bill-ios-code-review-testing`
+- Maximum 10 specialist reviews
+
+When the diff is large, high-risk, or spans multiple review surfaces, build per-specialist file lists so each selected review lane stays focused:
+
+1. Scan each changed file's name and imports for the routing-table signals above.
+2. Map each file to the specialists whose signals it matches.
+3. `bill-ios-code-review-architecture` always receives all changed files.
+4. Every other specialist receives only files matching its routing signals.
+5. If a non-architecture specialist's scoped file list is empty, drop it from the selected set.
+6. After scoping, re-check the minimum-2-specialist requirement; if only architecture remains, add `bill-ios-code-review-platform-correctness` with all changed files as the default second.
+
+This is a lightweight file-level classification, not a full review.

--- a/platform-packs/ios/code-review/bill-ios-code-review/native-agents/agents.yaml
+++ b/platform-packs/ios/code-review/bill-ios-code-review/native-agents/agents.yaml
@@ -1,0 +1,32 @@
+contract_version: "0.1"
+agents:
+  - name: bill-ios-code-review-api-contracts
+    description: "Use when reviewing iOS changes for API contracts, request validation, and serialization."
+    compose: governed-content
+  - name: bill-ios-code-review-architecture
+    description: "Use when reviewing iOS changes for architecture, boundaries, and dependency direction."
+    compose: governed-content
+  - name: bill-ios-code-review-performance
+    description: "Use when reviewing iOS changes for performance risks on hot paths, blocking I/O, and resource usage."
+    compose: governed-content
+  - name: bill-ios-code-review-persistence
+    description: "Use when reviewing iOS changes for persistence, transactions, migrations, and data consistency."
+    compose: governed-content
+  - name: bill-ios-code-review-platform-correctness
+    description: "Use when reviewing iOS changes for lifecycle, concurrency, threading, and logic correctness."
+    compose: governed-content
+  - name: bill-ios-code-review-reliability
+    description: "Use when reviewing iOS changes for timeouts, retries, background work, and observability."
+    compose: governed-content
+  - name: bill-ios-code-review-security
+    description: "Use when reviewing iOS changes for secrets handling, auth, and sensitive-data exposure."
+    compose: governed-content
+  - name: bill-ios-code-review-testing
+    description: "Use when reviewing iOS changes for test coverage quality and regression protection."
+    compose: governed-content
+  - name: bill-ios-code-review-ui
+    description: "Use when reviewing iOS changes for UI correctness and framework usage."
+    compose: governed-content
+  - name: bill-ios-code-review-ux-accessibility
+    description: "Use when reviewing iOS changes for UX correctness and accessibility."
+    compose: governed-content

--- a/platform-packs/ios/platform.yaml
+++ b/platform-packs/ios/platform.yaml
@@ -63,6 +63,32 @@ area_metadata:
 
 declared_quality_check_file: "quality-check/bill-ios-code-check/content.md"
 
+addon_usage:
+  code-review/bill-ios-code-review:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-sync-consistency.md
+        - offline-conflict-resolution.md
+        - offline-background-reliability.md
+  code-review/bill-ios-code-review-persistence:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-sync-consistency.md
+        - offline-conflict-resolution.md
+  code-review/bill-ios-code-review-reliability:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-background-reliability.md
+        - offline-sync-consistency.md
+  code-review/bill-ios-code-review-platform-correctness:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-conflict-resolution.md
+
 # Pointer files are generated into render/install output from this block.
 pointers:
   code-review/bill-ios-code-review:
@@ -80,6 +106,14 @@ pointers:
       target: orchestration/stack-routing/PLAYBOOK.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-sync-consistency.md
+      target: platform-packs/ios/addons/offline-sync-consistency.md
+    - name: offline-conflict-resolution.md
+      target: platform-packs/ios/addons/offline-conflict-resolution.md
+    - name: offline-background-reliability.md
+      target: platform-packs/ios/addons/offline-background-reliability.md
   code-review/bill-ios-code-review-api-contracts:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md
@@ -108,6 +142,12 @@ pointers:
       target: orchestration/shell-content-contract/shell-ceremony.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-sync-consistency.md
+      target: platform-packs/ios/addons/offline-sync-consistency.md
+    - name: offline-conflict-resolution.md
+      target: platform-packs/ios/addons/offline-conflict-resolution.md
   code-review/bill-ios-code-review-platform-correctness:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md
@@ -115,6 +155,10 @@ pointers:
       target: orchestration/shell-content-contract/shell-ceremony.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-conflict-resolution.md
+      target: platform-packs/ios/addons/offline-conflict-resolution.md
   code-review/bill-ios-code-review-reliability:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md
@@ -122,6 +166,12 @@ pointers:
       target: orchestration/shell-content-contract/shell-ceremony.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-background-reliability.md
+      target: platform-packs/ios/addons/offline-background-reliability.md
+    - name: offline-sync-consistency.md
+      target: platform-packs/ios/addons/offline-sync-consistency.md
   code-review/bill-ios-code-review-security:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md

--- a/platform-packs/ios/platform.yaml
+++ b/platform-packs/ios/platform.yaml
@@ -1,0 +1,159 @@
+platform: "ios"
+contract_version: "1.1"
+display_name: "iOS"
+
+routing_signals:
+  strong:
+    - ".xcodeproj"
+    - ".xcworkspace"
+    - "import SwiftUI"
+    - "import UIKit"
+    - "iOSApplicationExtension"
+  tie_breakers:
+    - "Package.swift alone is not a strong signal (ambiguous with server-side/macOS-only Swift); only route on it when the repo root also has an .xcodeproj/.xcworkspace."
+    - "A diff touching a local SPM package with no UIKit/SwiftUI import is still iOS-scoped when the repo root contains an .xcodeproj/.xcworkspace that consumes that package."
+    - "Never match on iosMain, androidMain, commonMain, expect/actual — those are KMP shared-source-set markers, not native iOS markers."
+
+declared_code_review_areas:
+  - "api-contracts"
+  - "architecture"
+  - "performance"
+  - "persistence"
+  - "platform-correctness"
+  - "reliability"
+  - "security"
+  - "testing"
+  - "ui"
+  - "ux-accessibility"
+
+declared_files:
+  baseline: "code-review/bill-ios-code-review/content.md"
+  areas:
+    api-contracts: "code-review/bill-ios-code-review-api-contracts/content.md"
+    architecture: "code-review/bill-ios-code-review-architecture/content.md"
+    performance: "code-review/bill-ios-code-review-performance/content.md"
+    persistence: "code-review/bill-ios-code-review-persistence/content.md"
+    platform-correctness: "code-review/bill-ios-code-review-platform-correctness/content.md"
+    reliability: "code-review/bill-ios-code-review-reliability/content.md"
+    security: "code-review/bill-ios-code-review-security/content.md"
+    testing: "code-review/bill-ios-code-review-testing/content.md"
+    ui: "code-review/bill-ios-code-review-ui/content.md"
+    ux-accessibility: "code-review/bill-ios-code-review-ux-accessibility/content.md"
+area_metadata:
+  api-contracts:
+    focus: "API contracts, request validation, and serialization"
+  architecture:
+    focus: "architecture, boundaries, and dependency direction"
+  performance:
+    focus: "performance risks on hot paths, blocking I/O, and resource usage"
+  persistence:
+    focus: "persistence, transactions, migrations, and data consistency"
+  platform-correctness:
+    focus: "lifecycle, concurrency, threading, and logic correctness"
+  reliability:
+    focus: "timeouts, retries, background work, and observability"
+  security:
+    focus: "secrets handling, auth, and sensitive-data exposure"
+  testing:
+    focus: "test coverage quality and regression protection"
+  ui:
+    focus: "UI correctness and framework usage"
+  ux-accessibility:
+    focus: "UX correctness and accessibility"
+
+declared_quality_check_file: "quality-check/bill-ios-code-check/content.md"
+
+# Pointer files are generated into render/install output from this block.
+pointers:
+  code-review/bill-ios-code-review:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: review-delegation.md
+      target: orchestration/review-delegation/PLAYBOOK.md
+    - name: review-scope.md
+      target: orchestration/review-scope/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: specialist-contract.md
+      target: orchestration/review-orchestrator/specialist-contract.md
+    - name: stack-routing.md
+      target: orchestration/stack-routing/PLAYBOOK.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-api-contracts:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-architecture:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-performance:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-persistence:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-platform-correctness:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-reliability:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-security:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-testing:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-ui:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-ux-accessibility:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  quality-check/bill-ios-code-check:
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: stack-routing.md
+      target: orchestration/stack-routing/PLAYBOOK.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md

--- a/platform-packs/ios/quality-check/bill-ios-code-check/content.md
+++ b/platform-packs/ios/quality-check/bill-ios-code-check/content.md
@@ -1,0 +1,23 @@
+---
+name: bill-ios-code-check
+description: Use when validating iOS changes with the shared quality-check contract.
+---
+
+# Quality-Check Content
+
+## Purpose
+
+Use when validating iOS changes with the shared quality-check contract.
+
+## Execution Steps
+
+1. Determine the files in scope for the current unit of work.
+2. Run the platform's quality-check entrypoint and capture the failures.
+3. Fix only the failures that belong to the scoped work unless the contract says otherwise.
+4. Re-run the quality check until the scoped failures are resolved.
+
+## Fix Strategy
+
+- Prefer root-cause fixes over suppressions or TODO comments.
+- Keep changes aligned with the project's existing conventions and build tooling.
+- Call out any blocker that requires a maintainer decision instead of guessing.

--- a/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
+++ b/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Braian Gapur <braian.gapur@capmo.de>
+# Maintainer: Braian Gapur <scatmetal@gmail.com>
 pkgname=skillbill
 pkgver=1.0.0
 pkgrel=1


### PR DESCRIPTION
Adds a first-class, generic `ios` platform pack for code review — same shape as the kotlin/kmp/php packs.

## What's included
- `bill-ios-code-review` router + 10 area specialists (architecture, performance, platform-correctness, security, testing, api-contracts, persistence, reliability, ui, ux-accessibility)
- `bill-ios-code-check` quality gate
- `platform.yaml` routing signals (`.xcodeproj`/`.xcworkspace`, `import SwiftUI`/`UIKit`, `iOSApplicationExtension`), disjoint from KMP's `iosMain`/`androidMain`/`commonMain`
- generated native-agent config

## Calibration
Specialist rubrics were calibrated against a 10-PR precision benchmark (~83% strict precision): in-reduce side-effect flags require a concrete consequence; statement-test coverage is a recommendation, not a hard rule; SQL-interpolation severity keys off input trust; plus a shared Finding-Discipline section (verify a triggering precondition, scan removed lines, Swift-semantics cheat-sheet).

Specialists optionally read a repo's own `.agents/skills/*/references/*.md` and root `AGENTS.md`/`CLAUDE.md` when present — no external project's content is vendored into this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)