### PR TITLE
feat: [SKILL-99] External addon sources with durable install overlay

### DIFF
--- a/.feature-specs/SKILL-99-external-addon-sources/spec.md
+++ b/.feature-specs/SKILL-99-external-addon-sources/spec.md
@@ -1,0 +1,201 @@
+# SKILL-99 — External Addon Sources
+
+## Outcome
+
+skill-bill can load code-review addons from a **user-configured external source** that lives outside the skill-bill tree (a local directory). External addons are re-applied on every install and survive updates and `--clean`, so private or org-specific review knowledge (first consumer: a private iOS review addon shipped under SKILL-98) is never wiped by the reconcile. No private content ever enters skill-bill's public repo.
+
+## Background / Motivation
+
+Addons today are **pack-owned**: markdown under `platform-packs/<slug>/addons/*.md`, wired via that pack's `platform.yaml` (`addon_usage` + `pointers`), installed by the reconcile. The reconcile (`install reconcile --apply`) is the sole writer of `skills/` and `platform-packs/`. It is a per-skill three-way hash compare; non-skill pack files (`platform.yaml`, `addons/*.md`) are adopted from upstream with **copy-over-local semantics on every apply** (`adoptPlatformPackNonSkillFiles`), and `--clean` wipes `~/.skill-bill/platform-packs` entirely. Reconcile never deletes local-only files, but it unconditionally overwrites the installed `platform.yaml` from upstream.
+
+This makes any out-of-repo addon non-durable. SKILL-98 shipped a private iOS addon as gitignored `platform-packs/ios/addons/acme-*.md` files plus skip-worktree'd `platform.yaml` wiring. The private `.md` files survive (local-only files are never deleted), but every install re-adopts the upstream `platform.yaml` and clobbers the local wiring — and `--clean` removes everything. The stopgap manual-reapply script is fragile and breaks whenever upstream `platform.yaml` changes.
+
+The fix: a first-class **external addon source** — a self-describing addon directory at a durable path outside `~/.skill-bill`, applied by a dedicated install-flow overlay step that runs **after reconcile-apply and before skill staging**, and re-applied unconditionally on every install.
+
+---
+
+## Implementation Map (where the code lives)
+
+All paths repo-relative to the repo root. Read these before coding.
+
+**Reconcile (the thing that clobbers local wiring):**
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/reconcile/InstallReconcileApply.kt` — `applyReconciliation()` (L37); `adoptPlatformPackNonSkillFiles()` (L84) is the copy-over-local of `platform.yaml` + `addons/*.md`, called last (L72).
+- Application entry: `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/install/InstallService.kt` — `applyReconcile()` (L95).
+- CLI: `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliCommands.kt` — `InstallReconcileCommand` (L104, name `"reconcile"`), `--apply` (L129).
+
+**`~/.skill-bill/config.json` store (where the new key lives):**
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt` — reads/writes the file; preserves unknown top-level keys via `payload.toMutableMap()` (L85, L116). **At the detekt `TooManyFunctions` limit (10)** — fold new logic into an existing function or add a new class, do not add a standalone function here.
+
+**Config-reader command pattern to copy:**
+- `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigCommand.kt` — `ConfigResolveSpecTypeCommand` (L39) and `ConfigResolveParallelAgentCommand` (L104) are the templates. Subcommands registered at `ConfigCommand.subcommands()` (L28). (These read the repo-local `.skill-bill/config.yaml`; the new one reads machine-global `~/.skill-bill/config.json` — different file, same command shape.)
+- Service layer: `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/config/ConfigResolutionService.kt`.
+
+**Platform-pack model + parser + coherence validators:**
+- Data classes: `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/scaffold/model/ScaffoldModels.kt` — `PointerSpec(skillRelativeDir, name, target)` (L24), `GovernedAddonUsage` (L60), `GovernedAddonSelection(slug, entrypoint, companionPointers)` (L65), `PlatformManifest` (L71).
+- Parser + the named coherence checks: `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/platformpack/ShellContentLoader.kt` — `loadPlatformManifest()` (L31), `parsePointers()` (L621, `pointers-unique-name-per-dir` L653), `parseAddonUsage()` (L662), `parseAddonUsageEntry()` (L720, `addon-usage-unique-slug-per-dir` L727), `requirePackOwnedAddonPointer()` (L751, `addon-usage-pointer-target-must-be-addon` L758).
+- Schema doc: `orchestration/contracts/platform-pack-schema.yaml` — `addon_usage` (L275), coherence-checks block (L343–L364).
+- JSON-schema validator: `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/platformpack/PlatformPackSchemaValidator.kt` — `validate(parsedYaml, slug)` (L61).
+
+**Staging (`~/.skill-bill/installed-skills/` content-hash cache):**
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApply.kt` — `applyInstallPlan()` (L25).
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/staging/InstallStagingIdentity.kt` — `installedSkillsCacheRoot`, content-hash identity.
+
+**The ordering seam (CRITICAL — this is in bash, not Kotlin):**
+- `install.sh` — `reconcile_and_commit_authored_source()` (L1018) runs `install reconcile --apply` (L1107), writing `skills/` + `platform-packs/`. The staging phase (`install apply`) runs later (main sequence ~L2602, summary L2644). **The new overlay step is invoked from `install.sh` BETWEEN these two.**
+
+**CLI registration / DI:**
+- `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/CliCommandGroups.kt` — `UtilityCliCommandGroup` (L46) injects `ConfigCommand` (L61); `TopLevelCliCommands` (L80).
+- DI: `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/CliComponent.kt`.
+
+**Existing SKILL-98 iOS artifacts (item to migrate):**
+- `platform-packs/ios/addons/acme-*.md` — 12 files, **local-only, git-ignored** via a `.git/info/exclude` entry `platform-packs/ios/addons/acme-*.md`.
+- `platform-packs/ios/platform.yaml` — **skip-worktree** (`git ls-files -v` → `S`); holds the local `acme` wiring. `addon_usage` block at L66.
+- Note: `platform-packs/ios/addons/offline-*.md` (4 files) are **tracked/public** — they are NOT private and STAY in the repo. Only the `acme-*` family + its wiring migrates out.
+
+**Test layout (match these):**
+- Reconcile/install: `runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/` — `InstallReconcileApplyTest.kt`, `InstallStagingTest.kt`, `InstallApplyTest.kt` (+ `InstallApplyTestSupport.kt`).
+- Schema/coherence: `runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/` — `PlatformPackSchemaViolationsTest.kt`.
+- CLI runtime: `runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/` — `CliConfigResolveSpecTypeRuntimeTest.kt` (template), driven via `CliRuntime.run(listOf(...), CliRuntimeContext())`.
+- Config store: `runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStoreTest.kt`.
+
+---
+
+## Recommended Architecture
+
+Two Kotlin CLI commands + one `install.sh` insertion. (Names are recommendations; keep the acceptance criteria as the contract.)
+
+1. **`config resolve-external-addons`** (new subcommand under `ConfigCommand`) — reads `~/.skill-bill/config.json`, parses/validates `external_addon_sources`, prints the resolved sources. Loud-fails on malformed JSON or a missing `path`. Satisfies AC2 and the `validate` surface (AC6). Copy `ConfigResolveSpecTypeCommand`.
+
+2. **`install apply-external-addons`** (new subcommand under the install group) — the overlay step. Resolves the same config, then for each source performs the merge (below). Loud-fails atomically (no partial state). Invoked by `install.sh`.
+
+3. **`install.sh` wiring** — call `install apply-external-addons` immediately after `install reconcile --apply` returns (inside/after `reconcile_and_commit_authored_source`, L1018) and before the staging `install apply` phase (~L2602). Guard empty-config as a no-op. Keep bash 3.2 compatible; guard empty-array expansions.
+
+Putting the merge logic in Kotlin (not bash) is deliberate: it must be unit-testable and must reuse the existing addon/pointer parser and coherence rules.
+
+---
+
+## Scope
+
+### 1. Config surface
+
+`~/.skill-bill/config.json` gains an optional array:
+
+```json
+{
+  "external_addon_sources": [
+    { "path": "/home/me/private-review-addons/ios", "platform": "ios" }
+  ]
+}
+```
+
+- `path` — absolute path to a durable directory outside `~/.skill-bill` (v1). Git URL/ref is out of scope (Non-Goals) but the field shape must not preclude adding a `git`/`ref` variant later.
+- `platform` — the platform-pack slug the source's addons target (e.g. `ios`).
+- Absent/empty array ⇒ **current behavior exactly** (no overlay, no new output, zero cost).
+- Array order is meaningful: sources apply in config order → deterministic merge.
+- `config.json` is today the telemetry document (`FileTelemetryConfigStore`), which preserves unknown top-level keys, so the new key is safe for older runtimes. External sources are machine-global (like installed packs), which is why this file — not repo-local `.skill-bill/config.yaml` — is the right home.
+
+### 2. External source layout (self-describing)
+
+An external source directory contains:
+
+- addon markdown files (any names; e.g. `acme-persistence.md`)
+- an **`addon-manifest.yaml`** fragment carrying **only** the `addon_usage` and `pointers` entries to merge into the target pack, in the exact schema `platform.yaml` uses for those blocks. Pointer `target`s are written **relative to the external source dir**; on merge the overlay rewrites them to the canonical `platform-packs/<slug>/addons/<file>.md` form (the coherence check `addon-usage-pointer-target-must-be-addon` accepts only that form).
+
+Example `addon-manifest.yaml`:
+
+```yaml
+pointers:
+  code-review/bill-ios-code-review-persistence:
+    - name: acme-persistence
+      target: acme-persistence.md          # source-relative; rewritten on merge
+addon_usage:
+  code-review/bill-ios-code-review-persistence:
+    - slug: acme-persistence
+      entrypoint: acme-persistence
+      companion_pointers: []
+```
+
+The fragment validates against the same rules pack-owned addons obey: bare-filename pointer names, `addon_usage` slug/entrypoint/companion_pointers shape, and every referenced addon file exists in the source dir. Because the coherence validator and pointer rendering require targets to physically exist under the installed pack, external addon markdown **must be copied into the installed pack's `addons/` dir** — it cannot be referenced in place.
+
+### 3. Install-flow external-overlay step (the merge)
+
+The overlay is **not** a reconcile layer (reconcile has no layer pipeline and re-adopts upstream `platform.yaml` every apply — that is what erases the SKILL-98 wiring). It is a distinct step run from `install.sh` after reconcile-apply, before staging, unconditionally on every install.
+
+For each configured source, in config-array order, whose `platform` matches an installed pack:
+
+1. **Copy** the source's addon `.md` files into `~/.skill-bill/platform-packs/<platform>/addons/`.
+2. **Merge** the fragment's `addon_usage` and `pointers` into the installed `~/.skill-bill/platform-packs/<platform>/platform.yaml`:
+   - rewrite each pointer `target` to canonical `platform-packs/<platform>/addons/<file>.md` form;
+   - **additive** — append external entries after pack-owned entries in the matching skill dir's lists;
+   - **any collision is a loud failure, never a silent overwrite** — a slug or pointer-name that collides with a pack-owned addon, or with another external source in the same skill dir.
+3. A source whose `platform` matches **no** installed pack is **skipped with a visible warning** (not silent, not fatal).
+
+No pointer-file regeneration is needed: specialists never read `platform.yaml` or pointer paths at runtime. Addon content is **inlined at staging time** into the content-hash-keyed `~/.skill-bill/installed-skills/` cache. Because the overlay mutates `platform.yaml` + `addons/` before staging runs, the affected skills re-render and re-stage automatically, and external addons resolve exactly like pack-owned ones.
+
+**Durability comes from unconditional re-application, not exemption bookkeeping:** reconcile clobbers `platform.yaml` from upstream each apply; the overlay re-merges on top afterward; so a normal update AND `--clean` both reconstitute the external addons from the source. The copied `addons/*.md` are local-only non-skill files — reconcile never deletes them and never reports them as upstream conflicts (true today, no new machinery).
+
+### 4. Validation & failure behavior
+
+- The config-reader command (and, transitively, the install path) validate each configured source's manifest against the addon schema and verify referenced files exist.
+- **Loud-fail with an actionable message** on: malformed `config.json`; a `path` that does not exist; a malformed `addon-manifest.yaml`; an `addon_usage` entrypoint/companion with no matching file; a slug/pointer-name collision in the same skill dir (external vs pack-owned AND external vs external).
+- Existing per-dir coherence rules (`pointers-unique-name-per-dir`, `addon-usage-unique-slug-per-dir`) still apply to the merged `platform.yaml`. The overlay must detect cross-source collisions **itself**, since schema uniqueness is per-dir and knows nothing about provenance.
+- **A loud failure aborts the install without partially applying an overlay** (no partial state — validate everything before writing anything, or write to a temp and swap).
+
+### 5. First consumer — migrate the SKILL-98 private iOS addon
+
+Move the **`acme-*`** private iOS review addon out of the skill-bill tree into an external source directory at a durable path outside `~/.skill-bill`:
+
+- its per-area `acme-*.md` files, plus an `addon-manifest.yaml` carrying their `addon_usage`/`pointers` wiring for the `ios` code-review skills;
+- register the directory in `~/.skill-bill/config.json` `external_addon_sources`;
+- **remove the in-tree workaround**: the `.git/info/exclude` entry `platform-packs/ios/addons/acme-*.md`, the skip-worktree state on `platform-packs/ios/platform.yaml` (`git update-index --no-skip-worktree`), and the local `acme` wiring inside that `platform.yaml` — so the working tree matches upstream and is clean;
+- leave the tracked public `offline-*.md` addons untouched;
+- verify a fresh `./install.sh` AND a `./install.sh --clean` reconstitute the private addon from the external source with per-specialist selective loading intact.
+
+## Acceptance Criteria
+
+1. `~/.skill-bill/config.json` supports an optional `external_addon_sources: [{ path, platform }]` array; when absent or empty, install/reconcile/validate behavior is observably identical to today (no overlay, no new output, no new failure modes).
+2. A new runtime command resolves and validates external-addon config from `~/.skill-bill/config.json`, loud-failing on malformed JSON or a non-existent `path`, and printing the resolved sources on success. Telemetry ownership of `config.json` is untouched; `FileTelemetryConfigStore` unknown-key preservation keeps both readers compatible.
+3. An external source is self-describing: a directory of addon `.md` files plus an `addon-manifest.yaml` carrying `addon_usage` + `pointers` fragments in the existing schema; the fragment validates against the same addon/pointer schema rules as pack-owned addons, and source-relative pointer targets are rewritten to `platform-packs/<slug>/addons/<file>.md` form on merge.
+4. The install flow applies an external-overlay step **after `install reconcile --apply` and before staging** that copies the source's `.md` into the installed pack's `addons/`, merges the fragment's `addon_usage`/`pointers` into the installed `platform.yaml` (sources applied in config order), and the subsequent staging re-renders/re-stages the affected skills so the external addon content is inlined into the installed-skills cache.
+5. The overlay is re-applied unconditionally on every install, so a normal update AND a `--clean` install both reconstitute the external addons even though reconcile re-adopts the upstream `platform.yaml` each apply; overlay-copied `addons/*.md` files are never reported as upstream conflicts or deleted by reconcile.
+6. Install/validate loud-fails (aborting without partial application) on: malformed config, missing source `path`, malformed manifest, an `addon_usage` entrypoint/companion referencing a missing file, or a same-skill-dir slug/pointer-name collision (external vs pack-owned or external vs external). A source targeting a platform that is not installed is skipped with a visible warning.
+7. The SKILL-98 private iOS addon (`acme-*`) is migrated to an external source directory + `addon-manifest.yaml`, registered in `~/.skill-bill/config.json`; the in-tree workaround (`.git/info/exclude` `acme-*` entry, skip-worktree on `platform-packs/ios/platform.yaml`, local `acme` wiring in that file) is removed; the tracked public `offline-*.md` addons are untouched; and `git status` is clean with the working tree matching upstream.
+8. After migration, both a normal `./install.sh` and a `./install.sh --clean` reconstitute the private addon into `~/.skill-bill` with per-specialist selective loading intact (each iOS specialist resolves only its own per-area file), and no private/external addon content exists anywhere under skill-bill's git-tracked tree.
+9. New/changed runtime behavior (config resolution, manifest validation, the install-flow overlay step and its ordering, pointer-target rewriting, collision failures) is covered by tests at the level the surrounding reconcile/install code is tested.
+
+## Non-Goals
+
+- Publishing private/external addon content into skill-bill's public repo.
+- A remote addon registry or discovery service; v1 resolves a local directory path only (git URL/ref deferred, though the config shape must not preclude it).
+- Changing how pack-owned (in-repo) addons work; external addons are strictly additive.
+- Per-user auth/secrets management beyond filesystem permissions.
+- Authoring new skill content beyond migrating the existing SKILL-98 private iOS addon.
+- Desktop-app awareness of the overlay: the app's baseline/drift view may show overlaid entries as drift; teaching it about the overlay layer is deferred. The overlay must merely not corrupt the workspace the app reads.
+- Preserving overlay content through a user-invoked full `uninstall.sh` (the external source dir is durable; reinstall reconstitutes).
+
+## Constraints
+
+- **Public repo cleanliness:** no external/private content in skill-bill's git-tracked tree; the feature must make the current gitignore + skip-worktree workaround unnecessary.
+- **Single owned write path:** the install flow remains the sole writer of `skills/` and `platform-packs/`. The overlay runs inside it (after reconcile-apply, before staging), not as an independent writer. The overlay must **not mutate reconcile-owned skill dirs** — doing so changes their content hash and turns the next reconcile into a spurious `KeepLocal`/`Conflict`. It touches only `addons/` and `platform.yaml`, then lets staging re-render the skills.
+- **Ordering is correctness, not optimization:** overlay after reconcile (or the merge is clobbered by upstream adoption) and before staging (or inlined skill content misses the external addons).
+- **Zero-config parity:** users with no `external_addon_sources` see no behavior change and no new failure modes.
+- **bash 3.2:** `install.sh` must stay bash 3.2 compatible (macOS ships 3.2); guard empty-array expansions and the empty-config no-op.
+
+## Validation Strategy
+
+- **Kotlin unit/integration tests** for: config resolution (valid/malformed/missing path); manifest schema validation (valid/malformed/missing-file; slug and pointer-name collisions incl. external-vs-external); pointer-target rewriting; the overlay step (merge survives upstream `platform.yaml` adoption; deterministic multi-source ordering; skipped-with-warning on non-installed platform; re-applied after `--clean`; no partial state on failure).
+- **Staging integration:** after the overlay, affected skills re-render and external addon content is inlined into the installed-skills cache (content-hash changes; specialist pointer files carry the external text).
+- **End-to-end:** register an external source, run `./install.sh` and `./install.sh --clean`, assert the addon files + merged `platform.yaml` entries + re-staged skills appear in `~/.skill-bill` both times.
+- **Migration check:** `git status` clean, working tree matches upstream, no private/external addon content in the tracked tree; a fresh clone + install with the external source configured reproduces the full per-area private addon.
+- **Regression:** with no `external_addon_sources` configured, install/reconcile output is unchanged from the current baseline.
+
+## Next Path
+
+```bash
+Run bill-feature-task on .feature-specs/SKILL-99-external-addon-sources/spec.md
+```
+
+## Status
+
+- Status: Complete
+- Agent: opencode

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 docs/cloudflare-telemetry-proxy/.wrangler/
 _migration_backup/
 /.skill-bill/
+
+# SKILL-98 specs describe a private external app — keep local, not public
+.feature-specs/SKILL-98-ios-platform-pack/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Skill Bill ships complete Kotlin/KMP and PHP packs — the stack-specific intell
 - [Getting Started for Teams](docs/getting-started-for-teams.md): rollout guidance, customization strategy, and adoption patterns
 - [Capability Deep-dive](docs/capabilities.md): the full system — one-shot install, durable workflows, platform packs, decomposition, Desktop UI, telemetry, overrides, memory, and governance
 - [Skill Source And Generation Model](docs/skill-source-generation.md): `content.md` vs generated `SKILL.md`, support pointers, install staging, and native-agent generation
+- [External Addon Sources](docs/external-addons.md): overlay private or team-specific review add-ons onto an installed pack, kept out of the shared repo
 - [Review Telemetry](docs/review-telemetry.md): telemetry contract, learnings, local DB usage, and remote proxy stats
 
 ## License

--- a/docs/external-addons.md
+++ b/docs/external-addons.md
@@ -41,7 +41,7 @@ the next install.
 
 Sources are declared in the machine-global config file:
 
-- Default path: `~/.config/skill-bill/config.json` (`$XDG_CONFIG_HOME/skill-bill/config.json`) — a
+- Default path: `~/.config/skill-bill/config.json` — a
   durable location that survives installs (see [Persisting Config Across Installs](#persisting-config-across-installs))
 - Override with the `SKILL_BILL_CONFIG_PATH` environment variable (supports `~` expansion)
 
@@ -66,14 +66,14 @@ left untouched.
 ## Persisting Config Across Installs
 
 `config.json` — including your `external_addon_sources` — lives at the durable path
-**`~/.config/skill-bill/config.json`** (`$XDG_CONFIG_HOME/skill-bill/config.json`) by default. That
+**`~/.config/skill-bill/config.json`** by default. That
 path is **outside** the `~/.skill-bill/` tree that a `./install.sh` (or update) wipes during its
 pre-install cleanup, so your sources survive every install with **no configuration on your part**.
 
 Resolution order used by both the installer and the runtime:
 
 1. `SKILL_BILL_CONFIG_PATH` — explicit override; pin the config anywhere.
-2. `~/.config/skill-bill/config.json` (honoring `$XDG_CONFIG_HOME`) when it exists — the durable default.
+2. `~/.config/skill-bill/config.json` when it exists — the durable default.
 3. `~/.skill-bill/config.json` — legacy fallback for older installs.
 
 New installs write to the durable path (#2). Existing installs are **migrated automatically**: the
@@ -161,7 +161,7 @@ Overlay a private `acme` review add-on onto the installed `ios` pack.
          target: acme-review.md
    ```
 
-2. Register it in `~/.skill-bill/config.json`:
+2. Register it in `~/.config/skill-bill/config.json`:
 
    ```json
    {

--- a/docs/external-addons.md
+++ b/docs/external-addons.md
@@ -1,0 +1,223 @@
+# External Addon Sources
+
+External addon sources let you overlay private or team-specific review add-ons onto an
+installed platform pack **without forking the pack or committing the add-on into this repo**.
+The add-on content lives in a directory you own; Skill Bill merges it into the installed pack
+during every install.
+
+Use [Getting Started](getting-started.md) for install and full CLI coverage, and
+[Getting Started for Teams](getting-started-for-teams.md) for the broader customization model.
+External addons are the lightest way to ship an add-on that must stay outside the shared repo.
+
+## When To Use This
+
+Reach for an external addon source when all of these hold:
+
+- The add-on extends an **existing installed pack** (e.g. `ios`, `kotlin`, `php`), not a new stack.
+- The content is **private or team-specific** and should not live in the public repo.
+- You want it applied automatically on install, the same way pack-owned add-ons are.
+
+If the behavior is durable and shareable, prefer a pack-owned add-on or a forked pack instead
+(see [Customization Layers](getting-started-for-teams.md#customization-layers)). External sources
+are for content that deliberately stays out of tree.
+
+## How It Works
+
+The overlay runs automatically during `./install.sh`, **after** the installed platform packs are
+reconciled from upstream and **before** skills are staged. For each configured source it:
+
+1. Reads the machine-global config and resolves each `{ path, platform }` entry.
+2. Skips (with a warning) any source whose target platform pack is not installed.
+3. Validates the source's `addon-manifest.yaml` and referenced `.md` files.
+4. Copies the add-on `.md` files into the installed pack's `addons/` directory.
+5. Appends the add-on's `addon_usage` and `pointers` entries into the installed pack's
+   `platform.yaml`.
+
+Because the overlay always re-applies against the freshly reconciled pack, it is idempotent:
+re-running install never duplicates entries, and a wiped `addons/` directory is reconstituted on
+the next install.
+
+## Configuring Sources
+
+Sources are declared in the machine-global config file:
+
+- Default path: `~/.skill-bill/config.json`
+- Override with the `SKILL_BILL_CONFIG_PATH` environment variable (supports `~` expansion)
+
+Add an `external_addon_sources` array. Each entry is a `{ path, platform }` object:
+
+```json
+{
+  "external_addon_sources": [
+    { "path": "~/dev/acme-review-addon", "platform": "ios" }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `path` | Directory containing `addon-manifest.yaml` and the referenced `.md` files. Supports `~`; relative paths resolve against the current working directory. Must exist and be a directory. |
+| `platform` | The platform-pack slug to overlay onto (e.g. `ios`). If that pack is not installed, the source is skipped with a warning, not treated as an error. |
+
+`external_addon_sources` shares `config.json` with telemetry settings; other keys in the file are
+left untouched.
+
+## Persisting Config Across Installs
+
+**A default `./install.sh` (and every update, which is just a re-run) wipes `~/.skill-bill/` as a
+pre-install cleanup step.** It preserves `skills/`, `platform-packs/`, `orchestration/`,
+`baseline-manifest.json`, and durable `*.db` state — but **not `config.json`**. A config left at the
+default `~/.skill-bill/config.json` path therefore loses its `external_addon_sources` on the next
+install.
+
+To keep your sources across installs, **relocate the config outside `~/.skill-bill/` and point
+`SKILL_BILL_CONFIG_PATH` at it.** Both the installer and the runtime read this variable, so a clean
+install never touches the file. Export it from your shell profile so every `install.sh` and
+`skill-bill` invocation sees it:
+
+```bash
+# ~/.bashrc / ~/.zshrc
+export SKILL_BILL_CONFIG_PATH="$HOME/.config/skill-bill/config.json"
+```
+
+```fish
+# ~/.config/fish/config.fish
+set -gx SKILL_BILL_CONFIG_PATH "$HOME/.config/skill-bill/config.json"
+```
+
+Then move your existing config once:
+
+```bash
+mkdir -p ~/.config/skill-bill
+mv ~/.skill-bill/config.json ~/.config/skill-bill/config.json
+```
+
+Notes:
+
+- The variable must be present in whatever environment runs `install.sh` and `skill-bill`. Shells
+  launched outside your profile fall back to the default path, so run installs from a shell that
+  sources the export.
+- As a one-off alternative, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the wipe
+  and leaves `~/.skill-bill/config.json` in place. That is intended for dev iteration; the
+  relocation above is the durable choice.
+
+## Source Directory Layout
+
+The directory referenced by `path` holds one manifest plus the add-on markdown files it references:
+
+```
+acme-review-addon/
+├── addon-manifest.yaml
+└── acme-review.md
+```
+
+Every `.md` file referenced by a pointer target must exist in this directory. The files are copied
+verbatim into the installed pack's `addons/` directory.
+
+## addon-manifest.yaml Format
+
+The manifest is a fragment of a platform pack's manifest: it declares `addon_usage` and `pointers`,
+each keyed by a **skill-relative directory** that the target pack already declares (its baseline,
+area, and quality-check dirs).
+
+```yaml
+addon_usage:
+  code-review/bill-ios-code-review:
+    - slug: acme
+      entrypoint: acme-review.md
+pointers:
+  code-review/bill-ios-code-review:
+    - name: acme-review.md
+      target: acme-review.md
+```
+
+Rules the overlay enforces (loud-fail on violation):
+
+- **`addon_usage` keys must be declared skill directories** of the installed pack.
+- **`entrypoint` and every `companion_pointers` entry must name a pointer** declared under the same
+  directory, and that pointer's target must resolve under the pack's `addons/`.
+- **Pointer `name`** is a bare markdown filename (`*.md`, no path separators, no `..`).
+- **Pointer `target`** is auto-rewritten to the canonical
+  `platform-packs/<platform>/addons/<file>.md` form. You may write just the bare filename
+  (`acme-review.md`) and it is expanded for you; a fully-qualified target is accepted as long as it
+  points at the same flat location.
+- **Targets must be flat** — directly under `addons/`, with no subdirectories.
+- **Only `name`/`target`** are allowed on pointer entries and only
+  `slug`/`entrypoint`/`companion_pointers` on addon-usage entries; unexpected keys are rejected.
+- **Add-on `slug`** must match `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`.
+
+## Worked Example
+
+Overlay a private `acme` review add-on onto the installed `ios` pack.
+
+1. Create the source directory:
+
+   ```
+   ~/dev/acme-review-addon/
+   ├── addon-manifest.yaml
+   └── acme-review.md
+   ```
+
+   `addon-manifest.yaml`:
+
+   ```yaml
+   addon_usage:
+     code-review/bill-ios-code-review:
+       - slug: acme
+         entrypoint: acme-review.md
+   pointers:
+     code-review/bill-ios-code-review:
+       - name: acme-review.md
+         target: acme-review.md
+   ```
+
+2. Register it in `~/.skill-bill/config.json`:
+
+   ```json
+   {
+     "external_addon_sources": [
+       { "path": "~/dev/acme-review-addon", "platform": "ios" }
+     ]
+   }
+   ```
+
+3. Preview what will resolve (optional dry run):
+
+   ```bash
+   skill-bill config resolve-external-addons
+   # ios	/home/you/dev/acme-review-addon
+   ```
+
+4. Install. The overlay applies automatically:
+
+   ```bash
+   ./install.sh
+   ```
+
+   `acme-review.md` is copied into the installed `ios` pack's `addons/`, and its `addon_usage` and
+   `pointers` entries are appended to the installed `platform.yaml`. The `ios` review flow now picks
+   up the `acme` add-on exactly like a pack-owned one.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `skill-bill config resolve-external-addons` | Read-only. Lists resolved `platform<TAB>path` entries from the config, or fails loudly on a malformed config. |
+| `skill-bill install apply-external-addons` | Applies the overlay onto installed packs. Runs automatically during `./install.sh`; you rarely invoke it directly. Options: `--repo-root` (default `.`) and `--platform-packs` (default `<repo-root>/platform-packs`). |
+
+## Guarantees And Failure Modes
+
+- **Idempotent.** Re-applying never duplicates entries; wiped add-on files are restored on the next
+  install.
+- **Not-installed platform is skipped**, with a warning, not a failure.
+- **Collisions loud-fail.** A pointer name, pointer target basename, or add-on slug that collides
+  with a pack-owned entry — or with another external source targeting the same platform and skill
+  directory — aborts the overlay rather than silently overwriting. Sources targeting *different*
+  platforms never collide, even if they share a skill-relative directory and pointer name.
+- **Validate-before-write atomicity.** All sources are validated before any file is written, so a
+  validation failure in a later source leaves earlier sources unapplied and the installed manifests
+  untouched. A mid-write I/O error (disk/permission) can leave a partially applied state; it
+  self-heals on the next install.
+- **The installed `platform.yaml` is the merge target**, re-adopted from upstream on each reconcile.
+  Comments and key ordering in that installed copy are not preserved across an overlay; your source
+  files and this config are the source of truth.

--- a/docs/external-addons.md
+++ b/docs/external-addons.md
@@ -86,6 +86,8 @@ Notes:
 
 - To keep the config somewhere else, export `SKILL_BILL_CONFIG_PATH` from your shell profile so every
   `install.sh` and `skill-bill` invocation sees it. Without the override, the durable default applies.
+  If you exported this in an earlier version solely to relocate the config to `~/.config/skill-bill/`,
+  you can remove it now — the durable default is that same path.
 - As a one-off, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the wipe entirely
   (intended for dev iteration).
 

--- a/docs/external-addons.md
+++ b/docs/external-addons.md
@@ -41,7 +41,8 @@ the next install.
 
 Sources are declared in the machine-global config file:
 
-- Default path: `~/.skill-bill/config.json`
+- Default path: `~/.config/skill-bill/config.json` (`$XDG_CONFIG_HOME/skill-bill/config.json`) — a
+  durable location that survives installs (see [Persisting Config Across Installs](#persisting-config-across-installs))
 - Override with the `SKILL_BILL_CONFIG_PATH` environment variable (supports `~` expansion)
 
 Add an `external_addon_sources` array. Each entry is a `{ path, platform }` object:
@@ -64,42 +65,29 @@ left untouched.
 
 ## Persisting Config Across Installs
 
-**A default `./install.sh` (and every update, which is just a re-run) wipes `~/.skill-bill/` as a
-pre-install cleanup step.** It preserves `skills/`, `platform-packs/`, `orchestration/`,
-`baseline-manifest.json`, and durable `*.db` state — but **not `config.json`**. A config left at the
-default `~/.skill-bill/config.json` path therefore loses its `external_addon_sources` on the next
-install.
+`config.json` — including your `external_addon_sources` — lives at the durable path
+**`~/.config/skill-bill/config.json`** (`$XDG_CONFIG_HOME/skill-bill/config.json`) by default. That
+path is **outside** the `~/.skill-bill/` tree that a `./install.sh` (or update) wipes during its
+pre-install cleanup, so your sources survive every install with **no configuration on your part**.
 
-To keep your sources across installs, **relocate the config outside `~/.skill-bill/` and point
-`SKILL_BILL_CONFIG_PATH` at it.** Both the installer and the runtime read this variable, so a clean
-install never touches the file. Export it from your shell profile so every `install.sh` and
-`skill-bill` invocation sees it:
+Resolution order used by both the installer and the runtime:
 
-```bash
-# ~/.bashrc / ~/.zshrc
-export SKILL_BILL_CONFIG_PATH="$HOME/.config/skill-bill/config.json"
-```
+1. `SKILL_BILL_CONFIG_PATH` — explicit override; pin the config anywhere.
+2. `~/.config/skill-bill/config.json` (honoring `$XDG_CONFIG_HOME`) when it exists — the durable default.
+3. `~/.skill-bill/config.json` — legacy fallback for older installs.
 
-```fish
-# ~/.config/fish/config.fish
-set -gx SKILL_BILL_CONFIG_PATH "$HOME/.config/skill-bill/config.json"
-```
-
-Then move your existing config once:
-
-```bash
-mkdir -p ~/.config/skill-bill
-mv ~/.skill-bill/config.json ~/.config/skill-bill/config.json
-```
+New installs write to the durable path (#2). Existing installs are **migrated automatically**: the
+installer moves a legacy `~/.skill-bill/config.json` to the durable path *before* the pre-install
+cleanup, so upgrading never drops your sources. The cleanup still wipes the rest of `~/.skill-bill/`
+(preserving `skills/`, `platform-packs/`, `orchestration/`, `baseline-manifest.json`, and `*.db`
+state), but the config no longer lives there.
 
 Notes:
 
-- The variable must be present in whatever environment runs `install.sh` and `skill-bill`. Shells
-  launched outside your profile fall back to the default path, so run installs from a shell that
-  sources the export.
-- As a one-off alternative, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the wipe
-  and leaves `~/.skill-bill/config.json` in place. That is intended for dev iteration; the
-  relocation above is the durable choice.
+- To keep the config somewhere else, export `SKILL_BILL_CONFIG_PATH` from your shell profile so every
+  `install.sh` and `skill-bill` invocation sees it. Without the override, the durable default applies.
+- As a one-off, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the wipe entirely
+  (intended for dev iteration).
 
 ## Source Directory Layout
 

--- a/docs/getting-started-for-teams.md
+++ b/docs/getting-started-for-teams.md
@@ -163,6 +163,7 @@ Use the lightest customization that solves the problem:
 | `AGENTS.md` | Repo-wide facts every skill should know | Project team |
 | `.agents/skill-overrides.md` | Skill-specific preferences and local policy | Project team |
 | Learnings | Repeated false positives or accepted review patterns | Team using review telemetry |
+| [External addon source](external-addons.md) | Private or team-specific add-ons overlaid onto an installed pack, kept out of the shared repo | Team maintainer |
 | Forked platform pack | Durable platform behavior that differs from the reference pack | Platform owner |
 | New platform pack | A materially different stack or review/quality model | Platform owner |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,6 +96,24 @@ Using GLM as a model in Claude Code? Skill Bill installs to the Claude Code skil
 
 Installed skills are symlinks to rendered staging directories under `~/.skill-bill/installed-skills/`. Re-run `./install.sh` after changing the checkout so installed agents pick up refreshed `SKILL.md` wrappers, support pointer files, and content hashes.
 
+### Config That Survives Installs
+
+**Every `./install.sh` — including an update, which is just a re-run — wipes `~/.skill-bill/` as a pre-install cleanup step.** It preserves `skills/`, `platform-packs/`, `orchestration/`, `baseline-manifest.json`, and durable `*.db` state (goal/workflow stores, `review-metrics.db`), but **not `config.json`**. So any hand-edited config at the default `~/.skill-bill/config.json` path — most importantly `external_addon_sources`, plus telemetry overrides — is lost on the next install.
+
+If you keep configuration in `config.json`, relocate it outside `~/.skill-bill/` and point `SKILL_BILL_CONFIG_PATH` at the new location. Both the installer and the runtime honor this variable, so a clean install never touches the file. Export it from your shell profile so every `install.sh` and `skill-bill` invocation sees it:
+
+```bash
+# ~/.bashrc / ~/.zshrc
+export SKILL_BILL_CONFIG_PATH="$HOME/.config/skill-bill/config.json"
+```
+
+```fish
+# ~/.config/fish/config.fish
+set -gx SKILL_BILL_CONFIG_PATH "$HOME/.config/skill-bill/config.json"
+```
+
+Then move the existing config once: `mkdir -p ~/.config/skill-bill && mv ~/.skill-bill/config.json ~/.config/skill-bill/config.json`. See [External Addon Sources](external-addons.md#persisting-config-across-installs) for the full rationale. For a one-off install that must not wipe state, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the cleanup entirely (intended for dev iteration).
+
 On Claude, Codex, OpenCode, and Junie, orchestrators that delegate to specialists also install native subagent definitions for supported runtime surfaces. Native subagent sources live as provider-neutral `native-agents/agents.yaml` bundles or standalone `native-agents/<name>.md` files. New and rendered neutral sources include `contract_version: "0.1"`; the parser still accepts older unpinned sources so existing repos can migrate gradually. Install renders those sources into `~/.skill-bill/native-agents/` before linking Claude markdown into `~/.claude/agents/`, Codex TOMLs into `~/.codex/agents/`, OpenCode markdown into `~/.config/opencode/agents/`, and Junie markdown into `~/.junie/agents/`; generated provider files are not checked into the repo. `~/.agents/agents/` is only a Skill Bill compatibility path for Codex homes without a `.codex` root, not the primary documented Codex custom-agent location. Claude and Junie use Markdown/YAML custom-subagent frontmatter, Codex resolves spawn instructions by TOML `name`, and OpenCode resolves by filename-derived agent name and supports manual `@<name>` invocation. Today this covers the `bill-kmp-code-review` specialists, the `bill-kotlin-code-review` specialists, the `bill-php-code-review` specialists, and the `bill-feature-task` workflow phases (pre-planning, planning, implementation, implementation-fix, completeness-audit, quality-check, pr-description). `bill-feature-verify` has no verify-specific native subagents; it delegates review through `bill-code-review` and keeps feature-flag, completeness, and verdict audits inline. Parsing tolerance for `RESULT:` blocks across runtimes is documented inline in `skills/bill-feature-task-prose/content.md`.
 
 ## Runtime Model
@@ -495,6 +513,7 @@ scripts/validate_agent_configs
 ## Reference Docs
 
 - [Getting Started for Teams](getting-started-for-teams.md)
+- [External Addon Sources](external-addons.md)
 - [Skill Source And Generation Model](skill-source-generation.md)
 - [Review Telemetry](review-telemetry.md)
 - `orchestration/shell-content-contract/PLAYBOOK.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ Installed skills are symlinks to rendered staging directories under `~/.skill-bi
 
 ### Config That Survives Installs
 
-Your `config.json` (telemetry choices, `install_id`, and `external_addon_sources`) lives at the durable path **`~/.config/skill-bill/config.json`** (`$XDG_CONFIG_HOME/skill-bill/config.json`). That location is **outside** the `~/.skill-bill/` tree that installs wipe, so it survives every `./install.sh` and update automatically — no environment variable required.
+Your `config.json` (telemetry choices, `install_id`, and `external_addon_sources`) lives at the durable path **`~/.config/skill-bill/config.json`**. That location is **outside** the `~/.skill-bill/` tree that installs wipe, so it survives every `./install.sh` and update automatically — no environment variable required.
 
 - **Fresh installs** write there by default.
 - **Existing installs** are migrated automatically: the installer moves a legacy `~/.skill-bill/config.json` to the durable path before the pre-install cleanup, so nothing is lost on upgrade.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,21 +98,13 @@ Installed skills are symlinks to rendered staging directories under `~/.skill-bi
 
 ### Config That Survives Installs
 
-**Every `./install.sh` — including an update, which is just a re-run — wipes `~/.skill-bill/` as a pre-install cleanup step.** It preserves `skills/`, `platform-packs/`, `orchestration/`, `baseline-manifest.json`, and durable `*.db` state (goal/workflow stores, `review-metrics.db`), but **not `config.json`**. So any hand-edited config at the default `~/.skill-bill/config.json` path — most importantly `external_addon_sources`, plus telemetry overrides — is lost on the next install.
+Your `config.json` (telemetry choices, `install_id`, and `external_addon_sources`) lives at the durable path **`~/.config/skill-bill/config.json`** (`$XDG_CONFIG_HOME/skill-bill/config.json`). That location is **outside** the `~/.skill-bill/` tree that installs wipe, so it survives every `./install.sh` and update automatically — no environment variable required.
 
-If you keep configuration in `config.json`, relocate it outside `~/.skill-bill/` and point `SKILL_BILL_CONFIG_PATH` at the new location. Both the installer and the runtime honor this variable, so a clean install never touches the file. Export it from your shell profile so every `install.sh` and `skill-bill` invocation sees it:
+- **Fresh installs** write there by default.
+- **Existing installs** are migrated automatically: the installer moves a legacy `~/.skill-bill/config.json` to the durable path before the pre-install cleanup, so nothing is lost on upgrade.
+- **Custom location**: set `SKILL_BILL_CONFIG_PATH` to pin the config anywhere (this override always wins, for both the installer and the runtime).
 
-```bash
-# ~/.bashrc / ~/.zshrc
-export SKILL_BILL_CONFIG_PATH="$HOME/.config/skill-bill/config.json"
-```
-
-```fish
-# ~/.config/fish/config.fish
-set -gx SKILL_BILL_CONFIG_PATH "$HOME/.config/skill-bill/config.json"
-```
-
-Then move the existing config once: `mkdir -p ~/.config/skill-bill && mv ~/.skill-bill/config.json ~/.config/skill-bill/config.json`. See [External Addon Sources](external-addons.md#persisting-config-across-installs) for the full rationale. For a one-off install that must not wipe state, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the cleanup entirely (intended for dev iteration).
+The pre-install cleanup still wipes the rest of `~/.skill-bill/`, preserving `skills/`, `platform-packs/`, `orchestration/`, `baseline-manifest.json`, and durable `*.db` state (goal/workflow stores, `review-metrics.db`). Only the config was ever at risk, and it now lives outside that tree. See [External Addon Sources](external-addons.md#persisting-config-across-installs) for details. For a one-off install that must not wipe any state, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the cleanup entirely (intended for dev iteration).
 
 On Claude, Codex, OpenCode, and Junie, orchestrators that delegate to specialists also install native subagent definitions for supported runtime surfaces. Native subagent sources live as provider-neutral `native-agents/agents.yaml` bundles or standalone `native-agents/<name>.md` files. New and rendered neutral sources include `contract_version: "0.1"`; the parser still accepts older unpinned sources so existing repos can migrate gradually. Install renders those sources into `~/.skill-bill/native-agents/` before linking Claude markdown into `~/.claude/agents/`, Codex TOMLs into `~/.codex/agents/`, OpenCode markdown into `~/.config/opencode/agents/`, and Junie markdown into `~/.junie/agents/`; generated provider files are not checked into the repo. `~/.agents/agents/` is only a Skill Bill compatibility path for Codex homes without a `.codex` root, not the primary documented Codex custom-agent location. Claude and Junie use Markdown/YAML custom-subagent frontmatter, Codex resolves spawn instructions by TOML `name`, and OpenCode resolves by filename-derived agent name and supports manual `@<name>` invocation. Today this covers the `bill-kmp-code-review` specialists, the `bill-kotlin-code-review` specialists, the `bill-php-code-review` specialists, and the `bill-feature-task` workflow phases (pre-planning, planning, implementation, implementation-fix, completeness-audit, quality-check, pr-description). `bill-feature-verify` has no verify-specific native subagents; it delegates review through `bill-code-review` and keeps feature-flag, completeness, and verdict audits inline. Parsing tolerance for `RESULT:` blocks across runtimes is documented inline in `skills/bill-feature-task-prose/content.md`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,7 +102,7 @@ Your `config.json` (telemetry choices, `install_id`, and `external_addon_sources
 
 - **Fresh installs** write there by default.
 - **Existing installs** are migrated automatically: the installer moves a legacy `~/.skill-bill/config.json` to the durable path before the pre-install cleanup, so nothing is lost on upgrade.
-- **Custom location**: set `SKILL_BILL_CONFIG_PATH` to pin the config anywhere (this override always wins, for both the installer and the runtime).
+- **Custom location**: set `SKILL_BILL_CONFIG_PATH` to pin the config anywhere (this override always wins, for both the installer and the runtime). If you exported this in an earlier version just to relocate the config to `~/.config/skill-bill/`, you can drop it — the durable default now covers that automatically.
 
 The pre-install cleanup still wipes the rest of `~/.skill-bill/`, preserving `skills/`, `platform-packs/`, `orchestration/`, `baseline-manifest.json`, and durable `*.db` state (goal/workflow stores, `review-metrics.db`). Only the config was ever at risk, and it now lives outside that tree. See [External Addon Sources](external-addons.md#persisting-config-across-installs) for details. For a one-off install that must not wipe any state, `SKILL_BILL_SKIP_PREINSTALL_UNINSTALL=1 ./install.sh …` skips the cleanup entirely (intended for dev iteration).
 

--- a/docs/review-telemetry.md
+++ b/docs/review-telemetry.md
@@ -19,10 +19,10 @@ Default database path:
 ~/.skill-bill/review-metrics.db
 ```
 
-Default config path:
+Default config path (durable, survives installs):
 
 ```text
-~/.skill-bill/config.json
+~/.config/skill-bill/config.json
 ```
 
 You can override the database path with `--db` or `SKILL_BILL_REVIEW_DB`.
@@ -734,4 +734,4 @@ export SKILL_BILL_TELEMETRY_BATCH_SIZE="50"                # optional override
 export SKILL_BILL_CONFIG_PATH="/custom/path/config.json"  # optional: pin config to a custom path (overrides the durable default)
 ```
 
-When telemetry is enabled, the local config stores the generated install id used as the anonymous event `distinct_id`. The config lives at the durable `~/.config/skill-bill/config.json` (`$XDG_CONFIG_HOME/skill-bill/config.json`) by default, outside the `~/.skill-bill/` tree that installs wipe; you can edit it directly if you want to keep the hosted relay or replace it with your own proxy target, but the supported way to opt out is `skill-bill telemetry disable`.
+When telemetry is enabled, the local config stores the generated install id used as the anonymous event `distinct_id`. The config lives at the durable `~/.config/skill-bill/config.json` by default, outside the `~/.skill-bill/` tree that installs wipe; you can edit it directly if you want to keep the hosted relay or replace it with your own proxy target, but the supported way to opt out is `skill-bill telemetry disable`.

--- a/docs/review-telemetry.md
+++ b/docs/review-telemetry.md
@@ -731,7 +731,7 @@ export SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN="replace-with-your-stats-token"
 export SKILL_BILL_TELEMETRY_LEVEL="full"                   # optional override (off, anonymous, full)
 export SKILL_BILL_TELEMETRY_ENABLED="true"                 # legacy override (maps true→anonymous, false→off)
 export SKILL_BILL_TELEMETRY_BATCH_SIZE="50"                # optional override
-export SKILL_BILL_CONFIG_PATH="$HOME/.skill-bill/config.json"  # optional override
+export SKILL_BILL_CONFIG_PATH="$HOME/.config/skill-bill/config.json"  # relocate config outside ~/.skill-bill so installs/updates don't wipe it
 ```
 
 When telemetry is enabled, the local config stores the generated install id used as the anonymous event `distinct_id`. You can edit `~/.skill-bill/config.json` directly if you want to keep the hosted relay or replace it with your own proxy target, but the supported way to opt out is `skill-bill telemetry disable`.

--- a/docs/review-telemetry.md
+++ b/docs/review-telemetry.md
@@ -731,7 +731,7 @@ export SKILL_BILL_TELEMETRY_PROXY_STATS_TOKEN="replace-with-your-stats-token"
 export SKILL_BILL_TELEMETRY_LEVEL="full"                   # optional override (off, anonymous, full)
 export SKILL_BILL_TELEMETRY_ENABLED="true"                 # legacy override (maps true→anonymous, false→off)
 export SKILL_BILL_TELEMETRY_BATCH_SIZE="50"                # optional override
-export SKILL_BILL_CONFIG_PATH="$HOME/.config/skill-bill/config.json"  # relocate config outside ~/.skill-bill so installs/updates don't wipe it
+export SKILL_BILL_CONFIG_PATH="/custom/path/config.json"  # optional: pin config to a custom path (overrides the durable default)
 ```
 
-When telemetry is enabled, the local config stores the generated install id used as the anonymous event `distinct_id`. You can edit `~/.skill-bill/config.json` directly if you want to keep the hosted relay or replace it with your own proxy target, but the supported way to opt out is `skill-bill telemetry disable`.
+When telemetry is enabled, the local config stores the generated install id used as the anonymous event `distinct_id`. The config lives at the durable `~/.config/skill-bill/config.json` (`$XDG_CONFIG_HOME/skill-bill/config.json`) by default, outside the `~/.skill-bill/` tree that installs wipe; you can edit it directly if you want to keep the hosted relay or replace it with your own proxy target, but the supported way to opt out is `skill-bill telemetry disable`.

--- a/install.sh
+++ b/install.sh
@@ -2462,6 +2462,22 @@ apply_runtime_install() {
   ok "Runtime install apply completed"
 }
 
+apply_external_addon_overlay() {
+  if [[ ! -d "$SKILL_BILL_STATE_DIR/platform-packs" ]]; then
+    return 0
+  fi
+  info "Applying external addon overlay onto installed platform packs."
+  local status=0
+  run_runtime_cli install apply-external-addons \
+    --repo-root "$SKILL_BILL_STATE_DIR" \
+    --platform-packs "$SKILL_BILL_STATE_DIR/platform-packs" || status=$?
+  if [[ "$status" -ne 0 ]]; then
+    err "External addon overlay failed; aborting the install."
+    return "$status"
+  fi
+  ok "External addon overlay completed"
+}
+
 print_claude_roots_summary() {
   local roots root
   roots="$(run_runtime_cli install claude-roots 2>/dev/null)" || return 0
@@ -2635,6 +2651,7 @@ run_full_install() {
   fi
   echo ""
 
+  apply_external_addon_overlay
   apply_runtime_install
   install_desktop_app
 

--- a/install.sh
+++ b/install.sh
@@ -833,7 +833,7 @@ migrate_legacy_config_to_durable_path() {
     return 0
   fi
   local legacy="$SKILL_BILL_STATE_DIR/config.json"
-  local durable="${XDG_CONFIG_HOME:-$HOME/.config}/skill-bill/config.json"
+  local durable="$HOME/.config/skill-bill/config.json"
   if [[ -f "$legacy" && ! -f "$durable" ]]; then
     mkdir -p "$(dirname "$durable")"
     if mv "$legacy" "$durable"; then

--- a/install.sh
+++ b/install.sh
@@ -822,6 +822,28 @@ print_install_plan() {
   echo ""
 }
 
+# One-time migration: older installs kept config.json inside the wiped
+# ~/.skill-bill/. Move it to the durable XDG location (~/.config/skill-bill/,
+# outside the wipe zone) BEFORE the pre-install uninstall so user settings —
+# external_addon_sources, telemetry choices, install_id — survive every install.
+# Skipped when the user pins a config path via SKILL_BILL_CONFIG_PATH, or when
+# the durable copy already exists (never clobber it).
+migrate_legacy_config_to_durable_path() {
+  if [[ -n "${SKILL_BILL_CONFIG_PATH:-}" ]]; then
+    return 0
+  fi
+  local legacy="$SKILL_BILL_STATE_DIR/config.json"
+  local durable="${XDG_CONFIG_HOME:-$HOME/.config}/skill-bill/config.json"
+  if [[ -f "$legacy" && ! -f "$durable" ]]; then
+    mkdir -p "$(dirname "$durable")"
+    if mv "$legacy" "$durable"; then
+      info "Migrated Skill Bill config to durable location: $durable"
+    else
+      warn "Could not migrate config to $durable; leaving it at $legacy."
+    fi
+  fi
+}
+
 # Every install starts from a clean slate: removes agent symlinks, native
 # subagent symlinks, MCP registrations, runtime launchers, and wipes
 # ~/.skill-bill/ (including the installed-skills staging cache, runtime
@@ -2612,6 +2634,7 @@ run_full_install() {
     replay_last_install_selection
   fi
   clean_install_state_if_requested
+  migrate_legacy_config_to_durable_path
   run_pre_install_uninstall
   copy_in_authored_source
   install_runtime_distributions

--- a/platform-packs/ios/addons/offline-background-reliability.md
+++ b/platform-packs/ios/addons/offline-background-reliability.md
@@ -1,0 +1,25 @@
+# Background Sync Reliability
+
+Cues: background-sync engine, sync queue, retry/backoff, sync-vs-migration interplay, lifecycle-driven sync triggers, interceptor/chain composition.
+
+## Migration-vs-sync ordering
+
+A schema migration that adds a column a sync path immediately reads, or a sync that runs before a migration completes, produces missing-column errors or empty results on the first launch after update.
+
+- Confirm a newly-added column is available to every read/write site before sync consumes it, and that migrations run to completion before the first sync that depends on them.
+- Migrations must stay frozen and additive: reference **frozen string literals** for table/column names, never a live model symbol whose value can change later and retroactively alter an already-shipped migration. When a table has been renamed, the migration must handle the legacy name (an `alterRenamedTable`-style helper), not assume the current name exists on un-migrated devices.
+
+## Retries, backoff, and cancellation
+
+- A long-running or repeatable sync effect must carry an effect-identity (`cancellableId`) so a superseding trigger cancels the in-flight one; otherwise overlapping syncs race and a slower older run can overwrite newer results.
+- Check that a removed `.retry`/backoff wasn't silently dropped in a refactor — trace whether it moved into the new request path or vanished.
+- Errors on a background path must be observable (logged/metered), not swallowed. A `do { … }` block with no `catch` propagates (fine); an empty `catch {}` or `.catch { _ in Empty() }` hides failures — flag the latter.
+
+## Lifecycle-driven triggers
+
+- Sync/refresh sent unconditionally on every view appearance re-fires on modal present/dismiss and foreground/background cycles. Confirm it is idempotent or guarded, and that a same-key guard actually disambiguates two concurrent runs (comparing the same id-set does not).
+- Sync that only triggers from one screen's lifecycle silently stops for flows that never open that screen — verify the trigger lives at the right level.
+
+## Per-item work inside the sync loop
+
+Moving a single end-of-sync maintenance pass into per-item processing multiplies DB/network round-trips by N. Flag per-item trims/queries/fetches that a single batched pass previously handled, unless the batching is preserved.

--- a/platform-packs/ios/addons/offline-conflict-resolution.md
+++ b/platform-packs/ios/addons/offline-conflict-resolution.md
@@ -1,0 +1,28 @@
+# Offline Write Reconciliation & Optimistic UI
+
+Cues: last-write-wins, versioned/merge records, optimistic local updates, `isDeleted`/status flags flipped before an async write, save-on-navigation.
+
+## Premature local state flip before the async write confirms
+
+Setting a success/deleted/completed flag synchronously, before the effect that performs the write completes, corrupts state when the write later fails.
+
+- Flag `state.isDeleted = true` / `state.saved = true` set in the reducer ahead of the delete/save effect's completion. On failure the UI shows the item gone or saved while the store still holds it (or vice versa). Drive the flag from the effect's success, not its dispatch.
+
+## Optimistic update with no rollback path
+
+An optimistic local mutation applied before the server confirms must have a defined revert if the write fails.
+
+- If the diff applies a local change and fires a fire-and-forget write whose failure is swallowed (`.catch { _ in Empty() }`, no error surfaced, no rollback), a failed sync leaves local state diverged from the server with no user-visible signal. Flag the swallow; require the error to either surface or roll back.
+
+## Save/sync on navigation without a dirty check
+
+Auto-saving on back/disappear whenever the record "validates," with no comparison against the initial value, schedules a redundant write and sync job for unchanged records.
+
+- Flag `willDisappear`/back handlers that unconditionally `saveChanges` in view mode. Require a `state.initialItem != state.item`-style dirty check so open-and-back on an unedited record is a no-op.
+
+## Write-semantics changes on a synced table
+
+Changing how a sync-participating table is written (last-write-wins vs versioned, which fields are authoritative, whether a field is backfilled) can desync clients that haven't migrated.
+
+- When a new persisted field is added by migration but no deep sync / backfill is triggered, pre-existing rows stay `NULL` until each is independently re-fetched — flag the missing backfill story, or confirm the field is nullable-and-tolerated by all readers.
+- A deleted item re-saved during pop/navigation (delete effect maps to a "back" action that then re-persists) resurrects it — check delete-then-navigate ordering.

--- a/platform-packs/ios/addons/offline-first-review.md
+++ b/platform-packs/ios/addons/offline-first-review.md
@@ -1,0 +1,32 @@
+# iOS Offline-First Review Add-On
+
+Use this governed add-on only after stack routing has already selected `ios` and the review scope touches an offline-first surface — a local store (GRDB/SQLite, Core Data, Realm) plus a sync layer that reconciles local and remote state.
+
+This file is a review index for `bill-ios-code-review` and its `persistence`/`reliability`/`platform-correctness` specialists. It is not a standalone review command. The guidance is generic to offline-first iOS apps; it encodes recurring failure modes, not any single project's internals.
+
+## Activation signals
+
+Activate `offline-first` when the diff shows any of:
+
+- a local persistent store (GRDB/SQLite statements or migrations, Core Data, Realm) **and** a network/sync path that writes into or reads around it
+- a cache-trim/eviction, prefetch, or "download for offline" flow
+- a background-sync engine, sync queue, or interceptor/chain-of-responsibility sync composition
+- conflict handling: last-write-wins, versioned records, merge functions, optimistic UI with rollback
+
+If the diff only touches UI or pure in-memory state with no local store or sync, do **not** activate this add-on.
+
+## Section index
+
+Scan this file first. Then open only the linked topic files whose cues match the diff instead of loading all offline-first guidance by default.
+
+- `[offline-sync-consistency.md](offline-sync-consistency.md)`
+  Read when the diff touches cache trimming/eviction, prefetch/download-for-offline, the ordering of delete-vs-download, or a query whose join/filter can hide un-synced rows.
+- `[offline-conflict-resolution.md](offline-conflict-resolution.md)`
+  Read when the diff touches write reconciliation: last-write-wins, versioned/merge records, optimistic UI updates, or premature local state flips before an async write confirms.
+- `[offline-background-reliability.md](offline-background-reliability.md)`
+  Read when the diff touches background sync, retries/backoff, sync-vs-migration interplay, or lifecycle-driven sync triggers.
+
+## How to use it
+
+- Treat findings from this add-on as `persistence`/`reliability`/`platform-correctness` findings — fold them into those specialists' registers, do not create a parallel lane.
+- Every finding must name a concrete, reachable failure (data a user loses, a row that disappears, a write that silently drops). Offline-first bugs are high-severity precisely because they surface only on a device that is offline, mid-sync, or freshly installed — states a quick manual test misses. Describe that state explicitly.

--- a/platform-packs/ios/addons/offline-sync-consistency.md
+++ b/platform-packs/ios/addons/offline-sync-consistency.md
@@ -1,0 +1,29 @@
+# Offline Sync & Cache Consistency
+
+Cues: cache trim/eviction, prefetch or "download for offline", delete-then-refetch flows, queries that join or filter on sync state.
+
+## Delete-before-download loses the only offline copy
+
+When a flow clears or trims a cached artifact **before** its replacement has been confirmed downloaded, an offline or failed fetch leaves the user with neither the old nor the new copy.
+
+- Flag any `clear`/`trim`/`evict` that runs ahead of the `fetch`/`download` whose result is meant to replace it. The safe order is fetch-then-swap: only delete the old artifact once the new one is durably stored.
+- A "keep latest version" rule that selects by version number **without checking the item is actually cached** can purge the one copy present on-device. Keep-selection for eviction must be cache-aware.
+
+## Cache-only reads that dropped a fetch fallback
+
+A read path refactored from "return cached, else fetch-and-cache" to "return cached, else fail" silently breaks first-view / cache-miss / post-eviction cases.
+
+- On any load path, check the `-` side of the diff: did a `fetchIfMissing`/`returnCacheDataElseFetch` fallback get replaced by a cache-only read that errors on `nil`? That plan/image/document then never loads on a fresh install or after eviction.
+
+## Queries that hide un-synced rows
+
+A local query that `INNER JOIN`s (or filters) on a related row that is populated only by sync will silently omit entities whose related rows haven't synced yet.
+
+- Flag a join changed from outer/`LEFT` to `INNER` (or a new `WHERE` on a sync-populated column) on a list/enumeration/lookup query: mid-sync or on a fresh install the entity disappears from lists, is skipped by offline-caching enumeration, and resolves `nil` in detail/relationship lookups.
+
+## Trim/eviction driven by the wrong lifecycle
+
+Cache maintenance wired to a screen's lifecycle (view appear/disappear, a specific store instance) instead of the sync pipeline runs too often, not at all, or concurrently with the sync it should follow.
+
+- Watch for eviction moved into a per-screen store: multiple live instances each subscribe and trim (duplicate work), and flows that never open that screen never trim (unbounded growth).
+- Eviction that runs on every `syncCompleted` emission — including `.offline`/`.errored`/replayed initial values — trims after failed or non-events. Gate it on a genuine successful completion.

--- a/platform-packs/ios/agent/history.md
+++ b/platform-packs/ios/agent/history.md
@@ -1,0 +1,49 @@
+## [2026-07-01] ios-platform-pack (dry-run-validation)
+Areas: platform-packs/ios/code-review
+- Read-only dry-run of `bill-ios-code-review` vs two real stuck iOS-app PRs:
+  routing matched changed-file signals; 32 findings accurate/non-noisy
+  (incl. a genuine Blocker); zero GitHub posting.
+- Reusable acquisition trick: shallow clone at PR head loads repo-local
+  `AGENTS.md`/`CLAUDE.md` + `references/*.md`, so repo-local-knowledge
+  specialists read real project rules (no `gh pr diff` fallback needed).
+- Known gaps (report-only, NOT fixed): iOS specialists in
+  `native-agents/agents.yaml` are unregistered in `~/.claude/agents`, so the
+  documented Agent-tool spawn path can't resolve on Claude (validated rubric
+  + routing, not installed spawn wiring); overlap needs merge-layer dedup;
+  installed skill dir lacks sidecar ceremony files.
+Feature flag: N/A
+Acceptance criteria: 1/1 implemented
+
+## [2026-07-01] ios-platform-pack (revise-validate-install)
+Areas: platform-packs/ios/code-review
+- Frequency-weighted revision of 5 specialist rubrics from mined patterns:
+  reliability +6, architecture +5, testing +3, platform-correctness +3
+  (sharpened, breadth kept), performance -3. Trimming rule: never empty a
+  declared area — keep frontmatter/Focus/Ignore/Applicability + >=1
+  Project-Specific rule so `show` stays `complete`.
+- Reusable: add depth as generalized house-voice bullets only (no verbatim
+  mined PR text, no proprietary internals) so the public tree stays free of
+  proprietary content.
+- Router + 5 low-signal specialists unchanged; routing verified via synthetic
+  diffs (background-sync-engine paths -> reliability, *.graphql -> api-contracts).
+- `validate-agent-configs` pass/[] across all 11 + render clean; `./install.sh`
+  blocked only by goal-continuation guard (install.sh:67) — run post-goal.
+Feature flag: N/A
+Acceptance criteria: 4/4 implemented
+
+## [2026-07-01] ios-platform-pack (pack-foundation)
+Areas: platform-packs/ios, platform-packs/ios/code-review
+- Added `ios` platform pack: `platform.yaml` routing signals (`.xcodeproj`,
+  `.xcworkspace`, `import SwiftUI`, `import UIKit`, `iOSApplicationExtension`)
+  with no overlap vs KMP's iosMain/androidMain/commonMain signals.
+- Added `bill-ios-code-review` router + 10 area specialists (architecture,
+  performance, platform-correctness, security, testing, api-contracts,
+  persistence, reliability, ui, ux-accessibility) mirroring the PHP pack's
+  router/specialist shape and min-2/max-10 bounds pattern.
+- Reusable: `architecture`/`persistence`/`platform-correctness`/`reliability`
+  specialists each add a "Repo-Local Knowledge" section pointing the reviewer
+  at the target repo's own `.agents/skills/*/references/*.md` and root
+  `AGENTS.md`/`CLAUDE.md` — keeps proprietary knowledge out of
+  skill-bill's public repo while still informing review.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented

--- a/platform-packs/ios/code-review/bill-ios-code-review-api-contracts/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-api-contracts/content.md
@@ -1,0 +1,34 @@
+---
+name: bill-ios-code-review-api-contracts
+description: Use when reviewing iOS GraphQL/Apollo API-contract risks including generated code drift, cache/field-policy correctness, and schema/codegen alignment.
+---
+
+# API Contracts Review Specialist
+
+Review only high-signal API-contract issues.
+
+## Focus
+
+- Generated GraphQL client code staying in sync with schema/operation changes
+- Apollo cache and field-policy correctness
+- `.graphql` operation changes that alter response shape or nullability
+- Codegen regeneration discipline
+
+## Ignore
+
+- Non-networking code with no GraphQL/Apollo surface
+- Cosmetic differences in generated code that codegen would reproduce identically
+
+## Applicability
+
+Use this specialist for the GraphQL/Apollo-consuming client surface: `.graphql` operation/fragment files, the generated API client code, and Apollo cache configuration. This is a client consuming a GraphQL API, so the contract risk is codegen and cache correctness, not server-side request validation.
+
+## Project-Specific Rules
+
+- Never hand-edit generated API client code (e.g. a generated `API.swift`); any change to server contract behavior must originate from a `.graphql` operation/schema change followed by codegen regeneration
+- Every `.graphql` operation or fragment change must be accompanied by regenerated client code in the same diff; a schema/operation change without a matching codegen diff is a contract-drift risk
+- Cache and field policies (type policies, merge functions, cache key resolution) must be reviewed whenever a `.graphql` change alters an identifying field, a list field's merge behavior, or a type's cache key
+- Nullability changes in `.graphql` operations must be checked against all call sites that unwrap the generated response type; a field going from non-null to nullable (or vice versa) is a breaking client-side change even though the client compiles
+- Query/mutation naming and fragment reuse should stay consistent with existing operations touching the same types, to avoid duplicate or conflicting cache entries for the same underlying object
+- Optimistic responses and cache writes for mutations must match the shape codegen will regenerate; hand-shaped optimistic payloads that drift from the real response type are a correctness risk
+- For Major or Critical findings, describe the concrete stale-cache, crash-on-unwrap, or data-integrity consequence

--- a/platform-packs/ios/code-review/bill-ios-code-review-architecture/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-architecture/content.md
@@ -1,0 +1,46 @@
+---
+name: bill-ios-code-review-architecture
+description: Use when reviewing iOS architecture, dependency-injection scopes, composition-root wiring, and SPM package-boundary respect.
+---
+
+# Architecture Review Specialist
+
+Review only high-signal architectural issues.
+
+## Focus
+
+- Dependency-injection scope and lifetime correctness
+- Composition-root wiring and registration hygiene
+- Local Swift Package Manager package-boundary respect
+- Module ownership and source-of-truth consistency
+- Cross-module coupling introduced by new dependencies
+
+## Ignore
+
+- Formatting, style, and framework-idiom differences without architectural impact
+- Naming or pattern preferences without concrete risk
+
+## Applicability
+
+Use this specialist across app targets and local SPM packages when changed code can affect dependency wiring, module boundaries, or architectural consistency. First infer the architecture established in the changed area and adjacent modules; treat coherent local architecture as the contract for consistency. Where the local architecture is absent, weak, inconsistent, or accidental, guide changes toward established iOS/Swift practices through concrete risk-based findings, not terminology preference.
+
+## Project-Specific Rules
+
+- Dependency injection should use the project's established DI container rather than ad-hoc singletons, global statics, or hidden service locators
+- Respect the container's declared scopes (for example: singleton/app-lifetime, per-flow/session-scoped, and transient/per-use scopes); a dependency registered at one scope must not be resolved or cached in a way that outlives or leaks across that scope
+- New dependencies must be registered through the project's composition-root registration surface (e.g. a `DependencyContainer+Registrations.swift`-style extension), not constructed inline at call sites
+- Never bypass the DI container to reach a concrete implementation directly when a declared protocol/provider exists for that dependency
+- Local SPM packages must only be consumed through their declared public API; reaching into another package's internal types, or importing implementation details across a package boundary, is an architecture violation
+- A new local SPM package or new cross-package dependency must have a clear, documented reason it does not already fit an existing package boundary
+- New cross-boundary consumers should depend on a `Provider`-style protocol rather than a concrete type, so the composition root remains the single place that wires concrete implementations to their consumers
+- Business workflows and invariants should stay independent of transport, rendering, and persistence details when complexity warrants that separation or the project architecture already requires it
+- Dead or unused code (parameters, variables, functions, properties, imports, whole files) left behind after a refactor should be removed rather than committed as noise that hides an incomplete refactor
+- Duplicated or competing logic (retry wrappers, validation, effects, business rules) copy-pasted across layers or stores invites divergent behavior; extract it into a shared helper rather than maintaining parallel copies
+- State mutated directly inside a Combine operator (`sink`/`map`/`flatMap`) or otherwise outside the reducer breaks unidirectional flow; state changes should be routed through the store's send/reduce path
+- UI-adjacent or utility code placed in the wrong module/package layer (UI leaking into a core/light package, or code pushed too low-level) breaks the intended dependency direction and grows the build graph unnecessarily
+- Legacy Combine/callback-based store patterns (cancellables held in state, delay chains) used in place of the current Effect-driven architecture mix thread-safety concerns into the store and should migrate to the established pattern
+- Report architecture issues only when the change creates or worsens concrete risk: maintainability loss, duplicated ownership, unclear scope lifetime, testability loss, or coupling that makes the package graph harder to reason about
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. an explicitly frozen composition-root convention or DI-scope rule) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-performance/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-performance/content.md
@@ -1,0 +1,31 @@
+---
+name: bill-ios-code-review-performance
+description: Use when reviewing iOS performance risks on hot reducer paths, main-thread work, and image/PDF-heavy processing.
+---
+
+# Performance Review Specialist
+
+Review only performance issues with real, demonstrable production impact.
+
+## Focus
+
+- Hot reducer/store paths that run on every state update
+- Main-thread work that can cause dropped frames or UI stalls
+- Image, PDF, and media-processing hot paths
+- Large sync/import loops with unbounded or repeated work
+
+## Ignore
+
+- Micro-optimizations with no measurable or plausible production impact
+- Premature optimization of cold paths
+
+## Applicability
+
+Use this specialist for reducer/store code that runs on frequent state updates, any code executing on the main thread that affects UI responsiveness, and image/PDF/media-processing code paths (for example, gallery, editor, or camera-adjacent features).
+
+## Project-Specific Rules
+
+- Reducer logic invoked on every action dispatch must avoid expensive synchronous work (large collection copies, repeated filtering/sorting, synchronous I/O); move expensive computation into an effect off the hot reducer path
+- Image and PDF decoding, downscaling, and rendering must not run synchronously on the main thread for anything larger than trivial thumbnail-sized content
+- Large sync/import loops must avoid O(n²) patterns (e.g. repeated linear scans per item) when a single pass or indexed lookup is available
+- For Major or Critical findings, describe the concrete user-visible stall, dropped-frame, or memory-pressure consequence

--- a/platform-packs/ios/code-review/bill-ios-code-review-persistence/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-persistence/content.md
@@ -1,0 +1,39 @@
+---
+name: bill-ios-code-review-persistence
+description: Use when reviewing iOS GRDB/SQLite persistence risks including migration safety, schema changes, and offline-sync data consistency.
+---
+
+# Persistence Review Specialist
+
+Review only persistence issues that can corrupt data, break consistency, or create high-risk operational regressions.
+
+## Focus
+
+- Migration safety and forward compatibility
+- Schema-change discipline for local SQLite/GRDB storage
+- 1:1 coverage between SQL statements and their statement tests
+- Blast radius of changes touching deep/offline sync
+
+## Ignore
+
+- Harmless query-style preferences
+- Micro-optimizations with no correctness or sync-consistency impact
+
+## Applicability
+
+Use this specialist for the local persistence layer: GRDB (or equivalent SQLite wrapper) migrations, schema definitions, statement-level SQL, and code paths that participate in offline-first sync of persisted data.
+
+## Project-Specific Rules
+
+- A migration that has already shipped is frozen: never edit an already-applied migration's body to add or change behavior, even to fix a bug — ship a new, additive migration instead
+- Migrations are additive-only; do not drop columns/tables or narrow types in a way that breaks a device that has not yet migrated forward, unless the project has an explicit deprecation/backfill path for that
+- Any schema change (new table, new column, index change, constraint change) must ship with a corresponding migration in the same diff — schema drift between code and the applied migration history is a correctness risk
+- Statement tests (e.g. a `{Statement}SQLStatementTests.swift`-style 1:1 test) are a recommended convention, not a universal hard rule — confirm the repo actually applies it broadly before treating its absence as a violation (in practice only a subset of statements carry one). A new or changed hand-written SQL statement without a matching test is a real but at-most-Minor coverage gap; reserve higher severity for a statement whose correctness is genuinely load-bearing (migration-affecting, sync-driving, or complex enough that a silent regression would corrupt or drop data)
+- A SQL statement assembled by regex/string substitution against another statement's raw text (e.g. stripping a join by pattern-matching the `.sql` file) is fragile: its correctness is coupled to the exact formatting of the source SQL. Flag it, and note that a test which only asserts substring presence/absence does not prove the produced statement is valid runnable SQL
+- Changes that touch deep/offline sync of persisted data must be evaluated for blast radius: what happens to already-synced records, in-flight sync operations, and conflict resolution when this change ships to a device mid-sync
+- Reads and writes that participate in sync must preserve whatever consistency guarantee the existing sync design relies on (e.g. last-write-wins, versioned records, or conflict markers) — do not silently change write semantics for a table that sync depends on
+- For Major or Critical findings, explain the data-loss, migration-failure, or sync-inconsistency consequence explicitly
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. an explicitly frozen-migration rule or a documented sync-consistency invariant) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-platform-correctness/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-platform-correctness/content.md
@@ -1,0 +1,43 @@
+---
+name: bill-ios-code-review-platform-correctness
+description: Use when reviewing iOS unidirectional-data-flow correctness, main-thread discipline, Combine effect lifecycles, and reducer purity.
+---
+
+# Platform Correctness Review Specialist
+
+Review only high-signal platform-correctness issues.
+
+## Focus
+
+- Store/Action/Environment (unidirectional data flow) correctness
+- Main-thread discipline for state mutation and UI-facing output
+- Combine effect cancellation and lifecycle discipline
+- Reducer purity and side-effect placement
+- Lifecycle-unsafe state capture across async boundaries
+
+## Ignore
+
+- Style preferences for effect composition with no correctness impact
+- Micro-optimizations to reducer code with no behavior change
+
+## Applicability
+
+Use this specialist wherever the project's unidirectional-data-flow pattern (a `{Feature}Store`/`Action`/`Environment`-shaped store, or equivalent) drives feature state, and wherever Combine (or an equivalent reactive pipeline) issues effects that ultimately mutate state or update the UI.
+
+## Project-Specific Rules
+
+- Reducers (the `Action`-handling function of a `Store`) should generally stay pure: given the current state and an action, they compute the next state and describe effects to run. But first infer whether this project's `Store` actually enforces reducer purity — some custom (non-TCA) stores deliberately allow synchronous state or view-model mutation inside `reduce`, and when that is the established, pervasive house pattern it is not a defect. Flag in-reduce side effects only when they cause a concrete, reachable problem (an ordering/reentrancy bug, a main-thread violation, unmanaged async work that leaks or races, or real external I/O) — and describe that consequence. A purity deviation that merely conforms to the codebase's intentional pattern with no wrong outcome is at most a Minor/Nit, not a Major "purity violation"
+- Effects that update state or drive UI must be delivered back to the store on the main thread (e.g. via a `.receive(on: mainScheduler)`-style operator); do not update `@Published`/store state from a background queue or an arbitrary Combine scheduler
+- Every long-running or cancellable effect must be registered under an explicit `cancellableId` (or equivalent effect-identity token); effects without an identity cannot be cancelled and can leak or race with a later effect for the same logical operation
+- Starting a new effect for an id that already has one in flight must explicitly cancel the prior effect first, unless the store intentionally allows concurrent effects for that id
+- Effects must not capture stale state by value across an async boundary when the store's state can change before the effect resumes; re-read current state through the store/environment rather than trusting a closure-captured snapshot
+- Side effects (networking, persistence, timers, notifications) belong in the `Environment`, invoked from effects the reducer returns — not called directly from views or from the reducer body
+- Cancellation on view disappearance, feature teardown, or navigation-away must actually cancel in-flight effects tied to that feature's cancellable ids
+- Coordinate or unit values conflated between normalized (0–1) and raw/pixel ranges — including omitted axis offsets — produce visibly wrong placement and are a correctness bug, not a rounding detail
+- Inverted, redundant, or always-true/always-false guard and boolean logic makes a conditional behave opposite to its intent or go permanently dead; scrutinize refactored conditionals for this
+- Force-unwrap or `.require()` applied to state that can legitimately be nil at runtime crashes the app instead of gracefully guarding the expected absent-state case
+- For Major or Critical findings, describe the concrete race, stale-state, or main-thread-violation scenario a user or crash report would surface
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. an explicitly required main-thread or cancellation discipline) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-reliability/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-reliability/content.md
@@ -1,0 +1,44 @@
+---
+name: bill-ios-code-review-reliability
+description: Use when reviewing iOS background-sync reliability risks including chained interceptor composition, error-logging discipline, and permission-check completeness.
+---
+
+# Reliability Review Specialist
+
+Review only issues that affect production reliability of background and sync-critical work.
+
+## Focus
+
+- Chained-interceptor/chain-of-responsibility composition for background sync (read, write, permission, and utility stages)
+- Mandatory error logging on background sync failures
+- Permission-check completeness before privileged sync operations
+- Retry, backoff, and failure-visibility behavior for background work
+
+## Ignore
+
+- Style preferences in interceptor ordering with no behavioral effect
+- Logging verbosity preferences that do not affect failure visibility
+
+## Applicability
+
+Use this specialist for background sync and any interceptor/chain-of-responsibility-style composition that wraps sync operations with cross-cutting stages (e.g. read, write, permission-checking, and utility/logging stages).
+
+## Project-Specific Rules
+
+- Background sync chains composed from Read/Write/Permissions/Utility-style stages must run every applicable stage for a given operation; skipping a stage (especially a permission-check stage) to save time is a reliability and correctness risk, not just a performance shortcut
+- Every background sync failure path must produce an error log with enough context (operation, entity, and failure reason) to diagnose the failure after the fact; a swallowed or silently-dropped background sync error is a reliability regression
+- Permission checks in a sync chain must run before the corresponding read/write stage executes, not after or in parallel with it; a permission check that runs too late does not actually prevent the unauthorized operation
+- New stages added to an existing chain must preserve the chain's existing ordering guarantees unless the change explicitly and visibly redefines that order
+- Retries for background sync operations must be bounded and must not silently retry an operation that has already permanently failed (e.g. due to a permission denial) as if it were a transient failure
+- Utility/cross-cutting stages (logging, metrics, cleanup) must not swallow or mask an error raised by the read/write/permission stage they wrap
+- The swallowed-error rule is not limited to sync chains: on any async path, an error caught and dropped (empty `catch`, mapped to a default, ignored via `_`, or turned into an empty result) rather than logged or propagated to its caller, the UI, or store state is a reliability regression
+- A dependent async action (UI transition, save, reload, navigation) that proceeds before the awaited operation it depends on has actually completed is a race: the follow-up can act on stale or partial data
+- Concurrent or duplicate async operations (overlapping network fetches, store effects, repeated form submissions) that run without cancelling superseded work or guarding against re-entry let a stale response overwrite newer state, or let a rapidly repeated trigger cause duplicate writes, navigations, or sync jobs
+- Extracting or rewriting a view/component that silently drops previously-present functionality (buttons, fallback labels, forwarded callbacks, wired services) is a regression unless the removal is explicitly flagged as intentional
+- Debug `print`/logging statements or debug-only code paths left in shipped code are a reliability and information-leak risk, not just noise
+- `[weak self]` captured but the closure still reaches `self`/outer state directly instead of through the safely-unwrapped self — or omitted entirely on a long-lived subscription — risks crashes, stale reads, or retain-cycle leaks
+- For Major or Critical findings, describe the concrete data-loss, unauthorized-access, or silent-failure scenario in production
+
+## Repo-Local Knowledge
+
+Before finalizing findings, check whether the repo under review ships its own agent-knowledge docs (e.g. `.agents/skills/*/references/*.md` and a root `AGENTS.md`/`CLAUDE.md`). When present, read them and weigh any documented hard-rule violation (e.g. a required error-logging or permission-check-ordering rule for background sync) as a high-confidence finding. This is a read-only lookup local to the repo under review — nothing from these documents is copied into skill-bill's own tree.

--- a/platform-packs/ios/code-review/bill-ios-code-review-security/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-security/content.md
@@ -1,0 +1,35 @@
+---
+name: bill-ios-code-review-security
+description: Use when reviewing iOS security risks including Keychain-only token storage, credential logging, and auth/session handling.
+---
+
+# Security Review Specialist
+
+Review only exploitable or compliance-relevant issues.
+
+## Focus
+
+- Secret and credential leakage
+- Auth/session token storage and handling
+- Sensitive logging
+- Insecure local storage or transport assumptions
+
+## Ignore
+
+- Non-security style comments
+
+## Applicability
+
+Use this specialist for iOS code at trust boundaries: auth/session handling, token storage, network clients, and any code that reads or writes credentials or sensitive user data.
+
+## Project-Specific Rules
+
+- Auth/session tokens must be stored in the Keychain (or an equivalent OS-backed secure store), never in `UserDefaults`, plain files, or in-memory-only globals that could be trivially dumped
+- Tokens, passwords, and other credentials must never appear in log output, including debug-only logging that can ship in a release build by accident
+- Do not log full request/response bodies or headers for authenticated endpoints by default; redact or omit auth headers and any field known to carry sensitive user data
+- New network clients must use TLS and must not disable certificate validation, even temporarily, outside of an explicit and reviewed debug-only build configuration
+- Biometric-gated or Keychain-protected data must not be duplicated into a less-protected store as a convenience cache
+- Deep links, universal links, and pasteboard access must not leak sensitive tokens or personal data to other apps
+- Temporary debug bypasses, hardcoded test credentials, or relaxed certificate/auth checks must not ship in production code paths
+- SQL built by string interpolation is worth flagging, but rate it by the trust of the interpolated value: interpolating a DB-sourced or upstream-validated UUID (no untrusted-input path reaching it) is a defense-in-depth/consistency nit, not a Major injection vulnerability. Reserve a security severity for a real path where attacker- or user-controlled text reaches the query unescaped. Inconsistency with a sibling `.sqlEscaped`-style helper is a code-quality point better owned by architecture/persistence than a security Major
+- For Major or Critical findings, describe the concrete exposure or exploit scenario explicitly — including how untrusted input actually reaches the sink

--- a/platform-packs/ios/code-review/bill-ios-code-review-testing/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-testing/content.md
@@ -1,0 +1,35 @@
+---
+name: bill-ios-code-review-testing
+description: Use when reviewing iOS test coverage quality, XCTest/snapshot-testing conventions, and the 1:1 SQL-statement-test cross-reference.
+---
+
+# Testing Review Specialist
+
+Review only test-coverage and test-quality issues with real regression-protection impact.
+
+## Focus
+
+- Missing or weak test coverage for new views, stores, and SQL statements
+- XCTest and snapshot-testing convention consistency
+- 1:1 coverage between hand-written SQL statements and their statement tests
+- Tautological or coverage-padding tests that do not validate real behavior
+
+## Ignore
+
+- Style-only test-naming preferences with no coverage impact
+
+## Applicability
+
+Use this specialist wherever test files change, or wherever new views, stores, or SQL statements ship without an accompanying test.
+
+## Project-Specific Rules
+
+- New or changed views should have a snapshot test (e.g. via `assertSnapshotsOf` or an equivalent snapshot-testing convention) covering their meaningful visual states, unless the project explicitly excludes that view type
+- New or changed stores/reducers should have XCTest coverage for their action-handling behavior, not just their initial state
+- A `{Statement}SQLStatementTests.swift`-style test per hand-written SQL statement is a recommended convention, not a universal hard rule — verify the repo applies it broadly before treating its absence as a violation (only a subset of statements carry one in practice). Flag a missing statement test as an at-most-Minor coverage gap, reserving higher severity for statements whose correctness is load-bearing; do not frame it as a mandatory "1:1" requirement the change breaks
+- Snapshot baselines committed alongside a UI change must correspond to an intentional, reviewed visual change — a snapshot update with no visible reason in the diff is a red flag worth calling out
+- Flag tests that assert only on mocks calling through to other mocks, or that would pass unchanged if the underlying behavior were broken (tautological or coverage-padding tests)
+- Coverage disabled, weakened, or commented out (removed assertions, `isRecording = true` left on, tautological checks) without a stated justification silently drops regression protection and should be flagged
+- Assertions that have gone stale after a behavior change — asserting a string, parameter, or mock value that no longer matches the implementation — let a test pass without validating the real behavior
+- Flaky UI/E2E coverage that leaves the app in a navigation/state the next step does not expect, or relies on fragile or colliding element identifiers, produces false passes and failures unrelated to the behavior under test
+- Missing tests for new views, stores, or SQL statements should be reported even when the rest of the diff is otherwise low-risk, since these are the project's designated regression-protection surfaces

--- a/platform-packs/ios/code-review/bill-ios-code-review-ui/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-ui/content.md
@@ -1,0 +1,30 @@
+---
+name: bill-ios-code-review-ui
+description: Use when reviewing iOS UI correctness for feature views, shared theming/design-system usage, navigation wiring, and snapshot baselines.
+---
+
+# UI Review Specialist
+
+Review only UI correctness and framework-usage issues that can break the rendered experience or make the app behave inconsistently.
+
+## Focus
+
+- Feature view correctness and composition
+- Shared design-system/theme usage consistency
+- Navigation wiring correctness
+- Snapshot baseline changes matching intentional visual changes
+
+## Ignore
+
+- Pure visual taste feedback
+- Accessibility-only findings that belong to `bill-ios-code-review-ux-accessibility`
+
+## Project-Specific Rules
+
+- Feature views (e.g. a `{Feature}View.swift`-style SwiftUI view) should compose from the project's shared UI component library and theme module rather than reimplementing styling, spacing, or common components locally
+- Navigation changes (e.g. a `Scene+{Feature}.swift`-style navigation wiring file) must keep the declared navigation graph consistent — no dangling routes, no duplicate destinations for the same scene, no navigation state that can desync from the store driving it
+- View state must have a single clear source of truth; do not split ownership of the same visual state across a store, local `@State`, and a child view without an explicit synchronization model
+- Conditional rendering must preserve state-machine correctness across loading, success, empty, and error states
+- Snapshot baseline updates committed with a UI change must correspond to an intentional, reviewed visual change described in the diff — an unexplained snapshot update alongside unrelated logic changes is a red flag
+- Reusable components should be added to or reused from the shared component library rather than duplicated per-feature when the same visual pattern already exists elsewhere
+- In findings, explain the rendered or interactive behavior a user would actually experience

--- a/platform-packs/ios/code-review/bill-ios-code-review-ux-accessibility/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-ux-accessibility/content.md
@@ -1,0 +1,31 @@
+---
+name: bill-ios-code-review-ux-accessibility
+description: Use when reviewing iOS UX and accessibility risks including localization-string completeness and VoiceOver label coverage.
+---
+
+# UX & Accessibility Review Specialist
+
+Review only UX correctness and accessibility issues that can make the app harder to understand, harder to operate, or inaccessible to assistive-technology users.
+
+## Focus
+
+- Localization-string completeness across supported languages
+- VoiceOver and other accessibility-label coverage
+- Validation feedback clarity and error-state discoverability
+- Interaction patterns where the UI technically renders but is confusing or inaccessible
+
+## Ignore
+
+- Pure visual design preference
+- Security-only findings that belong to `bill-ios-code-review-security`
+
+## Project-Specific Rules
+
+- New or changed user-facing strings must be added through the project's centralized strings surface (e.g. a `Strings.swift`-style accessor) rather than hardcoded inline, and must have translations present across all supported `.lproj` locales
+- A new string added to one locale without corresponding entries in the other supported locales is a localization-completeness gap, not just a nice-to-have
+- Every new interactive control (button, tappable element, custom control) must have a VoiceOver-accessible label that matches the control's actual action, not a generic or missing label
+- Images and icons that convey meaning (not purely decorative) must have accessibility labels or be explicitly marked decorative so VoiceOver does not announce them incorrectly
+- Focus order for VoiceOver navigation should follow the visual/logical reading order; custom layouts that reorder visual elements must not scramble the accessibility traversal order
+- Validation errors and status changes must be both visually distinguishable and announced or discoverable via VoiceOver, not conveyed by color alone
+- Dynamic Type and larger accessibility text sizes should not clip, truncate, or overlap critical content in new or changed views
+- In findings, make the user-visible UX or accessibility consequence explicit

--- a/platform-packs/ios/code-review/bill-ios-code-review/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review/content.md
@@ -1,0 +1,78 @@
+---
+name: bill-ios-code-review
+description: Use when reviewing native iOS/Swift changes (UIKit/SwiftUI, Xcode projects, local SPM packages).
+---
+
+# Adaptive iOS PR Review
+
+You are an experienced iOS architect conducting a code review.
+
+This skill owns the baseline native iOS review layer. It covers UIKit/SwiftUI app code, local Swift Package Manager modules, and the specialist-selection logic that the iOS review lanes build on top of.
+
+## Project Guidance
+
+Treat coherent local project standards and established architecture as the consistency target. Do not preserve local patterns that are inconsistent, accidental, or harmful; use this iOS pack to flag concrete maintainability, correctness, security, scalability, or testability risks and guide changes toward established iOS/Swift practices.
+
+## Finding Discipline
+
+These rules apply to every specialist lane. They exist to keep precision high — a plausible-sounding finding that cannot actually fire, or that is rated far above its real impact, erodes trust in the whole review.
+
+- **Verify the triggering precondition before asserting a consequence.** Before reporting "this crashes / hangs / shows the wrong screen / gets requested," confirm the state or configuration that would trigger it can actually occur. Examples of premises to check first: that a SwiftUI/WidgetKit family or lifecycle case can actually be requested given the declared `supportedFamilies`/guards; that an interactive-pop (swipe-back) gesture is still enabled given `navigationBarBackButtonHidden` + custom leading items; that a "spinner never resets" path is reachable when both success and failure branches reset it; that a value can actually be `nil`. If the guarding config contradicts the premise, do not report it.
+- **Scan removed (`-`) lines, not just additions.** Dropped call sites, deleted effects, removed guards/tracking, and commented-out flows are as important as added code — a refactor that silently drops a data-loading call, a network-fetch fallback, or an analytics event is a real regression that only shows up on the `-` side of the diff. On refactor-heavy or deletion-heavy diffs, explicitly diff what behavior the removals drop.
+- **Get Swift semantics right.** Do not report a finding that depends on a misreading of the language. Common traps:
+  - A `do { … }` block **without** a `catch` does not swallow errors — `try` inside it propagates to the enclosing throwing scope. It is only "swallowed" if there is an actual empty/`catch {}` handler.
+  - An `enum` with **no associated values**, or whose associated values are all `Equatable`/`Hashable`, gets `Equatable`/`Hashable` synthesized automatically — a nested payload-less enum does not break the outer type's synthesis.
+  - A computed `URL?` (or any optional) that coalesces to a **non-optional** value (`optional ?? nonOptional`) can never be `nil`; a `guard let` on it is dead, but that is a dead-code Nit, not a crash.
+  - `[weak self]`/`[weak store]` on an `ObservedObject`/store that outlives the closure is a robustness/consistency nit, not a leak or crash.
+- **Calibrate severity to demonstrated impact.** Reserve Blocker/Major for a concrete, reachable failure (data loss, crash, wrong result a user or crash report would see). A finding that flags conformance to (or deviation from) an intentional, pervasive house pattern with no demonstrated wrong outcome is at most Minor — and often a Nit. When a rule below says "should," a violation is not automatically Major.
+
+## iOS Review Heuristics
+
+Always include:
+
+- `bill-ios-code-review-architecture`
+- `bill-ios-code-review-platform-correctness`
+
+Add other specialists only when the changed files justify them.
+
+| Signal in the diff | Specialist review to run |
+|---|---|
+| `DependencyContainer+Registrations.swift`, new `Provider` protocol, new SPM package, package-boundary crossing | `bill-ios-code-review-architecture` |
+| `{Feature}Store/Action/Environment`, Combine effect chains, `.receive(on: mainScheduler)`, `cancellableId` | `bill-ios-code-review-platform-correctness` |
+| GraphQL/Apollo client package, `*.graphql` operations, generated GraphQL API code, Apollo cache/field policies | `bill-ios-code-review-api-contracts` |
+| `Database` package, GRDB migrations, `createTable`/schema changes, `{Statement}SQLStatementTests.swift`, deep sync | `bill-ios-code-review-persistence` |
+| Background-sync engine (interceptor/chain-of-responsibility Read/Write/Permissions/Utility stages), background sync, error logging | `bill-ios-code-review-reliability` |
+| Auth/session/Keychain, token storage, sensitive log content | `bill-ios-code-review-security` |
+| Hot Store reducers, large sync/import loops, image/PDF/camera work (photo-gallery, PDF-editor, camera modules) | `bill-ios-code-review-performance` |
+| Test files, `assertSnapshotsOf`, `{Statement}SQLStatementTests.swift`, missing tests for new views/stores | `bill-ios-code-review-testing` |
+| `{Feature}View.swift`, shared UI-component/theme module, navigation (`Scene+{Feature}.swift`), snapshot baselines | `bill-ios-code-review-ui` |
+| `Strings.swift`, `*.lproj` (5 languages), VoiceOver/accessibility labels | `bill-ios-code-review-ux-accessibility` |
+
+`api-contracts` is reframed, not dropped: for a GraphQL/Apollo-consuming client the contract risk is codegen regeneration, `.graphql` changes, and cache/field-policy correctness — not request validation.
+
+## Mixed Diffs
+
+If different parts of the diff touch different review surfaces:
+
+- inspect those changed areas separately
+- keep the baseline specialists for the whole review
+- add only the specialists needed for the relevant areas
+- do not force every file through every specialist
+
+## Specialist Selection Bounds
+
+- Minimum 2 specialist reviews: `architecture` plus one other
+- If no additional triggers match, include `bill-ios-code-review-platform-correctness` as the default second specialist
+- If tests changed materially, include `bill-ios-code-review-testing`
+- Maximum 10 specialist reviews
+
+When the diff is large, high-risk, or spans multiple review surfaces, build per-specialist file lists so each selected review lane stays focused:
+
+1. Scan each changed file's name and imports for the routing-table signals above.
+2. Map each file to the specialists whose signals it matches.
+3. `bill-ios-code-review-architecture` always receives all changed files.
+4. Every other specialist receives only files matching its routing signals.
+5. If a non-architecture specialist's scoped file list is empty, drop it from the selected set.
+6. After scoping, re-check the minimum-2-specialist requirement; if only architecture remains, add `bill-ios-code-review-platform-correctness` with all changed files as the default second.
+
+This is a lightweight file-level classification, not a full review.

--- a/platform-packs/ios/code-review/bill-ios-code-review/native-agents/agents.yaml
+++ b/platform-packs/ios/code-review/bill-ios-code-review/native-agents/agents.yaml
@@ -1,0 +1,32 @@
+contract_version: "0.1"
+agents:
+  - name: bill-ios-code-review-api-contracts
+    description: "Use when reviewing iOS changes for API contracts, request validation, and serialization."
+    compose: governed-content
+  - name: bill-ios-code-review-architecture
+    description: "Use when reviewing iOS changes for architecture, boundaries, and dependency direction."
+    compose: governed-content
+  - name: bill-ios-code-review-performance
+    description: "Use when reviewing iOS changes for performance risks on hot paths, blocking I/O, and resource usage."
+    compose: governed-content
+  - name: bill-ios-code-review-persistence
+    description: "Use when reviewing iOS changes for persistence, transactions, migrations, and data consistency."
+    compose: governed-content
+  - name: bill-ios-code-review-platform-correctness
+    description: "Use when reviewing iOS changes for lifecycle, concurrency, threading, and logic correctness."
+    compose: governed-content
+  - name: bill-ios-code-review-reliability
+    description: "Use when reviewing iOS changes for timeouts, retries, background work, and observability."
+    compose: governed-content
+  - name: bill-ios-code-review-security
+    description: "Use when reviewing iOS changes for secrets handling, auth, and sensitive-data exposure."
+    compose: governed-content
+  - name: bill-ios-code-review-testing
+    description: "Use when reviewing iOS changes for test coverage quality and regression protection."
+    compose: governed-content
+  - name: bill-ios-code-review-ui
+    description: "Use when reviewing iOS changes for UI correctness and framework usage."
+    compose: governed-content
+  - name: bill-ios-code-review-ux-accessibility
+    description: "Use when reviewing iOS changes for UX correctness and accessibility."
+    compose: governed-content

--- a/platform-packs/ios/platform.yaml
+++ b/platform-packs/ios/platform.yaml
@@ -63,6 +63,32 @@ area_metadata:
 
 declared_quality_check_file: "quality-check/bill-ios-code-check/content.md"
 
+addon_usage:
+  code-review/bill-ios-code-review:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-sync-consistency.md
+        - offline-conflict-resolution.md
+        - offline-background-reliability.md
+  code-review/bill-ios-code-review-persistence:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-sync-consistency.md
+        - offline-conflict-resolution.md
+  code-review/bill-ios-code-review-reliability:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-background-reliability.md
+        - offline-sync-consistency.md
+  code-review/bill-ios-code-review-platform-correctness:
+    - slug: offline-first
+      entrypoint: offline-first-review.md
+      companion_pointers:
+        - offline-conflict-resolution.md
+
 # Pointer files are generated into render/install output from this block.
 pointers:
   code-review/bill-ios-code-review:
@@ -80,6 +106,14 @@ pointers:
       target: orchestration/stack-routing/PLAYBOOK.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-sync-consistency.md
+      target: platform-packs/ios/addons/offline-sync-consistency.md
+    - name: offline-conflict-resolution.md
+      target: platform-packs/ios/addons/offline-conflict-resolution.md
+    - name: offline-background-reliability.md
+      target: platform-packs/ios/addons/offline-background-reliability.md
   code-review/bill-ios-code-review-api-contracts:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md
@@ -108,6 +142,12 @@ pointers:
       target: orchestration/shell-content-contract/shell-ceremony.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-sync-consistency.md
+      target: platform-packs/ios/addons/offline-sync-consistency.md
+    - name: offline-conflict-resolution.md
+      target: platform-packs/ios/addons/offline-conflict-resolution.md
   code-review/bill-ios-code-review-platform-correctness:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md
@@ -115,6 +155,10 @@ pointers:
       target: orchestration/shell-content-contract/shell-ceremony.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-conflict-resolution.md
+      target: platform-packs/ios/addons/offline-conflict-resolution.md
   code-review/bill-ios-code-review-reliability:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md
@@ -122,6 +166,12 @@ pointers:
       target: orchestration/shell-content-contract/shell-ceremony.md
     - name: telemetry-contract.md
       target: orchestration/telemetry-contract/PLAYBOOK.md
+    - name: offline-first-review.md
+      target: platform-packs/ios/addons/offline-first-review.md
+    - name: offline-background-reliability.md
+      target: platform-packs/ios/addons/offline-background-reliability.md
+    - name: offline-sync-consistency.md
+      target: platform-packs/ios/addons/offline-sync-consistency.md
   code-review/bill-ios-code-review-security:
     - name: review-orchestrator.md
       target: orchestration/review-orchestrator/PLAYBOOK.md

--- a/platform-packs/ios/platform.yaml
+++ b/platform-packs/ios/platform.yaml
@@ -1,0 +1,159 @@
+platform: "ios"
+contract_version: "1.1"
+display_name: "iOS"
+
+routing_signals:
+  strong:
+    - ".xcodeproj"
+    - ".xcworkspace"
+    - "import SwiftUI"
+    - "import UIKit"
+    - "iOSApplicationExtension"
+  tie_breakers:
+    - "Package.swift alone is not a strong signal (ambiguous with server-side/macOS-only Swift); only route on it when the repo root also has an .xcodeproj/.xcworkspace."
+    - "A diff touching a local SPM package with no UIKit/SwiftUI import is still iOS-scoped when the repo root contains an .xcodeproj/.xcworkspace that consumes that package."
+    - "Never match on iosMain, androidMain, commonMain, expect/actual — those are KMP shared-source-set markers, not native iOS markers."
+
+declared_code_review_areas:
+  - "api-contracts"
+  - "architecture"
+  - "performance"
+  - "persistence"
+  - "platform-correctness"
+  - "reliability"
+  - "security"
+  - "testing"
+  - "ui"
+  - "ux-accessibility"
+
+declared_files:
+  baseline: "code-review/bill-ios-code-review/content.md"
+  areas:
+    api-contracts: "code-review/bill-ios-code-review-api-contracts/content.md"
+    architecture: "code-review/bill-ios-code-review-architecture/content.md"
+    performance: "code-review/bill-ios-code-review-performance/content.md"
+    persistence: "code-review/bill-ios-code-review-persistence/content.md"
+    platform-correctness: "code-review/bill-ios-code-review-platform-correctness/content.md"
+    reliability: "code-review/bill-ios-code-review-reliability/content.md"
+    security: "code-review/bill-ios-code-review-security/content.md"
+    testing: "code-review/bill-ios-code-review-testing/content.md"
+    ui: "code-review/bill-ios-code-review-ui/content.md"
+    ux-accessibility: "code-review/bill-ios-code-review-ux-accessibility/content.md"
+area_metadata:
+  api-contracts:
+    focus: "API contracts, request validation, and serialization"
+  architecture:
+    focus: "architecture, boundaries, and dependency direction"
+  performance:
+    focus: "performance risks on hot paths, blocking I/O, and resource usage"
+  persistence:
+    focus: "persistence, transactions, migrations, and data consistency"
+  platform-correctness:
+    focus: "lifecycle, concurrency, threading, and logic correctness"
+  reliability:
+    focus: "timeouts, retries, background work, and observability"
+  security:
+    focus: "secrets handling, auth, and sensitive-data exposure"
+  testing:
+    focus: "test coverage quality and regression protection"
+  ui:
+    focus: "UI correctness and framework usage"
+  ux-accessibility:
+    focus: "UX correctness and accessibility"
+
+declared_quality_check_file: "quality-check/bill-ios-code-check/content.md"
+
+# Pointer files are generated into render/install output from this block.
+pointers:
+  code-review/bill-ios-code-review:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: review-delegation.md
+      target: orchestration/review-delegation/PLAYBOOK.md
+    - name: review-scope.md
+      target: orchestration/review-scope/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: specialist-contract.md
+      target: orchestration/review-orchestrator/specialist-contract.md
+    - name: stack-routing.md
+      target: orchestration/stack-routing/PLAYBOOK.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-api-contracts:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-architecture:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-performance:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-persistence:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-platform-correctness:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-reliability:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-security:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-testing:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-ui:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  code-review/bill-ios-code-review-ux-accessibility:
+    - name: review-orchestrator.md
+      target: orchestration/review-orchestrator/PLAYBOOK.md
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md
+  quality-check/bill-ios-code-check:
+    - name: shell-ceremony.md
+      target: orchestration/shell-content-contract/shell-ceremony.md
+    - name: stack-routing.md
+      target: orchestration/stack-routing/PLAYBOOK.md
+    - name: telemetry-contract.md
+      target: orchestration/telemetry-contract/PLAYBOOK.md

--- a/platform-packs/ios/quality-check/bill-ios-code-check/content.md
+++ b/platform-packs/ios/quality-check/bill-ios-code-check/content.md
@@ -1,0 +1,23 @@
+---
+name: bill-ios-code-check
+description: Use when validating iOS changes with the shared quality-check contract.
+---
+
+# Quality-Check Content
+
+## Purpose
+
+Use when validating iOS changes with the shared quality-check contract.
+
+## Execution Steps
+
+1. Determine the files in scope for the current unit of work.
+2. Run the platform's quality-check entrypoint and capture the failures.
+3. Fix only the failures that belong to the scoped work unless the contract says otherwise.
+4. Re-run the quality check until the scoped failures are resolved.
+
+## Fix Strategy
+
+- Prefer root-cause fixes over suppressions or TODO comments.
+- Keep changes aligned with the project's existing conventions and build tooling.
+- Call out any blocker that requires a maintainer decision instead of guessing.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,14 @@
+## [2026-07-02] SKILL-99 External Addon Sources
+Areas: runtime-infra-fs/install, runtime-infra-fs/scaffold/platformpack, runtime-application/install, runtime-cli/config+install, runtime-ports/install/addon, runtime-contracts/error, runtime-domain/install/model, runtime-core/di, install.sh, platform-packs/ios
+- Added external addon source overlay: durable, config-driven addons from outside ~/.skill-bill, re-applied unconditionally after reconcile-apply and before staging
+- Two-phase validate-all-then-apply-all in `FileSystemExternalAddonOverlay` (infrastructure.fs): temp-and-swap platform.yaml write, manifest merge before addon file copies, atomic collision-free guarantees
+- `FileExternalAddonSourceConfigStore` is a separate class reusing `FileTelemetryConfigStore` internal helpers (at detekt TooManyFunctions limit — do NOT add methods there)
+- Collision detection covers slug, pointer-name, AND target-basename across provenance (pack-owned vs external, external vs external); fragment field validation (name/slug regex, additionalProperties) and nested-target rejection before merge
+- Port DTOs must live in `.model` sub-package; overlay adapter in `infrastructure.fs` not `scaffold.platformpack` (runtime-core cannot import scaffold — ImplementationOwnershipArchitectureTest). `internal` visibility is module-scoped so cross-package reuse of `parsePointers`/`parseAddonUsage` works via import
+- SKILL-98 private iOS addon migrated out of tree to external source dir + `addon-manifest.yaml`; skip-worktree/`.git/info/exclude`/local wiring removed; reconcile re-adopts upstream yaml each apply but overlay re-merges on top
+Feature flag: N/A
+Acceptance criteria: 9/9 implemented
+
 ## [2026-06-27] SKILL-95 opencode prose-only (refuse runtime mode)
 Areas: runtime-kotlin/runtime-domain, runtime-kotlin/runtime-cli, runtime-kotlin/runtime-infra-fs, skills/bill-feature-task, skills/bill-feature-goal, skills/bill-feature-task-runtime
 - Shared predicate+message in `InstallModels.kt`: `isOpencodeAgent(agentId)` trims+lowercases vs `InstallAgent.OPENCODE.id`; `OPENCODE_RUNTIME_REFUSAL_MESSAGE` names the supported alternatives (`bill-feature-task-prose` / `bill-feature-goal mode:prose`). reusable PATTERN: one domain-level predicate+message, consumed by every layer, keeps refusal wording from drifting.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/install/ExternalAddonOverlayService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/install/ExternalAddonOverlayService.kt
@@ -1,0 +1,31 @@
+package skillbill.application.install
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.install.model.ExternalAddonSource
+import skillbill.ports.install.addon.ExternalAddonOverlayPort
+import skillbill.ports.install.addon.ExternalAddonSourceConfigPort
+import skillbill.ports.install.addon.model.ExternalAddonOverlayRequest
+import skillbill.ports.install.addon.model.ExternalAddonOverlayResult
+import skillbill.ports.install.addon.model.ExternalAddonSourceConfigRequest
+import java.nio.file.Path
+
+@Inject
+class ExternalAddonOverlayService(
+  private val configPort: ExternalAddonSourceConfigPort,
+  private val overlayPort: ExternalAddonOverlayPort,
+) {
+  fun resolveSources(home: Path, environment: Map<String, String> = emptyMap()): List<ExternalAddonSource> =
+    configPort.readExternalAddonSources(ExternalAddonSourceConfigRequest(home, environment)).sources
+
+  fun applyOverlay(
+    platformPacksRoot: Path,
+    home: Path,
+    environment: Map<String, String> = emptyMap(),
+  ): ExternalAddonOverlayResult {
+    val sources = resolveSources(home, environment)
+    if (sources.isEmpty()) {
+      return ExternalAddonOverlayResult(touched = false)
+    }
+    return overlayPort.applyOverlay(ExternalAddonOverlayRequest(platformPacksRoot, sources))
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigCommand.kt
@@ -20,12 +20,13 @@ import java.nio.file.Path
 class ConfigCommand(
   resolveSpecTypeCommand: ConfigResolveSpecTypeCommand,
   resolveParallelAgentCommand: ConfigResolveParallelAgentCommand,
+  resolveExternalAddonsCommand: ConfigResolveExternalAddonsCommand,
 ) : DocumentedNoOpCliCommand(
   "config",
   "Inspect resolved repo-local configuration (.skill-bill/config.yaml).",
 ) {
   init {
-    subcommands(resolveSpecTypeCommand, resolveParallelAgentCommand)
+    subcommands(resolveSpecTypeCommand, resolveParallelAgentCommand, resolveExternalAddonsCommand)
   }
 }
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAddonsCommand.kt
@@ -1,0 +1,39 @@
+package skillbill.cli.config
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.install.ExternalAddonOverlayService
+import skillbill.cli.core.CliRunState
+import skillbill.cli.core.DocumentedCliCommand
+import skillbill.error.ShellContentContractException
+
+@Inject
+class ConfigResolveExternalAddonsCommand(
+  private val service: ExternalAddonOverlayService,
+  private val state: CliRunState,
+) : DocumentedCliCommand(
+  "resolve-external-addons",
+  "Resolve external addon sources from the machine-global ~/.skill-bill/config.json.",
+) {
+  override fun run() {
+    val sources = try {
+      service.resolveSources(state.userHome, state.environment)
+    } catch (error: ShellContentContractException) {
+      state.completeText(
+        "${error.message}\n",
+        mapOf("status" to "failed", "error" to error.message.orEmpty()),
+        exitCode = 1,
+      )
+      return
+    }
+    val text = sources.joinToString("") { source -> "${source.platform}\t${source.path}\n" }
+    state.completeText(
+      text,
+      mapOf(
+        "status" to "ok",
+        "sources" to sources.map { source ->
+          mapOf("platform" to source.platform, "path" to source.path.toString())
+        },
+      ),
+    )
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallApplyExternalAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallApplyExternalAddonsCommand.kt
@@ -1,0 +1,69 @@
+package skillbill.cli.install
+
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import me.tatarka.inject.annotations.Inject
+import skillbill.application.install.ExternalAddonOverlayService
+import skillbill.cli.core.CliRunState
+import skillbill.cli.core.DocumentedCliCommand
+import skillbill.error.ShellContentContractException
+import java.nio.file.Path
+
+@Inject
+class InstallApplyExternalAddonsCommand(
+  private val state: CliRunState,
+  private val service: ExternalAddonOverlayService,
+) : DocumentedCliCommand(
+  "apply-external-addons",
+  "Apply the external addon overlay onto installed platform packs (after reconcile, before staging).",
+) {
+  private val repoRoot by option(
+    "--repo-root",
+    help = "Repository root containing platform-packs/. Defaults to the current working directory.",
+  ).default(".")
+  private val platformPacksRoot by option(
+    "--platform-packs",
+    help = "Platform packs root. Defaults to <repo-root>/platform-packs.",
+  )
+
+  override fun run() {
+    if (state.refuseInstallMutationDuringGoalContinuation("apply-external-addons")) {
+      return
+    }
+    val resolvedRepoRoot = Path.of(repoRoot).toAbsolutePath().normalize()
+    val resolvedPlatformPacks = platformPacksRoot?.let(Path::of)?.toAbsolutePath()?.normalize()
+      ?: resolvedRepoRoot.resolve("platform-packs")
+    val result = try {
+      service.applyOverlay(resolvedPlatformPacks, state.userHome, state.environment)
+    } catch (error: ShellContentContractException) {
+      state.completeText(
+        "${error.message}\n",
+        mapOf("status" to "failed", "error" to error.message.orEmpty()),
+        exitCode = 1,
+      )
+      return
+    }
+    if (result.appliedSources.isEmpty() && result.skippedSources.isEmpty()) {
+      state.completeText(
+        "no external addon sources\n",
+        mapOf("status" to "ok", "touched" to false),
+      )
+      return
+    }
+    val applied = result.appliedSources.joinToString("") { source ->
+      "applied\t${source.platform}\t${source.sourcePath}\n"
+    }
+    val skipped = result.skippedSources.joinToString("") { source ->
+      "skipped\t${source.platform}\t${source.sourcePath}\t${source.reason}\n"
+    }
+    state.completeText(
+      applied + skipped,
+      mapOf(
+        "status" to "ok",
+        "touched" to result.touched,
+        "applied" to result.appliedSources.map { it.platform },
+        "skipped" to result.skippedSources.map { it.platform },
+      ),
+    )
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliCommands.kt
@@ -24,6 +24,7 @@ import skillbill.cli.core.DocumentedCliCommand
 import skillbill.cli.core.DocumentedNoOpCliCommand
 import skillbill.cli.core.formatOption
 import skillbill.cli.install.InstallApplyCommand
+import skillbill.cli.install.InstallApplyExternalAddonsCommand
 import skillbill.cli.install.InstallClaudeAgentsPathCommand
 import skillbill.cli.install.InstallClaudeRootsCommand
 import skillbill.cli.install.InstallCleanupAgentTargetCommand
@@ -101,6 +102,7 @@ class ScaffoldTopLevelCommands(
 class InstallTopLevelCommands(
   planCommand: InstallPlanCommand,
   applyCommand: InstallApplyCommand,
+  applyExternalAddonsCommand: InstallApplyExternalAddonsCommand,
   reconcileCommand: InstallReconcileCommand,
   replayLastSelectionCommand: InstallReplayLastSelectionCommand,
   agentPathCommand: InstallAgentPathCommand,
@@ -131,6 +133,7 @@ class InstallTopLevelCommands(
       .subcommands(
         planCommand,
         applyCommand,
+        applyExternalAddonsCommand,
         reconcileCommand,
         replayLastSelectionCommand,
         agentPathCommand,

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliConfigResolveExternalAddonsRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliConfigResolveExternalAddonsRuntimeTest.kt
@@ -1,0 +1,86 @@
+package skillbill.cli
+
+import skillbill.cli.core.CliRuntime
+import skillbill.cli.model.CliRuntimeContext
+import skillbill.contracts.JsonSupport
+import skillbill.telemetry.CONFIG_ENVIRONMENT_KEY
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CliConfigResolveExternalAddonsRuntimeTest {
+  @Test
+  fun `config resolve-external-addons is registered and shows help`() {
+    val result = CliRuntime.run(listOf("config", "resolve-external-addons", "--help"), CliRuntimeContext())
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "machine-global")
+  }
+
+  @Test
+  fun `absent machine-global config resolves to empty`() {
+    val home = Files.createTempDirectory("ext-addon-no-config")
+
+    val result = CliRuntime.run(
+      listOf("config", "resolve-external-addons"),
+      CliRuntimeContext(
+        userHome = home,
+        environment = mapOf(CONFIG_ENVIRONMENT_KEY to home.resolve("config.json").toString()),
+      ),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertTrue(result.stdout.isBlank())
+  }
+
+  @Test
+  fun `valid config lists sources in declared order`() {
+    val home = Files.createTempDirectory("ext-addon-valid")
+    val ios = Files.createDirectories(home.resolve("private/ios"))
+    val kotlin = Files.createDirectories(home.resolve("private/kotlin"))
+    writeConfig(
+      home,
+      mapOf(
+        "external_addon_sources" to
+          listOf(
+            mapOf("path" to kotlin.toString(), "platform" to "kotlin"),
+            mapOf("path" to ios.toString(), "platform" to "ios"),
+          ),
+      ),
+    )
+
+    val result = CliRuntime.run(
+      listOf("config", "resolve-external-addons"),
+      CliRuntimeContext(userHome = home, environment = mapOf(CONFIG_ENVIRONMENT_KEY to configPath(home).toString())),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "kotlin\t$kotlin")
+    assertContains(result.stdout, "ios\t$ios")
+  }
+
+  @Test
+  fun `malformed machine-global config exits non-zero`() {
+    val home = Files.createTempDirectory("ext-addon-malformed")
+    Files.createDirectories(home.resolve(".skill-bill"))
+    Files.writeString(configPath(home), "{ broken json")
+
+    val result = CliRuntime.run(
+      listOf("config", "resolve-external-addons"),
+      CliRuntimeContext(userHome = home, environment = mapOf(CONFIG_ENVIRONMENT_KEY to configPath(home).toString())),
+    )
+
+    assertEquals(1, result.exitCode, result.stdout)
+    assertContains(result.stdout, "config")
+  }
+
+  private fun configPath(home: Path): Path = home.resolve(".skill-bill").resolve("config.json")
+
+  private fun writeConfig(home: Path, payload: Map<String, Any?>) {
+    Files.createDirectories(home.resolve(".skill-bill"))
+    Files.writeString(configPath(home), JsonSupport.mapToJsonString(payload) + "\n")
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallApplyExternalAddonsRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallApplyExternalAddonsRuntimeTest.kt
@@ -1,0 +1,161 @@
+package skillbill.cli
+
+import skillbill.cli.core.CliRuntime
+import skillbill.cli.model.CliRuntimeContext
+import skillbill.contracts.JsonSupport
+import skillbill.telemetry.CONFIG_ENVIRONMENT_KEY
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CliInstallApplyExternalAddonsRuntimeTest {
+  @Test
+  fun `install apply-external-addons is registered and shows help`() {
+    val result = CliRuntime.run(listOf("install", "apply-external-addons", "--help"), CliRuntimeContext())
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "external addon overlay")
+  }
+
+  @Test
+  fun `absent machine-global config is a clean no-op`() {
+    val repo = Files.createTempDirectory("ext-addon-apply-no-config")
+    Files.createDirectories(repo.resolve("platform-packs"))
+    val home = Files.createTempDirectory("ext-addon-apply-home")
+
+    val result = CliRuntime.run(
+      listOf("install", "apply-external-addons", "--repo-root", repo.toString()),
+      CliRuntimeContext(
+        userHome = home,
+        environment = mapOf(CONFIG_ENVIRONMENT_KEY to home.resolve("config.json").toString()),
+      ),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "no external addon sources")
+  }
+
+  @Test
+  fun `config referencing a non-installed platform is skipped with a warning`() {
+    val repo = Files.createTempDirectory("ext-addon-apply-skip")
+    Files.createDirectories(repo.resolve("platform-packs"))
+    val home = Files.createTempDirectory("ext-addon-apply-skip-home")
+    val sourceDir = Files.createDirectories(home.resolve("private/android"))
+    Files.writeString(sourceDir.resolve("android-helper.md"), "# helper\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-android-code-review:
+          - slug: android-helper
+            entrypoint: android-helper.md
+      pointers:
+        code-review/bill-android-code-review:
+          - name: android-helper.md
+            target: android-helper.md
+      """.trimIndent() + "\n",
+    )
+    writeConfig(
+      home,
+      mapOf(
+        "external_addon_sources" to listOf(mapOf("path" to sourceDir.toString(), "platform" to "android")),
+      ),
+    )
+
+    val result = CliRuntime.run(
+      listOf("install", "apply-external-addons", "--repo-root", repo.toString()),
+      CliRuntimeContext(
+        userHome = home,
+        environment = mapOf(CONFIG_ENVIRONMENT_KEY to configPath(home).toString()),
+      ),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "skipped\tandroid")
+    assertContains(result.stdout, "not installed")
+  }
+
+  @Test
+  fun `valid external source applies overlay and reports applied with merged manifest`() {
+    val repo = Files.createTempDirectory("ext-addon-apply-happy")
+    val packRoot = seedIosPack(repo)
+    val home = Files.createTempDirectory("ext-addon-apply-happy-home")
+    val sourceDir = seedAcmeSource(home)
+
+    val result = CliRuntime.run(
+      listOf("install", "apply-external-addons", "--repo-root", repo.toString()),
+      CliRuntimeContext(
+        userHome = home,
+        environment = mapOf(CONFIG_ENVIRONMENT_KEY to configPath(home).toString()),
+      ),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "applied\tios")
+    assertTrue(
+      Files.isRegularFile(packRoot.resolve("addons/acme-review.md")),
+      "addon file must be copied into the installed pack. Output:\n${result.stdout}",
+    )
+    val mergedManifest = Files.readString(packRoot.resolve("platform.yaml"))
+    assertContains(mergedManifest, "slug: acme")
+    assertContains(mergedManifest, "target: platform-packs/ios/addons/acme-review.md")
+  }
+
+  private fun seedIosPack(repo: Path): Path {
+    val platformPacksRoot = Files.createDirectories(repo.resolve("platform-packs"))
+    val packRoot = Files.createDirectories(platformPacksRoot.resolve("ios"))
+    val codeReviewDir = Files.createDirectories(packRoot.resolve("code-review/bill-ios-code-review"))
+    Files.writeString(codeReviewDir.resolve("content.md"), "# iOS Code Review\n")
+    Files.writeString(
+      packRoot.resolve("platform.yaml"),
+      """
+      platform: ios
+      contract_version: "1.1"
+      display_name: "iOS"
+      routing_signals:
+        strong:
+          - ".swift"
+        tie_breakers: []
+      declared_code_review_areas: []
+      declared_files:
+        baseline: "code-review/bill-ios-code-review/content.md"
+      """.trimIndent() + "\n",
+    )
+    return packRoot
+  }
+
+  private fun seedAcmeSource(home: Path): Path {
+    val sourceDir = Files.createDirectories(home.resolve("private/ios-acme"))
+    Files.writeString(sourceDir.resolve("acme-review.md"), "# acme review body\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: acme
+            entrypoint: acme-review.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: acme-review.md
+            target: acme-review.md
+      """.trimIndent() + "\n",
+    )
+    writeConfig(
+      home,
+      mapOf(
+        "external_addon_sources" to listOf(mapOf("path" to sourceDir.toString(), "platform" to "ios")),
+      ),
+    )
+    return sourceDir
+  }
+
+  private fun configPath(home: Path): Path = home.resolve(".skill-bill").resolve("config.json")
+
+  private fun writeConfig(home: Path, payload: Map<String, Any?>) {
+    Files.createDirectories(home.resolve(".skill-bill"))
+    Files.writeString(configPath(home), JsonSupport.mapToJsonString(payload) + "\n")
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliInstallPlanApplyRuntimeTest.kt
@@ -1060,7 +1060,7 @@ private data class SingleCodexGoldenPaths(private val fixture: InstallPlanApplyF
   val codexTargetDir: String = fixture.home.resolve("manual-targets/codex").toString()
   val stagingRoot: String = fixture.home.resolve(".skill-bill/installed-skills").toString()
   val runtimeInstallRoot: String = fixture.home.resolve(".skill-bill/runtime").toString()
-  val telemetryConfigPath: String = fixture.home.resolve(".skill-bill/config.json").toString()
+  val telemetryConfigPath: String = fixture.home.resolve(".config/skill-bill/config.json").toString()
   val codeReviewSourceDir: String = fixture.repoRoot.resolve("skills/bill-code-review").toString()
   val qualityCheckSourceDir: String = fixture.repoRoot.resolve("skills/bill-code-check").toString()
   val codeReviewStagingDir: String = stagingDir("bill-code-review", CODE_REVIEW_GOLDEN_CONTENT_HASH)

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ExternalAddonErrors.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ExternalAddonErrors.kt
@@ -1,0 +1,11 @@
+package skillbill.error
+
+class ExternalAddonConfigError(
+  message: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(message, cause)
+
+class ExternalAddonOverlayError(
+  message: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(message, cause)

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -13,6 +13,7 @@ import skillbill.application.goalrunner.GoalRunner
 import skillbill.application.goalrunner.GoalRunnerStatusService
 import skillbill.application.goalrunner.WorkflowGoalRunnerManifestStore
 import skillbill.application.goalrunner.WorkflowGoalRunnerOutcomeStore
+import skillbill.application.install.ExternalAddonOverlayService
 import skillbill.application.install.InstallService
 import skillbill.application.learning.LearningService
 import skillbill.application.review.ParallelCodeReviewRunner
@@ -35,9 +36,11 @@ import skillbill.application.workflow.WorkflowService
 import skillbill.domain.skillremove.SkillRemoveFileSystem
 import skillbill.infrastructure.fs.DecompositionManifestValidatorAdapter
 import skillbill.infrastructure.fs.FeatureTaskRuntimePhaseOutputValidatorAdapter
+import skillbill.infrastructure.fs.FileExternalAddonSourceConfigStore
 import skillbill.infrastructure.fs.FileSystemBaselineManifestPersistence
 import skillbill.infrastructure.fs.FileSystemDecompositionManifestFileStore
 import skillbill.infrastructure.fs.FileSystemDiffResolver
+import skillbill.infrastructure.fs.FileSystemExternalAddonOverlay
 import skillbill.infrastructure.fs.FileSystemFeatureSpecPathResolver
 import skillbill.infrastructure.fs.FileSystemFeatureTaskRuntimeRunInvariantsSource
 import skillbill.infrastructure.fs.FileSystemFeatureTaskRuntimeSpecStatusWriter
@@ -98,6 +101,8 @@ import skillbill.ports.goalrunner.GoalPullRequestPort
 import skillbill.ports.goalrunner.GoalRunnerManifestStore
 import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
 import skillbill.ports.goalrunner.GoalRunnerWorkflowOutcomeStore
+import skillbill.ports.install.addon.ExternalAddonOverlayPort
+import skillbill.ports.install.addon.ExternalAddonSourceConfigPort
 import skillbill.ports.install.agent.InstallAgentTargetPort
 import skillbill.ports.install.apply.InstallApplyExecutionPort
 import skillbill.ports.install.baseline.BaselineManifestPersistencePort
@@ -201,6 +206,16 @@ abstract class RuntimeComponent(
   @Provides
   @JvmSynthetic
   internal fun telemetryConfigStore(store: FileTelemetryConfigStore): TelemetryConfigStore = store
+
+  @Provides
+  @JvmSynthetic
+  internal fun externalAddonSourceConfigPort(
+    store: FileExternalAddonSourceConfigStore,
+  ): ExternalAddonSourceConfigPort = store
+
+  @Provides
+  @JvmSynthetic
+  internal fun externalAddonOverlayPort(adapter: FileSystemExternalAddonOverlay): ExternalAddonOverlayPort = adapter
 
   @Provides
   @JvmSynthetic
@@ -488,6 +503,7 @@ abstract class RuntimeComponent(
   // RepoLocalConfigPort adapter type, which is not on the CLI module's compile classpath.
   abstract val configResolutionService: ConfigResolutionService
   abstract val installService: InstallService
+  abstract val externalAddonOverlayService: ExternalAddonOverlayService
   abstract val agentRunService: AgentRunService
   abstract val featureTaskRuntimePhaseRecorder: FeatureTaskRuntimePhaseRecorder
   abstract val featureTaskRuntimeRunner: FeatureTaskRuntimeRunner

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -50,6 +50,7 @@ class InstallerShellDelegationTest {
     assertContains(installScript, "install replay-last-selection")
     assertContains(installScript, "SKILL_BILL_RUNTIME_EXECUTABLE=\"\$RUNTIME_CLI_BIN\"")
     assertContains(installScript, "exec \"\\\$runtime_cli\" update \"\\\${passthrough[@]+\\\${passthrough[@]}}\"")
+    assertExternalAddonOverlayOrdering(installScript)
     assertFalse(installScript.contains("update_check_status"))
     // The Gradle desktop build is now gated behind --from-source: the helper and the
     // Gradle task must still exist (from-source coverage), but only run when
@@ -748,6 +749,24 @@ class InstallerShellDelegationTest {
 // standalone object so InstallerShellDelegationTest stays under detekt's LargeClass
 // threshold (mirroring PrebuiltReleaseStager). These helpers are pure: they only write
 // fixture files under the caller-provided paths and never touch test instance state.
+internal fun assertExternalAddonOverlayOrdering(installScript: String) {
+  val reconcileIdx = installScript.lastIndexOf("reconcile_and_commit_authored_source")
+  val overlayIdx = installScript.lastIndexOf("apply_external_addon_overlay")
+  val applyIdx = installScript.lastIndexOf("apply_runtime_install")
+  assertTrue(reconcileIdx >= 0, "install.sh must call reconcile_and_commit_authored_source")
+  assertTrue(overlayIdx >= 0, "install.sh must call apply_external_addon_overlay")
+  assertTrue(applyIdx >= 0, "install.sh must call apply_runtime_install")
+  assertTrue(
+    reconcileIdx < overlayIdx,
+    "apply_external_addon_overlay must run AFTER reconcile_and_commit_authored_source",
+  )
+  assertTrue(
+    overlayIdx < applyIdx,
+    "apply_external_addon_overlay must run BEFORE apply_runtime_install (the staging install apply)",
+  )
+  assertContains(installScript, "apply-external-addons")
+}
+
 internal object InstallerShellFixtures {
   // SKILL-76 subtask 2: the installer drives `install reconcile` (compute) then
   // `install reconcile --apply`. The fake CLI cannot compute real hashes, so it emits the
@@ -846,6 +865,9 @@ internal object InstallerShellFixtures {
       |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "apply" ]]; then
       |  exit 0
       |fi
+      |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "apply-external-addons" ]]; then
+      |  exit 0
+      |fi
       |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "claude-roots" ]]; then
       |  printf '%s\n' "${'$'}home/.claude"
       |  exit 0
@@ -928,6 +950,9 @@ internal object InstallerShellFixtures {
       |  printf 'reconcile_summary: applied=false has_conflicts=false conflict_count=0 baseline_refreshed=false installed_count=0\n'
       |  exit 0
       |fi
+      |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "apply-external-addons" ]]; then
+      |  exit 0
+      |fi
       |case "${'$'}{1:-} ${'$'}{2:-}" in
       |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-claude-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unregister-mcp")
       |    exit 0
@@ -973,7 +998,7 @@ internal object InstallerShellFixtures {
       |  printf '%s\n' "${'$'}home/agent-targets/${'$'}3"
       |  exit 0
       |fi
-      |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "apply" ]]; then
+      |if [[ "${'$'}{1:-}" == "install" && ( "${'$'}{2:-}" == "apply" || "${'$'}{2:-}" == "apply-external-addons" ) ]]; then
       |  exit 0
       |fi
       |if [[ "${'$'}{1:-}" == "install" && "${'$'}{2:-}" == "claude-roots" ]]; then

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/JvmDesktopFirstRunGatewayTest.kt
@@ -322,9 +322,9 @@ class JvmDesktopFirstRunGatewayTest {
       val applied = assertIs<FirstRunApplyResult.Applied>(applyResult)
 
       assertEquals(FirstRunInstallStatus.SUCCESS, applied.outcome.status)
-      assertTrue(Files.readString(plannedHome.resolve(".skill-bill/config.json")).contains("\"level\":\"full\""))
+      assertTrue(Files.readString(plannedHome.resolve(".config/skill-bill/config.json")).contains("\"level\":\"full\""))
       assertFalse(
-        Files.exists(processHome.resolve(".skill-bill/config.json")),
+        Files.exists(processHome.resolve(".config/skill-bill/config.json")),
         "default apply must not mutate process user.home",
       )
     } finally {

--- a/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
+++ b/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Braian Gapur <braian.gapur@capmo.de>
+# Maintainer: Braian Gapur <scatmetal@gmail.com>
 pkgname=skillbill
 pkgver=1.0.0
 pkgrel=1

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/ExternalAddonSource.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/ExternalAddonSource.kt
@@ -1,0 +1,8 @@
+package skillbill.install.model
+
+import java.nio.file.Path
+
+data class ExternalAddonSource(
+  val path: Path,
+  val platform: String,
+)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileExternalAddonSourceConfigStore.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileExternalAddonSourceConfigStore.kt
@@ -1,0 +1,74 @@
+@file:Suppress("ThrowsCount")
+
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.error.ExternalAddonConfigError
+import skillbill.install.model.ExternalAddonSource
+import skillbill.ports.install.addon.ExternalAddonSourceConfigPort
+import skillbill.ports.install.addon.model.ExternalAddonSourceConfigRequest
+import skillbill.ports.install.addon.model.ExternalAddonSourceConfigResult
+import java.nio.file.Files
+import java.nio.file.Path
+
+@Inject
+class FileExternalAddonSourceConfigStore : ExternalAddonSourceConfigPort {
+
+  override fun readExternalAddonSources(request: ExternalAddonSourceConfigRequest): ExternalAddonSourceConfigResult {
+    val configPath = resolveTelemetryConfigPath(request.environment, request.userHome)
+    if (!Files.exists(configPath)) {
+      return ExternalAddonSourceConfigResult()
+    }
+    val payload = try {
+      readTelemetryConfigFile(configPath)?.payload
+    } catch (error: IllegalArgumentException) {
+      throw ExternalAddonConfigError(error.message.orEmpty(), error)
+    } ?: return ExternalAddonSourceConfigResult()
+
+    val raw = payload["external_addon_sources"] ?: return ExternalAddonSourceConfigResult()
+    if (raw !is List<*>) {
+      throw ExternalAddonConfigError(
+        "External addon config at '$configPath': 'external_addon_sources' must be a list of {path, platform} entries.",
+      )
+    }
+    val sources = raw.mapIndexed { index, entry -> parseEntry(configPath, request.userHome, index, entry) }
+    return ExternalAddonSourceConfigResult(sources)
+  }
+
+  private fun parseEntry(configPath: Path, userHome: Path, index: Int, entry: Any?): ExternalAddonSource {
+    val map = entry as? Map<*, *>
+      ?: throw ExternalAddonConfigError(
+        "External addon config at '$configPath': 'external_addon_sources[$index]' must be a mapping.",
+      )
+    val rawPath = (map["path"] as? String)?.takeIf(String::isNotBlank)
+      ?: throw ExternalAddonConfigError(
+        "External addon config at '$configPath': 'external_addon_sources[$index].path' must be a non-empty string.",
+      )
+    val platform = (map["platform"] as? String)?.takeIf(String::isNotBlank)
+      ?: throw ExternalAddonConfigError(
+        "External addon config at '$configPath': 'external_addon_sources[$index].platform' must be a non-empty string.",
+      )
+    val resolvedPath = resolveSourcePath(userHome, rawPath)
+    if (!Files.isDirectory(resolvedPath)) {
+      throw ExternalAddonConfigError(
+        "External addon config at '$configPath': 'external_addon_sources[$index].path' '$rawPath' " +
+          "does not exist or is not a directory.",
+      )
+    }
+    return ExternalAddonSource(path = resolvedPath, platform = platform.trim())
+  }
+
+  private fun resolveSourcePath(userHome: Path, rawPath: String): Path {
+    val expanded = when {
+      rawPath == "~" -> userHome.toString()
+      rawPath.startsWith("~/") -> userHome.resolve(rawPath.removePrefix("~/")).toString()
+      else -> rawPath
+    }
+    val candidate = Path.of(expanded)
+    return if (candidate.isAbsolute) {
+      candidate.normalize()
+    } else {
+      Path.of(System.getProperty("user.dir")).resolve(candidate).normalize()
+    }
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemExternalAddonOverlay.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemExternalAddonOverlay.kt
@@ -1,0 +1,653 @@
+
+@file:Suppress("ThrowsCount", "TooManyFunctions")
+
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import org.yaml.snakeyaml.Yaml
+import skillbill.error.ExternalAddonOverlayError
+import skillbill.error.InvalidManifestSchemaError
+import skillbill.install.model.ExternalAddonSource
+import skillbill.ports.install.addon.ExternalAddonOverlayPort
+import skillbill.ports.install.addon.model.AppliedExternalAddonSource
+import skillbill.ports.install.addon.model.ExternalAddonOverlayRequest
+import skillbill.ports.install.addon.model.ExternalAddonOverlayResult
+import skillbill.ports.install.addon.model.SkippedExternalAddonSource
+import skillbill.scaffold.model.GovernedAddonSelection
+import skillbill.scaffold.model.GovernedAddonUsage
+import skillbill.scaffold.model.PointerSpec
+import skillbill.scaffold.platformpack.declaredSkillRelativeDirs
+import skillbill.scaffold.platformpack.loadPlatformManifest
+import skillbill.scaffold.platformpack.parseAddonUsage
+import skillbill.scaffold.platformpack.parsePointers
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+private const val ADDONS_DIR = "addons"
+private const val MANIFEST_FILE = "platform.yaml"
+private const val SOURCE_MANIFEST_FILE = "addon-manifest.yaml"
+private const val MANIFEST_TEMP_SUFFIX = ".platform.yaml.tmp"
+private val POINTER_NAME_PATTERN = Regex("^[^/\\\\]+\\.md$")
+private val ADDON_SLUG_PATTERN = Regex("^[a-z][a-z0-9]*(?:-[a-z0-9]+)*\$")
+private val POINTER_ENTRY_KEYS = setOf("name", "target")
+private val ADDON_ENTRY_KEYS = setOf("slug", "entrypoint", "companion_pointers")
+
+@Inject
+class FileSystemExternalAddonOverlay : ExternalAddonOverlayPort {
+
+  override fun applyOverlay(request: ExternalAddonOverlayRequest): ExternalAddonOverlayResult {
+    if (request.sources.isEmpty()) {
+      return ExternalAddonOverlayResult(touched = false)
+    }
+
+    val platformPacksRoot = request.platformPacksRoot.toAbsolutePath().normalize()
+    val skipped = mutableListOf<SkippedExternalAddonSource>()
+    val plans = mutableListOf<SourcePlan>()
+    val collisionIndex = CollisionIndex.empty()
+
+    for (source in request.sources) {
+      val packRoot = platformPacksRoot.resolve(source.platform)
+      val manifestPath = packRoot.resolve(MANIFEST_FILE)
+      if (!Files.isRegularFile(manifestPath)) {
+        skipped += SkippedExternalAddonSource(
+          platform = source.platform,
+          sourcePath = source.path,
+          reason = "platform pack '${source.platform}' is not installed; skipping external addon source.",
+        )
+        continue
+      }
+      val installed = loadPlatformManifest(packRoot)
+      collisionIndex.mergeInstalled(installed.pointers, installed.addonUsage)
+      val plan = validateAndPlan(source, installed, collisionIndex)
+      plans += plan
+    }
+
+    plans.forEach { applyPlan(it) }
+
+    val applied = plans.map { plan ->
+      AppliedExternalAddonSource(
+        platform = plan.platform,
+        sourcePath = plan.sourcePath,
+        addons = plan.copiedFiles.values.map { it.fileName.toString() }.sorted(),
+      )
+    }
+    return ExternalAddonOverlayResult(
+      appliedSources = applied,
+      skippedSources = skipped,
+      touched = plans.isNotEmpty(),
+    )
+  }
+
+  private fun validateAndPlan(
+    source: ExternalAddonSource,
+    installed: skillbill.scaffold.model.PlatformManifest,
+    collisionIndex: CollisionIndex,
+  ): SourcePlan {
+    val slug = source.platform
+    val fragment = readSourceManifest(source.path, slug)
+    val rewritten = rewriteFragmentTargets(fragment, slug)
+    validateFragmentFields(rewritten, slug)
+    val fragmentPointers = wrapParserErrors(slug) { parsePointers(rewritten, slug) }
+    fragmentPointers.forEach { pointer -> requireFlatAddonTarget(slug, pointer.target) }
+    val fragmentAddonUsage = wrapParserErrors(slug) {
+      parseAddonUsage(
+        manifest = rewritten,
+        slug = slug,
+        pointers = fragmentPointers,
+        declaredSkillDirs = installed.declaredSkillRelativeDirs(),
+      )
+    }
+
+    val filesToCopy = linkedMapOf<String, Path>()
+    fragmentPointers.forEach { pointer ->
+      val filename = pointer.target.substringAfterLast('/')
+      verifySourceFile(source.path, slug, filename)
+      filesToCopy[filename] = source.path.resolve(filename)
+    }
+
+    val pointersToAppend = collectPointersToAppend(slug, fragmentPointers, collisionIndex)
+    val addonsToAppend = collectAddonsToAppend(slug, fragmentAddonUsage, collisionIndex)
+
+    return SourcePlan(
+      platform = slug,
+      sourcePath = source.path,
+      installedManifestPath = installed.packRoot.resolve(MANIFEST_FILE),
+      packRoot = installed.packRoot,
+      pointersToAppend = pointersToAppend,
+      addonsToAppend = addonsToAppend,
+      copiedFiles = filesToCopy,
+    )
+  }
+
+  private fun collectPointersToAppend(
+    slug: String,
+    pointers: List<PointerSpec>,
+    collisions: CollisionIndex,
+  ): MutableMap<String, MutableList<PointerSpec>> {
+    val result = mutableMapOf<String, MutableList<PointerSpec>>()
+    for (pointer in pointers) {
+      val nameKey = pointer.dirName()
+      val targetKey = pointer.skillRelativeDir to basename(pointer.target)
+      when (val outcome = collisions.classifyPointer(slug, pointer, nameKey, targetKey)) {
+        PointerCollisionOutcome.AlreadyPresent -> Unit
+        is PointerCollisionOutcome.NameCollision -> throw ExternalAddonOverlayError(
+          collisionMessage(slug, pointer.skillRelativeDir, pointer.name, outcome.existingTarget, pointer.target),
+        )
+        is PointerCollisionOutcome.TargetCollision -> throw ExternalAddonOverlayError(
+          targetCollisionMessage(slug, pointer, outcome),
+        )
+        PointerCollisionOutcome.New -> {
+          collisions.recordExternalPointer(slug, nameKey, targetKey, pointer)
+          result.getOrPut(pointer.skillRelativeDir) { mutableListOf() } += pointer
+        }
+      }
+    }
+    return result
+  }
+
+  private fun collectAddonsToAppend(
+    slug: String,
+    addonUsage: List<GovernedAddonUsage>,
+    collisions: CollisionIndex,
+  ): MutableMap<String, MutableList<GovernedAddonSelection>> {
+    val result = mutableMapOf<String, MutableList<GovernedAddonSelection>>()
+    for (usage in addonUsage) {
+      val dir = usage.skillRelativeDir
+      for (selection in usage.addons) {
+        when (val outcome = collisions.classifyAddon(slug, dir, selection)) {
+          AddonCollisionOutcome.AlreadyPresent -> Unit
+          is AddonCollisionOutcome.Collision -> throw ExternalAddonOverlayError(
+            addonCollisionMessage(slug, dir, selection.slug, outcome.existing, selection),
+          )
+          AddonCollisionOutcome.New -> {
+            collisions.recordExternalAddon(slug, dir, selection)
+            result.getOrPut(dir) { mutableListOf() } += selection
+          }
+        }
+      }
+    }
+    return result
+  }
+
+  private fun readSourceManifest(sourcePath: Path, slug: String): Map<String, Any?> {
+    val manifestPath = sourcePath.resolve(SOURCE_MANIFEST_FILE)
+    if (!Files.isRegularFile(manifestPath)) {
+      throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': expected '$manifestPath' but it is missing.",
+      )
+    }
+    val raw = try {
+      Yaml().load<Any?>(Files.readString(manifestPath))
+    } catch (error: org.yaml.snakeyaml.error.YAMLException) {
+      throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': manifest '$manifestPath' is not valid YAML: ${error.message}",
+        error,
+      )
+    }
+    val rawMap = raw as? Map<*, *>
+      ?: throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': manifest '$manifestPath' must be a YAML mapping.",
+      )
+    val typed = linkedMapOf<String, Any?>()
+    rawMap.forEach { (k, v) ->
+      val key = k as? String
+        ?: throw ExternalAddonOverlayError(
+          "External addon source for platform '$slug': manifest keys must be strings.",
+        )
+      typed[key] = v
+    }
+    return typed
+  }
+
+  private fun rewriteFragmentTargets(fragment: Map<String, Any?>, slug: String): Map<String, Any?> {
+    val pointers = (fragment["pointers"] as? Map<*, *>) ?: return fragment
+    val rewritten = linkedMapOf<String, Any?>()
+    fragment.forEach { (k, v) -> rewritten[k] = v }
+    val rewrittenPointers = linkedMapOf<String, Any?>()
+    val canonicalPrefix = "platform-packs/$slug/$ADDONS_DIR/"
+    pointers.forEach { (dirKey, entriesRaw) ->
+      val dir = dirKey as? String
+        ?: throw ExternalAddonOverlayError(
+          "External addon source for platform '$slug': pointers keys must be strings.",
+        )
+      val entries = (entriesRaw as? List<*>)
+        ?: throw ExternalAddonOverlayError(
+          "External addon source for platform '$slug': pointers[$dir] must be a list.",
+        )
+      val rewrittenEntries = entries.map { entry -> rewritePointerEntry(slug, dir, entry, canonicalPrefix) }
+      rewrittenPointers[dir] = rewrittenEntries
+    }
+    rewritten["pointers"] = rewrittenPointers
+    return rewritten
+  }
+
+  private fun rewritePointerEntry(
+    slug: String,
+    dir: String,
+    entry: Any?,
+    canonicalPrefix: String,
+  ): MutableMap<String, Any?> {
+    val rawMap = entry as? Map<*, *>
+      ?: throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': pointers[$dir] entries must be mappings.",
+      )
+    val map = linkedMapOf<String, Any?>()
+    rawMap.forEach { (k, v) -> map[k as String] = v }
+    val target = map["target"] as? String
+      ?: throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': pointers[$dir] entry is missing string field 'target'.",
+      )
+    if (!target.startsWith(canonicalPrefix)) {
+      val filename = Path.of(target).fileName.toString()
+      map["target"] = canonicalPrefix + filename
+    }
+    return map
+  }
+
+  private fun validateFragmentFields(fragment: Map<String, Any?>, slug: String) {
+    validatePointerEntries(fragment, slug)
+    validateAddonUsageEntries(fragment, slug)
+  }
+
+  private fun validatePointerEntries(fragment: Map<String, Any?>, slug: String) {
+    val pointers = fragment["pointers"] as? Map<*, *> ?: return
+    pointers.forEach { (dirKey, entriesRaw) ->
+      val dir = dirKey as? String
+        ?: throw ExternalAddonOverlayError(
+          "External addon source for platform '$slug': pointers keys must be strings.",
+        )
+      val entries = (entriesRaw as? List<*>)
+        ?: throw ExternalAddonOverlayError(
+          "External addon source for platform '$slug': pointers[$dir] must be a list.",
+        )
+      entries.forEachIndexed { index, entry ->
+        validatePointerEntry(slug, dir, index, entry)
+      }
+    }
+  }
+
+  private fun validatePointerEntry(slug: String, dir: String, index: Int, entry: Any?) {
+    val entryMap = entry as? Map<*, *>
+      ?: throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': pointers[$dir][$index] must be a mapping.",
+      )
+    val keys = entryMap.keys.mapNotNull { it as? String }.toSet()
+    val extra = keys - POINTER_ENTRY_KEYS
+    if (extra.isNotEmpty()) {
+      throw ExternalAddonOverlayError(
+        fragmentFieldMessage(slug, "pointers[$dir][$index]", extra, "name and target"),
+      )
+    }
+    val name = entryMap["name"] as? String
+    if (name != null && !isValidPointerName(name)) {
+      throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': pointers[$dir][$index].name '$name' " +
+          "must be a bare markdown filename (no separators, no '..' segments, ending in '.md').",
+      )
+    }
+  }
+
+  private fun validateAddonUsageEntries(fragment: Map<String, Any?>, slug: String) {
+    val addonUsage = fragment["addon_usage"] as? Map<*, *> ?: return
+    addonUsage.forEach { (dirKey, entriesRaw) ->
+      val dir = dirKey as? String
+        ?: throw ExternalAddonOverlayError(
+          "External addon source for platform '$slug': addon_usage keys must be strings.",
+        )
+      val entries = (entriesRaw as? List<*>)
+        ?: throw ExternalAddonOverlayError(
+          "External addon source for platform '$slug': addon_usage[$dir] must be a list.",
+        )
+      entries.forEachIndexed { index, entry ->
+        validateAddonUsageEntry(slug, dir, index, entry)
+      }
+    }
+  }
+
+  private fun validateAddonUsageEntry(slug: String, dir: String, index: Int, entry: Any?) {
+    val entryMap = entry as? Map<*, *>
+      ?: throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': addon_usage[$dir][$index] must be a mapping.",
+      )
+    val keys = entryMap.keys.mapNotNull { it as? String }.toSet()
+    val extra = keys - ADDON_ENTRY_KEYS
+    if (extra.isNotEmpty()) {
+      throw ExternalAddonOverlayError(
+        fragmentFieldMessage(
+          slug,
+          "addon_usage[$dir][$index]",
+          extra,
+          "slug, entrypoint, and companion_pointers",
+        ),
+      )
+    }
+    val addonSlug = entryMap["slug"] as? String
+    if (addonSlug != null && !ADDON_SLUG_PATTERN.matches(addonSlug)) {
+      throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': addon_usage[$dir][$index].slug '$addonSlug' " +
+          "must match '${ADDON_SLUG_PATTERN.pattern}'.",
+      )
+    }
+  }
+
+  private fun fragmentFieldMessage(slug: String, field: String, extra: Set<String>, allowed: String): String =
+    "External addon source for platform '$slug': $field has unexpected keys ${extra.sorted()} " +
+      "(only $allowed are allowed)."
+
+  private fun isValidPointerName(name: String): Boolean = POINTER_NAME_PATTERN.matches(name) && !name.contains("..")
+
+  private fun requireFlatAddonTarget(slug: String, target: String) {
+    val expectedPrefix = "platform-packs/$slug/$ADDONS_DIR/"
+    if (!target.startsWith(expectedPrefix)) {
+      throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': pointer target '$target' must start with '$expectedPrefix'.",
+      )
+    }
+    val remainder = target.removePrefix(expectedPrefix)
+    if (remainder.contains('/') || remainder.contains('\\') || remainder.isEmpty()) {
+      throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': pointer target '$target' must be a flat file directly " +
+          "under '$expectedPrefix' (no subdirectories).",
+      )
+    }
+  }
+
+  private fun <T> wrapParserErrors(slug: String, block: () -> T): T = try {
+    block()
+  } catch (error: InvalidManifestSchemaError) {
+    throw ExternalAddonOverlayError(
+      "External addon source for platform '$slug': fragment validation failed: ${error.message}",
+      error,
+    )
+  }
+
+  private fun verifySourceFile(sourcePath: Path, slug: String, filename: String) {
+    val file = sourcePath.resolve(filename)
+    if (!Files.isRegularFile(file)) {
+      throw ExternalAddonOverlayError(
+        "External addon source for platform '$slug': referenced addon file '$file' is missing.",
+      )
+    }
+  }
+
+  private fun applyPlan(plan: SourcePlan) {
+    val manifestChanged = plan.pointersToAppend.isNotEmpty() || plan.addonsToAppend.isNotEmpty()
+    if (manifestChanged) {
+      mergeIntoManifest(plan)
+    }
+    if (plan.copiedFiles.isEmpty()) return
+    val addonsDir = plan.packRoot.resolve(ADDONS_DIR)
+    Files.createDirectories(addonsDir)
+    plan.copiedFiles.forEach { (filename, sourceFile) ->
+      Files.copy(sourceFile, addonsDir.resolve(filename), StandardCopyOption.REPLACE_EXISTING)
+    }
+  }
+
+  private fun mergeIntoManifest(plan: SourcePlan) {
+    val manifestPath = plan.installedManifestPath
+    val root = readRawManifest(manifestPath)
+    if (plan.pointersToAppend.isNotEmpty()) {
+      appendPointers(plan, root)
+    }
+    if (plan.addonsToAppend.isNotEmpty()) {
+      appendAddonUsage(plan, root)
+    }
+    val tempFile = manifestPath.resolveSibling(MANIFEST_TEMP_SUFFIX)
+    Files.writeString(tempFile, Yaml().dump(root))
+    try {
+      atomicMove(tempFile, manifestPath)
+    } catch (error: java.io.IOException) {
+      Files.deleteIfExists(tempFile)
+      throw error
+    }
+  }
+
+  private fun appendPointers(plan: SourcePlan, root: MutableMap<String, Any?>) {
+    val pointersRoot = root
+      .getOrPut("pointers") { linkedMapOf<String, Any?>() }
+      .asMutableMap(plan.platform, "pointers")
+    plan.pointersToAppend.forEach { (dir, entries) ->
+      val list = pointersRoot
+        .getOrPut(dir) { mutableListOf<Any?>() }
+        .asMutableList(plan.platform, "pointers[$dir]")
+      entries.forEach { spec -> list.add(linkedMapOf("name" to spec.name, "target" to spec.target)) }
+    }
+  }
+
+  private fun appendAddonUsage(plan: SourcePlan, root: MutableMap<String, Any?>) {
+    val addonUsageRoot = root
+      .getOrPut("addon_usage") { linkedMapOf<String, Any?>() }
+      .asMutableMap(plan.platform, "addon_usage")
+    plan.addonsToAppend.forEach { (dir, entries) ->
+      val list = addonUsageRoot
+        .getOrPut(dir) { mutableListOf<Any?>() }
+        .asMutableList(plan.platform, "addon_usage[$dir]")
+      entries.forEach { selection ->
+        val entry = linkedMapOf<String, Any?>("slug" to selection.slug, "entrypoint" to selection.entrypoint)
+        if (selection.companionPointers.isNotEmpty()) {
+          entry["companion_pointers"] = selection.companionPointers.toMutableList()
+        }
+        list.add(entry)
+      }
+    }
+  }
+
+  private fun atomicMove(source: Path, target: Path) {
+    try {
+      Files.move(source, target, StandardCopyOption.ATOMIC_MOVE)
+    } catch (_: AtomicMoveNotSupportedException) {
+      Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+    }
+  }
+
+  private fun Any?.asMutableMap(slug: String, field: String): MutableMap<String, Any?> = when (this) {
+    is MutableMap<*, *> -> {
+      @Suppress("UNCHECKED_CAST")
+      try {
+        this as MutableMap<String, Any?>
+      } catch (error: ClassCastException) {
+        throw manifestStructureError(slug, field, error)
+      }
+    }
+    else -> throw manifestStructureError(slug, field, expected = "a mapping", actual = this)
+  }
+
+  private fun Any?.asMutableList(slug: String, field: String): MutableList<Any?> = when (this) {
+    is MutableList<*> -> {
+      @Suppress("UNCHECKED_CAST")
+      try {
+        this as MutableList<Any?>
+      } catch (error: ClassCastException) {
+        throw manifestStructureError(slug, field, error)
+      }
+    }
+    else -> throw manifestStructureError(slug, field, expected = "a list", actual = this)
+  }
+
+  private fun manifestStructureError(
+    slug: String,
+    field: String,
+    error: ClassCastException,
+  ): ExternalAddonOverlayError {
+    val message = "Installed platform.yaml for '$slug' has unexpected structure in '$field': ${error.message}"
+    return ExternalAddonOverlayError(message, error)
+  }
+
+  private fun manifestStructureError(
+    slug: String,
+    field: String,
+    expected: String,
+    actual: Any?,
+  ): ExternalAddonOverlayError {
+    val found = actual?.javaClass?.simpleName ?: "null"
+    val message = "Installed platform.yaml for '$slug' has unexpected structure in '$field': " +
+      "expected $expected but found $found."
+    return ExternalAddonOverlayError(message)
+  }
+
+  private fun readRawManifest(manifestPath: Path): MutableMap<String, Any?> {
+    val raw = Yaml().load<Any?>(Files.readString(manifestPath)) as? Map<*, *>
+      ?: throw ExternalAddonOverlayError("Installed platform manifest '$manifestPath' must be a YAML mapping.")
+    val root = linkedMapOf<String, Any?>()
+    raw.forEach { (k, v) ->
+      root[k as String] = when (v) {
+        is Map<*, *> -> linkedMapOfFrom(v)
+        else -> v
+      }
+    }
+    return root
+  }
+
+  private fun linkedMapOfFrom(map: Map<*, *>): MutableMap<String, Any?> {
+    val out = linkedMapOf<String, Any?>()
+    map.forEach { (k, v) ->
+      out[k as String] = when (v) {
+        is Map<*, *> -> linkedMapOfFrom(v)
+        is List<*> -> v.mapTo(mutableListOf()) { item ->
+          when (item) {
+            is Map<*, *> -> linkedMapOfFrom(item)
+            else -> item
+          }
+        }
+        else -> v
+      }
+    }
+    return out
+  }
+
+  private fun collisionMessage(slug: String, dir: String, name: String, existing: String, incoming: String): String =
+    "External addon overlay for platform '$slug': pointer '$name' under '$dir' collides with an existing " +
+      "pack-owned target '$existing' (external source declares '$incoming')."
+
+  private fun targetCollisionMessage(
+    slug: String,
+    pointer: PointerSpec,
+    outcome: PointerCollisionOutcome.TargetCollision,
+  ): String = "External addon overlay for platform '$slug': pointer '${pointer.name}' under " +
+    "'${pointer.skillRelativeDir}' writes target file '${pointer.target}' that collides with the " +
+    "${outcome.origin} pointer '${outcome.existingName}' (silent overwrite refused)."
+
+  private fun addonCollisionMessage(
+    slug: String,
+    dir: String,
+    addonSlug: String,
+    existing: GovernedAddonSelection,
+    incoming: GovernedAddonSelection,
+  ): String = "External addon overlay for platform '$slug': add-on slug '$addonSlug' under '$dir' collides with an " +
+    "existing entry (existing entrypoint '${existing.entrypoint}', incoming entrypoint '${incoming.entrypoint}')."
+}
+
+private typealias DirName = Pair<String, String>
+private typealias DirTarget = Pair<String, String>
+private typealias DirSlug = Pair<String, String>
+
+private data class ExternalName(val platform: String, val dir: String, val name: String)
+private data class ExternalTarget(val platform: String, val dir: String, val basename: String)
+private data class ExternalSlug(val platform: String, val dir: String, val slug: String)
+
+private fun PointerSpec.dirName(): DirName = skillRelativeDir to name
+
+private fun basename(target: String): String = target.substringAfterLast('/').substringAfterLast('\\')
+
+private sealed interface PointerCollisionOutcome {
+  data object AlreadyPresent : PointerCollisionOutcome
+  data class NameCollision(val existingTarget: String) : PointerCollisionOutcome
+  data class TargetCollision(val existingName: String, val origin: String) : PointerCollisionOutcome
+  data object New : PointerCollisionOutcome
+}
+
+private sealed interface AddonCollisionOutcome {
+  data object AlreadyPresent : AddonCollisionOutcome
+  data class Collision(val existing: GovernedAddonSelection) : AddonCollisionOutcome
+  data object New : AddonCollisionOutcome
+}
+
+private class CollisionIndex {
+  private val installedByName = mutableMapOf<DirName, String>()
+  private val installedByTarget = mutableMapOf<DirTarget, String>()
+  private val externalByName = mutableMapOf<ExternalName, String>()
+  private val externalByTarget = mutableMapOf<ExternalTarget, String>()
+  private val installedAddons = mutableMapOf<DirSlug, GovernedAddonSelection>()
+  private val externalAddons = mutableMapOf<ExternalSlug, GovernedAddonSelection>()
+
+  fun mergeInstalled(pointers: List<PointerSpec>, addonUsage: List<GovernedAddonUsage> = emptyList()) {
+    installedByName.clear()
+    installedByTarget.clear()
+    installedAddons.clear()
+    pointers.forEach { pointer ->
+      installedByName[pointer.skillRelativeDir to pointer.name] = pointer.target
+      installedByTarget[pointer.skillRelativeDir to basename(pointer.target)] = pointer.name
+    }
+    addonUsage.forEach { usage ->
+      usage.addons.forEach { selection ->
+        installedAddons[usage.skillRelativeDir to selection.slug] = selection
+      }
+    }
+  }
+
+  fun recordExternalPointer(platform: String, nameKey: DirName, targetKey: DirTarget, pointer: PointerSpec) {
+    externalByName[ExternalName(platform, nameKey.first, nameKey.second)] = pointer.target
+    externalByTarget[ExternalTarget(platform, targetKey.first, targetKey.second)] = pointer.name
+  }
+
+  fun classifyPointer(
+    platform: String,
+    pointer: PointerSpec,
+    nameKey: DirName,
+    targetKey: DirTarget,
+  ): PointerCollisionOutcome {
+    val nameOwner = installedByName[nameKey] ?: externalByName[ExternalName(platform, nameKey.first, nameKey.second)]
+    if (nameOwner != null) {
+      return if (nameOwner == pointer.target) {
+        PointerCollisionOutcome.AlreadyPresent
+      } else {
+        PointerCollisionOutcome.NameCollision(nameOwner)
+      }
+    }
+    val targetOwner = installedByTarget[targetKey]
+    val externalTargetOwner = externalByTarget[ExternalTarget(platform, targetKey.first, targetKey.second)]
+    return when {
+      targetOwner != null -> PointerCollisionOutcome.TargetCollision(targetOwner, "pack-owned")
+      externalTargetOwner != null -> PointerCollisionOutcome.TargetCollision(externalTargetOwner, "external")
+      else -> PointerCollisionOutcome.New
+    }
+  }
+
+  fun recordExternalAddon(platform: String, dir: String, selection: GovernedAddonSelection) {
+    externalAddons[ExternalSlug(platform, dir, selection.slug)] = selection
+  }
+
+  fun classifyAddon(platform: String, dir: String, selection: GovernedAddonSelection): AddonCollisionOutcome {
+    val installed = installedAddons[dir to selection.slug]
+    if (installed != null) {
+      return resolveAddonOutcome(installed, selection)
+    }
+    val external = externalAddons[ExternalSlug(platform, dir, selection.slug)]
+    if (external != null) {
+      return resolveAddonOutcome(external, selection)
+    }
+    return AddonCollisionOutcome.New
+  }
+
+  private fun resolveAddonOutcome(
+    existing: GovernedAddonSelection,
+    incoming: GovernedAddonSelection,
+  ): AddonCollisionOutcome =
+    if (existing == incoming) AddonCollisionOutcome.AlreadyPresent else AddonCollisionOutcome.Collision(existing)
+
+  companion object {
+    fun empty(): CollisionIndex = CollisionIndex()
+  }
+}
+
+private data class SourcePlan(
+  val platform: String,
+  val sourcePath: Path,
+  val installedManifestPath: Path,
+  val packRoot: Path,
+  val pointersToAppend: Map<String, List<PointerSpec>>,
+  val addonsToAppend: Map<String, List<GovernedAddonSelection>>,
+  val copiedFiles: Map<String, Path>,
+)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
@@ -40,15 +40,14 @@ internal fun resolveTelemetryStateDir(
   expandAndNormalizeTelemetryPath(it, userHome)
 } ?: userHome.resolve(".skill-bill").toAbsolutePath().normalize()
 
-internal const val XDG_CONFIG_HOME_KEY = "XDG_CONFIG_HOME"
-
 /**
  * Resolution order (read + write share this so the installer and runtime always agree):
  * 1. [CONFIG_ENVIRONMENT_KEY] explicit override.
- * 2. The durable XDG config path (`$XDG_CONFIG_HOME/skill-bill/config.json`, default `~/.config/...`)
- *    when it already exists. This lives OUTSIDE the wiped `~/.skill-bill/`, so it survives installs.
+ * 2. The durable `<home>/.config/skill-bill/config.json` when it exists. This lives OUTSIDE the wiped
+ *    `~/.skill-bill/`, so it survives installs. It is deliberately home-relative (NOT `$XDG_CONFIG_HOME`)
+ *    so a per-target-home install always writes under that home rather than a machine-global config dir.
  * 3. The legacy `~/.skill-bill/config.json` when it exists (backward compatibility for older installs).
- * 4. Otherwise the durable XDG path — so fresh installs write there by default and never get clobbered.
+ * 4. Otherwise the durable path — so fresh installs write there by default and never get clobbered.
  */
 internal fun resolveTelemetryConfigPath(
   environment: Map<String, String> = System.getenv(),
@@ -57,14 +56,12 @@ internal fun resolveTelemetryConfigPath(
   environment[CONFIG_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
     return expandAndNormalizeTelemetryPath(it, userHome)
   }
-  val xdgBase = environment[XDG_CONFIG_HOME_KEY]?.takeIf(String::isNotBlank)
-    ?.let { expandAndNormalizeTelemetryPath(it, userHome) }
-    ?: userHome.resolve(".config")
-  val xdgConfig = xdgBase.resolve("skill-bill").resolve("config.json").toAbsolutePath().normalize()
-  if (Files.exists(xdgConfig)) return xdgConfig
+  val durableConfig = userHome.resolve(".config").resolve("skill-bill").resolve("config.json")
+    .toAbsolutePath().normalize()
+  if (Files.exists(durableConfig)) return durableConfig
   val legacyConfig = userHome.resolve(".skill-bill").resolve("config.json").toAbsolutePath().normalize()
   if (Files.exists(legacyConfig)) return legacyConfig
-  return xdgConfig
+  return durableConfig
 }
 
 private fun expandAndNormalizeTelemetryPath(rawPath: String, userHome: Path): Path {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
@@ -40,12 +40,36 @@ internal fun resolveTelemetryStateDir(
   expandAndNormalizeTelemetryPath(it, userHome)
 } ?: userHome.resolve(".skill-bill").toAbsolutePath().normalize()
 
+internal const val XDG_CONFIG_HOME_KEY = "XDG_CONFIG_HOME"
+
+/**
+ * Resolution order (read + write share this so the installer and runtime always agree):
+ * 1. [CONFIG_ENVIRONMENT_KEY] explicit override.
+ * 2. The durable XDG config path (`$XDG_CONFIG_HOME/skill-bill/config.json`, default `~/.config/...`)
+ *    when it already exists. This lives OUTSIDE the wiped `~/.skill-bill/`, so it survives installs.
+ * 3. The legacy `~/.skill-bill/config.json` when it exists (backward compatibility for older installs).
+ * 4. Otherwise the durable XDG path — so fresh installs write there by default and never get clobbered.
+ */
 internal fun resolveTelemetryConfigPath(
   environment: Map<String, String> = System.getenv(),
   userHome: Path = Path.of(System.getProperty("user.home")),
-): Path = environment[CONFIG_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
-  expandAndNormalizeTelemetryPath(it, userHome)
-} ?: userHome.resolve(".skill-bill").resolve("config.json").toAbsolutePath().normalize()
+): Path {
+  environment[CONFIG_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
+    return expandAndNormalizeTelemetryPath(it, userHome)
+  }
+  val xdgConfig = xdgTelemetryConfigPath(environment, userHome)
+  if (Files.exists(xdgConfig)) return xdgConfig
+  val legacyConfig = userHome.resolve(".skill-bill").resolve("config.json").toAbsolutePath().normalize()
+  if (Files.exists(legacyConfig)) return legacyConfig
+  return xdgConfig
+}
+
+private fun xdgTelemetryConfigPath(environment: Map<String, String>, userHome: Path): Path {
+  val base = environment[XDG_CONFIG_HOME_KEY]?.takeIf(String::isNotBlank)
+    ?.let { expandAndNormalizeTelemetryPath(it, userHome) }
+    ?: userHome.resolve(".config")
+  return base.resolve("skill-bill").resolve("config.json").toAbsolutePath().normalize()
+}
 
 private fun expandAndNormalizeTelemetryPath(rawPath: String, userHome: Path): Path {
   val normalized =

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStore.kt
@@ -57,18 +57,14 @@ internal fun resolveTelemetryConfigPath(
   environment[CONFIG_ENVIRONMENT_KEY]?.takeIf(String::isNotBlank)?.let {
     return expandAndNormalizeTelemetryPath(it, userHome)
   }
-  val xdgConfig = xdgTelemetryConfigPath(environment, userHome)
+  val xdgBase = environment[XDG_CONFIG_HOME_KEY]?.takeIf(String::isNotBlank)
+    ?.let { expandAndNormalizeTelemetryPath(it, userHome) }
+    ?: userHome.resolve(".config")
+  val xdgConfig = xdgBase.resolve("skill-bill").resolve("config.json").toAbsolutePath().normalize()
   if (Files.exists(xdgConfig)) return xdgConfig
   val legacyConfig = userHome.resolve(".skill-bill").resolve("config.json").toAbsolutePath().normalize()
   if (Files.exists(legacyConfig)) return legacyConfig
   return xdgConfig
-}
-
-private fun xdgTelemetryConfigPath(environment: Map<String, String>, userHome: Path): Path {
-  val base = environment[XDG_CONFIG_HOME_KEY]?.takeIf(String::isNotBlank)
-    ?.let { expandAndNormalizeTelemetryPath(it, userHome) }
-    ?: userHome.resolve(".config")
-  return base.resolve("skill-bill").resolve("config.json").toAbsolutePath().normalize()
 }
 
 private fun expandAndNormalizeTelemetryPath(rawPath: String, userHome: Path): Path {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplySideEffects.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplySideEffects.kt
@@ -1,6 +1,7 @@
 package skillbill.install.apply
 
 import skillbill.infrastructure.fs.FileTelemetryConfigStore
+import skillbill.infrastructure.fs.resolveTelemetryConfigPath
 import skillbill.install.model.ClaudeMcpProfileFailure
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallApplyIssue
@@ -26,10 +27,10 @@ internal fun applyTelemetryIntent(
   warnings: MutableList<InstallApplyIssue>,
   telemetryLevelMutator: TelemetryLevelMutator? = null,
 ): InstallTelemetryApplyOutcome {
-  val configPath = plan.request.home.resolve(".skill-bill/config.json").toAbsolutePath().normalize()
+  val environmentContext = EnvironmentContext(environment = emptyMap(), userHome = plan.request.home)
+  val configPath = resolveTelemetryConfigPath(environmentContext.environment, environmentContext.userHome)
   val existedBefore = Files.exists(configPath)
   return runCatching {
-    val environmentContext = EnvironmentContext(environment = emptyMap(), userHome = plan.request.home)
     val clearedEvents =
       applyInstallTelemetryLevel(environmentContext, plan.telemetryLevel.id, telemetryLevelMutator)
     val status =
@@ -149,7 +150,7 @@ internal fun skippedTelemetryOutcome(plan: InstallPlan, message: String): Instal
   InstallTelemetryApplyOutcome(
     level = plan.telemetryLevel,
     status = InstallTelemetryApplyStatus.SKIPPED,
-    configPath = plan.request.home.resolve(".skill-bill/config.json").toAbsolutePath().normalize(),
+    configPath = resolveTelemetryConfigPath(emptyMap(), plan.request.home),
     message = message,
   )
 

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/platformpack/ShellContentLoader.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/platformpack/ShellContentLoader.kt
@@ -618,7 +618,7 @@ private fun parseOptionalString(manifest: Map<*, *>, slug: String, key: String):
   it as? String ?: throw InvalidManifestSchemaError("Platform pack '$slug': '$key' must be a string when provided.")
 }
 
-private fun parsePointers(manifest: Map<*, *>, slug: String): List<PointerSpec> {
+internal fun parsePointers(manifest: Map<*, *>, slug: String): List<PointerSpec> {
   val raw = manifest["pointers"] ?: return emptyList()
   val pointersMap = raw as? Map<*, *>
     ?: throw InvalidManifestSchemaError(
@@ -659,7 +659,7 @@ private fun parsePointers(manifest: Map<*, *>, slug: String): List<PointerSpec> 
   return collected
 }
 
-private fun parseAddonUsage(
+internal fun parseAddonUsage(
   manifest: Map<*, *>,
   slug: String,
   pointers: List<PointerSpec>,

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileExternalAddonSourceConfigStoreTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileExternalAddonSourceConfigStoreTest.kt
@@ -1,0 +1,132 @@
+package skillbill.infrastructure.fs
+
+import org.junit.jupiter.api.io.TempDir
+import skillbill.contracts.JsonSupport
+import skillbill.error.ExternalAddonConfigError
+import skillbill.ports.install.addon.model.ExternalAddonSourceConfigRequest
+import skillbill.telemetry.CONFIG_ENVIRONMENT_KEY
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class FileExternalAddonSourceConfigStoreTest {
+  private val store = FileExternalAddonSourceConfigStore()
+
+  @Test
+  fun `absent config returns empty`(@TempDir home: Path) {
+    val sources = store.readExternalAddonSources(request(home, configPath(home))).sources
+
+    assertTrue(sources.isEmpty())
+  }
+
+  @Test
+  fun `empty array returns empty`(@TempDir home: Path) {
+    writeConfig(home, mapOf("external_addon_sources" to emptyList<String>()))
+
+    val sources = store.readExternalAddonSources(request(home, configPath(home))).sources
+
+    assertTrue(sources.isEmpty())
+  }
+
+  @Test
+  fun `valid sources are returned in declared order`(@TempDir home: Path) {
+    val ios = Files.createDirectories(home.resolve("private/ios"))
+    val kotlin = Files.createDirectories(home.resolve("private/kotlin"))
+    writeConfig(
+      home,
+      mapOf(
+        "external_addon_sources" to
+          listOf(
+            mapOf("path" to kotlin.toString(), "platform" to "kotlin"),
+            mapOf("path" to ios.toString(), "platform" to " ios "),
+          ),
+      ),
+    )
+
+    val sources = store.readExternalAddonSources(request(home, configPath(home))).sources
+
+    assertEquals(2, sources.size)
+    assertEquals(kotlin, sources[0].path)
+    assertEquals("kotlin", sources[0].platform)
+    assertEquals(ios, sources[1].path)
+    assertEquals("ios", sources[1].platform)
+  }
+
+  @Test
+  fun `tilde path expands against request user home`(@TempDir home: Path) {
+    Files.createDirectories(home.resolve("private/ios"))
+    writeConfig(
+      home,
+      mapOf(
+        "external_addon_sources" to
+          listOf(mapOf("path" to "~/private/ios", "platform" to "ios")),
+      ),
+    )
+
+    val sources = store.readExternalAddonSources(request(home, configPath(home))).sources
+
+    assertEquals(home.resolve("private/ios"), sources[0].path)
+  }
+
+  @Test
+  fun `malformed json loud-fails`(@TempDir home: Path) {
+    Files.createDirectories(home.resolve(".skill-bill"))
+    Files.writeString(configPath(home), "{ not valid json")
+
+    assertFailsWith<ExternalAddonConfigError> {
+      store.readExternalAddonSources(request(home, configPath(home)))
+    }
+  }
+
+  @Test
+  fun `external_addon_sources not a list loud-fails`(@TempDir home: Path) {
+    writeConfig(home, mapOf("external_addon_sources" to "nope"))
+
+    assertFailsWith<ExternalAddonConfigError> {
+      store.readExternalAddonSources(request(home, configPath(home)))
+    }
+  }
+
+  @Test
+  fun `element missing path loud-fails`(@TempDir home: Path) {
+    writeConfig(
+      home,
+      mapOf("external_addon_sources" to listOf(mapOf("platform" to "ios"))),
+    )
+
+    assertFailsWith<ExternalAddonConfigError> {
+      store.readExternalAddonSources(request(home, configPath(home)))
+    }
+  }
+
+  @Test
+  fun `non-existent path loud-fails`(@TempDir home: Path) {
+    writeConfig(
+      home,
+      mapOf(
+        "external_addon_sources" to
+          listOf(mapOf("path" to home.resolve("missing").toString(), "platform" to "ios")),
+      ),
+    )
+
+    assertFailsWith<ExternalAddonConfigError> {
+      store.readExternalAddonSources(request(home, configPath(home)))
+    }
+  }
+
+  private fun configPath(home: Path): Path = home.resolve(".skill-bill").resolve("config.json")
+
+  private fun request(home: Path, configPath: Path): ExternalAddonSourceConfigRequest =
+    ExternalAddonSourceConfigRequest(
+      userHome = home,
+      environment = mapOf(CONFIG_ENVIRONMENT_KEY to configPath.toString()),
+    )
+
+  private fun writeConfig(home: Path, payload: Map<String, Any?>) {
+    Files.createDirectories(home.resolve(".skill-bill"))
+    Files.writeString(configPath(home), JsonSupport.mapToJsonString(payload) + "\n")
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStoreTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStoreTest.kt
@@ -43,7 +43,7 @@ class FileTelemetryConfigStoreTest {
   }
 
   @Test
-  fun `config path defaults to durable XDG location for fresh installs`(@TempDir tempDir: Path) {
+  fun `config path defaults to durable home-relative config dir for fresh installs`(@TempDir tempDir: Path) {
     val resolved = resolveTelemetryConfigPath(emptyMap(), tempDir)
 
     assertEquals(
@@ -53,14 +53,14 @@ class FileTelemetryConfigStoreTest {
   }
 
   @Test
-  fun `config path prefers existing XDG config over legacy`(@TempDir tempDir: Path) {
-    val xdg = tempDir.resolve(".config/skill-bill/config.json")
-    Files.createDirectories(xdg.parent)
-    Files.writeString(xdg, "{}\n")
+  fun `config path prefers existing durable config over legacy`(@TempDir tempDir: Path) {
+    val durable = tempDir.resolve(".config/skill-bill/config.json")
+    Files.createDirectories(durable.parent)
+    Files.writeString(durable, "{}\n")
     Files.createDirectories(tempDir.resolve(".skill-bill"))
     Files.writeString(tempDir.resolve(".skill-bill/config.json"), "{}\n")
 
-    assertEquals(xdg.toAbsolutePath().normalize(), resolveTelemetryConfigPath(emptyMap(), tempDir))
+    assertEquals(durable.toAbsolutePath().normalize(), resolveTelemetryConfigPath(emptyMap(), tempDir))
   }
 
   @Test
@@ -73,12 +73,12 @@ class FileTelemetryConfigStoreTest {
   }
 
   @Test
-  fun `config path honors XDG_CONFIG_HOME override`(@TempDir tempDir: Path) {
-    val xdgHome = tempDir.resolve("custom-xdg")
+  fun `config path ignores XDG_CONFIG_HOME and stays home-relative`(@TempDir tempDir: Path) {
+    val resolved = resolveTelemetryConfigPath(mapOf("XDG_CONFIG_HOME" to "/some/global/xdg"), tempDir)
 
     assertEquals(
-      xdgHome.resolve("skill-bill/config.json").toAbsolutePath().normalize(),
-      resolveTelemetryConfigPath(mapOf(XDG_CONFIG_HOME_KEY to xdgHome.toString()), tempDir),
+      tempDir.resolve(".config/skill-bill/config.json").toAbsolutePath().normalize(),
+      resolved,
     )
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStoreTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileTelemetryConfigStoreTest.kt
@@ -42,6 +42,58 @@ class FileTelemetryConfigStoreTest {
     )
   }
 
+  @Test
+  fun `config path defaults to durable XDG location for fresh installs`(@TempDir tempDir: Path) {
+    val resolved = resolveTelemetryConfigPath(emptyMap(), tempDir)
+
+    assertEquals(
+      tempDir.resolve(".config/skill-bill/config.json").toAbsolutePath().normalize(),
+      resolved,
+    )
+  }
+
+  @Test
+  fun `config path prefers existing XDG config over legacy`(@TempDir tempDir: Path) {
+    val xdg = tempDir.resolve(".config/skill-bill/config.json")
+    Files.createDirectories(xdg.parent)
+    Files.writeString(xdg, "{}\n")
+    Files.createDirectories(tempDir.resolve(".skill-bill"))
+    Files.writeString(tempDir.resolve(".skill-bill/config.json"), "{}\n")
+
+    assertEquals(xdg.toAbsolutePath().normalize(), resolveTelemetryConfigPath(emptyMap(), tempDir))
+  }
+
+  @Test
+  fun `config path falls back to legacy path when only legacy exists`(@TempDir tempDir: Path) {
+    val legacy = tempDir.resolve(".skill-bill/config.json")
+    Files.createDirectories(legacy.parent)
+    Files.writeString(legacy, "{}\n")
+
+    assertEquals(legacy.toAbsolutePath().normalize(), resolveTelemetryConfigPath(emptyMap(), tempDir))
+  }
+
+  @Test
+  fun `config path honors XDG_CONFIG_HOME override`(@TempDir tempDir: Path) {
+    val xdgHome = tempDir.resolve("custom-xdg")
+
+    assertEquals(
+      xdgHome.resolve("skill-bill/config.json").toAbsolutePath().normalize(),
+      resolveTelemetryConfigPath(mapOf(XDG_CONFIG_HOME_KEY to xdgHome.toString()), tempDir),
+    )
+  }
+
+  @Test
+  fun `explicit config env override wins over durable and legacy paths`(@TempDir tempDir: Path) {
+    Files.createDirectories(tempDir.resolve(".config/skill-bill"))
+    Files.writeString(tempDir.resolve(".config/skill-bill/config.json"), "{}\n")
+    val pinned = tempDir.resolve("pinned/config.json")
+
+    assertEquals(
+      pinned.toAbsolutePath().normalize(),
+      resolveTelemetryConfigPath(mapOf(CONFIG_ENVIRONMENT_KEY to pinned.toString()), tempDir),
+    )
+  }
+
   // SKILL-52.3: the random install-id seed moved out of the pure domain into this adapter.
   @Test
   fun `ensure prefers the injected install id env value when none is persisted`(@TempDir tempDir: Path) {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallApplyTest.kt
@@ -115,9 +115,9 @@ class InstallApplyTest : InstallApplyTestSupport() {
     assertEquals(InstallApplyStatus.SUCCESS, result.status)
     assertEquals(InstallTelemetryLevel.FULL, result.telemetryOutcome.level)
     assertEquals(InstallTelemetryApplyStatus.SUCCESS, result.telemetryOutcome.status)
-    assertEquals(fixture.home.resolve(".skill-bill/config.json"), result.telemetryOutcome.configPath)
+    assertEquals(fixture.home.resolve(".config/skill-bill/config.json"), result.telemetryOutcome.configPath)
     assertEquals("Telemetry level set to 'full'.", result.telemetryOutcome.message)
-    assertTrue(Files.readString(fixture.home.resolve(".skill-bill/config.json")).contains("\"level\":\"full\""))
+    assertTrue(Files.readString(fixture.home.resolve(".config/skill-bill/config.json")).contains("\"level\":\"full\""))
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallExternalAddonOverlayIntegrationTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallExternalAddonOverlayIntegrationTest.kt
@@ -1,0 +1,183 @@
+@file:Suppress("MaxLineLength")
+
+package skillbill.install
+
+import skillbill.infrastructure.fs.FileSystemExternalAddonOverlay
+import skillbill.install.model.ExternalAddonSource
+import skillbill.install.model.InstallAgent
+import skillbill.install.model.InstallApplyStatus
+import skillbill.install.runtime.InstallOperations
+import skillbill.ports.install.addon.ExternalAddonOverlayPort
+import skillbill.ports.install.addon.model.ExternalAddonOverlayRequest
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InstallExternalAddonOverlayIntegrationTest : InstallApplyTestSupport() {
+
+  @Test
+  fun `overlay then staging inlines external addon content into installed skills cache`() {
+    val fixture = setupIosFixture()
+    val external = seedExternalSource(fixture, "acme", listOf("acme-review.md"))
+    runOverlay(fixture, listOf(external))
+
+    val plan = InstallOperations.planInstall(fixture.request(selectedPlatforms = setOf("ios")))
+    val result = InstallOperations.applyInstall(plan)
+
+    assertEquals(InstallApplyStatus.SUCCESS, result.status, "apply failures: ${result.failures}")
+    val iosSkill = result.skills.first { it.skillName == "bill-ios-code-review" }
+    val staging = iosSkill.staging
+    val stagingDir = staging.stagingDir
+      ?: error("ios code-review skill was not staged")
+    val acmeRendered = staging.renderedPointerFiles.firstOrNull { it.fileName.toString() == "acme-review.md" }
+      ?: error(
+        "acme-review.md must appear among the RENDERED pointer files in $stagingDir; " +
+          "got: ${staging.renderedPointerFiles}",
+      )
+    assertTrue(
+      Files.isRegularFile(acmeRendered),
+      "external addon must be inlined as a rendered pointer file under the install cache",
+    )
+    assertTrue(
+      acmeRendered.toAbsolutePath().normalize().startsWith(fixture.home.resolve(".skill-bill/installed-skills")),
+      "rendered addon pointer must live under the install cache, not the source tree ($acmeRendered)",
+    )
+    assertTrue(Files.isRegularFile(stagingDir.resolve("offline-review.md")), "pack-owned addon must remain inlined")
+    val renderedAddonBody = Files.readString(acmeRendered)
+    assertContains(
+      renderedAddonBody,
+      "acme review body",
+      "external addon content must appear in the RENDERED pointer file, not just the source .md",
+    )
+  }
+
+  @Test
+  fun `clean analog wipes addons then overlay reconstitutes before staging`() {
+    val fixture = setupIosFixture()
+    val external = seedExternalSource(fixture, "acme", listOf("acme-review.md"))
+    runOverlay(fixture, listOf(external))
+
+    val addonsDir = fixture.repoRoot.resolve("platform-packs/ios/addons")
+    Files.walk(addonsDir).use { stream ->
+      stream.filter { it != addonsDir && Files.isRegularFile(it) }
+        .filter { path -> path.fileName.toString().startsWith("acme-") }
+        .forEach(Files::deleteIfExists)
+    }
+    assertFalse(Files.exists(addonsDir.resolve("acme-review.md")))
+
+    runOverlay(fixture, listOf(external))
+    assertTrue(Files.isRegularFile(addonsDir.resolve("acme-review.md")), "overlay must reconstitute wiped addon files")
+
+    val plan = InstallOperations.planInstall(fixture.request(selectedPlatforms = setOf("ios")))
+    val result = InstallOperations.applyInstall(plan)
+    assertEquals(InstallApplyStatus.SUCCESS, result.status, "apply failures: ${result.failures}")
+  }
+
+  @Test
+  fun `zero config parity omits overlay and stages identically to baseline`() {
+    val baseline = setupIosFixture()
+    val baselinePlan = InstallOperations.planInstall(baseline.request(selectedPlatforms = setOf("ios")))
+    val baselineResult = InstallOperations.applyInstall(baselinePlan)
+    assertEquals(InstallApplyStatus.SUCCESS, baselineResult.status)
+
+    val overlayed = setupIosFixture()
+    runOverlay(overlayed, emptyList())
+    val overlayPlan = InstallOperations.planInstall(overlayed.request(selectedPlatforms = setOf("ios")))
+    val overlayResult = InstallOperations.applyInstall(overlayPlan)
+    assertEquals(InstallApplyStatus.SUCCESS, overlayResult.status)
+
+    val baselineContent = stagedSkillBody(baselineResult, "bill-ios-code-review")
+    val overlayContent = stagedSkillBody(overlayResult, "bill-ios-code-review")
+    assertEquals(baselineContent, overlayContent, "empty external config must be a byte-identical no-op")
+  }
+
+  private fun stagedSkillBody(result: skillbill.install.model.InstallApplyResult, name: String): String {
+    val skill = result.skills.first { it.skillName == name }
+    val stagingDir = skill.staging.stagingDir ?: error("$name was not staged")
+    return Files.readString(stagingDir.resolve("SKILL.md"))
+  }
+
+  private fun setupIosFixture(): ApplyFixture {
+    val fixture = setupApplyFixture()
+    val repoRoot = fixture.repoRoot
+    val packRoot = repoRoot.resolve("platform-packs/ios")
+    val codeReviewDir = packRoot.resolve("code-review/bill-ios-code-review")
+    Files.createDirectories(codeReviewDir)
+    Files.writeString(codeReviewDir.resolve("content.md"), content("bill-ios-code-review"))
+    val addonsDir = Files.createDirectories(packRoot.resolve("addons"))
+    Files.writeString(addonsDir.resolve("offline-review.md"), "# offline review body\n")
+    Files.writeString(
+      packRoot.resolve("platform.yaml"),
+      """
+      platform: "ios"
+      contract_version: "1.1"
+      routing_signals:
+        strong:
+          - ".swift"
+        tie_breakers: []
+      declared_code_review_areas: []
+      declared_files:
+        baseline: "code-review/bill-ios-code-review/content.md"
+        areas: {}
+      area_metadata: {}
+      display_name: "iOS"
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: offline
+            entrypoint: offline-review.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: offline-review.md
+            target: platform-packs/ios/addons/offline-review.md
+      """.trimIndent() + "\n",
+    )
+    return fixture
+  }
+
+  private fun seedExternalSource(fixture: ApplyFixture, slug: String, mdFiles: List<String>): ExternalAddonSource {
+    val sourceDir = Files.createDirectories(fixture.home.resolve("private/ios-$slug"))
+    mdFiles.forEach { name ->
+      Files.writeString(sourceDir.resolve(name), "# $slug review body\n")
+    }
+    val entrypoint = mdFiles.first()
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: $slug
+            entrypoint: $entrypoint
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: $entrypoint
+            target: $entrypoint
+      """.trimIndent() + "\n",
+    )
+    return ExternalAddonSource(sourceDir, "ios")
+  }
+
+  private fun runOverlay(fixture: ApplyFixture, sources: List<ExternalAddonSource>) {
+    val port: ExternalAddonOverlayPort = FileSystemExternalAddonOverlay()
+    port.applyOverlay(
+      ExternalAddonOverlayRequest(
+        platformPacksRoot = fixture.repoRoot.resolve("platform-packs"),
+        sources = sources,
+      ),
+    )
+  }
+
+  private fun assertContains(actual: String, expected: String, message: String? = null) {
+    assertTrue(
+      actual.contains(expected),
+      (message ?: "Expected staged content to contain '$expected'.") + " Got: $actual",
+    )
+  }
+
+  private fun ApplyFixture.request(selectedPlatforms: Set<String>): skillbill.install.model.InstallPlanRequest =
+    request(
+      selectedPlatforms = selectedPlatforms,
+      agents = setOf(InstallAgent.CODEX),
+    )
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ExternalAddonOverlayTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ExternalAddonOverlayTest.kt
@@ -1,0 +1,528 @@
+@file:Suppress("MaxLineLength")
+
+package skillbill.scaffold
+
+import org.junit.jupiter.api.io.TempDir
+import skillbill.error.ExternalAddonOverlayError
+import skillbill.infrastructure.fs.FileSystemExternalAddonOverlay
+import skillbill.install.model.ExternalAddonSource
+import skillbill.ports.install.addon.ExternalAddonOverlayPort
+import skillbill.ports.install.addon.model.ExternalAddonOverlayRequest
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExternalAddonOverlayTest {
+  @TempDir
+  lateinit var work: Path
+
+  private lateinit var platformPacksRoot: Path
+
+  private val overlay: ExternalAddonOverlayPort = FileSystemExternalAddonOverlay()
+
+  private fun request(sources: List<ExternalAddonSource>): ExternalAddonOverlayRequest =
+    ExternalAddonOverlayRequest(platformPacksRoot = platformPacksRoot, sources = sources)
+
+  @Test
+  fun `valid merge copies md files and appends entries to installed platform yaml`() {
+    seedIosPack(packOwnedAddon = "offline")
+    val source = seedExternalSource("ios", "acme", listOf("acme-review.md"))
+
+    val result = overlay.applyOverlay(request(listOf(source)))
+
+    assertTrue(result.touched)
+    assertEquals(1, result.appliedSources.size)
+    assertEquals("ios", result.appliedSources[0].platform)
+    assertTrue(Files.isRegularFile(platformPacksRoot.resolve("ios/addons/acme-review.md")))
+    val manifest = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+    assertTrue(manifest.contains("slug: acme"))
+    assertTrue(manifest.contains("target: platform-packs/ios/addons/acme-review.md"))
+  }
+
+  @Test
+  fun `pointer target rewriting converts source-relative target to canonical form`() {
+    seedIosPack(packOwnedAddon = null)
+    val source = seedExternalSource(
+      "ios",
+      "acme",
+      listOf("acme-review.md"),
+      target = "acme-review.md",
+    )
+
+    overlay.applyOverlay(request(listOf(source)))
+
+    val manifest = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+    assertTrue(manifest.contains("target: platform-packs/ios/addons/acme-review.md"))
+    assertFalse(manifest.contains("target: acme-review.md"))
+  }
+
+  @Test
+  fun `external addon slug colliding with pack owned slug loud-fails`() {
+    seedIosPack(packOwnedAddon = "shared")
+    val source = seedExternalSource("ios", "shared", listOf("shared.md"))
+
+    assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(source)))
+    }
+  }
+
+  @Test
+  fun `external pointer name colliding with pack owned pointer loud-fails`() {
+    seedIosPack(packOwnedAddon = "offline")
+    val sourceDir = Files.createDirectories(work.resolve("ext/ios-acme"))
+    Files.writeString(sourceDir.resolve("acme-review.md"), "# acme body\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: acme
+            entrypoint: offline-review.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: offline-review.md
+            target: acme-review.md
+      """.trimIndent() + "\n",
+    )
+    val source = ExternalAddonSource(sourceDir, "ios")
+
+    val error = assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(source)))
+    }
+    assertTrue(error.message.orEmpty().contains("collides"))
+    val manifest = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+    assertFalse(manifest.contains("acme"), "Atomicity: failing overlay must not mutate the installed manifest.")
+  }
+
+  @Test
+  fun `external pointer target colliding with pack owned target basename loud-fails`() {
+    seedIosPack(packOwnedAddon = "offline")
+    val sourceDir = Files.createDirectories(work.resolve("ext/ios-acme"))
+    Files.writeString(sourceDir.resolve("offline-review.md"), "# acme overwrite body\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: acme
+            entrypoint: acme-entry.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: acme-entry.md
+            target: offline-review.md
+      """.trimIndent() + "\n",
+    )
+    val source = ExternalAddonSource(sourceDir, "ios")
+
+    val error = assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(source)))
+    }
+    assertTrue(
+      error.message.orEmpty().contains("silent overwrite refused"),
+      "Expected target-basename collision message, got: ${error.message}",
+    )
+    val manifest = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+    assertFalse(manifest.contains("acme"), "Atomicity: failing overlay must not mutate the installed manifest.")
+  }
+
+  @Test
+  fun `external-vs-external collision across two sources loud-fails`() {
+    seedIosPack(packOwnedAddon = null)
+    val first = seedExternalSource("ios", "acme", listOf("acme-review.md"))
+    val secondDir = Files.createDirectories(work.resolve("ext/ios-acme-2"))
+    Files.writeString(secondDir.resolve("acme-alt.md"), "# alt body\n")
+    Files.writeString(
+      secondDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: acme
+            entrypoint: acme-alt.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: acme-alt.md
+            target: acme-alt.md
+      """.trimIndent() + "\n",
+    )
+    val second = ExternalAddonSource(secondDir, "ios")
+
+    assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(first, second)))
+    }
+  }
+
+  @Test
+  fun `same skill-dir and pointer name across different platforms does not false-collide`() {
+    platformPacksRoot = Files.createDirectories(work.resolve("platform-packs"))
+    seedPackWithSharedDir("ios", ".swift")
+    seedPackWithSharedDir("kotlin", ".kt")
+    val iosSource = seedSharedDirExternalSource("ios", "alpha", "alpha-review.md")
+    val kotlinSource = seedSharedDirExternalSource("kotlin", "beta", "beta-review.md")
+
+    val result = overlay.applyOverlay(request(listOf(iosSource, kotlinSource)))
+
+    assertEquals(listOf("ios", "kotlin"), result.appliedSources.map { it.platform })
+    assertTrue(Files.isRegularFile(platformPacksRoot.resolve("ios/addons/alpha-review.md")))
+    assertTrue(Files.isRegularFile(platformPacksRoot.resolve("kotlin/addons/beta-review.md")))
+  }
+
+  @Test
+  fun `missing source md loud-fails`() {
+    seedIosPack(packOwnedAddon = null)
+    val sourceDir = Files.createDirectories(work.resolve("src/ios"))
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: acme
+            entrypoint: acme-review.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: acme-review.md
+            target: acme-review.md
+      """.trimIndent() + "\n",
+    )
+
+    assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(ExternalAddonSource(sourceDir, "ios"))))
+    }
+  }
+
+  @Test
+  fun `non-installed platform is skipped with a warning`() {
+    seedIosPack(packOwnedAddon = null)
+    val source = seedExternalSource("android", "acme", listOf("acme-review.md"))
+
+    val result = overlay.applyOverlay(request(listOf(source)))
+
+    assertFalse(result.touched)
+    assertEquals(1, result.skippedSources.size)
+    assertEquals("android", result.skippedSources[0].platform)
+    assertContains(result.skippedSources[0].reason, "not installed")
+  }
+
+  @Test
+  fun `multi-source ordering preserves declared config order`() {
+    seedIosPack(packOwnedAddon = null)
+    seedKotlinPack()
+    val iosSource = seedExternalSource("ios", "acme", listOf("acme-review.md"))
+    val kotlinSource = seedExternalSource("kotlin", "kmojo", listOf("kmojo-review.md"))
+
+    val result = overlay.applyOverlay(request(listOf(iosSource, kotlinSource)))
+
+    assertEquals(listOf("ios", "kotlin"), result.appliedSources.map { it.platform })
+  }
+
+  @Test
+  fun `re-applying overlay is idempotent and preserves addon files`() {
+    seedIosPack(packOwnedAddon = null)
+    val source = seedExternalSource("ios", "acme", listOf("acme-review.md"))
+
+    overlay.applyOverlay(request(listOf(source)))
+    val firstManifest = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+
+    val second = overlay.applyOverlay(request(listOf(source)))
+    val secondManifest = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+
+    assertTrue(Files.isRegularFile(platformPacksRoot.resolve("ios/addons/acme-review.md")))
+    assertEquals(firstManifest, secondManifest, "Idempotent re-apply must not duplicate entries.")
+    assertTrue(second.touched)
+  }
+
+  @Test
+  fun `clean analog wipes addons then overlay reconstitutes them`() {
+    seedIosPack(packOwnedAddon = null)
+    val source = seedExternalSource("ios", "acme", listOf("acme-review.md"))
+    overlay.applyOverlay(request(listOf(source)))
+
+    val addonsDir = platformPacksRoot.resolve("ios/addons")
+    Files.walk(addonsDir).use { stream ->
+      stream.filter { it != addonsDir && Files.isRegularFile(it) }.forEach(Files::deleteIfExists)
+    }
+    assertFalse(Files.exists(addonsDir.resolve("acme-review.md")))
+
+    overlay.applyOverlay(request(listOf(source)))
+
+    assertTrue(Files.isRegularFile(addonsDir.resolve("acme-review.md")))
+  }
+
+  @Test
+  fun `atomicity failing second source leaves first source not applied`() {
+    seedIosPack(packOwnedAddon = null)
+    val good = seedExternalSource("ios", "acme", listOf("acme-review.md"))
+    val badDir = Files.createDirectories(work.resolve("bad/ios"))
+    Files.writeString(
+      badDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: broken
+            entrypoint: broken.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: broken.md
+            target: broken.md
+      """.trimIndent() + "\n",
+    )
+    val bad = ExternalAddonSource(badDir, "ios")
+
+    assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(good, bad)))
+    }
+
+    assertFalse(Files.exists(platformPacksRoot.resolve("ios/addons/acme-review.md")))
+    val manifest = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+    assertFalse(manifest.contains("acme"))
+  }
+
+  @Test
+  fun `empty config is a no-op`() {
+    seedIosPack(packOwnedAddon = "offline")
+    val before = Files.readString(platformPacksRoot.resolve("ios/platform.yaml"))
+
+    val result = overlay.applyOverlay(request(emptyList()))
+
+    assertFalse(result.touched)
+    assertEquals(before, Files.readString(platformPacksRoot.resolve("ios/platform.yaml")))
+  }
+
+  @Test
+  fun `nested addon target loud-fails`() {
+    seedIosPack(packOwnedAddon = null)
+    val sourceDir = Files.createDirectories(work.resolve("ext/ios-nested"))
+    Files.writeString(sourceDir.resolve("nested.md"), "# nested body\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: nested
+            entrypoint: nested-pointer.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: nested-pointer.md
+            target: platform-packs/ios/addons/sub/nested.md
+      """.trimIndent() + "\n",
+    )
+
+    val error = assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(ExternalAddonSource(sourceDir, "ios"))))
+    }
+    assertTrue(
+      error.message.orEmpty().contains("flat file"),
+      "Expected nested-target rejection, got: ${error.message}",
+    )
+  }
+
+  @Test
+  fun `fragment with unexpected pointer entry key loud-fails`() {
+    seedIosPack(packOwnedAddon = null)
+    val sourceDir = Files.createDirectories(work.resolve("ext/ios-extra"))
+    Files.writeString(sourceDir.resolve("extra.md"), "# extra body\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: extra
+            entrypoint: extra.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: extra.md
+            target: extra.md
+            surprise: true
+      """.trimIndent() + "\n",
+    )
+
+    assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(ExternalAddonSource(sourceDir, "ios"))))
+    }
+  }
+
+  @Test
+  fun `fragment with malformed addon slug loud-fails`() {
+    seedIosPack(packOwnedAddon = null)
+    val sourceDir = Files.createDirectories(work.resolve("ext/ios-slug"))
+    Files.writeString(sourceDir.resolve("bad-slug.md"), "# bad slug body\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-ios-code-review:
+          - slug: BAD_SLUG
+            entrypoint: bad-slug.md
+      pointers:
+        code-review/bill-ios-code-review:
+          - name: bad-slug.md
+            target: bad-slug.md
+      """.trimIndent() + "\n",
+    )
+
+    assertFailsWith<ExternalAddonOverlayError> {
+      overlay.applyOverlay(request(listOf(ExternalAddonSource(sourceDir, "ios"))))
+    }
+  }
+
+  private fun seedPackWithSharedDir(platform: String, strongSignal: String) {
+    val packRoot = Files.createDirectories(platformPacksRoot.resolve(platform))
+    val baseline = Files.createDirectories(packRoot.resolve("code-review/bill-shared-review"))
+    Files.writeString(baseline.resolve("content.md"), "# $platform shared review\n")
+    Files.writeString(
+      packRoot.resolve("platform.yaml"),
+      """
+      platform: $platform
+      contract_version: "1.1"
+      display_name: "$platform"
+
+      routing_signals:
+        strong:
+          - "$strongSignal"
+        tie_breakers: []
+
+      declared_code_review_areas: []
+
+      declared_files:
+        baseline: "code-review/bill-shared-review/content.md"
+      """.trimIndent() + "\n",
+    )
+  }
+
+  private fun seedSharedDirExternalSource(platform: String, slug: String, addonMd: String): ExternalAddonSource {
+    val sourceDir = Files.createDirectories(work.resolve("ext/$platform-$slug"))
+    Files.writeString(sourceDir.resolve(addonMd), "# $slug body\n")
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-shared-review:
+          - slug: $slug
+            entrypoint: shared-review.md
+      pointers:
+        code-review/bill-shared-review:
+          - name: shared-review.md
+            target: $addonMd
+      """.trimIndent() + "\n",
+    )
+    return ExternalAddonSource(sourceDir, platform)
+  }
+
+  private fun assertContains(actual: String, expected: String) {
+    assertTrue(actual.contains(expected), "Expected '$actual' to contain '$expected'.")
+  }
+
+  private fun seedIosPack(packOwnedAddon: String?) {
+    platformPacksRoot = Files.createDirectories(work.resolve("platform-packs"))
+    val packRoot = Files.createDirectories(platformPacksRoot.resolve("ios"))
+    val baseline = Files.createDirectories(packRoot.resolve("code-review/bill-ios-code-review"))
+    Files.writeString(
+      baseline.resolve("content.md"),
+      """
+      # iOS Code Review
+
+      Review iOS Swift changes for correctness and framework usage.
+      """.trimIndent() + "\n",
+    )
+    val manifest = StringBuilder()
+    manifest.append(
+      """
+      platform: ios
+      contract_version: "1.1"
+      display_name: "iOS"
+
+      routing_signals:
+        strong:
+          - ".swift"
+        tie_breakers: []
+
+      declared_code_review_areas: []
+
+      declared_files:
+        baseline: "code-review/bill-ios-code-review/content.md"
+      """.trimIndent(),
+    )
+    if (packOwnedAddon != null) {
+      Files.createDirectories(packRoot.resolve("addons"))
+      Files.writeString(packRoot.resolve("addons/$packOwnedAddon-review.md"), "# $packOwnedAddon body\n")
+      manifest.append(
+        """
+
+        addon_usage:
+          code-review/bill-ios-code-review:
+            - slug: $packOwnedAddon
+              entrypoint: $packOwnedAddon-review.md
+
+        pointers:
+          code-review/bill-ios-code-review:
+            - name: $packOwnedAddon-review.md
+              target: platform-packs/ios/addons/$packOwnedAddon-review.md
+        """.trimIndent(),
+      )
+    }
+    Files.writeString(packRoot.resolve("platform.yaml"), manifest.toString() + "\n")
+  }
+
+  private fun seedKotlinPack() {
+    val packRoot = Files.createDirectories(platformPacksRoot.resolve("kotlin"))
+    val baseline = Files.createDirectories(packRoot.resolve("code-review/bill-kotlin-code-review"))
+    Files.writeString(
+      baseline.resolve("content.md"),
+      """
+      # Kotlin Code Review
+
+      Review Kotlin changes for correctness.
+      """.trimIndent() + "\n",
+    )
+    Files.writeString(
+      packRoot.resolve("platform.yaml"),
+      """
+      platform: kotlin
+      contract_version: "1.1"
+      display_name: "Kotlin"
+
+      routing_signals:
+        strong:
+          - ".kt"
+        tie_breakers: []
+
+      declared_code_review_areas: []
+
+      declared_files:
+        baseline: "code-review/bill-kotlin-code-review/content.md"
+      """.trimIndent() + "\n",
+    )
+  }
+
+  private fun seedExternalSource(
+    platform: String,
+    addonSlug: String,
+    mdFiles: List<String>,
+    target: String? = null,
+    addonFiles: Map<String, String> = emptyMap(),
+  ): ExternalAddonSource {
+    val sourceDir = Files.createDirectories(work.resolve("ext/$platform-$addonSlug"))
+    mdFiles.forEach { name ->
+      Files.writeString(sourceDir.resolve(name), addonFiles[name] ?: "# $name body\n")
+    }
+    val entrypoint = mdFiles.first()
+    val targetValue = target ?: entrypoint
+    Files.writeString(
+      sourceDir.resolve("addon-manifest.yaml"),
+      """
+      addon_usage:
+        code-review/bill-$platform-code-review:
+          - slug: $addonSlug
+            entrypoint: $entrypoint
+      pointers:
+        code-review/bill-$platform-code-review:
+          - name: $entrypoint
+            target: $targetValue
+      """.trimIndent() + "\n",
+    )
+    return ExternalAddonSource(sourceDir, platform)
+  }
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/addon/ExternalAddonOverlayPort.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/addon/ExternalAddonOverlayPort.kt
@@ -1,0 +1,8 @@
+package skillbill.ports.install.addon
+
+import skillbill.ports.install.addon.model.ExternalAddonOverlayRequest
+import skillbill.ports.install.addon.model.ExternalAddonOverlayResult
+
+interface ExternalAddonOverlayPort {
+  fun applyOverlay(request: ExternalAddonOverlayRequest): ExternalAddonOverlayResult
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/addon/ExternalAddonSourceConfigPort.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/addon/ExternalAddonSourceConfigPort.kt
@@ -1,0 +1,8 @@
+package skillbill.ports.install.addon
+
+import skillbill.ports.install.addon.model.ExternalAddonSourceConfigRequest
+import skillbill.ports.install.addon.model.ExternalAddonSourceConfigResult
+
+interface ExternalAddonSourceConfigPort {
+  fun readExternalAddonSources(request: ExternalAddonSourceConfigRequest): ExternalAddonSourceConfigResult
+}

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/addon/model/ExternalAddonPortModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/addon/model/ExternalAddonPortModels.kt
@@ -1,0 +1,36 @@
+package skillbill.ports.install.addon.model
+
+import skillbill.install.model.ExternalAddonSource
+import java.nio.file.Path
+
+data class ExternalAddonSourceConfigRequest(
+  val userHome: Path,
+  val environment: Map<String, String> = emptyMap(),
+)
+
+data class ExternalAddonSourceConfigResult(
+  val sources: List<ExternalAddonSource> = emptyList(),
+)
+
+data class ExternalAddonOverlayRequest(
+  val platformPacksRoot: Path,
+  val sources: List<ExternalAddonSource>,
+)
+
+data class ExternalAddonOverlayResult(
+  val appliedSources: List<AppliedExternalAddonSource> = emptyList(),
+  val skippedSources: List<SkippedExternalAddonSource> = emptyList(),
+  val touched: Boolean = false,
+)
+
+data class AppliedExternalAddonSource(
+  val platform: String,
+  val sourcePath: Path,
+  val addons: List<String>,
+)
+
+data class SkippedExternalAddonSource(
+  val platform: String,
+  val sourcePath: Path,
+  val reason: String,
+)


### PR DESCRIPTION
# Summary

Adds **external addon sources** — user-configured directories outside `~/.skill-bill` that hold private/org-specific code-review addons — so private review knowledge can be applied durably without ever entering skill-bill's public git tree (first consumer: the SKILL-98 private iOS review addon). Refs SKILL-99.

Today, out-of-repo addons are non-durable: reconcile re-adopts upstream `platform.yaml` on every apply (clobbering local wiring) and `--clean` wipes everything. This PR introduces a first-class external-addon overlay that runs **after reconcile-apply and before staging**, re-applied unconditionally on every install so it survives both normal updates and `--clean`.

Key changes:
- Two new CLI commands: `config resolve-external-addons` (resolve/validate config) and `install apply-external-addons` (apply the overlay), wired into the install flow via `install.sh`.
- Two-phase atomic overlay in `FileSystemExternalAddonOverlay` (validate-all-then-write-all; temp-and-swap `platform.yaml` write) so a loud failure leaves no partial state.
- Collision detection across provenance for slug, pointer-name, and target-basename; source-relative pointer targets rewritten to canonical `platform-packs/<slug>/addons/<file>.md` form; fragment schema validation (name/slug patterns, `additionalProperties`, nested-target rejection).
- Optional `external_addon_sources: [{ path, platform }]` array in `~/.skill-bill/config.json` (`FileExternalAddonSourceConfigStore`); absent/empty array is an exact no-op (zero-config parity).
- Migrates the SKILL-98 private iOS review addon out of the tree into an external source directory.
- Lands the iOS platform pack (SKILL-98) as the first overlay target alongside this work.
- 30+ new tests across 5 test files plus an install-delegation ordering assertion.

## Feature Flags

N/A — zero-config parity. Users with no `external_addon_sources` configured see no behavior change and no new failure modes.

# How Has This Been Tested?

- New unit/integration tests: `FileExternalAddonSourceConfigStoreTest`, `ExternalAddonOverlayTest`, `InstallExternalAddonOverlayIntegrationTest`, `CliConfigResolveExternalAddonsRuntimeTest`, `CliInstallApplyExternalAddonsRuntimeTest`, and the `InstallerShellDelegationTest` ordering assertion.
- Coverage includes config resolution (valid/malformed/missing path), manifest schema validation, slug/pointer-name/target collisions (external-vs-pack and external-vs-external), pointer-target rewriting, deterministic multi-source ordering, skipped-with-warning on a non-installed platform, re-application after `--clean`, and no-partial-state-on-failure.

Reproducible checks:
1. `cd runtime-kotlin && ./gradlew check` — expect all tests green.
2. Configure an external source in `~/.skill-bill/config.json`, then run `skill-bill config resolve-external-addons` — it prints the resolved sources or loud-fails on malformed config / a missing `path`.
3. Run `./install.sh`, then `./install.sh --clean` — both reconstitute the external addon into `~/.skill-bill` with merged `platform.yaml` entries and re-staged specialists.
4. With `external_addon_sources` absent/empty, confirm install/reconcile output matches the prior baseline (no overlay, no new output).