### PR TITLE
SKILL-100: zcode-agent-support

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.skill-bill]
+command = "skill-bill-mcp"

--- a/.feature-specs/SKILL-100-zcode-agent-support/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-100-zcode-agent-support/decomposition-manifest.yaml
@@ -1,0 +1,63 @@
+---
+contract_version: "0.4"
+issue_key: "SKILL-100"
+feature_name: "zcode-agent-support"
+parent_spec_path: ".feature-specs/SKILL-100-zcode-agent-support/spec.md"
+spec_source: "local"
+status: "complete"
+execution_model: "same_branch_commit_per_subtask"
+base_branch: "main"
+feature_branch: "feat/SKILL-100-zcode-agent-support"
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: "complete"
+subtasks:
+- id: 1
+  name: "Foundation: enums & install-path detection"
+  spec_path: ".feature-specs/SKILL-100-zcode-agent-support/spec_subtask_1_foundation.md"
+  status: "complete"
+  branch: null
+  commit_sha: null
+  workflow_id: "wftr-20260702-204226-76uk"
+  blocked_reason: null
+  last_resumable_step: "commit_push"
+  linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
+  dependencies: []
+- id: 2
+  name: "Native-agent linking, MCP registration, runtime command builder"
+  spec_path: ".feature-specs/SKILL-100-zcode-agent-support/spec_subtask_2_native-agent-mcp-runtime.md"
+  status: "complete"
+  branch: null
+  commit_sha: null
+  workflow_id: "wftr-20260703-061410-f03x"
+  blocked_reason: null
+  last_resumable_step: "commit_push"
+  linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
+  dependencies:
+  - subtask_id: 1
+    optional: false
+    skipped: false
+- id: 3
+  name: "CLI commands, shell scripts, schema"
+  spec_path: ".feature-specs/SKILL-100-zcode-agent-support/spec_subtask_3_cli-shell-schema.md"
+  status: "complete"
+  branch: null
+  commit_sha: null
+  workflow_id: "wftr-20260703-063108-m8mh"
+  blocked_reason: null
+  last_resumable_step: "commit_push"
+  linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
+  dependencies:
+  - subtask_id: 1
+    optional: false
+    skipped: false
+  - subtask_id: 2
+    optional: false
+    skipped: false

--- a/.feature-specs/SKILL-100-zcode-agent-support/spec.md
+++ b/.feature-specs/SKILL-100-zcode-agent-support/spec.md
@@ -1,0 +1,202 @@
+# SKILL-100 — ZCode Full Runtime Agent Support
+
+## Outcome
+
+`zcode` becomes a full runtime-capable agent in skill-bill, wired into every
+touch point that `claude`/`codex`/`junie` already use: install/skills paths,
+native-agent rendering and linking, MCP registration, the headless
+`AgentRunCommandBuilder` runtime driver, CLI commands, `install.sh`/
+`uninstall.sh`, the install-plan schema, and all parity/contract tests. It
+must **not** be treated like opencode's prose-only refusal path — ZCode has a
+non-TTY headless mode (`zcode --prompt <text> --json --cwd <dir> --mode yolo
+--no-color`) and no short foreground timeout, satisfying both criteria
+SKILL-95 required for runtime viability.
+
+## Background
+
+A prior investigation (`.feature-specs/zcode-agent-support-investigation.md`,
+verified against a live ZCode 3.2.3 install and the codebase at commit
+`ce422474`) confirmed ZCode is runtime-capable and produced a complete,
+ordered touch-surface edit list. skill-bill has no single agent registry:
+agent identity is hardcoded across 6 duplicated enums, ~8 `when`/list
+branches, a bash array, a YAML enum, and parity tests. Adding a new runtime
+agent means touching all of them consistently, in dependency order (an enum
+entry must exist before anything that switches on it can reference it).
+
+Per repo policy, only Claude and Codex are verified end-to-end as runtime
+agents today; agent-support claims are tiered and an unverified agent is
+never advertised as equal to a verified one. This spec wires zcode in fully
+and gets its parity tests passing — it does not claim zcode is verified
+end-to-end, and no code comment, CLI help text, or doc string produced here
+may say otherwise.
+
+Two facts genuinely could not be confirmed live during investigation (no
+configured Z.AI model provider was available): the exact `--json` output
+envelope shape, and whether `~/.zcode/cli/config.json` accepts nested
+`mcp.servers` vs. top-level `mcpServers`. Both are implemented against the
+best-documented/best-guess shape per the investigation doc's explicit
+recommendation, with a clear non-blocking follow-up note left for a human to
+confirm against a real run. See Non-Goals.
+
+## Scope
+
+The full 30-item touch list (grouped A–I in the investigation doc) breaks
+into three dependency-ordered pieces:
+
+1. **Foundation** — 6 duplicated agent-identity enums (`InstallAgent`,
+   `NativeAgentProviderId`, `NativeAgentProvider`, `NativeAgentLinkProvider`,
+   `FirstRunSetupAgent`, `AgentSymlinkProvider`/`DesktopAgentSymlinkProvider`)
+   plus the install-path/detection layer (`SUPPORTED_AGENTS`, `agentPaths()`,
+   `agentIsPresent()`, `agentDirectory()`). Every later piece switches on
+   symbols this introduces.
+2. **Native-agent linking, MCP registration, runtime command builder** —
+   three independently pluggable capability layers that all depend only on
+   the foundation: `linkZcodeAgents`/`unlinkZcodeAgents` +
+   `nativeAgentInstallers`, a `McpZcodeConfig` writer wired into
+   `McpRegistrationOperations`, and a `ZcodeAgentRunCommandBuilder` wired
+   into `headlessAgentRunAdapters`.
+3. **CLI commands, shell scripts, schema** — the CLI surface
+   (`InstallZcodeAgentsPathCommand`/`InstallLinkZcodeAgentsCommand`/
+   `InstallUnlinkZcodeAgentsCommand`) that calls into piece 2's link/unlink
+   functions, `install.sh`/`uninstall.sh`, the install-plan schema's
+   `agentId` enum, and the shell-delegation test whose literal command lists
+   must reference the exact subcommand name this piece introduces. Ends with
+   a full `./gradlew check` gate.
+
+Do not add zcode to `RUNTIME_REFUSED_AGENTS` at any point — that pattern is
+opencode-specific and intentionally not generalized.
+
+## Acceptance Criteria
+
+1. `InstallAgent` enum contains `ZCODE("zcode")` and `ZCODE` is **not** added
+   to `RUNTIME_REFUSED_AGENTS`.
+2. `NativeAgentProviderId`, `NativeAgentProvider` (with a
+   `Zcode("zcode-agents","md")` entry using `renderFrontmatterAgent(mode =
+   null)` and `homeAgentDirs = listOf(home.resolve(".zcode/agents"))`),
+   `NativeAgentLinkProvider`, `FirstRunSetupAgent` (`ZCODE("zcode","ZCode")`),
+   `AgentSymlinkProvider`, and `DesktopAgentSymlinkProvider` all include a
+   `ZCODE` entry.
+3. `"zcode"` is present in `SUPPORTED_AGENTS`, `agentPaths()` (mapping to
+   `~/.zcode/skills`), `agentIsPresent()` (detecting `~/.zcode`), and
+   `agentDirectory()` (via a new `InstallOperations.zcodeAgentsPath` helper
+   resolving `~/.zcode/agents`, modeled on `junieAgentsPath`).
+4. `linkZcodeAgents`/`unlinkZcodeAgents` functions exist, are wired into both
+   `FileSystemInstallAdapters` provider `when`-branches, and a
+   `NativeAgentInstaller` entry for `ZCODE` exists in the
+   `nativeAgentInstallers` list.
+5. A `McpZcodeConfig` writer class exists that reads/writes
+   `~/.zcode/cli/config.json` under the nested `mcp.servers` key (JSON, not
+   TOML), and `McpRegistrationOperations.register`/`.unregister`/
+   `.configPathFor` all handle `InstallAgent.ZCODE`.
+6. A `ZcodeAgentRunCommandBuilder` exists (`usePtyStdio = false`,
+   `idlePolicy = DB_PROGRESS_ONLY`) building `zcode --prompt <prompt> --json
+   --cwd <dir> --mode yolo --no-color`, and it is registered in
+   `headlessAgentRunAdapters` so it survives the `RUNTIME_REFUSED_AGENTS`
+   filter.
+7. New CLI commands (`InstallZcodeAgentsPathCommand`,
+   `InstallLinkZcodeAgentsCommand`, `InstallUnlinkZcodeAgentsCommand`) exist,
+   modeled on the junie equivalents, and are registered as subcommands in
+   `ScaffoldCliCommands`.
+8. `install.sh`'s `SUPPORTED_AGENTS` array and both help strings include
+   zcode; `uninstall.sh` has a `~/.zcode` removal block and includes zcode in
+   its agent loop.
+9. `orchestration/contracts/install-plan-schema.yaml`'s `agentId` enum
+   includes `zcode`.
+10. All parity/contract tests pass with zcode included:
+    `requireSupportedAgentContract()` (auto-satisfied),
+    `FirstRunSetupModelsTest`, `InstallPlanContractCoverageTest` and
+    `InstallPlanSchemaValidatesExistingFixturesTest` (including their literal
+    per-agent fixture-directory lists), `InstallerShellDelegationTest`'s
+    three literal `unlink-*-agents` command lists, `HeadlessAgentRunAdapterTest`
+    extended with zcode assertions, and `McpRegistrationOperationsTest`'s
+    "non-claude agents stay single-target" test extended with a zcode entry.
+11. `(cd runtime-kotlin && ./gradlew check)` passes with zero suppressions
+    after all subtasks land.
+
+## Non-Goals
+
+- Live-verifying the exact `--json` output envelope shape against a running,
+  model-configured ZCode install — infeasible without a configured Z.AI
+  provider. Implement the parser against the best-documented/best-guess
+  envelope shape (mirroring Claude/Codex/Junie's parsing conventions), and
+  leave a clear non-blocking follow-up note in code for a human to confirm
+  against a real run before this is relied on in production. Do not claim it
+  is confirmed.
+- Live-verifying `--attach` vs. argv `--prompt` behavior for large phase
+  prompts — implement via `--prompt` argv only (documented safe well under
+  Linux's 128 KiB `MAX_ARG_STRLEN`); no `--attach` handling in this spec.
+- Live-verifying ZCode's user-scope subagent authoring format by dropping
+  test files into `~/.zcode/agents/` — implement `NativeAgentProvider.Zcode`
+  using the same `renderFrontmatterAgent(mode = null)` pattern as
+  Claude/Junie (the best-evidenced format) without live confirmation.
+- Live-verifying whether `~/.zcode/cli/config.json` accepts `mcp.servers` vs.
+  `mcpServers` — implement per the official ZCode configuration guide (nested
+  `mcp.servers`), matching the investigation doc's explicit recommendation.
+- Determining whether bare workspace `.mcp.json` is read by zcode at
+  workspace scope — does not affect the user-scope install target and is out
+  of scope.
+- Adding a `ZCODE` entry to `INVOKING_AGENT_CONTEXT_SIGNALS` unless the
+  subtask-1 implementer confirms it's consistent with existing precedent
+  (`JUNIE` currently has no entry there either) — do not blindly add a case
+  that breaks the existing pattern; leave a one-line rationale either way.
+- Advertising or documenting zcode as "verified end-to-end" in README or
+  marketing copy — out of scope; only the code and tests are wired in this
+  spec.
+
+## Constraints
+
+- zcode must **not** be added to `RUNTIME_REFUSED_AGENTS` or otherwise routed
+  through opencode's prose-only refusal machinery (`isRuntimeRefusedAgent`,
+  `OPENCODE_RUNTIME_REFUSAL_MESSAGE`) — that pattern is opencode-specific and
+  intentionally not generalized.
+- The `zcode` binary must be resolved via `PATH` (assume `zcode` is on
+  `PATH`), mirroring claude/codex/junie builders — never hardcode the
+  AppImage mount path (it changes every launch).
+- MCP config write target is `~/.zcode/cli/config.json` under nested
+  `mcp.servers`, JSON format — distinct from codex's TOML and from the
+  `.agents/mcp.json` fallback's top-level `mcpServers` shape.
+- No code comment, CLI help text, or doc string may claim zcode is "verified
+  e2e" — passing implementation plus the CLI's own parity tests is the bar,
+  not a live e2e session.
+- No unnecessary comments — new classes/functions should match the terse
+  style of sibling builders. Prefer Junie as the template throughout
+  (simplest, most recently added, no special-case stdin/multi-profile logic
+  Claude's builder has).
+- `InstallApplyNativeAgents.kt` lives at
+  `runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplyNativeAgents.kt`
+  (package `skillbill.install.apply`) — the investigation doc's stated
+  package (`skillbill.apply`) is wrong; use the corrected path.
+
+## Dependency Notes
+
+Subtask 1 (foundation) has no dependencies and must land first — every later
+subtask's `when`-branches and registries reference the
+`InstallAgent.ZCODE`/`NativeAgentProviderId.ZCODE`/
+`NativeAgentLinkProvider.ZCODE`/`FirstRunSetupAgent.ZCODE` symbols it
+introduces. Subtask 2 (native-agent linking, MCP registration, runtime
+command builder) depends only on subtask 1. Subtask 3 (CLI commands, shell
+scripts, schema) depends on both 1 and 2, since the CLI commands call
+subtask 2's link/unlink functions and the shell scripts/tests must reference
+the exact subcommand name the CLI introduces.
+
+## Validation Strategy
+
+- Each subtask runs its own targeted Gradle test slice (see each
+  `spec_subtask_*.md`).
+- Subtask 3 runs the full `(cd runtime-kotlin && ./gradlew check)` gate as
+  the final integration checkpoint, confirming zero suppressions and no
+  drift anywhere in the 30-item touch surface.
+- `bash -n install.sh && bash -n uninstall.sh` as a shell syntax sanity
+  check.
+
+## Next Path
+
+This feature is decomposed into 3 dependency-ordered subtasks (see
+`decomposition-manifest.yaml`): foundation (6 enums + install-path/detection
+wiring), native-agent linking + MCP registration + the headless runtime
+command builder, and CLI commands + shell scripts + schema (with the final
+`./gradlew check` gate).
+
+```bash
+skill-bill goal SKILL-100
+```

--- a/.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_1_foundation.md
+++ b/.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_1_foundation.md
@@ -1,0 +1,149 @@
+# SKILL-100 · Subtask 1 — Foundation: enums & install-path detection
+
+Parent overview: [spec.md](./spec.md)
+
+This is the **first** subtask and has no upstream dependency. It adds a
+`ZCODE`/`Zcode` entry to all 6 duplicated agent-identity enums and wires
+`"zcode"` into the install-path/detection layer. Every later subtask's
+`when`-branches and registries reference the symbols this subtask
+introduces, so it must land first.
+
+Branch: `feat/SKILL-100-zcode-agent-support` (same-branch model, one commit
+for this subtask).
+
+## Dependencies
+
+- depends_on: `[]` (runs first)
+- dependency_reason: No upstream work exists yet; this subtask creates the
+  foundational enum entries and install-path wiring everything else
+  references by symbol.
+
+## Scope (owns)
+
+### 1a. The six duplicated agent-identity enums
+
+- `InstallAgent` — `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt`
+  (enum entries near line 13). Add `ZCODE("zcode")`. Do **not** add it to
+  `RUNTIME_REFUSED_AGENTS` (near line 37) — zcode is runtime-capable.
+- `NativeAgentProviderId` — same file, near line 386. Add `ZCODE`.
+- `NativeAgentProvider` — `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/nativeagent/rendering/NativeAgentRendering.kt`
+  (enum entries near line 13). Add a `Zcode("zcode-agents", "md")` entry,
+  modeled directly on the adjacent `Junie` entry, with
+  `render = renderFrontmatterAgent(mode = null)` and `homeAgentDirs`
+  returning `listOf(home.resolve(".zcode/agents"))`.
+- `NativeAgentLinkProvider` — `runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/model/InstallPortModels.kt`
+  (near line 11). Add `ZCODE`.
+- `FirstRunSetupAgent` — `runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt`
+  (entries near line 17). Add `ZCODE("zcode", "ZCode")`; confirm its
+  `supportedIds` companion transitively includes `"zcode"`.
+- `AgentSymlinkProvider` — `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/domain/skillremove/model/SkillRemovalPreview.kt`
+  (near line 81). Add `ZCODE`.
+- `DesktopAgentSymlinkProvider` — `runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillRemovalModels.kt`
+  (near line 83). Add `ZCODE`.
+
+Re-locate every site above by symbol/pattern search before editing — line
+numbers are approximate and may have drifted since the source investigation.
+
+### 1b. Install-path & detection layer
+
+All in `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/plan/InstallPrimitives.kt`
+unless noted:
+
+- `SUPPORTED_AGENTS` list (near line 15) — add `"zcode"`.
+- `agentPaths(...)` map (near lines 21-30) — add `"zcode" ->
+  resolvedHome.resolve(".zcode/skills")`.
+- `agentIsPresent(...)` `when (agent)` block (near lines 153-160) — add a
+  `"zcode" -> listOf(home.resolve(".zcode"))` case.
+- `agentDirectory(...)` `when` block in
+  `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallAdapters.kt`
+  (near lines 193-199) — add a `"zcode" ->
+  InstallOperations.zcodeAgentsPath(request.home)` case.
+- New `zcodeAgentsPath(home)` helper in
+  `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/runtime/InstallOperations.kt`
+  (modeled on `junieAgentsPath`, near lines 53-56), returning
+  `home.resolve(".zcode/agents")`.
+
+### 1c. Decide on `INVOKING_AGENT_CONTEXT_SIGNALS`
+
+`INVOKING_AGENT_CONTEXT_SIGNALS` (same `InstallModels.kt`, near lines 70-74)
+maps some agents to an env-var detection marker
+(`ZCODE_APP_VERSION` would be the candidate for zcode). `JUNIE` currently has
+**no** entry there. Explicitly decide whether to add a `ZCODE` marker or
+follow the `JUNIE` precedent and omit it, and leave a one-line rationale for
+the choice in the diff or commit message — do not add it silently without
+considering the precedent.
+
+## Reusable patterns / pitfalls
+
+- Model every new enum entry directly on the adjacent `Junie`/`JUNIE` case —
+  it is the simplest, most recently added agent with no special-case
+  stdin/multi-profile logic.
+- `requireSupportedAgentContract()` (`InstallPlanBuilder.kt`, near lines
+  50-54) ties `SUPPORTED_AGENTS` to `InstallAgent.supportedIds` — it is
+  auto-satisfied only if both are updated together in this subtask.
+- No unnecessary comments — match the terse style of sibling enum entries
+  and functions.
+
+## Acceptance Criteria
+
+1. `InstallAgent` enum contains `ZCODE("zcode")`; `RUNTIME_REFUSED_AGENTS` is
+   **not** modified to include it.
+2. `NativeAgentProviderId` enum contains `ZCODE`.
+3. `NativeAgentProvider` enum contains a `Zcode("zcode-agents", "md")` entry
+   with `render = renderFrontmatterAgent(mode = null)` and `homeAgentDirs`
+   returning `listOf(home.resolve(".zcode/agents"))`, modeled on the
+   adjacent `Junie` entry.
+4. `NativeAgentLinkProvider` enum contains `ZCODE`.
+5. `FirstRunSetupAgent` enum contains `ZCODE("zcode", "ZCode")`, and its
+   `supportedIds` companion transitively includes `"zcode"`.
+6. `AgentSymlinkProvider` and `DesktopAgentSymlinkProvider` both contain
+   `ZCODE`.
+7. `SUPPORTED_AGENTS` includes `"zcode"`.
+8. `agentPaths()` maps `"zcode"` to `resolvedHome.resolve(".zcode/skills")`.
+9. `agentIsPresent()`'s `when(agent)` block adds a `"zcode" ->
+   listOf(home.resolve(".zcode"))` case.
+10. `agentDirectory()`'s `when` block adds a `"zcode" ->
+    InstallOperations.zcodeAgentsPath(request.home)` case, backed by a new
+    `zcodeAgentsPath(home)` helper returning `home.resolve(".zcode/agents")`.
+11. `requireSupportedAgentContract()` continues to pass.
+12. `FirstRunSetupModelsTest.kt` asserts `"zcode"` is present in
+    `FirstRunSetupAgent.supportedIds`, and passes.
+13. `InstallPlanContractCoverageTest.kt` and
+    `InstallPlanSchemaValidatesExistingFixturesTest.kt` each add a `.zcode`
+    fixture-directory entry alongside `.copilot`/`.claude`/`.codex`/
+    `.config/opencode`/`.junie` in their literal fixture lists, and both
+    tests pass.
+14. The implementer has explicitly decided whether to add a `ZCODE` marker
+    to `INVOKING_AGENT_CONTEXT_SIGNALS`, with a one-line rationale recorded
+    in the diff or commit message.
+
+## Non-goals
+
+- Native-agent linking functions (`linkZcodeAgents`/`unlinkZcodeAgents`) and
+  the `FileSystemInstallAdapters` provider `when`-branches that call them —
+  subtask 2.
+- MCP registration (`McpZcodeConfig`, `McpRegistrationOperations`) —
+  subtask 2.
+- The runtime `AgentRunCommandBuilder` — subtask 2.
+- CLI commands, shell scripts, and the install-plan-schema.yaml enum —
+  subtask 3.
+
+## Validation strategy
+
+```bash
+cd runtime-kotlin && ./gradlew :runtime-domain:test :runtime-ports:test \
+  :runtime-infra-fs:test :runtime-desktop:core:domain:jvmTest \
+  --tests "*FirstRunSetupModelsTest*" \
+  --tests "*InstallPlanContractCoverageTest*" \
+  --tests "*InstallPlanSchemaValidatesExistingFixturesTest*"
+```
+
+If any module/task name doesn't resolve, fall back to
+`(cd runtime-kotlin && ./gradlew check)` scoped to this subtask's affected
+modules. Also run `(cd runtime-kotlin && ./gradlew :runtime-infra-fs:test)`
+to confirm `requireSupportedAgentContract()` still passes.
+
+## Handoff prompt
+
+Run bill-feature-task on
+`.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_1_foundation.md`.

--- a/.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_2_native-agent-mcp-runtime.md
+++ b/.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_2_native-agent-mcp-runtime.md
@@ -1,0 +1,136 @@
+# SKILL-100 · Subtask 2 — Native-agent linking, MCP registration, runtime command builder
+
+Parent overview: [spec.md](./spec.md)
+
+Wires zcode into three pluggable capability layers that each depend only on
+subtask 1's enums and are otherwise independent of each other: native-agent
+markdown linking, MCP registration, and the headless runtime command
+builder. Treat these as one cohesive pass — all three are "plug a new agent
+into an existing pluggable system" work inside `runtime-infra-fs`.
+
+Branch: `feat/SKILL-100-zcode-agent-support` (same-branch model, one commit
+for this subtask).
+
+## Dependencies
+
+- depends_on: `[1]`
+- dependency_reason: This subtask's new functions/classes are wired into
+  `when`-branches keyed on `NativeAgentLinkProvider.ZCODE`,
+  `NativeAgentProviderId.ZCODE`, and `InstallAgent.ZCODE`, all introduced by
+  subtask 1. It cannot compile without subtask 1 landed first.
+
+## Scope (owns)
+
+### 2a. Native-agent linking
+
+- `linkZcodeAgents`/`unlinkZcodeAgents` functions in
+  `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/InstallNativeAgentOperations.kt`,
+  modeled on `linkJunieAgents` (near lines 96-107) and `unlinkJunieAgents`
+  (near lines 109-119).
+- `FileSystemInstallAdapters.kt`'s link `when`-branch (near lines 222-227)
+  and unlink `when`-branch (near lines 241-246) each add a
+  `NativeAgentLinkProvider.ZCODE` case calling the new functions.
+- The `nativeAgentInstallers` list in
+  `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplyNativeAgents.kt`
+  (package `skillbill.install.apply` — not `skillbill.apply`; near lines
+  199-224) includes a `NativeAgentInstaller(agent=InstallAgent.ZCODE,
+  provider=NativeAgentProviderId.ZCODE, link=::linkZcodeAgents,
+  unlink=::unlinkZcodeAgents)` entry, modeled on the adjacent Junie block.
+
+### 2b. MCP registration
+
+- A `McpZcodeConfig` class in
+  `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/`
+  (modeled on `McpJsonConfig.kt`) that reads/writes
+  `~/.zcode/cli/config.json` under the **nested** `"mcp"."servers"` key (not
+  top-level `mcpServers`), preserving any unrelated existing JSON content in
+  that file.
+- `McpRegistrationOperations.register` (near lines 22-30), `.unregister`
+  (near lines 42-50), and `.configPathFor` (near lines 53-59) each add an
+  `InstallAgent.ZCODE` case; `configPathFor` resolves to
+  `home.resolve(".zcode/cli/config.json")`.
+
+### 2c. Runtime command builder
+
+- A `ZcodeAgentRunCommandBuilder` class in
+  `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt`
+  building the command `zcode --prompt <prompt> --json --cwd <dir> --mode
+  yolo --no-color`, modeled on `JunieAgentRunCommandBuilder` (near lines
+  95-117 — not Claude's stdin-special-cased builder), relying on the
+  `AgentRunCommand` defaults `usePtyStdio = false` and `idlePolicy =
+  AgentRunIdlePolicy.DB_PROGRESS_ONLY` rather than overriding them.
+- `headlessAgentRunAdapters()` in
+  `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt`
+  (near lines 74-80) includes `ZcodeAgentRunCommandBuilder()` in its
+  `listOf(...)`; it must survive the `.filterNot { RUNTIME_REFUSED_AGENTS.contains(...)
+  }` step since `ZCODE` is not in that set.
+- The `--json` output parsing used by `ZcodeAgentRunCommandBuilder` (or its
+  output adapter) is implemented against the best-documented/best-guess
+  envelope shape and includes a clear, non-blocking follow-up note for
+  future live confirmation against a real ZCode session — it must not claim
+  to be confirmed.
+
+## Reusable patterns / pitfalls
+
+- Prefer Junie's builder/linking pattern as the template throughout — it has
+  no special-case stdin/multi-profile logic that Claude's builder carries.
+- The zcode binary is resolved via `PATH` (`zcode`), never a hardcoded
+  AppImage mount path — the mount path changes every launch.
+- Do not add `ZCODE` to `RUNTIME_REFUSED_AGENTS` or route it through
+  opencode's refusal machinery (`isRuntimeRefusedAgent`,
+  `OPENCODE_RUNTIME_REFUSAL_MESSAGE`) — that pattern is opencode-specific.
+- No unnecessary comments.
+
+## Acceptance Criteria
+
+1. `linkZcodeAgents`/`unlinkZcodeAgents` functions exist in
+   `InstallNativeAgentOperations.kt`, modeled on the Junie equivalents.
+2. `FileSystemInstallAdapters.kt`'s link and unlink `when`-branches each add
+   a `NativeAgentLinkProvider.ZCODE` case calling the new functions.
+3. `nativeAgentInstallers` includes a `NativeAgentInstaller` entry for
+   `InstallAgent.ZCODE`/`NativeAgentProviderId.ZCODE` wired to
+   `linkZcodeAgents`/`unlinkZcodeAgents`.
+4. A `McpZcodeConfig` class exists that reads/writes
+   `~/.zcode/cli/config.json` under the nested `mcp.servers` key, preserving
+   unrelated existing JSON content.
+5. `McpRegistrationOperations.register`, `.unregister`, and `.configPathFor`
+   each add an `InstallAgent.ZCODE` case; `configPathFor` resolves to
+   `home.resolve(".zcode/cli/config.json")`.
+6. A `ZcodeAgentRunCommandBuilder` class exists building the command `zcode
+   --prompt <prompt> --json --cwd <dir> --mode yolo --no-color`, using the
+   `usePtyStdio = false` / `idlePolicy = DB_PROGRESS_ONLY` defaults.
+7. `headlessAgentRunAdapters()` includes `ZcodeAgentRunCommandBuilder()` and
+   it is not filtered out by `RUNTIME_REFUSED_AGENTS`.
+8. `HeadlessAgentRunAdapterTest` (inside `AgentRunLauncherTest.kt`) is
+   extended so its adapter-presence assertion and per-agent command-shape
+   checks include `InstallAgent.ZCODE` alongside `CLAUDE`/`CODEX`/`JUNIE`,
+   and the test passes.
+9. `McpRegistrationOperationsTest`'s "non-claude agents stay single-target"
+   test is extended with a `"zcode" -> home.resolve(".zcode/cli/config.json")`
+   entry in its expected-paths map, and passes.
+10. The `--json` envelope parser carries a clear, non-blocking follow-up note
+    that its shape is unconfirmed against a live ZCode session — it does not
+    claim to be confirmed.
+
+## Non-goals
+
+- Enum additions — already done in subtask 1.
+- CLI command surface exposing link/unlink/path — subtask 3.
+- `install.sh`/`uninstall.sh`/schema changes — subtask 3.
+- Live verification of the `--json` envelope, `--attach` behavior, or the
+  `mcp.servers`-vs-`mcpServers` key naming — deferred per the parent spec's
+  non-goals.
+
+## Validation strategy
+
+```bash
+cd runtime-kotlin && ./gradlew :runtime-infra-fs:test \
+  --tests "*HeadlessAgentRunAdapterTest*" \
+  --tests "*McpRegistrationOperationsTest*"
+cd runtime-kotlin && ./gradlew :runtime-infra-fs:test
+```
+
+## Handoff prompt
+
+Run bill-feature-task on
+`.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_2_native-agent-mcp-runtime.md`.

--- a/.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_3_cli-shell-schema.md
+++ b/.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_3_cli-shell-schema.md
@@ -1,0 +1,110 @@
+# SKILL-100 · Subtask 3 — CLI commands, shell scripts, schema
+
+Parent overview: [spec.md](./spec.md)
+
+The final, integrating subtask. Exposes subtask 2's link/unlink/path
+capabilities through the CLI, extends `install.sh`/`uninstall.sh` and the
+install-plan schema, updates the shell-delegation test's literal command
+lists, and closes with the full `./gradlew check` gate to confirm no drift
+remains anywhere in the 30-item touch surface.
+
+Branch: `feat/SKILL-100-zcode-agent-support` (same-branch model, one commit
+for this subtask).
+
+## Dependencies
+
+- depends_on: `[1, 2]`
+- dependency_reason: The new CLI unlink/link commands call
+  `linkZcodeAgents`/`unlinkZcodeAgents` (subtask 2) and resolve zcode's
+  install path (subtask 1). `install.sh`/`uninstall.sh` and
+  `InstallerShellDelegationTest`'s literal command lists must reference the
+  exact `unlink-zcode-agents` subcommand name this subtask's CLI
+  registration introduces, so shell/test wiring is sequenced after the CLI
+  commands within this same subtask.
+
+## Scope (owns)
+
+### 3a. CLI commands
+
+- `InstallZcodeAgentsPathCommand`, `InstallLinkZcodeAgentsCommand`, and
+  `InstallUnlinkZcodeAgentsCommand` in
+  `runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliCommands.kt`,
+  modeled on `InstallJunieAgentsPathCommand` (near lines 575-583),
+  `InstallLinkJunieAgentsCommand` (near lines 752-778), and
+  `InstallUnlinkJunieAgentsCommand` (near lines 780-805).
+- `ScaffoldCliCommands.kt` imports the three new commands and registers them
+  as subcommands of `InstallTopLevelCommands` alongside the existing junie
+  entries (constructor params and `.subcommands(...)` registration).
+
+### 3b. Shell scripts
+
+- `install.sh`'s `SUPPORTED_AGENTS` bash array (near line 73) includes
+  `zcode`, and both help strings (near lines 2543 and 2649) list zcode among
+  supported agents.
+- `uninstall.sh` gets a zcode removal block (removing `~/.zcode/skills`,
+  modeled on the adjacent junie block) and the MCP-unregister agent loop
+  (near line 638) includes zcode.
+
+### 3c. Schema
+
+- `orchestration/contracts/install-plan-schema.yaml`'s `agentId` enum (near
+  lines 54-59) includes `zcode`.
+
+### 3d. Shell-delegation test
+
+- `InstallerShellDelegationTest.kt`'s three literal pipe-separated command
+  lists (near lines 879, 957, 1013) each include `"install
+  unlink-zcode-agents"`.
+
+### 3e. Final integration gate
+
+- Run `(cd runtime-kotlin && ./gradlew check)` to confirm the full
+  enum/install-path/native-agent/MCP/runtime-builder/CLI/shell/schema/test
+  surface is consistent with zero suppressions.
+
+## Reusable patterns / pitfalls
+
+- Model every new CLI command directly on its junie counterpart — junie has
+  the simplest, most recently added command shape.
+- Re-locate line numbers by symbol/pattern search before editing; they are
+  approximate.
+- No unnecessary comments.
+
+## Acceptance Criteria
+
+1. `InstallZcodeAgentsPathCommand`, `InstallLinkZcodeAgentsCommand`, and
+   `InstallUnlinkZcodeAgentsCommand` exist in `InstallCliCommands.kt`,
+   modeled on the junie equivalents.
+2. `ScaffoldCliCommands.kt` imports and registers the three new commands as
+   subcommands of `InstallTopLevelCommands` alongside the existing junie
+   entries.
+3. `install.sh`'s `SUPPORTED_AGENTS` bash array includes `zcode`, and both
+   help strings list zcode among supported agents.
+4. `uninstall.sh` has a zcode removal block (removing `~/.zcode/skills`) and
+   the MCP-unregister agent loop includes zcode.
+5. `orchestration/contracts/install-plan-schema.yaml`'s `agentId` enum
+   includes `zcode`.
+6. `InstallerShellDelegationTest.kt`'s three literal command lists each
+   include `"install unlink-zcode-agents"`, and the test passes.
+7. `(cd runtime-kotlin && ./gradlew check)` passes with zero suppressions.
+
+## Non-goals
+
+- Any further live verification of ZCode CLI behavior (already deferred at
+  the parent-spec level).
+- Modifying the opencode prose-only refusal machinery.
+- Adding zcode marketing/README claims about e2e verification status.
+
+## Validation strategy
+
+```bash
+cd runtime-kotlin && ./gradlew :runtime-cli:build
+cd runtime-kotlin && ./gradlew :runtime-core:test --tests "*InstallerShellDelegationTest*"
+bash -n install.sh && bash -n uninstall.sh
+cd runtime-kotlin && ./gradlew check
+```
+
+## Handoff prompt
+
+Run bill-feature-task on
+`.feature-specs/SKILL-100-zcode-agent-support/spec_subtask_3_cli-shell-schema.md`.

--- a/.feature-specs/zcode-agent-support-investigation.md
+++ b/.feature-specs/zcode-agent-support-investigation.md
@@ -1,0 +1,541 @@
+# ZCode Agent Support — Investigation Briefing
+
+**Purpose:** Complete, verified factual reference for adding `zcode` as a first-class
+supported agent in skill-bill. Hand this document to the supporting agent that plans
+and implements the change. Every fact below was confirmed against a live ZCode 3.2.3
+install on linux-x64 and against the skill-bill codebase at commit `ce422474`.
+
+---
+
+## TL;DR — the headline decision
+
+**ZCode is runtime-capable and should be added as a FULL runtime agent** (like
+claude / codex / junie), NOT prose-only like opencode. It satisfies both criteria
+that the SKILL-95 decision ("make opencode prose-only") identified as required for
+runtime viability:
+
+1. ✅ It has a **non-TTY, harvestable headless mode**: `zcode.cjs --prompt <text> --json`
+   runs a single prompt and prints machine-readable JSON, without opening the TUI.
+2. ✅ It has **no hard short foreground timeout**: it is a long-running Node process;
+   the 120s kill that doomed opencode was specific to opencode's foreground *Bash*
+   tool, not a general constraint.
+
+See the SKILL-95 decision in `runtime-kotlin/agent/decisions.md` and the "Revisit
+when" clause: opencode runtime becomes viable again when it "gains a non-TTY
+harvestable headless mode and a foreground budget longer than 120s." ZCode already
+has both.
+
+---
+
+## 1. ZCode architecture and how to reach the headless CLI
+
+### What ZCode is
+- ZCode is an **Electron desktop app** (AppImage on linux: `ZCode-3.2.3-linux-x64.AppImage`).
+  The GUI binary is a single `zcode` executable that hosts the full TUI/GUI.
+- The **headless agent backend** is a separate bundled Node script at
+  `resources/glm/zcode.cjs` inside the AppImage. This is the "glm" builtin agent CLI
+  provider (see `enabledBuiltinAgentCliProviders: ["glm"]` in settings), and it is
+  what powers agent execution (including this very session).
+- Self-reported CLI version: **`zcode 0.15.0`** (independent of the Electron app
+  version `3.2.3`).
+
+### Locating the executable
+The AppImage mounts at runtime under `/tmp/.mount_ZCode-<random>/`. The headless
+script path relative to the mount is:
+```
+resources/glm/zcode.cjs
+```
+Resolved from the running environment, these env vars are set and reliable for
+locating it:
+- `APPIMAGE` — absolute path to the AppImage, e.g.
+  `/home/<user>/Applications/ZCode-3.2.3-linux-x64.AppImage`
+- `APPDIR` — the mount root, e.g. `/tmp/.mount_ZCode-<random>`
+
+The headless script can be invoked directly with node:
+```
+node "$APPDIR/resources/glm/zcode.cjs" --prompt "..." --json --cwd <dir>
+```
+But the **stable, version-independent** way to reach it is the `zcode` launcher on
+`PATH` (the AppImage's `AppRun` shim), i.e. `which zcode`. The launcher forwards
+args to the Electron app; the agent CLI subcommands (`--prompt`, `skills`, etc.)
+are handled by the bundled `zcode.cjs`.
+
+> **Implementation note for the `AgentRunCommandBuilder`:** prefer resolving the
+> agent binary the same way the other builders do — assume the agent CLI is on
+> `PATH` as `zcode`, matching how `claude` / `codex` / `junie` builders assume
+> their CLIs are on PATH. Do NOT hardcode the AppImage mount path (it changes
+> every launch).
+
+### Full CLI help (authoritative, from `zcode.cjs --help`)
+```
+zcode 0.15.0
+
+Usage:
+  zcode [command] [options]
+
+With no command, zcode opens the full-screen TUI.
+
+Commands:
+  app-server Run the ZCode Protocol stdio app server
+  commands   List custom slash commands (`commands list`)
+  doctor     Inspect runtime and packaging assumptions
+  login      Sign in with Z.AI OAuth for model access
+  logout     Remove the shared Z.Ai login credentials
+  plugins    List and enable installed plugins (`plugins list`)
+  skills     List local skills (`skills list`)
+  tui        Open the terminal UI
+  version    Print the CLI version
+
+Options:
+  -h, --help       Show help
+  -v, --version    Show version
+  --prompt <text>  Run a single prompt without opening the TUI
+  --attach <path>  Attach a local file to --prompt; repeat for multiple files
+  --cwd <path>     Run this command from the given directory
+  --locale <locale>  UI locale: en-US, zh-CN, or auto
+  --mode <mode>    Permission mode for prompts: build, edit, plan, or yolo (default: yolo for --prompt)
+  --resume <sessionId>  Resume a persisted session by sessionId (sess_...)
+  --target <text>  Run or set the session goal in headless mode
+  --target-replace Replace any existing session goal set by --target
+  -c, --continue        Resume the latest session for the current directory
+  --json           Print machine-readable JSON where supported
+  --no-browser     Print the OAuth URL without opening a browser
+  --no-color       Disable ANSI colors
+  --verbose        Print extra diagnostic detail
+
+Slash Commands:
+  /help [command]       Show slash command help
+  /login                Sign in with Z.AI OAuth
+  /logout               Remove the shared Z.AI login credentials
+  /compact [instructions]  Compact the current conversation
+  /expert [status|resume|stop|<task>]  Run or manage the expert workflow
+  /fork [latest|checkpointId]  Fork a new session from a workspace checkpoint
+  /mcp [list|status|connect|disconnect]  Show or manage MCP servers
+  /mode [mode]          Show or switch permission mode: build, edit, plan, or yolo
+  /model [id]           Show or switch the current session model
+  /new                  Start a fresh session in the TUI
+  /resume [sessionId]   Resume a session by sessionId; omit it for latest in cwd
+  /rewind [latest|checkpointId]  Show latest checkpoint or restore workspace files
+  /skill [name] [task]  List skills, or force the next prompt to load one
+  /goal [action]        Show or set the current session goal
+```
+
+### Runtime-mode invocation pattern (the `AgentRunCommandBuilder` model)
+For the phase-loop driver, model the builder on `ClaudeAgentRunCommandBuilder` /
+`CodexAgentRunCommandBuilder`. The mapping:
+
+| skill-bill concept | ZCode equivalent |
+|---|---|
+| `claude --print --output-format text` | `zcode --prompt <prompt> --json` |
+| prompt via stdin | prompt via `--prompt <text>` argv (no stdin-prompt mode observed) |
+| `--dangerously-skip-permissions` (claude) | `--mode yolo` (default for `--prompt`; "yolo" = no permission prompts) |
+| working directory | `--cwd <path>` |
+| output format | `--json` (machine-readable) |
+
+Recommended command shape:
+```
+zcode --prompt "<phase prompt>" --json --cwd <repo> --mode yolo --no-color
+```
+
+**Prompt delivery caveat:** unlike claude/codex (which read the prompt from stdin),
+ZCode takes the prompt as an argv value to `--prompt <text>`. Phase prompts can be
+long. Options to evaluate during implementation:
+- Pass via `--prompt` argv (simplest; watch OS argv-length limits on very large
+  prompts — Linux `MAX_ARG_STRLEN` is 128 KiB per arg, which should be fine for
+  phase briefings).
+- Or write the prompt to a temp file and use `--attach <path>` to attach it, with a
+  short `--prompt` instructing the agent to read the attached file. (Unverified
+  whether `--attach` injects file *contents* into context vs. just making it
+  readable — confirm during implementation.)
+
+**Permission mode:** the default for `--prompt` is already `yolo` (no prompts), which
+is what an unattended runtime driver needs. Do not pass `--mode build`/`edit`/`plan`
+for the runtime driver.
+
+**`--json` output shape:** confirmed present but NOT captured in this investigation
+(a live run requires a configured model provider; the test run returned
+`Error: Model config is missing.` because `~/.zcode/cli/config.json` had no
+`provider`/model set in the probed location). **The implementer MUST run a real
+`--prompt ... --json` once and capture the exact JSON envelope** so the runtime can
+parse the assistant's final text out of it. This is the single biggest unknown left
+to resolve during implementation.
+
+### Process/strategy considerations (per AGENTS.md injectable strategies)
+- `usePtyStdio`: ZCode `--prompt` is a non-TTY stdout producer (it is *not* a PTY/TUI
+  stream when run headless — that was opencode's exact failure). Use separate
+  stdout/stderr streams, NOT a PTY pair (i.e. `usePtyStdio = false`), matching the
+  claude/codex builders.
+- `idlePolicy`: start with `DB_PROGRESS_ONLY` (the default). ZCode writes progress
+  to `~/.zcode/cli/db/db.sqlite` (tokens, tool-use counts) and to per-session
+  rollout files; whether token changes are detectable the same way as claude/codex
+  should be confirmed, but `DB_PROGRESS_ONLY` is the safe default.
+- `progressEmitter` / `activityProbe`: filesystem-activity detection works as-is
+  (ZCode writes files like any agent).
+
+---
+
+## 2. Agent identity and environment detection
+
+### Env-var detection signal (for `InvokingAgentContextResolver`)
+ZCode sets a distinctive set of env vars in every process it spawns. The most
+reliable detection markers (confirmed present in this session's env):
+
+| Env var | Example value | Reliability |
+|---|---|---|
+| `ZCODE_APP_VERSION` | `3.2.3` | ✅ set, ZCode-specific |
+| `ZCODE_BASE_URL` | `https://zcode.z.ai` | ✅ set, ZCode-specific |
+| `ZCODE_ENV` / `ZCODE_RUNTIME_ENV` | `production` | ✅ set |
+| `ZCODE_PROCESS_LABEL` | `local-1` | ✅ set |
+| `APPIMAGE` | `.../ZCode-*.AppImage` | present but not ZCode-exclusive (generic AppImage var) |
+| `ZAI_API_KEY` / `ZAI_BUSINESS_BASE_URL` / `ZAI_OAUTH_*` | various | set, but tied to the z.ai model provider, not strictly the client |
+
+**Recommended detection key:** `ZCODE_APP_VERSION` (or `ZCODE_BASE_URL`) — both are
+unambiguous and set on every ZCode-spawned process. Add an entry to
+`INVOKING_AGENT_CONTEXT_SIGNALS` in `InstallModels.kt` mapping the zcode agent to
+one of these marker keys (the existing table has per-agent env-var marker keys for
+CLAUDE, CODEX, OPENCODE).
+
+### Agent id and display
+- Canonical lowercase id: **`zcode`** (matches the `InstallAgent.id` convention used
+  by copilot/claude/codex/opencode/junie).
+- Display name: **"ZCode"** (for the desktop FirstRunSetup wizard, which carries a
+  display-name field alongside the id).
+
+---
+
+## 3. Install paths — where ZCode looks for skills, commands, agents
+
+### Skills discovery (authoritative, from ZCode's own configuration-guide skill)
+ZCode scans these locations **in precedence order** (first same-named skill wins):
+
+1. Explicitly configured roots
+2. **User `~/.zcode/skills/`**
+3. **User `~/.agents/skills/`** (universal/shared — same path Codex/Claude use)
+4. Workspace `<repo>/.zcode/skills/` (searched upward to repo root, every level)
+5. Workspace `<repo>/.agents/skills/`
+6. Enabled **plugin** roots (lowest precedence)
+
+Within a level, `.zcode` is scanned before `.agents`. Skill identity = the file path;
+a skill is a directory containing a `SKILL.md` with YAML frontmatter (`name`,
+`description`) + markdown body — **identical format to Claude Code / opencode**.
+
+### Recommended install target for skill-bill
+**Primary: `~/.zcode/skills/`** (user scope, ZCode-native).
+
+This mirrors how skill-bill installs into each agent's native skills dir
+(`~/.claude/skills`, `~/.codex/skills`, `~/.config/opencode/skills`, `~/.junie/skills`).
+The ZCode-native choice is `~/.zcode/skills/`.
+
+> Note: `~/.agents/skills/` is the universal cross-tool dir. skill-bill's
+> `agentPaths()` already special-cases codex to fall back to `~/.agents/skills`. For
+> zcode, prefer the native `~/.zcode/skills/` as the default path so installs are
+> scoped to ZCode and don't collide with other tools — but be aware ZCode *also*
+> reads `~/.agents/skills`, which is useful for the desktop "Import skills from
+> external agents" feature.
+
+### Agent/presence detection (for `agentIsPresent`)
+ZCode is "present" if its config home exists. Detection roots to check
+(`agentIsPresent` `when (agent)` branch):
+- `~/.zcode/` (the config home — always present on a ZCode install)
+- Optionally `~/.zcode/cli/` (CLI runtime data dir, also always present)
+
+The `zcode` binary on PATH is a further signal but the config-home check is the
+reliable one (matching how junie checks `~/.junie/`, opencode checks
+`~/.config/opencode/`).
+
+### Commands
+- User: `~/.zcode/commands/`, `~/.agents/commands/`
+- Workspace: `<repo>/.zcode/commands/`, `<repo>/.agents/commands/`
+- Not directly relevant to skill-bill's install (skill-bill installs skills, not
+  commands), but documented for completeness.
+
+---
+
+## 4. MCP server registration
+
+### Config file locations (authoritative)
+ZCode reads MCP config from, per scope (`.zcode` checked before `.agents`):
+
+| Scope | Primary | Fallback |
+|---|---|---|
+| **User** | `~/.zcode/cli/config.json` → `mcp.servers` | `~/.agents/mcp.json` → `mcpServers` |
+| **Workspace** | `<repo>/.zcode/config.json` → `mcp.servers` | `<repo>/.agents/mcp.json` → `mcpServers` |
+
+> ⚠️ **Two different JSON shapes:**
+> - `.zcode/config.json` uses **nested** `mcp.servers` (and `mcp_servers` is also
+>   accepted as a key variant observed in the asar).
+> - `.agents/mcp.json` (compatibility fallback) uses **top-level** `mcpServers`
+>   (the Claude/Codex/Cursor-standard shape).
+
+### Which file should skill-bill write?
+For ZCode MCP registration, write to **`~/.zcode/cli/config.json`** under the
+`mcp.servers` key (the ZCode-native user-scope location). This mirrors how
+skill-bill writes each agent's native config:
+- claude → `~/.claude.json` (JSON)
+- codex → `~/.codex/config.toml` (TOML)
+- opencode → `~/.config/opencode/opencode.json`
+- junie → `~/.junie/mcp/mcp.json`
+- **zcode → `~/.zcode/cli/config.json`** (JSON, `mcp.servers` nested key) ← NEW
+
+### Config format — JSON (not TOML)
+ZCode config is JSON. The server entry shape (stdio server) is the same as
+Claude's `mcpServers` entries:
+```json
+{
+  "mcp": {
+    "servers": {
+      "skill-bill": {
+        "type": "stdio",
+        "command": "skill-bill-mcp",
+        "args": []
+      }
+    }
+  }
+}
+```
+> **Confirm during implementation:** whether the nested key is exactly `mcp.servers`
+> or whether `config.json` also accepts top-level `mcpServers`. The configuration
+> guide states `.zcode` uses nested `mcp.servers`; the asar also contains
+> `mcp_servers` and `mcpServers` tokens. Safest: use `mcp.servers` (nested) for the
+> `.zcode/cli/config.json` target, per the official guide. A new
+> `McpZcodeConfig` writer class (modeled on `McpJsonConfig`) is the clean fit.
+
+### Auto-connect behavior
+MCP servers from **every** scope (user, workspace, plugin, env, CLI) are
+**trusted and connected automatically** at session start. So a user-scope
+registration in `~/.zcode/cli/config.json` will connect without manual
+authorization — good for skill-bill's MCP tools being immediately available.
+
+### Existing workspace MCP (reference)
+This repo already has a workspace-scope MCP config at `.mcp.json` (top-level
+`mcpServers`) registering `skill-bill-mcp`. ZCode reads workspace `.agents/mcp.json`
+but NOT a bare `.mcp.json` — **however** the session clearly has the skill-bill MCP
+available, so either ZCode also reads `.mcp.json` or the desktop app reads it
+directly. **Confirm during implementation** whether `.mcp.json` is a recognized
+workspace file; if not, the installer's workspace-MCP path is unaffected (user-scope
+registration is the install target anyway).
+
+---
+
+## 5. Instruction files (AGENTS.md)
+
+- **User scope:** `~/.zcode/AGENTS.md` (personal defaults, every workspace)
+- **Workspace scope:** `<repo>/AGENTS.md` (project rules; searched upward from cwd
+  to repo root)
+- **Merge order:** user `~/.zcode/AGENTS.md` injected first, then workspace
+  `<repo>/AGENTS.md` later (workspace can narrow/override user defaults).
+- ZCode reads `AGENTS.md` natively (this very session is governed by the repo's
+  `AGENTS.md`). No install action needed for instructions — skill-bill's governance
+  doc is already picked up.
+
+---
+
+## 6. Native subagents (the `native-agents/agents.yaml` rendering target)
+
+### Does ZCode support native subagents?
+**Yes** — ZCode has a first-class subagent system (the `Agent` tool in this session
+spawns them; the session metadata at
+`~/.zcode/cli/agents/<sessionId>/<agentId>/metadata.json` records subagent
+`profileSnapshot` with name/description/model/tools). Plugins can declare an
+`agents` component field in their manifest.
+
+### Rendering target directory
+Following the skill-bill convention (`claude-agents/`, `codex-agents/`,
+`opencode-agents/`, `junie-agents/`), the ZCode native-agent output directory
+should be **`zcode-agents/`**.
+
+### Render format
+ZCode subagents are defined with a name, description, model, and tool list. The
+closest existing render pattern is **`renderFrontmatterAgent`** (YAML frontmatter
+with `name`, `description`, optional `model`/`tools`) — the same shape Claude and
+opencode use. The `NativeAgentProvider` enum entry for ZCode should be:
+```kotlin
+Zcode("zcode-agents", "md") {
+    render = renderFrontmatterAgent(mode = null)   // or "subagent" — confirm
+    homeAgentDirs = listOf(home.resolve(".zcode/agents"), home.resolve(".agents/agents"))
+}
+```
+
+### Native-agent install/link target
+- **User:** `~/.zcode/agents/` and/or `~/.agents/agents/`
+- The link/unlink operations (`linkZcodeAgents` / `unlinkZcodeAgents`) should model
+  on `linkJunieAgents`/`linkOpencodeAgents` (markdown agent files symlinked into the
+  agents dir).
+
+> **Confirm during implementation:** the exact on-disk subagent definition format
+> ZCode loads (frontmatter keys, whether `model`/`tools` are honored from
+> user-scope files vs. only plugin manifests). The metadata.json captured for this
+> session's subagent shows the runtime *records* `profileSnapshot` with
+> `name/description/model/tools/source`, but the *authoring* format for
+> user-scope subagents should be verified by dropping a test agent file into
+> `~/.zcode/agents/` and running `zcode skills list` or inspecting the Subagents
+> settings.
+
+---
+
+## 7. The skill-bill touch surface (where to add `zcode`)
+
+There is **no single agent registry**. Agent identity is hardcoded across ~27 sites
+in 6 duplicated enums, ~8 `when`/list branches, a bash array, a YAML enum, and
+parity tests. Below is the complete, ordered edit list for adding `zcode` as a full
+runtime agent. (Source: codebase investigation at commit `ce422474`.)
+
+### A. Enums (6) — add a `ZCODE` entry to each
+1. **`InstallAgent`** — `runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt:13`
+   - Add `ZCODE("zcode")`.
+   - Add env-var marker to `INVOKING_AGENT_CONTEXT_SIGNALS` (~line 70) using
+     `ZCODE_APP_VERSION` (recommended).
+   - **Do NOT** add zcode to `RUNTIME_REFUSED_AGENTS` (line 37) — zcode IS runtime-capable.
+2. **`NativeAgentProviderId`** — `InstallModels.kt:386` (add `ZCODE`).
+3. **`NativeAgentProvider`** — `runtime-infra-fs/src/main/kotlin/skillbill/nativeagent/rendering/NativeAgentRendering.kt:13`
+   (add `Zcode("zcode-agents", "md")` with render fn + `homeAgentDirs`).
+4. **`NativeAgentLinkProvider`** — `runtime-ports/src/main/kotlin/skillbill/ports/install/model/InstallPortModels.kt:11`
+   (add `ZCODE`).
+5. **`FirstRunSetupAgent`** — `runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt:17`
+   (add `ZCODE("zcode", "ZCode")`).
+6. **`AgentSymlinkProvider`** + **`DesktopAgentSymlinkProvider`** —
+   `runtime-domain/src/main/kotlin/skillbill/domain/skillremove/model/SkillRemovalPreview.kt:81`
+   and `runtime-desktop/.../SkillRemovalModels.kt:83` (add `ZCODE`).
+
+### B. Install paths & detection
+7. **`SUPPORTED_AGENTS`** list — `runtime-infra-fs/src/main/kotlin/skillbill/install/plan/InstallPrimitives.kt:15`
+   (add `"zcode"`).
+8. **`agentPaths(...)`** map — `InstallPrimitives.kt:21-30`
+   (add `"zcode" -> resolvedHome.resolve(".zcode/skills")`).
+9. **`agentIsPresent`** `when (agent)` — `InstallPrimitives.kt:153-159`
+   (add zcode → check `~/.zcode/`).
+10. **`agentDirectory`** `when` — `runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallAdapters.kt:193-199`
+    (add `"zcode" -> ...`).
+11. **`InstallOperations`** junie-style helpers — `runtime-infra-fs/src/main/kotlin/skillbill/install/runtime/InstallOperations.kt`
+    (add a `zcodeAgentsPath` helper near line 53 if needed; model on `junieAgentsPath`).
+
+### C. Native-agent rendering & linking
+12. **`linkZcodeAgents` / `unlinkZcodeAgents`** — new functions in
+    `runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/InstallNativeAgentOperations.kt`
+    (model on `linkJunieAgents` lines 96-119).
+13. **Two `when (request.provider)` branches** —
+    `FileSystemInstallAdapters.kt:222-227` and `:241-246` (add `ZCODE` cases).
+14. **`nativeAgentInstallers` list** —
+    `runtime-infra-fs/src/main/kotlin/skillbill/apply/InstallApplyNativeAgents.kt:199-224`
+    (add a `NativeAgentInstaller(agent=ZCODE, provider=ZCODE, link=::linkZcodeAgents, unlink=::unlinkZcodeAgents)` entry).
+
+### D. MCP registration
+15. **`McpZcodeConfig`** — new writer class in
+    `runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/` (model on
+    `McpJsonConfig.kt`; writes JSON to `~/.zcode/cli/config.json` under `mcp.servers`).
+16. **`McpRegistrationOperations.register/unregister/configPathFor`** —
+    `runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/McpRegistrationOperations.kt`
+    - `register` `when` (lines 22-30): add `ZCODE -> McpZcodeConfig(...)`.
+    - `unregister` `when` (lines 42-50): add `ZCODE -> McpZcodeConfig(...)`.
+    - `configPathFor` `when` (lines 53-59): add `ZCODE -> home.resolve(".zcode/cli/config.json")`.
+
+### E. Runtime `AgentRunCommandBuilder` (zcode is runtime-capable — this is included)
+17. **`ZcodeAgentRunCommandBuilder`** — new class in
+    `runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt`
+    (model on `ClaudeAgentRunCommandBuilder` lines 42-68). Command:
+    `zcode --prompt <prompt> --json --cwd <dir> --mode yolo --no-color`.
+    Set `usePtyStdio = false`, `idlePolicy = DB_PROGRESS_ONLY`.
+18. **`headlessAgentRunAdapters` registry** —
+    `runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt:75-79`
+    (add `ZcodeAgentRunCommandBuilder()` to the `listOf(...)`).
+19. **`FileSystemAgentRunLauncher`** deep path —
+    `runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/FileSystemAgentRunLauncher.kt`
+    (no edit needed if the registry is wired; the launcher dispatches by builder map).
+
+### F. CLI commands
+20. **New CLI commands** — `runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliCommands.kt`
+    (add `InstallZcodeAgentsPathCommand`, `InstallLinkZcodeAgentsCommand`,
+    `InstallUnlinkZcodeAgentsCommand`; model on the junie commands at lines 545-805).
+21. **Register commands** — `runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliCommands.kt`
+    (add to `InstallTopLevelCommands` `.subcommands(...)` and imports, lines 33-40, 102-158).
+
+### G. Shell scripts
+22. **`install.sh` `SUPPORTED_AGENTS`** bash array — `install.sh:73`
+    (add `zcode`).
+23. **`install.sh` help strings** — `install.sh:2543, 2649` (add zcode to agent lists).
+24. **`uninstall.sh`** per-agent removal blocks — `uninstall.sh:522-545` and the loop
+    at `:638` (add a `~/.zcode/skills` removal block).
+
+### H. Schema
+25. **`agentId` enum** — `orchestration/contracts/install-plan-schema.yaml:54-59`
+    (add `zcode` to the enum).
+
+### I. Tests / parity guards (will FAIL until updated)
+26. **`requireSupportedAgentContract()`** — `runtime-infra-fs/.../InstallPlanBuilder.kt:50-54`
+    (ties `SUPPORTED_AGENTS` ↔ `InstallAgent.supportedIds` — auto-satisfied if both
+    are updated together; this is the only automated drift guard).
+27. **`FirstRunSetupModelsTest.kt:11`** — asserts the exact agent id list; add `zcode`.
+28. **`InstallPlanContractCoverageTest.kt`**, **`InstallPlanSchemaValidatesExistingFixturesTest.kt`**
+    — fixtures enumerate agents; add zcode fixtures.
+29. **`InstallerShellDelegationTest.kt:879,957,1013`** — reference the literal
+    `unlink-{codex,claude,opencode,junie}-agents` command list; add `unlink-zcode-agents`.
+30. **New tests:** `ZcodeAgentRunCommandBuilderTest` (model on
+    `ClaudeAgentRunCommandBuilderTest`), and an MCP registration test for the new
+    `McpZcodeConfig` writer.
+
+---
+
+## 8. Open questions to resolve during implementation
+
+These are the facts I could NOT fully verify without a configured model provider or
+by dropping test files. They are confirmations, not blockers:
+
+1. **`--json` output envelope.** Run `zcode --prompt "<short>" --json --cwd <dir>`
+   once with a valid model provider and capture the exact JSON shape the runtime
+   must parse to extract the assistant's final text. (The probe returned
+   `Error: Model config is missing.` because no provider was configured at
+   `~/.zcode/cli/config.json`.)
+2. **Prompt-size handling.** Confirm whether long phase prompts via `--prompt` argv
+   are reliable, or whether `--attach <file>` + a short `--prompt` ("read the
+   attached brief, then...") is the safer pattern. Verify whether `--attach`
+   injects contents into context or merely makes the file readable.
+3. **User-scope subagent authoring format.** Drop a test agent file into
+   `~/.zcode/agents/` and confirm the frontmatter keys ZCode loads
+   (`name`/`description`/`model`/`tools`) and whether `mode: "subagent"` vs `null`
+   matters for the frontmatter renderer.
+4. **MCP nested key.** Confirm `~/.zcode/cli/config.json` accepts `mcp.servers`
+   (nested) per the official guide, vs. needing top-level `mcpServers`. The guide
+   says nested; the asar contains both tokens.
+5. **Whether `.mcp.json` (bare) is read at workspace scope.** This repo's
+   `.mcp.json` appears to work, but the official guide only documents
+   `.zcode/config.json` and `.agents/mcp.json`. Clarify which workspace file the
+   installer should document (does not affect user-scope install target).
+
+---
+
+## 9. Reference: how the existing agents are wired (templates to copy)
+
+| Concern | Best template to copy for zcode |
+|---|---|
+| `AgentRunCommandBuilder` (runtime, headless) | `ClaudeAgentRunCommandBuilder` (`AgentRunCommandBuilders.kt:42-68`) — same "stdout, --json, no-PTY" shape |
+| Native-agent render format | `Junie` / `Claude` in `NativeAgentRendering.kt` (frontmatter `.md`) |
+| Native-agent link/unlink | `linkJunieAgents` / `unlinkJunieAgentMarkdown` (`InstallNativeAgentOperations.kt:96-119`) |
+| MCP config writer | `McpJsonConfig.kt` (JSON writer; zcode is JSON, unlike codex's TOML) |
+| Install path primitive | `junie` in `agentPaths()` / `agentIsPresent()` (simple `~/.<agent>/` home) |
+| CLI link/unlink commands | junie commands in `InstallCliCommands.kt:545-805` |
+
+**Do NOT copy the opencode runtime-refusal pattern** — zcode is runtime-capable and
+must NOT be added to `RUNTIME_REFUSED_AGENTS`. The opencode refusal machinery
+(`isRuntimeRefusedAgent`, `OPENCODE_RUNTIME_REFUSAL_MESSAGE`, the preflight gate) is
+intentionally opencode-specific and should not be extended for zcode.
+
+---
+
+## 10. Summary of confirmed facts (quick reference)
+
+- **Agent id:** `zcode` (lowercase). Display: "ZCode".
+- **Runtime-capable:** YES (headless `--prompt` + `--json`, no short timeout).
+- **Headless CLI:** `zcode` (AppImage `AppRun` shim) or `node .../resources/glm/zcode.cjs`.
+  CLI self-version `0.15.0`; app version `3.2.3`.
+- **Skills install dir:** `~/.zcode/skills/` (user scope, ZCode-native). Format:
+  `SKILL.md` with YAML frontmatter (identical to Claude/opencode).
+- **Agent detection roots:** `~/.zcode/` (present), `~/.zcode/cli/`.
+- **Env detection marker:** `ZCODE_APP_VERSION` (or `ZCODE_BASE_URL`).
+- **MCP config file:** `~/.zcode/cli/config.json`, nested key `mcp.servers`, JSON.
+- **MCP auto-connect:** yes (all scopes trusted at session start).
+- **Instructions:** reads `<repo>/AGENTS.md` and `~/.zcode/AGENTS.md` natively.
+- **Native subagents:** supported; render to `zcode-agents/` (frontmatter `.md`);
+  install target `~/.zcode/agents/` and/or `~/.agents/agents/`.
+- **Config home:** `~/.zcode/` (CLI runtime data under `~/.zcode/cli/`, provider
+  config under `~/.zcode/v2/config.json`).
+- **Skill discovery also reads:** `~/.agents/skills/` (universal, cross-tool).

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-07-03] SKILL-100 subtask 3 cli-shell-schema
+Areas: install.sh, uninstall.sh, runtime-kotlin/runtime-application (InstallAgentService), runtime-kotlin/runtime-cli (InstallCliCommands, ScaffoldCliCommands), runtime-kotlin/runtime-core (InstallerShellDelegationTest)
+- Completed zcode native-agent CLI/shell/schema wiring on top of subtasks 1-2 (enum/path fan-out, MCP+runtime): added `InstallZcodeAgentsPathCommand`/`InstallLinkZcodeAgentsCommand`/`InstallUnlinkZcodeAgentsCommand` modeled 1:1 on the junie equivalents, registered as `InstallTopLevelCommands` subcommands. reusable
+- `install.sh` `SUPPORTED_AGENTS` array and both help strings now list zcode; `uninstall.sh` gained a `remove_zcode_agent_mds()` block (mirrors junie, removes `~/.zcode/skills`) and the MCP-unregister agent loop now includes zcode.
+- `orchestration/contracts/install-plan-schema.yaml` needed NO edit here — subtask 1 (foundation) already added zcode to the `agentId` enum; verified via grep before touching it. reusable
+- Pitfall for future agent-onboarding subtasks: `InstallerShellDelegationTest.kt`'s three literal command-list fixtures must each list the new agent's `install unlink-<agent>-agents` entry, or the test silently drifts from the real CLI surface. reusable
+- Known pre-existing failure, NOT introduced by this subtask: `InstallerShellDelegationTest > install plan summary is printed before any mutation()` fails identically with this branch's diff fully stashed and on a clean worktree at the merge-base (ce422474) — a fresh-temp-HOME pre-install-cleanup guard mismatch, unrelated to any agent list. Leave it out of scope rather than re-diagnosing it as a zcode regression.
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented
+
 ## [2026-06-29] SKILL-97 fresh-install-curl-fixes
 Areas: install.sh, uninstall.sh, scripts/install_smoke_test.sh
 - Piped `curl … | bash` regressions: guard every `ORIGINAL_ARGS`/bootstrap-arg expansion with `${arr[@]+"${arr[@]}"}` so a no-arg piped install doesn't trip `set -u` (install.sh:270/272/276). reusable

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ if [[ "${SKILL_BILL_GOAL_CONTINUATION:-}" == "1" ]]; then
   exit 64
 fi
 
-declare -a SUPPORTED_AGENTS=(copilot claude codex opencode junie)
+declare -a SUPPORTED_AGENTS=(copilot claude codex opencode junie zcode)
 declare -a AGENT_NAMES=()
 declare -a AGENT_PATHS=()
 declare -a PLATFORM_PACKAGES=()
@@ -2540,7 +2540,7 @@ print_postinstall_agent_warning() {
   detected="$(run_runtime_cli install detect-agents 2>/dev/null)" || return 0
   [[ -n "$detected" ]] && return 0
   warn "No supported agents were detected — skills are not linked to any agent."
-  warn "  Install a supported agent (claude, codex, copilot, opencode, or junie),"
+  warn "  Install a supported agent (claude, codex, copilot, opencode, junie, or zcode),"
   warn "  then re-run ./install.sh. Choose 'manual' to select your agent explicitly."
 }
 
@@ -2646,7 +2646,7 @@ run_full_install() {
   echo ""
   printf "${CYAN}━━━ Skill Bill Installer ━━━${NC}\n"
   echo ""
-  info "Supported agents: copilot, claude, codex, opencode, junie"
+  info "Supported agents: copilot, claude, codex, opencode, junie, zcode"
   if [[ "$REUSE_LAST_SELECTION" -eq 1 ]]; then
     info "Install behavior: reuse saved choices, then delegate planning and apply to the Kotlin runtime."
   else

--- a/orchestration/contracts/install-plan-schema.yaml
+++ b/orchestration/contracts/install-plan-schema.yaml
@@ -57,6 +57,7 @@ $defs:
       - codex
       - opencode
       - junie
+      - zcode
   # Shared enum: agent-target source. Mirrors `InstallAgentTargetSource`
   # — wire form is `name.lowercase()`.
   agentSource:

--- a/orchestration/shell-content-contract/peak-hours-warner.md
+++ b/orchestration/shell-content-contract/peak-hours-warner.md
@@ -1,0 +1,32 @@
+# Peak-Hours Warner
+
+This sidecar applies to `bill-feature`, `bill-feature-task`, and the
+feature-task runtime/prose/subtask-runner launch surfaces.
+
+After any required update check and before intake, confirmation, workflow open,
+or child continuation, check the current local time. Z.AI peak hours are daily
+from 14:00 inclusive to 18:00 exclusive.
+
+If the current local time is outside that window, do nothing.
+
+If the current local time is inside that window, inspect every agent/model path
+that this launch is about to use:
+
+- the currently executing agent and model
+- `--agent`
+- `--agent-override`
+- each `--phase-agent <phase-id>=<agent-id>` entry
+- `parallel-review:<agent>` / `--parallel-review-agent`
+
+Treat `zcode` as GLM unconditionally. Treat any other agent, including
+`opencode`, as GLM only when explicit visible model metadata or an explicit model
+name says GLM. Do not infer GLM from the agent name alone.
+
+When at least one launch path is known to be GLM, tell the user:
+
+```text
+Z.AI/GLM peak hours are 14:00-18:00; this launch is inside peak hours.
+```
+
+When different launch paths use different agents, include the known GLM path or
+paths in the same notice, for example `GLM path: --phase-agent review=zcode`.

--- a/orchestration/skill-classes/feature-implement.yaml
+++ b/orchestration/skill-classes/feature-implement.yaml
@@ -5,6 +5,7 @@ matchers:
   - pattern: "^bill-[a-z0-9-]*feature-task$"
 
 pointers:
+  - peak-hours-warner
   - shell-ceremony
   - telemetry-contract
   - android-compose-implementation
@@ -16,5 +17,6 @@ pointers:
   - android-compose-adaptive-layouts
 
 ceremony_lines:
+  - "Before launch, follow [peak-hours-warner.md](peak-hours-warner.md)."
   - "Follow the shell ceremony in [shell-ceremony.md](shell-ceremony.md)."
   - "When telemetry applies, follow [telemetry-contract.md](telemetry-contract.md)."

--- a/orchestration/skill-classes/feature-launch-warning.yaml
+++ b/orchestration/skill-classes/feature-launch-warning.yaml
@@ -1,0 +1,14 @@
+class: feature-launch-warning
+contract_version: "1.1"
+
+matchers:
+  - exact: bill-feature
+  - exact: bill-feature-task-runtime
+  - exact: bill-feature-task-prose
+  - exact: bill-feature-task-subtask-runner
+
+pointers:
+  - peak-hours-warner
+
+ceremony_lines:
+  - "Before launch, follow [peak-hours-warner.md](peak-hours-warner.md)."

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/scaffold/InstallAgentService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/scaffold/InstallAgentService.kt
@@ -30,6 +30,8 @@ class InstallAgentService(
 
   fun junieAgentsPath(home: Path? = null): Path = agentDirectory("junie", home)
 
+  fun zcodeAgentsPath(home: Path? = null): Path = agentDirectory("zcode", home)
+
   fun cleanupAgentTarget(
     targetDir: Path,
     skillNames: List<String>,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliCommands.kt
@@ -583,6 +583,16 @@ class InstallJunieAgentsPathCommand(
 }
 
 @Inject
+class InstallZcodeAgentsPathCommand(
+  private val state: CliRunState,
+  private val installAgentService: InstallAgentService,
+) : DocumentedCliCommand("zcode-agents-path", "Print the zcode native subagent markdown directory.") {
+  override fun run() {
+    state.completeText(installAgentService.zcodeAgentsPath(state.userHome).toString(), emptyMap())
+  }
+}
+
+@Inject
 class InstallLinkClaudeAgentsCommand(
   private val state: CliRunState,
   private val nativeAgentInstallService: NativeAgentInstallService,
@@ -793,6 +803,61 @@ class InstallUnlinkJunieAgentsCommand(
     val removed =
       nativeAgentInstallService.unlinkNativeAgents(
         NativeAgentLinkProvider.JUNIE,
+        NativeAgentLinkRequest(
+          platformPacksRoot = Path.of(platformPacks),
+          skillsRoot = skills?.let(Path::of),
+          home = state.userHome,
+          selectedPlatforms = platforms.ifEmpty { null },
+        ),
+      )
+    state.completeText(removed.joinToString("\n"), mapOf("removed" to removed.map(Path::toString)))
+  }
+}
+
+@Inject
+class InstallLinkZcodeAgentsCommand(
+  private val state: CliRunState,
+  private val nativeAgentInstallService: NativeAgentInstallService,
+) : DocumentedCliCommand("link-zcode-agents", "Render and link zcode native subagent markdown from source agents.") {
+  private val platformPacks by option("--platform-packs", help = "platform-packs root.").required()
+  private val skills by option("--skills", help = "skills root.")
+  private val platforms by option("--platform", help = "Selected platform slug to include.").multiple()
+
+  override fun run() {
+    if (state.refuseInstallMutationDuringGoalContinuation("link-zcode-agents")) {
+      return
+    }
+    completeNativeAgentLinkOutcome(
+      state,
+      nativeAgentInstallService.linkNativeAgents(
+        NativeAgentLinkProvider.ZCODE,
+        NativeAgentLinkRequest(
+          platformPacksRoot = Path.of(platformPacks),
+          skillsRoot = skills?.let(Path::of),
+          home = state.userHome,
+          selectedPlatforms = platforms.ifEmpty { null },
+        ),
+      ),
+    )
+  }
+}
+
+@Inject
+class InstallUnlinkZcodeAgentsCommand(
+  private val state: CliRunState,
+  private val nativeAgentInstallService: NativeAgentInstallService,
+) : DocumentedCliCommand("unlink-zcode-agents", "Remove zcode native subagent markdown symlinks.") {
+  private val platformPacks by option("--platform-packs", help = "platform-packs root.").required()
+  private val skills by option("--skills", help = "skills root.")
+  private val platforms by option("--platform", help = "Selected platform slug to include.").multiple()
+
+  override fun run() {
+    if (state.refuseInstallMutationDuringGoalContinuation("unlink-zcode-agents")) {
+      return
+    }
+    val removed =
+      nativeAgentInstallService.unlinkNativeAgents(
+        NativeAgentLinkProvider.ZCODE,
         NativeAgentLinkRequest(
           platformPacksRoot = Path.of(platformPacks),
           skillsRoot = skills?.let(Path::of),

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliCommands.kt
@@ -34,6 +34,7 @@ import skillbill.cli.install.InstallLinkClaudeAgentsCommand
 import skillbill.cli.install.InstallLinkCodexAgentsCommand
 import skillbill.cli.install.InstallLinkJunieAgentsCommand
 import skillbill.cli.install.InstallLinkOpencodeAgentsCommand
+import skillbill.cli.install.InstallLinkZcodeAgentsCommand
 import skillbill.cli.install.InstallOpencodeAgentsPathCommand
 import skillbill.cli.install.InstallPlanCommand
 import skillbill.cli.install.InstallReconcileCommand
@@ -43,7 +44,9 @@ import skillbill.cli.install.InstallUnlinkClaudeAgentsCommand
 import skillbill.cli.install.InstallUnlinkCodexAgentsCommand
 import skillbill.cli.install.InstallUnlinkJunieAgentsCommand
 import skillbill.cli.install.InstallUnlinkOpencodeAgentsCommand
+import skillbill.cli.install.InstallUnlinkZcodeAgentsCommand
 import skillbill.cli.install.InstallUnregisterMcpCommand
+import skillbill.cli.install.InstallZcodeAgentsPathCommand
 import skillbill.cli.install.refuseInstallMutationDuringGoalContinuation
 import skillbill.cli.model.CliExecutionResult
 import skillbill.cli.model.CliFormat
@@ -113,6 +116,7 @@ class InstallTopLevelCommands(
   claudeAgentsPathCommand: InstallClaudeAgentsPathCommand,
   opencodeAgentsPathCommand: InstallOpencodeAgentsPathCommand,
   junieAgentsPathCommand: InstallJunieAgentsPathCommand,
+  zcodeAgentsPathCommand: InstallZcodeAgentsPathCommand,
   cleanupAgentTargetCommand: InstallCleanupAgentTargetCommand,
   linkClaudeAgentsCommand: InstallLinkClaudeAgentsCommand,
   unlinkClaudeAgentsCommand: InstallUnlinkClaudeAgentsCommand,
@@ -122,6 +126,8 @@ class InstallTopLevelCommands(
   unlinkOpencodeAgentsCommand: InstallUnlinkOpencodeAgentsCommand,
   linkJunieAgentsCommand: InstallLinkJunieAgentsCommand,
   unlinkJunieAgentsCommand: InstallUnlinkJunieAgentsCommand,
+  linkZcodeAgentsCommand: InstallLinkZcodeAgentsCommand,
+  unlinkZcodeAgentsCommand: InstallUnlinkZcodeAgentsCommand,
   registerMcpCommand: InstallRegisterMcpCommand,
   unregisterMcpCommand: InstallUnregisterMcpCommand,
 ) {
@@ -144,6 +150,7 @@ class InstallTopLevelCommands(
         claudeAgentsPathCommand,
         opencodeAgentsPathCommand,
         junieAgentsPathCommand,
+        zcodeAgentsPathCommand,
         cleanupAgentTargetCommand,
         linkClaudeAgentsCommand,
         unlinkClaudeAgentsCommand,
@@ -153,6 +160,8 @@ class InstallTopLevelCommands(
         unlinkOpencodeAgentsCommand,
         linkJunieAgentsCommand,
         unlinkJunieAgentsCommand,
+        linkZcodeAgentsCommand,
+        unlinkZcodeAgentsCommand,
         registerMcpCommand,
         unregisterMcpCommand,
       )

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -377,7 +377,10 @@ class InstallerShellDelegationTest {
   fun `install plan summary is printed before any mutation`() {
     // Do NOT set SKILL_BILL_SKIP_PREINSTALL_UNINSTALL: the plan must print before
     // the pre-install uninstall mutates anything.
-    val run = runPrebuiltInstaller(releaseValid = true, options = PrebuiltOptions(skipPreinstallUninstall = false))
+    val run = runPrebuiltInstaller(
+      releaseValid = true,
+      options = PrebuiltOptions(skipPreinstallUninstall = false, seedPriorInstall = true),
+    )
 
     assertEquals(0, run.exitCode, run.output)
     val planIndex = run.output.indexOf("What this installer will change")
@@ -678,6 +681,9 @@ class InstallerShellDelegationTest {
     builder.environment().remove("SKILL_BILL_GOAL_CONTINUATION")
     if (options.skipPreinstallUninstall) {
       builder.environment()["SKILL_BILL_SKIP_PREINSTALL_UNINSTALL"] = "1"
+    }
+    if (options.seedPriorInstall) {
+      Files.createDirectories(home.resolve(".skill-bill"))
     }
     // Headless by default: drop any inherited desktop-session signals.
     builder.environment().remove("DISPLAY")
@@ -1107,6 +1113,7 @@ private data class PrebuiltReuse(
 private data class PrebuiltOptions(
   val omitRuntimeAssets: Boolean = false,
   val skipPreinstallUninstall: Boolean = true,
+  val seedPriorInstall: Boolean = false,
   val desktopInput: String = "skip",
   val interactiveTty: Boolean = false,
 )

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/InstallerShellDelegationTest.kt
@@ -118,6 +118,10 @@ class InstallerShellDelegationTest {
         "junie",
         "--agent-target",
         "junie=${run.home.resolve("agent-targets/junie")}",
+        "--agent",
+        "zcode",
+        "--agent-target",
+        "zcode=${run.home.resolve("agent-targets/zcode")}",
       ),
       run.applyArgs,
     )
@@ -730,18 +734,6 @@ class InstallerShellDelegationTest {
       "desktop-extract assertions require a linux-x64 host with ar/tar",
     )
   }
-
-  private fun parseRuntimeCalls(logPath: Path): List<List<String>> {
-    val calls = mutableListOf<MutableList<String>>()
-    Files.readAllLines(logPath).forEach { line ->
-      if (line == "CALL") {
-        calls.add(mutableListOf())
-      } else if (line.startsWith("ARG\t")) {
-        calls.last().add(line.removePrefix("ARG\t"))
-      }
-    }
-    return calls
-  }
 }
 
 // Cohesive fixture-seeding helpers for the installer/uninstaller shell tests: runtime
@@ -765,6 +757,18 @@ internal fun assertExternalAddonOverlayOrdering(installScript: String) {
     "apply_external_addon_overlay must run BEFORE apply_runtime_install (the staging install apply)",
   )
   assertContains(installScript, "apply-external-addons")
+}
+
+internal fun parseRuntimeCalls(logPath: Path): List<List<String>> {
+  val calls = mutableListOf<MutableList<String>>()
+  Files.readAllLines(logPath).forEach { line ->
+    if (line == "CALL") {
+      calls.add(mutableListOf())
+    } else if (line.startsWith("ARG\t")) {
+      calls.last().add(line.removePrefix("ARG\t"))
+    }
+  }
+  return calls
 }
 
 internal object InstallerShellFixtures {
@@ -876,7 +880,7 @@ internal object InstallerShellFixtures {
       |# Pre-install uninstall (AC6 path) drives the same CLI for cleanup commands;
       |# answer them with empty output + success so the clean slate reset succeeds.
       |case "${'$'}{1:-} ${'$'}{2:-}" in
-      |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-claude-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unregister-mcp")
+      |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-claude-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unlink-zcode-agents"|"install unregister-mcp")
       |    exit 0
       |    ;;
       |esac
@@ -954,7 +958,7 @@ internal object InstallerShellFixtures {
       |  exit 0
       |fi
       |case "${'$'}{1:-} ${'$'}{2:-}" in
-      |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-claude-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unregister-mcp")
+      |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-claude-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unlink-zcode-agents"|"install unregister-mcp")
       |    exit 0
       |    ;;
       |esac
@@ -1010,7 +1014,7 @@ internal object InstallerShellFixtures {
       |  exit 0
       |fi
       |case "${'$'}{1:-} ${'$'}{2:-}" in
-      |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-claude-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unregister-mcp")
+      |  "install cleanup-agent-target"|"install unlink-codex-agents"|"install unlink-claude-agents"|"install unlink-opencode-agents"|"install unlink-junie-agents"|"install unlink-zcode-agents"|"install unregister-mcp")
       |    exit 0
       |    ;;
       |esac

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmRuntimeSkillRemoveGateway.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/JvmRuntimeSkillRemoveGateway.kt
@@ -180,6 +180,7 @@ private fun AgentSymlinkUnlink.toDesktop(): DesktopAgentSymlinkUnlink = DesktopA
     AgentSymlinkProvider.CODEX -> DesktopAgentSymlinkProvider.CODEX
     AgentSymlinkProvider.OPENCODE -> DesktopAgentSymlinkProvider.OPENCODE
     AgentSymlinkProvider.JUNIE -> DesktopAgentSymlinkProvider.JUNIE
+    AgentSymlinkProvider.ZCODE -> DesktopAgentSymlinkProvider.ZCODE
   },
   path = path,
 )

--- a/runtime-kotlin/runtime-desktop/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/runtime-kotlin/runtime-desktop/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="confirm_deletion_provider_codex">Codex</string>
     <string name="confirm_deletion_provider_opencode">OpenCode</string>
     <string name="confirm_deletion_provider_junie">Junie</string>
+    <string name="confirm_deletion_provider_zcode">ZCode</string>
 
     <string name="first_run_cd">First-run setup wizard</string>
     <string name="first_run_dismiss_cd">Dismiss setup wizard</string>

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModels.kt
@@ -19,6 +19,7 @@ enum class FirstRunSetupAgent(
   CODEX("codex", "Codex"),
   OPENCODE("opencode", "OpenCode"),
   JUNIE("junie", "Junie"),
+  ZCODE("zcode", "ZCode"),
   ;
 
   companion object {

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillRemovalModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillRemovalModels.kt
@@ -84,6 +84,7 @@ enum class DesktopAgentSymlinkProvider {
   CODEX,
   OPENCODE,
   JUNIE,
+  ZCODE,
 }
 
 data class DesktopReadmeCatalogEdit(

--- a/runtime-kotlin/runtime-desktop/core/domain/src/jvmTest/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModelsTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/jvmTest/kotlin/skillbill/desktop/core/domain/model/FirstRunSetupModelsTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertTrue
 class FirstRunSetupModelsTest {
   @Test
   fun `supported agents and telemetry ids match install contract ids`() {
-    assertEquals(listOf("copilot", "claude", "codex", "opencode", "junie"), FirstRunSetupAgent.supportedIds)
+    assertEquals(listOf("copilot", "claude", "codex", "opencode", "junie", "zcode"), FirstRunSetupAgent.supportedIds)
     assertEquals(listOf("anonymous", "full", "off"), FirstRunTelemetryLevel.entries.map(FirstRunTelemetryLevel::id))
   }
 

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/ConfirmDeletionDialog.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/ConfirmDeletionDialog.kt
@@ -68,6 +68,7 @@ import dev.skillbill.designsystem.generated.resources.confirm_deletion_provider_
 import dev.skillbill.designsystem.generated.resources.confirm_deletion_provider_codex
 import dev.skillbill.designsystem.generated.resources.confirm_deletion_provider_junie
 import dev.skillbill.designsystem.generated.resources.confirm_deletion_provider_opencode
+import dev.skillbill.designsystem.generated.resources.confirm_deletion_provider_zcode
 import dev.skillbill.designsystem.generated.resources.confirm_deletion_readme_decrement_count
 import dev.skillbill.designsystem.generated.resources.confirm_deletion_readme_edits
 import dev.skillbill.designsystem.generated.resources.confirm_deletion_readme_remove_row
@@ -507,4 +508,5 @@ private fun displayLabelFor(provider: DesktopAgentSymlinkProvider): String = whe
   DesktopAgentSymlinkProvider.CODEX -> stringResource(Res.string.confirm_deletion_provider_codex)
   DesktopAgentSymlinkProvider.OPENCODE -> stringResource(Res.string.confirm_deletion_provider_opencode)
   DesktopAgentSymlinkProvider.JUNIE -> stringResource(Res.string.confirm_deletion_provider_junie)
+  DesktopAgentSymlinkProvider.ZCODE -> stringResource(Res.string.confirm_deletion_provider_zcode)
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/domain/skillremove/model/SkillRemovalPreview.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/domain/skillremove/model/SkillRemovalPreview.kt
@@ -82,6 +82,7 @@ enum class AgentSymlinkProvider {
   CODEX,
   OPENCODE,
   JUNIE,
+  ZCODE,
 }
 
 /** A single edit to the root `README.md` catalog. */

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
@@ -15,6 +15,7 @@ enum class InstallAgent(
   CODEX("codex"),
   OPENCODE("opencode"),
   JUNIE("junie"),
+  ZCODE("zcode"),
   ;
 
   companion object {
@@ -387,6 +388,7 @@ enum class NativeAgentProviderId(
   CODEX("codex"),
   OPENCODE("opencode"),
   JUNIE("junie"),
+  ZCODE("zcode"),
 }
 
 enum class NativeAgentApplyStatus {

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/domain/skillremove/SkillRemoveTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/domain/skillremove/SkillRemoveTest.kt
@@ -67,7 +67,7 @@ class SkillRemoveTest {
   }
 
   @Test
-  fun `previewRemoval PlatformPack lists paired skills tree and four-provider symlinks`() {
+  fun `previewRemoval PlatformPack lists paired skills tree and per-provider symlinks`() {
     val fs = FakeSkillRemoveFileSystem(
       filesystemPaths = listOf("platform-packs/my-platform", "skills/my-platform"),
       symlinks = AgentSymlinkProvider.values().map { provider ->
@@ -80,7 +80,7 @@ class SkillRemoveTest {
     )
     val preview = SkillRemove(fs).previewRemoval(request).preview
     assertEquals(listOf("platform-packs/my-platform", "skills/my-platform"), preview.filesystemPaths)
-    assertEquals(4, preview.agentSymlinkUnlinks.size)
+    assertEquals(AgentSymlinkProvider.values().size, preview.agentSymlinkUnlinks.size)
     assertEquals(emptyList<String>(), preview.cascadedSkillNames)
   }
 

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/InstallPlanModelTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/install/model/InstallPlanModelTest.kt
@@ -9,7 +9,7 @@ class InstallPlanModelTest {
   @Test
   fun `supported install agents are exactly the install contract set`() {
     assertEquals(
-      listOf("copilot", "claude", "codex", "opencode", "junie"),
+      listOf("copilot", "claude", "codex", "opencode", "junie", "zcode"),
       InstallAgent.supportedIds,
     )
   }

--- a/runtime-kotlin/runtime-infra-fs/agent/history.md
+++ b/runtime-kotlin/runtime-infra-fs/agent/history.md
@@ -1,5 +1,16 @@
 # Boundary History — runtime-kotlin/runtime-infra-fs
 
+## [2026-07-03] SKILL-100 zcode agent support (subtask 2: native-agent-mcp-runtime)
+Areas: runtime-infra-fs/install/apply, runtime-infra-fs/launcher/agentrun, runtime-infra-fs/launcher/mcp
+- Closed the six exhaustive-`when` sites subtask 1 flagged as won't-compile: `linkZcodeAgents`/`unlinkZcodeAgents` (modeled on Junie) wired into `FileSystemInstallAdapters` link/unlink + a `nativeAgentInstallers` registry entry.
+- New `McpZcodeConfig` reads/writes `~/.zcode/cli/config.json` under a nested `mcp.servers.skill-bill` key — a different on-disk shape than the flat `mcpServers` key every other agent uses; reuses `McpJsonConfig`'s shared read/write/mutable-map helpers. reusable
+- `McpRegistrationOperations.register/unregister/configPathFor` add a ZCODE case; `unregister` drops `servers` then `mcp` only when both go empty, preserving sibling JSON keys at both nesting levels.
+- New `ZcodeAgentRunCommandBuilder` builds `zcode --prompt <p> --json --cwd <dir> --mode yolo --no-color`, inheriting `usePtyStdio=false`/`idlePolicy=DB_PROGRESS_ONLY` defaults (no override needed, unlike opencode's PTY path); registered in `headlessAgentRunAdapters()` and survives `RUNTIME_REFUSED_AGENTS` (only OPENCODE is refused).
+- Known non-blocking gap flagged in-code: the `--json` envelope parser shape is UNCONFIRMED against a live ZCode session — follow-up verification needed before relying on structured output.
+- Tests extended in lockstep: `AgentRunLauncherTest` (adapter-presence + command-shape for ZCODE alongside CLAUDE/CODEX/JUNIE) and `McpRegistrationOperationsTest` ("non-claude agents stay single-target" expected-paths map).
+Feature flag: N/A
+Acceptance criteria: subtask-2 10/10 implemented
+
 ## [2026-07-03] SKILL-100 zcode agent support
 Areas: runtime-infra-fs/install, runtime-infra-fs/nativeagent, runtime-domain/install/model, runtime-desktop/core/domain, orchestration/contracts
 - Adding a new supported agent = fan out across SIX enums, modeled on the adjacent Junie entry (reusable checklist): InstallAgent, NativeAgentProviderId, NativeAgentProvider, NativeAgentLinkProvider, FirstRunSetupAgent (+ its `supportedIds` companion), AgentSymlinkProvider & DesktopAgentSymlinkProvider.

--- a/runtime-kotlin/runtime-infra-fs/agent/history.md
+++ b/runtime-kotlin/runtime-infra-fs/agent/history.md
@@ -1,5 +1,18 @@
 # Boundary History — runtime-kotlin/runtime-infra-fs
 
+## [2026-07-03] SKILL-100 zcode agent support
+Areas: runtime-infra-fs/install, runtime-infra-fs/nativeagent, runtime-domain/install/model, runtime-desktop/core/domain, orchestration/contracts
+- Adding a new supported agent = fan out across SIX enums, modeled on the adjacent Junie entry (reusable checklist): InstallAgent, NativeAgentProviderId, NativeAgentProvider, NativeAgentLinkProvider, FirstRunSetupAgent (+ its `supportedIds` companion), AgentSymlinkProvider & DesktopAgentSymlinkProvider.
+- `NativeAgentProvider.Zcode("zcode-agents","md")` uses `render = renderFrontmatterAgent(mode = null)` and `homeAgentDirs = listOf(home.resolve(".zcode/agents"))` — mode=null (like Junie, unlike Claude).
+- Install-path layer: `SUPPORTED_AGENTS += "zcode"`; `agentPaths` "zcode"→`.zcode/skills`; `agentIsPresent` "zcode"→`listOf(.zcode)`; `agentDirectory` "zcode"→`InstallOperations.zcodeAgentsPath(home)`, backed by new `zcodeAgentsPath(home)=home.resolve(".zcode/agents")`.
+- Deliberate non-changes: `RUNTIME_REFUSED_AGENTS` untouched (only OPENCODE refused); `INVOKING_AGENT_CONTEXT_SIGNALS` left CLAUDE/CODEX/OPENCODE only — zcode has no distinct invoking-context signal yet (Decision C, AC14).
+- Exhaustive-`when` sites that WON'T compile until a ZCODE branch is added: McpRegistrationOperations (register/unregister/configPathFor), SkillRemoveJvmFileSystem.nativeProvider, JvmRuntimeSkillRemoveGateway, ConfirmDeletionDialog.displayLabelFor, FileSystemInstallAdapters NativeAgentLinkProvider link/unlink (+ new Junie-modeled `InstallNativeAgentOperations.link/unlinkZcodeAgents`).
+- detekt `TooManyFunctions` trips on `InstallOperations` and `InstallNativeAgentOperations` once the zcode path resolver + link/unlink pair land — resolve with `@Suppress("TooManyFunctions")` + one-line rationale (established 67-file pattern), not a refactor.
+- Tests extended in lockstep: FirstRunSetupModelsTest (supportedIds contains "zcode"), InstallPlanContractCoverageTest + InstallPlanSchemaValidatesExistingFixturesTest (add `.zcode` fixture-dir literal), and hardcoded provider-COUNT asserts bumped 5→6 (SkillRemoveTest, InstallPlanModelTest).
+- Pre-existing unrelated red: `InstallerShellDelegationTest "install plan summary is printed before any mutation"` fails on the base commit too — not caused by this change.
+Feature flag: N/A
+Acceptance criteria: 14/14 implemented
+
 ## [2026-06-23] SKILL-89 per-subtask agent attribution — Seam D fs adapter
 Areas: runtime-infra-fs/fs (new `FileSystemFeatureTaskRuntimeSpecStatusWriter`)
 - `FileSystemFeatureTaskRuntimeSpecStatusWriter` implements the new `FeatureTaskRuntimeSpecStatusWriter` port; writes an idempotent `Agent: <id>` line immediately after the `Status:` line under `## Status` in a tracked `spec.md`. Three cases: (1) `## Status` heading absent → no-op; (2) `Agent:` line present → update in place; (3) heading present, no `Agent:` line → insert on the next line.

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallAdapters.kt
@@ -195,6 +195,7 @@ class FileSystemInstallAgentTargets : InstallAgentTargetPort {
         "claude" -> InstallOperations.claudeAgentsPath(request.home)
         "opencode" -> InstallOperations.opencodeAgentsPath(request.home)
         "junie" -> InstallOperations.junieAgentsPath(request.home)
+        "zcode" -> InstallOperations.zcodeAgentsPath(request.home)
         else -> InstallOperations.agentPath(request.agent, request.home)
       },
     )
@@ -224,6 +225,7 @@ class FileSystemInstallNativeAgentLinks : InstallNativeAgentLinkPort {
       NativeAgentLinkProvider.CODEX -> InstallNativeAgentOperations.linkCodexAgents(fsRequest)
       NativeAgentLinkProvider.OPENCODE -> InstallNativeAgentOperations.linkOpencodeAgents(fsRequest)
       NativeAgentLinkProvider.JUNIE -> InstallNativeAgentOperations.linkJunieAgents(fsRequest)
+      NativeAgentLinkProvider.ZCODE -> InstallNativeAgentOperations.linkZcodeAgents(fsRequest)
     }
     return InstallNativeAgentLinkOperationResult(
       outcome = NativeAgentLinkOutcome(
@@ -243,6 +245,7 @@ class FileSystemInstallNativeAgentLinks : InstallNativeAgentLinkPort {
         NativeAgentLinkProvider.CODEX -> InstallNativeAgentOperations.unlinkCodexAgents(fsRequest)
         NativeAgentLinkProvider.OPENCODE -> InstallNativeAgentOperations.unlinkOpencodeAgents(fsRequest)
         NativeAgentLinkProvider.JUNIE -> InstallNativeAgentOperations.unlinkJunieAgents(fsRequest)
+        NativeAgentLinkProvider.ZCODE -> InstallNativeAgentOperations.unlinkZcodeAgents(fsRequest)
       },
     )
   }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplyNativeAgents.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/apply/InstallApplyNativeAgents.kt
@@ -221,4 +221,10 @@ private val nativeAgentInstallers: List<NativeAgentInstaller> = listOf(
     link = InstallNativeAgentOperations::linkJunieAgents,
     unlink = InstallNativeAgentOperations::unlinkJunieAgents,
   ),
+  NativeAgentInstaller(
+    agent = InstallAgent.ZCODE,
+    provider = NativeAgentProviderId.ZCODE,
+    link = InstallNativeAgentOperations::linkZcodeAgents,
+    unlink = InstallNativeAgentOperations::unlinkZcodeAgents,
+  ),
 )

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/InstallNativeAgentOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/InstallNativeAgentOperations.kt
@@ -3,6 +3,7 @@ package skillbill.install.nativeagent
 import skillbill.install.model.AgentTarget
 import skillbill.install.plan.CLAUDE_AGENTS_KIND
 import skillbill.install.plan.JUNIE_AGENTS_KIND
+import skillbill.install.plan.ZCODE_AGENTS_KIND
 import skillbill.install.plan.detectCodexAgentsTarget
 import skillbill.install.plan.detectOpencodeAgentsTarget
 import skillbill.nativeagent.composition.nativeAgentCompositionRepoRoot
@@ -35,6 +36,7 @@ data class NativeAgentLinkRequest(
   val overrides: NativeAgentLinkOverrides = NativeAgentLinkOverrides(),
 )
 
+@Suppress("TooManyFunctions") // cohesive facade: one link/unlink pair per native-agent provider
 object InstallNativeAgentOperations {
   fun linkClaudeAgents(request: NativeAgentLinkRequest): NativeAgentLinkOutcome {
     val resolvedHome = request.home ?: Path.of(System.getProperty("user.home"))
@@ -117,6 +119,24 @@ object InstallNativeAgentOperations {
     ) +
       unlinkedFromCache
   }
+
+  fun linkZcodeAgents(request: NativeAgentLinkRequest): NativeAgentLinkOutcome = linkProviderAgents(
+    provider = NativeAgentProvider.Zcode,
+    request = request,
+    detectTarget = { resolvedHome ->
+      val targetPath = NativeAgentProvider.Zcode.homeAgentDirs(resolvedHome).first()
+      if (Files.exists(targetPath) || Files.exists(resolvedHome.resolve(".zcode"))) {
+        AgentTarget(ZCODE_AGENTS_KIND, targetPath)
+      } else {
+        null
+      }
+    },
+  )
+
+  fun unlinkZcodeAgents(request: NativeAgentLinkRequest): List<Path> = unlinkProviderAgents(
+    provider = NativeAgentProvider.Zcode,
+    request = request,
+  )
 
   private fun linkProviderAgents(
     provider: NativeAgentProvider,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/plan/InstallPrimitives.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/plan/InstallPrimitives.kt
@@ -12,11 +12,12 @@ import skillbill.scaffold.model.PlatformManifest
 import java.nio.file.Files
 import java.nio.file.Path
 
-internal val SUPPORTED_AGENTS: List<String> = listOf("copilot", "claude", "codex", "opencode", "junie")
+internal val SUPPORTED_AGENTS: List<String> = listOf("copilot", "claude", "codex", "opencode", "junie", "zcode")
 internal const val CODEX_AGENTS_KIND: String = "codex-agents"
 internal const val CLAUDE_AGENTS_KIND: String = "claude-agents"
 internal const val OPENCODE_AGENTS_KIND: String = "opencode-agents"
 internal const val JUNIE_AGENTS_KIND: String = "junie-agents"
+internal const val ZCODE_AGENTS_KIND: String = "zcode-agents"
 
 internal fun agentPaths(home: Path? = null, environment: Map<String, String> = System.getenv()): Map<String, Path> {
   val resolvedHome = home ?: Path.of(System.getProperty("user.home"))
@@ -25,6 +26,7 @@ internal fun agentPaths(home: Path? = null, environment: Map<String, String> = S
     "claude" to claudeConfigRoot(resolvedHome, environment).resolve("skills"),
     "opencode" to resolvedHome.resolve(".config/opencode/skills"),
     "junie" to resolvedHome.resolve(".junie/skills"),
+    "zcode" to resolvedHome.resolve(".zcode/skills"),
     "codex" to codexPath(resolvedHome),
   )
 }
@@ -155,6 +157,7 @@ private fun agentIsPresent(
     "claude" -> claudeConfigRoots(home, environment)
     "opencode" -> listOf(home.resolve(".config/opencode"))
     "junie" -> listOf(home.resolve(".junie"))
+    "zcode" -> listOf(home.resolve(".zcode"))
     "codex" -> listOf(home.resolve(".codex"), home.resolve(".agents"))
     else -> emptyList()
   }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/runtime/InstallOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/runtime/InstallOperations.kt
@@ -20,6 +20,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 /** Public CLI-facing install operations backed by the internal install primitives. */
+@Suppress("TooManyFunctions") // cohesive facade: install lifecycle plus one path resolver per supported agent
 object InstallOperations {
   fun planInstall(request: InstallPlanRequest): InstallPlan = buildInstallPlan(request)
 
@@ -53,6 +54,11 @@ object InstallOperations {
   fun junieAgentsPath(home: Path? = null): Path {
     val resolvedHome = home ?: Path.of(System.getProperty("user.home"))
     return resolvedHome.resolve(".junie/agents")
+  }
+
+  fun zcodeAgentsPath(home: Path? = null): Path {
+    val resolvedHome = home ?: Path.of(System.getProperty("user.home"))
+    return resolvedHome.resolve(".zcode/agents")
   }
 
   fun linkSkill(source: Path, targetDir: Path, agent: String, repoRoot: Path? = null, home: Path? = null): List<Path> {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
@@ -77,6 +77,7 @@ fun headlessAgentRunAdapters(processRunner: AgentRunProcessRunner): Map<InstallA
   // opencode is prose-only and intentionally NOT registered, so the launcher yields
   // UnsupportedAgentRunLaunch for it (mirroring copilot) — no runtime phase can spawn it.
   JunieAgentRunCommandBuilder(),
+  ZcodeAgentRunCommandBuilder(),
 ).filterNot { builder -> RUNTIME_REFUSED_AGENTS.contains(builder.agent) }
   .associate { builder ->
     builder.agent to ProcessAgentRunAdapter(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
@@ -1,5 +1,6 @@
 package skillbill.launcher.agentrun
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.RUNTIME_REFUSED_AGENTS
 import skillbill.launcher.process.AgentRunProcessRequest
@@ -41,7 +42,7 @@ class ProcessAgentRunAdapter(
     return AgentRunLaunchFacts(
       agent = agent,
       exitStatus = result.exitStatus,
-      stdout = result.stdout,
+      stdout = normalizeStdout(agent, result.stdout),
       stderr = result.stderr,
       timedOut = result.timedOut,
       interrupted = result.interrupted,
@@ -69,6 +70,17 @@ class ProcessAgentRunAdapter(
       append(':')
       append(workingDirectory.fileName?.toString() ?: workingDirectory.toString())
     }
+}
+
+private val zcodeStdoutMapper: ObjectMapper by lazy { ObjectMapper() }
+
+private fun normalizeStdout(agent: InstallAgent, stdout: String): String {
+  if (agent != InstallAgent.ZCODE) return stdout
+  val trimmed = stdout.trim()
+  if (!trimmed.startsWith("{")) return stdout
+  return runCatching {
+    zcodeStdoutMapper.readTree(trimmed).get("response")?.takeIf { node -> node.isTextual }?.asText()
+  }.getOrNull() ?: stdout
 }
 
 fun headlessAgentRunAdapters(processRunner: AgentRunProcessRunner): Map<InstallAgent, AgentRunAdapter> = listOf(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
@@ -116,6 +116,30 @@ class JunieAgentRunCommandBuilder : AgentRunCommandBuilder {
     )
 }
 
+class ZcodeAgentRunCommandBuilder : AgentRunCommandBuilder {
+  override val agent: InstallAgent = InstallAgent.ZCODE
+
+  override fun build(request: SkillRunRequest): AgentRunCommand =
+    goalContinuationCommand(request, agent) ?: AgentRunCommand(
+      command = buildList {
+        add("zcode")
+        add("--prompt")
+        add(launchPrompt(request))
+        // The envelope shape of --json output is unconfirmed against a live zcode session;
+        // revisit parsing once that's verified.
+        add("--json")
+        add("--cwd")
+        add(request.repoRoot.toString())
+        add("--mode")
+        add("yolo")
+        add("--no-color")
+      },
+      workingDirectory = request.repoRoot,
+      timeout = request.timeout,
+      environment = goalContinuationEnvironment(request),
+    )
+}
+
 // A caller-supplied prompt override (e.g. a feature-task-runtime phase briefing) is delivered to
 // the per-agent CLI wholesale; the delivery mechanics (stdin vs argv) stay per-agent. The default
 // goal-continuation path no longer drives an agent at all — see goalContinuationCommand.

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
@@ -125,8 +125,6 @@ class ZcodeAgentRunCommandBuilder : AgentRunCommandBuilder {
         add("zcode")
         add("--prompt")
         add(launchPrompt(request))
-        // The envelope shape of --json output is unconfirmed against a live zcode session;
-        // revisit parsing once that's verified.
         add("--json")
         add("--cwd")
         add(request.repoRoot.toString())

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/McpRegistrationOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/McpRegistrationOperations.kt
@@ -27,7 +27,7 @@ object McpRegistrationOperations {
       InstallAgent.CODEX -> McpTomlConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
       InstallAgent.OPENCODE -> McpOpenCodeConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
       InstallAgent.JUNIE -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
-      InstallAgent.ZCODE -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
+      InstallAgent.ZCODE -> McpZcodeConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
     }
   }
 
@@ -48,7 +48,7 @@ object McpRegistrationOperations {
       InstallAgent.CODEX -> McpTomlConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
       InstallAgent.OPENCODE -> McpOpenCodeConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
       InstallAgent.JUNIE -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
-      InstallAgent.ZCODE -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+      InstallAgent.ZCODE -> McpZcodeConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
     }
   }
 
@@ -58,7 +58,7 @@ object McpRegistrationOperations {
     InstallAgent.CODEX -> home.resolve(".codex/config.toml")
     InstallAgent.OPENCODE -> home.resolve(".config/opencode/opencode.json")
     InstallAgent.JUNIE -> home.resolve(".junie/mcp/mcp.json")
-    InstallAgent.ZCODE -> home.resolve(".zcode/mcp/mcp.json")
+    InstallAgent.ZCODE -> home.resolve(".zcode/cli/config.json")
   }
 
   private fun claudeProfileConfigPaths(home: Path, environment: Map<String, String>): List<Path> {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/McpRegistrationOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/McpRegistrationOperations.kt
@@ -27,6 +27,7 @@ object McpRegistrationOperations {
       InstallAgent.CODEX -> McpTomlConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
       InstallAgent.OPENCODE -> McpOpenCodeConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
       InstallAgent.JUNIE -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
+      InstallAgent.ZCODE -> McpJsonConfig.register(agent, configPathFor(installAgent, resolvedHome), command)
     }
   }
 
@@ -47,6 +48,7 @@ object McpRegistrationOperations {
       InstallAgent.CODEX -> McpTomlConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
       InstallAgent.OPENCODE -> McpOpenCodeConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
       InstallAgent.JUNIE -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
+      InstallAgent.ZCODE -> McpJsonConfig.unregister(agent, configPathFor(installAgent, resolvedHome))
     }
   }
 
@@ -56,6 +58,7 @@ object McpRegistrationOperations {
     InstallAgent.CODEX -> home.resolve(".codex/config.toml")
     InstallAgent.OPENCODE -> home.resolve(".config/opencode/opencode.json")
     InstallAgent.JUNIE -> home.resolve(".junie/mcp/mcp.json")
+    InstallAgent.ZCODE -> home.resolve(".zcode/mcp/mcp.json")
   }
 
   private fun claudeProfileConfigPaths(home: Path, environment: Map<String, String>): List<Path> {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/McpZcodeConfig.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/mcp/McpZcodeConfig.kt
@@ -1,0 +1,42 @@
+package skillbill.launcher.mcp
+
+import skillbill.install.model.McpMutationResult
+import java.nio.file.Path
+
+internal object McpZcodeConfig {
+  fun register(agent: String, path: Path, command: String): McpMutationResult {
+    val settings = readJsonObject(path).toMutableMap()
+    val mcp = mutableStringAnyMap(settings["mcp"])
+    val servers = mutableStringAnyMap(mcp["servers"])
+    servers["skill-bill"] = linkedMapOf(
+      "type" to "stdio",
+      "command" to command,
+      "args" to emptyList<String>(),
+    )
+    mcp["servers"] = servers
+    settings["mcp"] = mcp
+    writeJson(path, settings)
+    return McpMutationResult(agent, path, changed = true)
+  }
+
+  fun unregister(agent: String, path: Path): McpMutationResult {
+    val settings = readJsonObject(path).toMutableMap()
+    val mcp = mutableStringAnyMap(settings["mcp"])
+    val servers = mutableStringAnyMap(mcp["servers"])
+    val changed = servers.remove("skill-bill") != null
+    if (changed) {
+      if (servers.isEmpty()) {
+        mcp.remove("servers")
+      } else {
+        mcp["servers"] = servers
+      }
+      if (mcp.isEmpty()) {
+        settings.remove("mcp")
+      } else {
+        settings["mcp"] = mcp
+      }
+      writeJson(path, settings)
+    }
+    return McpMutationResult(agent, path, changed = changed)
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/nativeagent/rendering/NativeAgentRendering.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/nativeagent/rendering/NativeAgentRendering.kt
@@ -27,6 +27,10 @@ enum class NativeAgentProvider(
     override fun render(source: NativeAgentSource): String = renderFrontmatterAgent(source, mode = null)
     override fun homeAgentDirs(home: Path): List<Path> = listOf(home.resolve(".junie/agents"))
   },
+  Zcode("zcode-agents", "md") {
+    override fun render(source: NativeAgentSource): String = renderFrontmatterAgent(source, mode = null)
+    override fun homeAgentDirs(home: Path): List<Path> = listOf(home.resolve(".zcode/agents"))
+  },
   ;
 
   abstract fun render(source: NativeAgentSource): String

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/ScaffoldSupport.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/ScaffoldSupport.kt
@@ -98,7 +98,10 @@ internal val ORCHESTRATION_PLAYBOOKS: Map<String, String> =
   )
 
 internal val ORCHESTRATION_SIDECARS: Map<String, String> =
-  mapOf("shell-ceremony" to "orchestration/shell-content-contract/shell-ceremony.md")
+  mapOf(
+    "shell-ceremony" to "orchestration/shell-content-contract/shell-ceremony.md",
+    "peak-hours-warner" to "orchestration/shell-content-contract/peak-hours-warner.md",
+  )
 
 internal fun supportingFileTargets(repoRoot: Path): Map<String, Path> = mapOf(
   "review-scope.md" to repoRoot.resolve(ORCHESTRATION_PLAYBOOKS.getValue("review-scope")),
@@ -109,6 +112,7 @@ internal fun supportingFileTargets(repoRoot: Path): Map<String, Path> = mapOf(
   "telemetry-contract.md" to repoRoot.resolve(ORCHESTRATION_PLAYBOOKS.getValue("telemetry-contract")),
   "shell-content-contract.md" to repoRoot.resolve(ORCHESTRATION_PLAYBOOKS.getValue("shell-content-contract")),
   "shell-ceremony.md" to repoRoot.resolve(ORCHESTRATION_SIDECARS.getValue("shell-ceremony")),
+  "peak-hours-warner.md" to repoRoot.resolve(ORCHESTRATION_SIDECARS.getValue("peak-hours-warner")),
   "android-compose-implementation.md" to repoRoot.resolve(
     "platform-packs/kmp/addons/android-compose-implementation.md",
   ),

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/validation/AuthoredContentValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/validation/AuthoredContentValidator.kt
@@ -29,6 +29,7 @@ private val GENERATED_SUPPORT_POINTER_FILENAMES: Set<String> =
     "shell-content-contract.md",
     "review-orchestrator.md",
     "telemetry-contract.md",
+    "peak-hours-warner.md",
   )
 
 private val GENERATED_SUPPORT_POINTER_LINK_PATTERN =

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/skillremove/SkillRemoveJvmFileSystem.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/skillremove/SkillRemoveJvmFileSystem.kt
@@ -497,6 +497,7 @@ class SkillRemoveJvmFileSystem(
     AgentSymlinkProvider.CODEX -> NativeAgentProvider.Codex
     AgentSymlinkProvider.OPENCODE -> NativeAgentProvider.Opencode
     AgentSymlinkProvider.JUNIE -> NativeAgentProvider.Junie
+    AgentSymlinkProvider.ZCODE -> NativeAgentProvider.Zcode
   }
 
   /**

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallPlanContractCoverageTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallPlanContractCoverageTest.kt
@@ -110,6 +110,7 @@ class InstallPlanContractCoverageTest {
     Files.createDirectories(fixture.home.resolve(".codex"))
     Files.createDirectories(fixture.home.resolve(".config/opencode"))
     Files.createDirectories(fixture.home.resolve(".junie"))
+    Files.createDirectories(fixture.home.resolve(".zcode"))
     val before = snapshotTree(fixture.repoRoot)
 
     val plan = InstallOperations.planInstall(
@@ -127,6 +128,7 @@ class InstallPlanContractCoverageTest {
         fixture.home.resolve(".codex/skills"),
         fixture.home.resolve(".config/opencode/skills"),
         fixture.home.resolve(".junie/skills"),
+        fixture.home.resolve(".zcode/skills"),
       ),
       plan.agents.map { target -> target.path },
     )

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallPlanSchemaValidatesExistingFixturesTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallPlanSchemaValidatesExistingFixturesTest.kt
@@ -94,6 +94,7 @@ class InstallPlanSchemaValidatesExistingFixturesTest {
     Files.createDirectories(fixture.home.resolve(".codex"))
     Files.createDirectories(fixture.home.resolve(".config/opencode"))
     Files.createDirectories(fixture.home.resolve(".junie"))
+    Files.createDirectories(fixture.home.resolve(".zcode"))
     val plan = InstallOperations.planInstall(
       fixture.request(agentSelection = InstallAgentSelection(mode = InstallAgentSelectionMode.DETECTED)),
     )

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -849,7 +849,11 @@ class HeadlessAgentRunAdapterTest {
     // Every runtime-refused agent is absent (the AC), while the known runtime agents stay registered.
     // Asserting a subset rather than exact-set equality keeps this robust to unrelated future agents.
     RUNTIME_REFUSED_AGENTS.forEach { refused -> assertFalse(adapters.keys.contains(refused)) }
-    assertTrue(adapters.keys.containsAll(setOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE)))
+    assertTrue(
+      adapters.keys.containsAll(
+        setOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE, InstallAgent.ZCODE),
+      ),
+    )
   }
 
   @Test
@@ -875,20 +879,45 @@ class HeadlessAgentRunAdapterTest {
   }
 
   @Test
-  fun `claude codex and junie builders emit usePtyStdio=false`() {
+  fun `claude codex junie and zcode builders emit usePtyStdio=false`() {
     val runner = RecordingAgentRunProcessRunner()
     val request = phaseRunRequest()
     val adapters = headlessAgentRunAdapters(runner)
 
-    listOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE).forEach { agent ->
+    listOf(InstallAgent.CLAUDE, InstallAgent.CODEX, InstallAgent.JUNIE, InstallAgent.ZCODE).forEach { agent ->
       requireNotNull(adapters[agent]).launch(request)
     }
 
     val otherRequests = runner.requests
-    assertTrue(otherRequests.size == 3)
+    assertTrue(otherRequests.size == 4)
     otherRequests.forEach { req ->
       assertFalse(req.usePtyStdio, "non-opencode agent must not request PTY-backed stdio")
     }
+  }
+
+  @Test
+  fun `zcode builder emits the expected command shape`() {
+    val runner = RecordingAgentRunProcessRunner()
+    val request = phaseRunRequest()
+    val adapters = headlessAgentRunAdapters(runner)
+
+    requireNotNull(adapters[InstallAgent.ZCODE]).launch(request)
+
+    val command = runner.requests.single().command
+    assertEquals(
+      listOf(
+        "zcode",
+        "--prompt",
+        "Phase: preplan",
+        "--json",
+        "--cwd",
+        request.repoRoot.toString(),
+        "--mode",
+        "yolo",
+        "--no-color",
+      ),
+      command,
+    )
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -921,6 +921,26 @@ class HeadlessAgentRunAdapterTest {
   }
 
   @Test
+  fun `zcode launch unwraps json response envelope`() {
+    val runner = RecordingAgentRunProcessRunner(
+      result = AgentRunProcessResult(
+        exitStatus = 0,
+        stdout = """{"sessionId":"sess_test","traceId":"trace_test","response":"phase-output"}""",
+        stderr = "",
+        timedOut = false,
+        interrupted = false,
+        spawnFailed = false,
+      ),
+    )
+    val request = phaseRunRequest()
+    val adapters = headlessAgentRunAdapters(runner)
+
+    val outcome = requireNotNull(adapters[InstallAgent.ZCODE]).launch(request)
+
+    assertEquals("phase-output", outcome.stdout)
+  }
+
+  @Test
   fun `process adapter threads usePtyStdio=false into the process request for supported agents`() {
     val runner = RecordingAgentRunProcessRunner()
     val request = phaseRunRequest()

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/McpRegistrationOperationsTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/McpRegistrationOperationsTest.kt
@@ -190,6 +190,7 @@ class McpRegistrationOperationsTest {
       "codex" to home.resolve(".codex/config.toml"),
       "opencode" to home.resolve(".config/opencode/opencode.json"),
       "junie" to home.resolve(".junie/mcp/mcp.json"),
+      "zcode" to home.resolve(".zcode/cli/config.json"),
       "copilot" to home.resolve(".copilot/mcp-config.json"),
       "glm" to home.resolve(".glm/mcp-config.json"),
     )

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/SkillClassLoaderTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/SkillClassLoaderTest.kt
@@ -35,7 +35,9 @@ private val LEGACY_POINTER_GOLDEN: Map<String, Set<String>> = mapOf(
   ),
   "bill-code-check" to setOf("stack-routing.md", "telemetry-contract.md", "shell-ceremony.md"),
   "bill-pr-description" to setOf("shell-ceremony.md", "telemetry-contract.md"),
+  "bill-feature" to setOf("peak-hours-warner.md"),
   "bill-feature-task" to setOf(
+    "peak-hours-warner.md",
     "shell-ceremony.md",
     "telemetry-contract.md",
     "android-compose-implementation.md",
@@ -46,6 +48,9 @@ private val LEGACY_POINTER_GOLDEN: Map<String, Set<String>> = mapOf(
     "android-compose-edge-to-edge.md",
     "android-compose-adaptive-layouts.md",
   ),
+  "bill-feature-task-runtime" to setOf("peak-hours-warner.md"),
+  "bill-feature-task-prose" to setOf("peak-hours-warner.md"),
+  "bill-feature-task-subtask-runner" to setOf("peak-hours-warner.md"),
   "bill-feature-verify" to setOf("shell-ceremony.md", "telemetry-contract.md"),
 )
 

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/model/InstallPortModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/install/model/InstallPortModels.kt
@@ -12,6 +12,7 @@ enum class NativeAgentLinkProvider {
   CODEX,
   OPENCODE,
   JUNIE,
+  ZCODE,
 }
 
 data class NativeAgentLinkOverrides(

--- a/scripts/agent_install_smoke_test.sh
+++ b/scripts/agent_install_smoke_test.sh
@@ -4,7 +4,7 @@
 # MCP registration did not fail. Reuses the already-installed runtime (no download) and
 # never touches the caller's real agent directories.
 #
-# Usage: scripts/agent_install_smoke_test.sh [agent ...]   (default: all five)
+# Usage: scripts/agent_install_smoke_test.sh [agent ...]   (default: all six)
 #   SKILL_BILL_BIN, SKILL_BILL_RUNTIME_ROOT override discovery.
 set -uo pipefail
 
@@ -12,7 +12,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="${SKILL_BILL_BIN:-$HOME/.local/bin/skill-bill}"
 RUNTIME_ROOT="${SKILL_BILL_RUNTIME_ROOT:-$HOME/.skill-bill/runtime}"
 MCP_BIN="$RUNTIME_ROOT/runtime-mcp/bin/runtime-mcp"
-if [[ $# -gt 0 ]]; then AGENTS=("$@"); else AGENTS=(copilot claude codex opencode junie); fi
+if [[ $# -gt 0 ]]; then AGENTS=("$@"); else AGENTS=(copilot claude codex opencode junie zcode); fi
 
 [[ -x "$BIN" ]] || { echo "FATAL: skill-bill not executable at $BIN" >&2; exit 2; }
 [[ -d "$RUNTIME_ROOT" ]] || { echo "FATAL: no installed runtime at $RUNTIME_ROOT (run ./install.sh first)" >&2; exit 2; }
@@ -30,6 +30,7 @@ for agent in "${AGENTS[@]}"; do
     codex)    mkdir -p "$FAKE/.codex" ;;
     opencode) mkdir -p "$FAKE/.config/opencode" ;;
     junie)    mkdir -p "$FAKE/.junie" ;;
+    zcode)    mkdir -p "$FAKE/.zcode" ;;
   esac
 
   echo "── $agent ──────────────────────────────────────────────"

--- a/scripts/install_smoke_test.sh
+++ b/scripts/install_smoke_test.sh
@@ -154,6 +154,7 @@ case "$cmd" in
         ;;
       opencode) echo "$effective_home/.config/opencode/skills" ;;
       junie)    echo "$effective_home/.junie/skills" ;;
+      zcode)    echo "$effective_home/.zcode/skills" ;;
       *) echo "unknown agent: $agent" >&2; exit 1 ;;
     esac
     ;;
@@ -347,7 +348,7 @@ FAKE_HOME="$(mktemp -d)"
 INTERACTIVE_OUTPUT="$(run_interactive_install_with_blank_defaults "$FAKE_HOME")"
 pass "interactive install with blank defaults exited 0"
 
-if [[ "$INTERACTIVE_OUTPUT" == *"Agents:         copilot, claude, codex, opencode, junie"* ]]; then
+if [[ "$INTERACTIVE_OUTPUT" == *"Agents:         copilot, claude, codex, opencode, junie, zcode"* ]]; then
   pass "blank agent selection defaults to all when none detected"
 else
   fail "blank agent selection summary unexpected"
@@ -365,7 +366,7 @@ FAKE_HOME="$(mktemp -d)"
 PIPED_OUTPUT="$(run_piped_install_with_eof_defaults "$FAKE_HOME")"
 pass "piped install with EOF defaults exited 0"
 
-if [[ "$PIPED_OUTPUT" == *"Agents:         copilot, claude, codex, opencode, junie"* ]]; then
+if [[ "$PIPED_OUTPUT" == *"Agents:         copilot, claude, codex, opencode, junie, zcode"* ]]; then
   pass "piped EOF agent selection defaults to all when none detected"
 else
   fail "piped EOF agent selection summary unexpected"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -543,6 +543,7 @@ remove_from_agent_dir "codex" "$HOME/.codex/skills"
 remove_from_agent_dir "codex" "$HOME/.agents/skills"
 remove_from_agent_dir "opencode" "$HOME/.config/opencode/skills"
 remove_from_agent_dir "junie" "$HOME/.junie/skills"
+remove_from_agent_dir "zcode" "$HOME/.zcode/skills"
 
 remove_codex_agents_tomls() {
   # Uninstall Codex native subagent TOML symlinks from both candidate
@@ -634,8 +635,30 @@ remove_junie_agent_mds() {
 info "Removing Junie subagent markdown installs."
 remove_junie_agent_mds
 
+remove_zcode_agent_mds() {
+  # Uninstall zcode native subagent markdown symlinks from ~/.zcode/agents.
+  # The source discovery walks governed platform-pack and skill zcode-agents/*.md
+  # definitions and is independent from other agent setup choices.
+  local output
+  output="$(run_runtime_cli install unlink-zcode-agents \
+    --platform-packs "$PLATFORM_PACKS_DIR" \
+    --skills "$SKILLS_DIR")"
+  if [[ -z "$output" ]]; then
+    info "  nothing to remove"
+    return 0
+  fi
+  while IFS= read -r link_path; do
+    [[ -n "$link_path" ]] || continue
+    REMOVED_TARGETS+=("$link_path")
+    ok "  removed $(basename "$link_path")"
+  done <<< "$output"
+}
+
+info "Removing zcode subagent markdown installs."
+remove_zcode_agent_mds
+
 info "Removing MCP server registrations."
-for agent in claude copilot codex glm opencode junie; do
+for agent in claude copilot codex glm opencode junie zcode; do
   if mcp_output="$(run_runtime_cli install unregister-mcp "$agent" 2>/dev/null)"; then
     ok "  removed skill-bill MCP server ($agent)"
     while IFS= read -r profile_path; do


### PR DESCRIPTION
Goal: zcode-agent-support

Subtasks:
- 1. Foundation: enums & install-path detection (6b90a02a5196d8a1ac5f07368c1e5d1d2018079b)
- 2. Native-agent linking, MCP registration, runtime command builder (2926f3fa8ffbba8eb10dc297cb8fb9dbef52a986)
- 3. CLI commands, shell scripts, schema (2bdb4343b39d0413facab584401394b8587d28bd)

Follow-up:
- Add reusable peak-hours warning sidecar for feature launch skills.
- Warn during Z.AI/GLM peak hours, treating zcode as GLM and requiring explicit GLM model metadata for opencode/other agents.

Validation:
- ./gradlew :runtime-infra-fs:test --tests skillbill.scaffold.SkillClassLoaderTest --tests skillbill.scaffold.RepoValidationRuntimeTest
- skill-bill validate
- scripts/validate_agent_configs
- git diff --check
- ./install.sh