### PR TITLE
SKILL-101 surface external add-ons in desktop nav

### DIFF
--- a/.feature-specs/SKILL-101-desktop-external-addons-in-nav-tree/spec.md
+++ b/.feature-specs/SKILL-101-desktop-external-addons-in-nav-tree/spec.md
@@ -1,0 +1,160 @@
+---
+status: Complete
+issue_key: SKILL-101
+source: inline user request in Claude Code session (desktop external-addons feature)
+---
+
+# SKILL-101: Surface external add-ons in the desktop navigation tree
+
+## Problem
+
+The Skill Bill desktop app never reads `external_addon_sources` from
+`~/.config/skill-bill/config.json`. That config is consumed only by the
+install/CLI overlay path (`ExternalAddonOverlayService`,
+`FileExternalAddonSourceConfigStore`). The nav tree's "Add-ons" group is built
+solely by `SkillTreeBuilder.loadAddons` →
+`RepoSourceDiscoveryService.discoverGovernedAddonFiles(root)`, which scans
+`<root>/platform-packs/*/addons/` and hard-labels every hit "Pack-owned add-on
+source."
+
+As a result, a user who registers a private external add-on source (for
+example a Capmo add-on directory declared for platform `ios`) has no way to see
+or edit those add-ons from the desktop app:
+
+- Browsing the **source repo**, external add-ons never appear — they live in a
+  separate configured directory outside `platform-packs/`.
+- Browsing the **installed workspace**, the overlaid copies appear but are
+  indistinguishable from pack-owned add-ons, and editing them there is futile
+  because `./install.sh` regenerates that directory on the next install.
+
+## Goal
+
+Make external add-on sources first-class in the desktop nav tree: read them
+from config, show them inside the existing "Add-ons" group under their target
+platform, mark them clearly as external with an "EXT" badge, and make them
+editable at their source location so edits persist across installs.
+
+## Decisions (confirmed with the user)
+
+1. **Approach:** browse the external source directories declared in config;
+   list each source directory's top-level `.md` files; edit them at source.
+2. **Placement:** merge into the existing "Add-ons" group, grouped by target
+   platform, each external item carrying an "EXT" badge. No new top-level tree
+   group.
+3. **Visibility:** show whenever config declares sources, independent of which
+   repo/workspace is currently open.
+
+## Proposed solution
+
+### 1. Expose an external-source resolver to the desktop data layer
+
+Reuse the existing resolver rather than re-parsing config:
+`ExternalAddonOverlayService.resolveSources(home, environment): List<ExternalAddonSource(path, platform)>`,
+reachable via `RuntimeComponent.externalAddonOverlayService`.
+
+In `DesktopRuntimeApplicationServices`
+(`runtime-desktop/core/data/.../di/DesktopRuntimeApplicationServices.kt`):
+add `externalAddonOverlayService` to the service bundle and expose
+`resolveExternalAddonSources(): List<ExternalAddonSource>` that delegates to it
+with `currentUserHome()` + `System.getenv()`.
+
+### 2. Add a testable seam
+
+Add an overridable `externalAddonSourcesResolver: () -> List<ExternalAddonSource>`
+on `RepoBrowserStore`, defaulting to `runtimeServices.resolveExternalAddonSources()`
+— mirroring the existing `baselineModifiedResolver` / `authoringSaver` /
+`sourceFileSaver` seams. Expose it on `RuntimeRepoBrowserService` the same way
+those seams are exposed. `RuntimeRepoSessionService.open()` passes the resolver
+into `SkillTreeBuilder.buildTree`. This lets tests inject a temp source
+directory instead of reading the real machine config.
+
+### 3. Merge external add-ons into the tree
+
+In `SkillTreeBuilder.loadAddons`, after pack-owned add-ons are gathered:
+
+- Resolve external sources via the seam, wrapped in `runCatching { … }.getOrDefault(emptyList())`
+  so a malformed/unreadable external config fails soft (external add-ons are
+  skipped; the pack-owned tree still loads).
+- For each source directory that exists, list its top-level `*.md` files and
+  build a `SkillBillTreeItem` per file: `kind = ADD_ON`, `editable = true`,
+  `external = true`, `contentFile` = the source `.md`, selection `detail` =
+  `"External add-on source (from <dir>)."`, placed under the `source.platform`
+  sub-group inside "Add-ons".
+- **Dedup:** when an external `(platform, slug)` matches a discovered pack-owned
+  add-on (the overlaid copy present in the installed workspace), keep the
+  external entry (the editable source of truth) and drop the pack-owned
+  duplicate, so each logical add-on shows exactly once.
+
+### 4. Domain model
+
+Add `external: Boolean = false` to `SkillBillTreeItem` in
+`runtime-desktop/core/domain/.../model/SkillBillModels.kt`.
+
+### 5. UI badge
+
+In `SkillBillNavTree`, render an "EXT" caption badge on the row when
+`node.external` is true, mirroring the existing `readOnlyLabel` caption slot and
+using `SkillBillTheme.frameTokens.primary` so it reads as a distinct provenance
+marker rather than a status.
+
+## Acceptance Criteria
+
+1. The desktop app resolves `external_addon_sources` through the existing
+   `ExternalAddonOverlayService.resolveSources` resolver; no config-parsing
+   logic is duplicated in the desktop layer.
+2. For each declared external source directory, its top-level `*.md` files
+   appear under their target-platform sub-group inside the existing "Add-ons"
+   group, each with `external = true` on the tree item.
+3. An external add-on item is editable and its editor targets the external
+   source `.md` file (its `contentFile`/`authoredPath` is the source path, not
+   an overlaid installed copy).
+4. When an external `(platform, slug)` matches a discovered pack-owned add-on,
+   the external entry is kept and the pack-owned duplicate is dropped, so the
+   add-on appears exactly once under that platform group.
+5. A malformed or unreadable external add-on config does not blank or fail the
+   tree: external add-ons are skipped and the pack-owned tree still loads.
+6. The nav tree row renders an "EXT" badge when, and only when, the item is
+   external.
+7. `RuntimeRepoBrowserServiceTest` covers, via the resolver seam and a temp
+   source directory: an external add-on appearing under its platform group with
+   `external = true` and editable, and the dedup dropping an overlaid pack-owned
+   duplicate. Existing add-on tests continue to pass.
+
+## Non-goals / constraints
+
+- Do not modify the install/CLI overlay path or the `external_addon_sources`
+  config schema.
+- Do not introduce a new top-level tree group; external add-ons live inside the
+  existing "Add-ons" group.
+- Do not make the overlaid installed copies editable-as-external — the feature
+  browses and edits the external **source**, not the overlaid copy.
+
+## Validation strategy
+
+- Unit tests in
+  `runtime-desktop/core/data/src/jvmTest/.../RuntimeRepoBrowserServiceTest.kt`
+  using the new resolver seam (external add-on visibility, `external` flag,
+  editability, source-path targeting, and dedup).
+- Module build + test for the touched Gradle modules
+  (`runtime-desktop/core/domain`, `runtime-desktop/core/data`,
+  `runtime-desktop/feature/skillbill`).
+- Manual smoke: with the real `~/.config/skill-bill/config.json` external source
+  registered, open the app and confirm the external add-ons show under
+  "Add-ons" with the EXT badge and open the source file for editing.
+
+## Affected files (expected)
+
+- `runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillBillModels.kt`
+- `runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt`
+- `runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RepoBrowserStore.kt`
+- `runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoSessionService.kt`
+- `runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/SkillTreeBuilder.kt`
+- `runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserService.kt`
+- `runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillNavTree.kt`
+- `runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserServiceTest.kt`
+
+## Next path
+
+```bash
+Run bill-feature-task on .feature-specs/SKILL-101-desktop-external-addons-in-nav-tree/spec.md
+```

--- a/platform-packs/ios/code-review/bill-ios-code-review-platform-correctness/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-platform-correctness/content.md
@@ -36,6 +36,9 @@ Use this specialist wherever the project's unidirectional-data-flow pattern (a `
 - Coordinate or unit values conflated between normalized (0–1) and raw/pixel ranges — including omitted axis offsets — produce visibly wrong placement and are a correctness bug, not a rounding detail
 - Inverted, redundant, or always-true/always-false guard and boolean logic makes a conditional behave opposite to its intent or go permanently dead; scrutinize refactored conditionals for this
 - Force-unwrap or `.require()` applied to state that can legitimately be nil at runtime crashes the app instead of gracefully guarding the expected absent-state case
+- `@Observable`-conforming state that a view creates and owns must be held with `@State`, never `let` or a plain stored property; without `@State`, SwiftUI can recreate the instance across a parent redraw and silently discard accumulated state
+- Any iOS 26-only API (Liquid Glass `glassEffect`/`GlassEffectContainer`/`.glass`/`.glassProminent` button styles, or other iOS 26+-only surface) added to a diff must be gated behind `#available(iOS 26, *)` with a working fallback path, unless the project's minimum deployment target is already iOS 26+
+- `.animation(_:value:)` must always specify a `value` argument; the value-less `.animation(_:)` overload is deprecated and animates every state change in scope, not just the one the diff intends to animate
 - For Major or Critical findings, describe the concrete race, stale-state, or main-thread-violation scenario a user or crash report would surface
 
 ## Repo-Local Knowledge

--- a/platform-packs/ios/code-review/bill-ios-code-review-ui/content.md
+++ b/platform-packs/ios/code-review/bill-ios-code-review-ui/content.md
@@ -27,4 +27,11 @@ Review only UI correctness and framework-usage issues that can break the rendere
 - Conditional rendering must preserve state-machine correctness across loading, success, empty, and error states
 - Snapshot baseline updates committed with a UI change must correspond to an intentional, reviewed visual change described in the diff — an unexplained snapshot update alongside unrelated logic changes is a red flag
 - Reusable components should be added to or reused from the shared component library rather than duplicated per-feature when the same visual pattern already exists elsewhere
+- `ForEach` over dynamic content must use stable identity (`Identifiable` conformance or a stable key path), never `.indices` — index-based identity can crash or silently show stale rows when the underlying collection is mutated. An `Identifiable` `id` must also be genuinely unique per element (not derived from a field like a URL or title that can repeat), and every element must render the same number of views from the row builder — a conditional that produces a different view count per row breaks diffing and can misrender or crash
 - In findings, explain the rendered or interactive behavior a user would actually experience
+
+## SwiftUI framework-version correctness
+
+- A version-gated SwiftUI API used **without** an `if #available` / `@available` guard *and* a working fallback path is a crash or blank render on the OS versions that lack it — flag as a real correctness finding, not a style note. This covers newly introduced APIs the diff adopts (e.g. `glassEffect`/`GlassEffectContainer` and other iOS 26 surfaces, `Chart3D`, the `@Animatable` macro, phase/keyframe animators) against the module's declared deployment target.
+- `.animation(_:)` applied without the `value:` parameter (the deprecated implicit form) re-animates on every surrounding change and is a behavior risk; the fix is `.animation(_:value:)`.
+- Deprecated-but-functional SwiftUI APIs introduced fresh by the diff (`foregroundColor`→`foregroundStyle`, `navigationBarItems`/`navigationBarTitle`→`toolbar`/`navigationTitle`, `alert(isPresented:content:)`→`alert(_:isPresented:actions:)`, `cornerRadius`→`clipShape(.rect(cornerRadius:))`, `edgesIgnoringSafeArea`→`ignoresSafeArea`) are a low-severity consistency nit — report only when the change adds them, never as a Blocker.

--- a/runtime-kotlin/runtime-desktop/core/data/agent/history.md
+++ b/runtime-kotlin/runtime-desktop/core/data/agent/history.md
@@ -1,5 +1,14 @@
 # core/data — history
 
+## [2026-07-04] SKILL-101 desktop external add-ons in nav tree
+Areas: runtime-desktop/core/data, runtime-desktop/core/domain, runtime-desktop/feature/skillbill
+- Desktop repo browsing now resolves external_addon_sources via ExternalAddonOverlayService through a testable resolver seam; core/data does not parse config directly.
+- SkillTreeBuilder merges top-level external source .md files into the existing Add-ons platform groups, marks them editable/external, targets the source path for authored content, and keeps pack-owned rows when external resolution fails.
+- Dedup rule: external (platform, slug) wins over an overlaid pack-owned duplicate, so installed workspace browsing shows one editable source-of-truth row. reusable
+- Domain tree items carry external provenance and the SkillBill nav row renders the EXT badge only from that flag.
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented
+
 ## [2026-06-11] SKILL-79 git/validate/render gateway impls deleted
 Areas: runtime-desktop/core/data, runtime-desktop/core/domain, runtime-desktop/core/testing
 - Deleted RuntimeGitGateway (~1564 lines), RuntimePrPublishingGateway, JvmInstalledWorkspaceGitProvisioner, mapper/ValidationSummaryMapper, and their tests; dropped all four gateway/provisioner @Provides bindings from JvmDataBindings and the matching fakes from core/testing FakeSkillBillServices (FakeInstalledWorkspaceGitProvisioner removed).

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/di/DesktopRuntimeApplicationServices.kt
@@ -1,6 +1,7 @@
 package skillbill.desktop.core.data.di
 
 import me.tatarka.inject.annotations.Inject
+import skillbill.application.install.ExternalAddonOverlayService
 import skillbill.application.install.InstallService
 import skillbill.application.scaffold.InstallAgentService
 import skillbill.application.scaffold.RepoSourceDiscoveryService
@@ -11,6 +12,7 @@ import skillbill.application.scaffold.SkillRemoveService
 import skillbill.desktop.core.common.di.UserScope
 import skillbill.di.RuntimeComponent
 import skillbill.di.create
+import skillbill.install.model.ExternalAddonSource
 import skillbill.model.RuntimeContext
 import skillbill.ports.install.baseline.InstalledWorkspaceBaselineStatusPort
 import skillbill.ports.install.selection.InstallSelectionPersistencePort
@@ -51,6 +53,9 @@ class DesktopRuntimeApplicationServices {
   val installedWorkspaceBaselineStatusPort: InstalledWorkspaceBaselineStatusPort
     get() = services.installedWorkspaceBaselineStatusPort
 
+  fun resolveExternalAddonSources(): List<ExternalAddonSource> =
+    services.externalAddonOverlayService.resolveSources(currentUserHome(), System.getenv())
+
   companion object {
     fun forCurrentUserHome(): DesktopRuntimeApplicationServices = DesktopRuntimeApplicationServices()
   }
@@ -82,6 +87,7 @@ private data class DesktopRuntimeApplicationServiceBundle(
   val repoValidationService: RepoValidationService,
   val skillRemoveService: SkillRemoveService,
   val installedWorkspaceBaselineStatusPort: InstalledWorkspaceBaselineStatusPort,
+  val externalAddonOverlayService: ExternalAddonOverlayService,
 )
 
 private fun buildDesktopRuntimeApplicationServices(home: Path): DesktopRuntimeApplicationServiceBundle {
@@ -93,6 +99,7 @@ private fun buildDesktopRuntimeApplicationServices(home: Path): DesktopRuntimeAp
     repoValidationService = component.repoValidationService,
     skillRemoveService = component.skillRemoveService,
     installedWorkspaceBaselineStatusPort = component.installedWorkspaceBaselineStatusPort,
+    externalAddonOverlayService = component.externalAddonOverlayService,
   )
 }
 

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RepoBrowserStore.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RepoBrowserStore.kt
@@ -5,6 +5,7 @@ import skillbill.desktop.core.common.di.UserScope
 import skillbill.desktop.core.data.di.DesktopRuntimeApplicationServices
 import skillbill.desktop.core.domain.model.RepoSession
 import skillbill.desktop.core.domain.service.InstalledWorkspaceBaselineService
+import skillbill.install.model.ExternalAddonSource
 import skillbill.ports.scaffold.source.model.ScaffoldSaveExactContentResult
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import java.nio.file.Files
@@ -30,6 +31,9 @@ class RepoBrowserStore(
   }
   var baselineModifiedResolver: (Path) -> Set<String> = { root ->
     installedWorkspaceBaselineService.modifiedSkillRelativePaths(root.toString())
+  }
+  var externalAddonSourcesResolver: () -> List<ExternalAddonSource> = {
+    runtimeServices.resolveExternalAddonSources()
   }
 
   internal fun selectionFor(session: RepoSession?, treeItemId: String?): SelectionDetail? {

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserService.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserService.kt
@@ -9,6 +9,7 @@ import skillbill.desktop.core.domain.model.SkillBillTreeItem
 import skillbill.desktop.core.domain.service.AuthoringGateway
 import skillbill.desktop.core.domain.service.RepoSessionService
 import skillbill.desktop.core.domain.service.SkillTreeService
+import skillbill.install.model.ExternalAddonSource
 import skillbill.ports.scaffold.source.model.ScaffoldSaveExactContentResult
 import java.nio.file.Path
 
@@ -40,6 +41,12 @@ class RuntimeRepoBrowserService(
     get() = store.baselineModifiedResolver
     set(value) {
       store.baselineModifiedResolver = value
+    }
+
+  internal var externalAddonSourcesResolver: () -> List<ExternalAddonSource>
+    get() = store.externalAddonSourcesResolver
+    set(value) {
+      store.externalAddonSourcesResolver = value
     }
 
   override fun open(repoPath: String): RepoSession = repoSessionService.open(repoPath)

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoSessionService.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/RuntimeRepoSessionService.kt
@@ -39,7 +39,9 @@ class RuntimeRepoSessionService(
     }
 
     val tree =
-      runCatching { treeBuilder.buildTree(root, store.baselineModifiedResolver) }
+      runCatching {
+        treeBuilder.buildTree(root, store.baselineModifiedResolver, store.externalAddonSourcesResolver)
+      }
         .getOrElse { error ->
           val invalidStatus =
             status.copy(

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/SkillTreeBuilder.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmMain/kotlin/skillbill/desktop/core/data/service/SkillTreeBuilder.kt
@@ -6,7 +6,10 @@ import skillbill.desktop.core.domain.model.GeneratedArtifactDetail
 import skillbill.desktop.core.domain.model.SkillBillTreeItem
 import skillbill.desktop.core.domain.model.SkillBillTreeItemMetadata
 import skillbill.desktop.core.domain.model.TreeItemKind
+import skillbill.install.model.ExternalAddonSource
 import skillbill.ports.scaffold.model.NativeAgentSourceProjection
+import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.nio.file.Path
 
 internal class SkillTreeBuilder(
@@ -15,11 +18,15 @@ internal class SkillTreeBuilder(
   private val scaffoldService get() = runtimeServices.scaffoldService
   private val repoSourceDiscoveryService get() = runtimeServices.repoSourceDiscoveryService
 
-  fun buildTree(root: Path, baselineModifiedResolver: (Path) -> Set<String>): TreeBuildResult {
+  fun buildTree(
+    root: Path,
+    baselineModifiedResolver: (Path) -> Set<String>,
+    externalAddonSourcesResolver: () -> List<ExternalAddonSource>,
+  ): TreeBuildResult {
     val repoToken = repoToken(root)
     val selections = linkedMapOf<String, SelectionDetail>()
     val authoredSkills = loadAuthoredSkills(root, repoToken, selections, baselineModifiedResolver)
-    val addons = loadAddons(root, repoToken, selections)
+    val addons = loadAddons(root, repoToken, selections, externalAddonSourcesResolver)
     val nativeAgents = loadNativeAgents(root, repoToken, selections)
     val generatedArtifacts = loadGeneratedArtifacts(root, repoToken, selections)
 
@@ -114,10 +121,47 @@ internal class SkillTreeBuilder(
     root: Path,
     repoToken: String,
     selections: MutableMap<String, SelectionDetail>,
+    externalAddonSourcesResolver: () -> List<ExternalAddonSource>,
   ): List<SkillBillTreeItem> {
     val addonsByPlatform = linkedMapOf<String, MutableList<SkillBillTreeItem>>()
+    val externalAddonKeys = linkedSetOf<AddonKey>()
+    runCatching { externalAddonSourcesResolver() }.getOrDefault(emptyList()).forEach { source ->
+      source.topLevelMarkdownFiles().forEach { addon ->
+        val platform = source.platform
+        val slug = addon.fileName.toString().removeSuffix(".md")
+        val key = AddonKey(platform, slug)
+        if (externalAddonKeys.add(key)) {
+          val authoredPath = relativePath(root, addon)
+          val id = selectionId(repoToken, "addon-external:$platform:${addon.stableSourcePath()}")
+          selections[id] =
+            SelectionDetail(
+              repoToken = repoToken,
+              title = addon.fileName.toString(),
+              detail = "External add-on source from ${source.path}.",
+              kind = "add-on",
+              authoredPath = authoredPath,
+              status = "authored",
+              contentFile = addon,
+              editable = true,
+            )
+          addonsByPlatform.getOrPut(platform) { mutableListOf() } += SkillBillTreeItem(
+            id = id,
+            label = slug,
+            kind = TreeItemKind.ADD_ON,
+            authoredPath = authoredPath,
+            status = "authored",
+            editable = true,
+            external = true,
+            metadata = SkillBillTreeItemMetadata(kind = "add-on", platform = platform),
+          )
+        }
+      }
+    }
     repoSourceDiscoveryService.discoverGovernedAddonFiles(root)
       .forEach { addonFile ->
+        if (AddonKey(addonFile.packSlug, addonFile.addonSlug) in externalAddonKeys) {
+          return@forEach
+        }
         val addon = addonFile.addonPath
         val relative = relativePath(root, addon)
         val id = selectionId(repoToken, "addon:$relative")
@@ -318,6 +362,23 @@ internal class SkillTreeBuilder(
       }
   }
 }
+
+private data class AddonKey(
+  val platform: String,
+  val slug: String,
+)
+
+private fun ExternalAddonSource.topLevelMarkdownFiles(): List<Path> = runCatching {
+  Files.list(path).use { paths ->
+    paths
+      .filter { file -> Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS) }
+      .filter { file -> file.fileName.toString().endsWith(".md") }
+      .sorted(Comparator { left, right -> left.fileName.toString().compareTo(right.fileName.toString()) })
+      .toList()
+  }
+}.getOrDefault(emptyList())
+
+private fun Path.stableSourcePath(): String = toAbsolutePath().normalize().toString().replace('\\', '/')
 
 private data class NativeAgentTreeLeaf(
   val groupPath: List<String>,

--- a/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserServiceTest.kt
+++ b/runtime-kotlin/runtime-desktop/core/data/src/jvmTest/kotlin/skillbill/desktop/core/data/service/RuntimeRepoBrowserServiceTest.kt
@@ -4,6 +4,7 @@ import skillbill.desktop.core.domain.model.RepoLoadState
 import skillbill.desktop.core.domain.model.RepoSession
 import skillbill.desktop.core.domain.model.TreeItemKind
 import skillbill.error.SkillBillRuntimeException
+import skillbill.install.model.ExternalAddonSource
 import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -215,6 +216,65 @@ class RuntimeRepoBrowserServiceTest {
     assertFalse(nativeAgentResult.success)
     assertTrue(nativeAgentResult.runtimeErrorMessage.orEmpty().contains("Only governed content.md files and add-ons"))
     assertEquals(nativeAgentBefore, Files.readString(repo.resolve("skills/bill-alpha/native-agents/alpha-agent.md")))
+  }
+
+  @Test
+  fun `external add-on appears under platform group and saves to external source`() {
+    val repo = seedRepo("external-addon-visible")
+    val externalDir = Files.createTempDirectory("skillbill-desktop-external-addons")
+    val externalAddon = externalDir.resolve("observability.md")
+    Files.writeString(externalAddon, "# Observability\n\nExternal guidance.\n")
+    val service = RuntimeRepoBrowserService()
+    service.externalAddonSourcesResolver = { listOf(ExternalAddonSource(externalDir, "kotlin")) }
+    val session = service.open(repo.toString())
+
+    val addonGroup = service.treeFor(session).single { it.kind == TreeItemKind.GROUP && it.label == "Add-ons" }
+    val kotlinAddons = addonGroup.children.single { it.kind == TreeItemKind.GROUP && it.label == "kotlin" }
+    val externalItem = kotlinAddons.children.single { it.label == "observability" }
+    val document = service.loadDocument(session, externalItem.id)
+    val saveResult = service.saveDocument(session, externalItem.id, "# Observability\n\nUpdated external guidance.\n")
+
+    assertTrue(externalItem.external)
+    assertTrue(externalItem.editable)
+    assertEquals(TreeItemKind.ADD_ON, externalItem.kind)
+    assertTrue(document.editable)
+    assertEquals(externalAddon.toString(), document.authoredPath)
+    assertTrue(document.text.contains("External guidance."))
+    assertTrue(saveResult.success, saveResult.runtimeErrorMessage.orEmpty())
+    assertTrue(Files.readString(externalAddon).contains("Updated external guidance."))
+  }
+
+  @Test
+  fun `external add-on duplicate drops pack-owned add-on from tree`() {
+    val repo = seedRepo("external-addon-dedup")
+    val externalDir = Files.createTempDirectory("skillbill-desktop-external-addons-dedup")
+    Files.writeString(externalDir.resolve("tracing-otel.md"), "# External tracing\n")
+    val service = RuntimeRepoBrowserService()
+    service.externalAddonSourcesResolver = { listOf(ExternalAddonSource(externalDir, "kotlin")) }
+    val session = service.open(repo.toString())
+
+    val addonGroup = service.treeFor(session).single { it.kind == TreeItemKind.GROUP && it.label == "Add-ons" }
+    val kotlinAddons = addonGroup.children.single { it.kind == TreeItemKind.GROUP && it.label == "kotlin" }
+    val tracingItems = kotlinAddons.children.filter { it.label == "tracing-otel" }
+
+    assertEquals(1, tracingItems.size)
+    assertTrue(tracingItems.single().external)
+  }
+
+  @Test
+  fun `external add-on resolver failure keeps pack-owned tree visible`() {
+    val repo = seedRepo("external-addon-resolver-failure")
+    val service = RuntimeRepoBrowserService()
+    service.externalAddonSourcesResolver = { throw IllegalStateException("bad external config") }
+
+    val session = service.open(repo.toString())
+    val addonGroup = service.treeFor(session).single { it.kind == TreeItemKind.GROUP && it.label == "Add-ons" }
+    val kotlinAddons = addonGroup.children.single { it.kind == TreeItemKind.GROUP && it.label == "kotlin" }
+    val packOwned = kotlinAddons.children.single { it.label == "tracing-otel" }
+
+    assertEquals(RepoLoadState.LOADED, session.loadStatus.state, session.loadStatus.message)
+    assertFalse(packOwned.external)
+    assertTrue(packOwned.editable)
   }
 
   @Test

--- a/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillBillModels.kt
+++ b/runtime-kotlin/runtime-desktop/core/domain/src/commonMain/kotlin/skillbill/desktop/core/domain/model/SkillBillModels.kt
@@ -59,6 +59,7 @@ data class SkillBillTreeItem(
   val metadata: SkillBillTreeItemMetadata? = null,
   val baselineModified: Boolean = false,
   val children: List<SkillBillTreeItem> = emptyList(),
+  val external: Boolean = false,
 )
 
 enum class TreeItemKind {

--- a/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillNavTree.kt
+++ b/runtime-kotlin/runtime-desktop/feature/skillbill/src/commonMain/kotlin/skillbill/desktop/feature/skillbill/ui/SkillBillNavTree.kt
@@ -256,6 +256,14 @@ private fun NavTreeNode(
     )
     val readOnlyLabel = node.readOnlyLabel ?: "RO".takeIf { !node.editable }
     OpenEditorTabIndicator(open = open)
+    if (node.external) {
+      Text(
+        text = "EXT",
+        color = SkillBillTheme.frameTokens.primary,
+        style = SkillBillTypeStyles.caption.copy(fontFamily = FontFamily.Monospace),
+        modifier = Modifier.padding(end = SkillBillDimens.padLg),
+      )
+    }
     if (readOnlyLabel != null) {
       Text(
         text = readOnlyLabel,


### PR DESCRIPTION
# Summary

Surface SKILL-101 external add-on sources in the desktop navigation tree so configured private add-ons can be discovered and edited at their source location instead of through regenerated overlay copies.

- Delegates desktop external-source resolution to `ExternalAddonOverlayService.resolveSources` through a testable data-layer seam.
- Merges top-level external `*.md` add-ons into the existing `Add-ons` platform groups, marks them with `external = true`, and prefers external source entries over duplicate pack-owned overlays.
- Renders the `EXT` badge for external rows and adds resolver-seam coverage in `RuntimeRepoBrowserServiceTest`.

## Feature Flags

N/A

# How Has This Been Tested?

Automated test coverage was added in `RuntimeRepoBrowserServiceTest` for external add-on visibility, editability, source-path targeting, external-over-pack deduplication, and resolver failure fallback.

The PR phase did not rerun validation; it used the committed SKILL-101 runtime outputs and clean pushed branch state from the previous phase.

1. Configure `external_addon_sources` with a source directory containing top-level `.md` add-ons for a platform such as `ios`.
2. Open the desktop repo browser.
3. Confirm the external add-ons appear under `Add-ons` > `<platform>` with the `EXT` badge and open the source `.md` file for editing.