### PR TITLE
SKILL-113: add per-phase execution matrix directives

### DIFF
--- a/.feature-specs/SKILL-113-execution-matrix/spec.md
+++ b/.feature-specs/SKILL-113-execution-matrix/spec.md
@@ -337,4 +337,4 @@ Run bill-feature on .feature-specs/SKILL-113-execution-matrix/spec.md
 
 ## Status
 
-- Status: Ready
+Complete

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-07-12] SKILL-113 execution matrix per-phase model and effort tiers
+Areas: runtime-kotlin/runtime-domain config/install, runtime-application feature-task/config, runtime-cli feature-task/core, runtime-infra-fs config/launcher, runtime-ports agent-run
+- Repo-local `execution_matrix` now maps per-agent reasoning/implementation tiers to model and optional effort, with default phase tiers, per-phase overrides, typed dotted-path validation failures, and unchanged behavior when absent. reusable
+- Runtime resolves each phase as CLI directive > matrix directive for its resolved agent > none, carries the directive into launch and phase-start telemetry, and preserves goal-continuation wrapper commands without model flags.
+- Pattern: declare CLI capability beside agent support in the domain, reject incompatible resolved phase/directive pairs before workflow or branch work, then retain a command-builder `require` as a defensive backstop. reusable
+- Claude and Codex render effort through their native command forms; Junie deliberately refuses directives, while parallel code-review `--model` behavior remains independent.
+Feature flag: N/A
+Acceptance criteria: 11/11 implemented
+
 ## [2026-07-09] SKILL-109 reliability contract test
 Areas: runtime-kotlin/runtime-application goal telemetry tests, runtime-kotlin/runtime-mcp telemetry contract tests
 - Issue-level terminal completeness is now asserted through the production GoalRunner telemetry path, proving completed goal runs emit exactly one `skillbill_goal_issue_finished` event with parent workflow, issue key, status, counts, timestamp, and mode. reusable

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/config/ConfigResolutionService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/config/ConfigResolutionService.kt
@@ -2,6 +2,7 @@ package skillbill.application.config
 
 import me.tatarka.inject.annotations.Inject
 import skillbill.application.workflow.repoRoot
+import skillbill.config.model.ExecutionMatrix
 import skillbill.config.model.RepoLocalConfig
 import skillbill.config.model.RepoLocalConfigResolution
 import skillbill.config.model.SpecType
@@ -19,6 +20,9 @@ import java.nio.file.Path
 class ConfigResolutionService(
   private val repoLocalConfigPort: RepoLocalConfigPort,
 ) {
+  fun resolveExecutionMatrix(repoRoot: Path): ExecutionMatrix? =
+    repoLocalConfigPort.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot)).config.executionMatrix
+
   fun resolveSpecType(repoRoot: Path, explicit: SpecType?): SpecType {
     val config = repoLocalConfigPort.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot)).config
     return RepoLocalConfigResolution.resolve(explicit, config.specType, SpecType.LOCAL)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeModelResolver.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeModelResolver.kt
@@ -1,0 +1,13 @@
+package skillbill.application.featuretask
+
+import skillbill.application.model.FeatureTaskRuntimeModelAssignment
+import skillbill.config.model.PhaseModelDirective
+
+object FeatureTaskRuntimeModelResolver {
+  fun resolve(
+    phaseId: String,
+    resolvedAgentId: String,
+    assignment: FeatureTaskRuntimeModelAssignment,
+  ): PhaseModelDirective? = assignment.perPhaseDirectives[phaseId]
+    ?: assignment.matrix?.directiveFor(resolvedAgentId, phaseId)
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunObservability.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunObservability.kt
@@ -3,6 +3,7 @@ package skillbill.application.featuretask
 import skillbill.application.model.FeatureTaskRuntimePhaseLedgerRequest
 import skillbill.application.model.FeatureTaskRuntimeRunEvent
 import skillbill.application.model.FeatureTaskRuntimeRunRequest
+import skillbill.config.model.PhaseModelDirective
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseLedgerAction
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeVerdict
 
@@ -53,7 +54,13 @@ internal class FeatureTaskRuntimeRunObservability(
     )
   }
 
-  fun started(phaseId: String, resolvedAgentId: String, attemptCount: Int, resumed: Boolean) {
+  fun started(
+    phaseId: String,
+    resolvedAgentId: String,
+    attemptCount: Int,
+    resumed: Boolean,
+    directive: PhaseModelDirective?,
+  ) {
     request.eventSink.emit(
       FeatureTaskRuntimeRunEvent.PhaseStarted(
         workflowId = request.workflowId,
@@ -61,6 +68,8 @@ internal class FeatureTaskRuntimeRunObservability(
         resolvedAgentId = resolvedAgentId,
         attemptCount = attemptCount,
         resumed = resumed,
+        model = directive?.model,
+        effort = directive?.effort,
       ),
     )
     appendLedger(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunner.kt
@@ -12,6 +12,7 @@ import skillbill.application.model.FeatureTaskRuntimeRunReport
 import skillbill.application.model.FeatureTaskRuntimeRunRequest
 import skillbill.application.model.FeatureTaskRuntimeSubtaskOutcome
 import skillbill.application.workflow.repoRoot
+import skillbill.config.model.PhaseModelDirective
 import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
 import skillbill.goalrunner.model.GoalRunnerLaunchFacts
@@ -623,13 +624,19 @@ class FeatureTaskRuntimeRunner(
         unresolvedFindings,
         unmetCriteria,
       )
+      val resolvedAgent = FeatureTaskRuntimeAgentResolver.resolve(
+        phaseId = phaseId,
+        assignment = request.agentAssignment,
+        invokedAgentId = request.invokedAgentId,
+      )
       val run = PhaseRun(
         phaseId = phaseId,
         declaration = phaseDeclaration(phaseId, request.runInvariants.featureSize),
-        resolvedAgent = FeatureTaskRuntimeAgentResolver.resolve(
-          phaseId = phaseId,
-          assignment = request.agentAssignment,
-          invokedAgentId = request.invokedAgentId,
+        resolvedAgent = resolvedAgent,
+        modelDirective = FeatureTaskRuntimeModelResolver.resolve(
+          phaseId,
+          resolvedAgent.resolvedAgentId,
+          request.modelAssignment,
         ),
         request = request,
         specSource = specSource,
@@ -714,13 +721,19 @@ class FeatureTaskRuntimeRunner(
     reentry: PendingReentry?,
     phaseTokenAccumulator: MutableMap<String, Pair<Int, Int>>? = null,
   ): PhaseOutcome {
+    val resolvedAgent = FeatureTaskRuntimeAgentResolver.resolve(
+      phaseId = phaseId,
+      assignment = request.agentAssignment,
+      invokedAgentId = request.invokedAgentId,
+    )
     val run = PhaseRun(
       phaseId = phaseId,
       declaration = phaseDeclaration(phaseId, request.runInvariants.featureSize),
-      resolvedAgent = FeatureTaskRuntimeAgentResolver.resolve(
-        phaseId = phaseId,
-        assignment = request.agentAssignment,
-        invokedAgentId = request.invokedAgentId,
+      resolvedAgent = resolvedAgent,
+      modelDirective = FeatureTaskRuntimeModelResolver.resolve(
+        phaseId,
+        resolvedAgent.resolvedAgentId,
+        request.modelAssignment,
       ),
       request = request,
       specSource = specSource,
@@ -794,7 +807,13 @@ class FeatureTaskRuntimeRunner(
     FeatureTaskRuntimeFixLoopPolicy
       .blockReasonIfBudgetExhausted(run.phaseId, iteration - budgetBaseOffset)
       ?.let { reason -> return blockAndPersistInPhase(run, iteration, reason, observability) }
-    observability.started(run.phaseId, agentId, iteration, iteration > 1 || state.hasPriorRecord(run.phaseId))
+    observability.started(
+      run.phaseId,
+      agentId,
+      iteration,
+      iteration > 1 || state.hasPriorRecord(run.phaseId),
+      run.modelDirective,
+    )
     var outcome: PhaseOutcome? = null
     // The prior attempt's schema-gate reason, threaded into the next attempt's prompt so a retry is a
     // corrective attempt rather than a blind re-roll of the identical prompt (null on the first attempt).
@@ -975,6 +994,8 @@ class FeatureTaskRuntimeRunner(
           repoRoot = run.request.repoRoot,
           dbPathOverride = run.request.dbPathOverride,
           timeout = run.request.timeout,
+          modelOverride = run.modelDirective?.model,
+          effortOverride = run.modelDirective?.effort,
           promptOverride = FeatureTaskRuntimePhasePromptComposer.compose(
             issueKey = run.request.issueKey,
             briefing = briefing,
@@ -1031,6 +1052,7 @@ class FeatureTaskRuntimeRunner(
     val phaseId: String,
     val declaration: FeatureTaskRuntimePhaseDeclaration,
     val resolvedAgent: FeatureTaskRuntimeResolvedPhaseAgent,
+    val modelDirective: PhaseModelDirective?,
     val request: FeatureTaskRuntimeRunRequest,
     val specSource: SpecSource,
     // Set only when this launch is a backward-edge re-entry; null for an ordinary forward launch.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimeModelAssignment.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimeModelAssignment.kt
@@ -1,0 +1,20 @@
+package skillbill.application.model
+
+import skillbill.config.model.ExecutionMatrix
+import skillbill.config.model.PhaseModelDirective
+
+data class FeatureTaskRuntimeModelAssignment(
+  val perPhaseDirectives: Map<String, PhaseModelDirective> = emptyMap(),
+  val matrix: ExecutionMatrix? = null,
+) {
+  init {
+    perPhaseDirectives.forEach { (phaseId, directive) ->
+      require(phaseId.isNotBlank()) {
+        "FeatureTaskRuntimeModelAssignment.perPhaseDirectives must not contain a blank phase id."
+      }
+      require(directive.model.isNotBlank()) {
+        "FeatureTaskRuntimeModelAssignment.perPhaseDirectives['$phaseId'] must not contain a blank model."
+      }
+    }
+  }
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimeRunModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimeRunModels.kt
@@ -18,6 +18,7 @@ data class FeatureTaskRuntimeRunRequest(
   val runInvariants: FeatureTaskRuntimeRunInvariants,
   val invokedAgentId: String,
   val agentAssignment: FeatureTaskRuntimeAgentAssignment = FeatureTaskRuntimeAgentAssignment(),
+  val modelAssignment: FeatureTaskRuntimeModelAssignment = FeatureTaskRuntimeModelAssignment(),
   val environment: Map<String, String> = emptyMap(),
   val dbPathOverride: String? = null,
   val repoRoot: Path,
@@ -203,6 +204,8 @@ sealed interface FeatureTaskRuntimeRunEvent {
     val resolvedAgentId: String,
     val attemptCount: Int,
     val resumed: Boolean,
+    val model: String? = null,
+    val effort: String? = null,
   ) : FeatureTaskRuntimeRunEvent
 
   data class PhaseFixLoopIteration(

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
@@ -1,0 +1,61 @@
+package skillbill.application
+
+import skillbill.application.model.FeatureTaskRuntimeAgentAssignment
+import skillbill.application.model.FeatureTaskRuntimeModelAssignment
+import skillbill.application.model.FeatureTaskRuntimeRunEvent
+import skillbill.application.model.FeatureTaskRuntimeRunReport
+import skillbill.config.model.ExecutionMatrix
+import skillbill.config.model.ExecutionTier
+import skillbill.config.model.PhaseModelDirective
+import skillbill.install.model.InstallAgent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class FeatureTaskRuntimeModelDirectiveRunnerTest {
+  @Test
+  fun `matrix directives populate phase launches and started events`() {
+    val harness = runnerHarness(agentAssignment = FeatureTaskRuntimeAgentAssignment(override = "claude"))
+    val matrix = ExecutionMatrix(
+      agents = mapOf(
+        InstallAgent.CLAUDE to mapOf(
+          ExecutionTier.REASONING to PhaseModelDirective("claude-opus", "high"),
+          ExecutionTier.IMPLEMENTATION to PhaseModelDirective("claude-sonnet", "medium"),
+        ),
+      ),
+    )
+
+    assertIs<FeatureTaskRuntimeRunReport.Completed>(
+      harness.runner.run(harness.request().copy(modelAssignment = FeatureTaskRuntimeModelAssignment(matrix = matrix))),
+    )
+
+    val plan = harness.requestForPhase("plan")
+    val implement = harness.requestForPhase("implement")
+    assertEquals("claude-opus", plan.modelOverride)
+    assertEquals("high", plan.effortOverride)
+    assertEquals("claude-sonnet", implement.modelOverride)
+    assertEquals("medium", implement.effortOverride)
+    val planStarted = harness.events.filterIsInstance<FeatureTaskRuntimeRunEvent.PhaseStarted>()
+      .single { it.phaseId == "plan" }
+    assertEquals("claude-opus", planStarted.model)
+    assertEquals("high", planStarted.effort)
+  }
+
+  @Test
+  fun `zero config model assignment keeps launch directives absent`() {
+    val harness = runnerHarness()
+
+    assertIs<FeatureTaskRuntimeRunReport.Completed>(harness.runner.run(harness.request()))
+
+    assertTrue(
+      harness.launcher.requests.all { request ->
+        request.skillRunRequest.modelOverride == null && request.skillRunRequest.effortOverride == null
+      },
+    )
+  }
+
+  private fun RunnerHarness.requestForPhase(phaseId: String) = launcher.requests.single { request ->
+    requireNotNull(request.skillRunRequest.promptOverride).contains("Phase: $phaseId ")
+  }.skillRunRequest
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeModelResolverTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeModelResolverTest.kt
@@ -1,0 +1,64 @@
+package skillbill.application.featuretask
+
+import skillbill.application.model.FeatureTaskRuntimeModelAssignment
+import skillbill.config.model.ExecutionMatrix
+import skillbill.config.model.ExecutionTier
+import skillbill.config.model.PhaseModelDirective
+import skillbill.install.model.InstallAgent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FeatureTaskRuntimeModelResolverTest {
+  @Test
+  fun `cli directive wins over matrix directive`() {
+    val assignment = FeatureTaskRuntimeModelAssignment(
+      perPhaseDirectives = mapOf("plan" to PhaseModelDirective("cli-model", "high")),
+      matrix = matrix(),
+    )
+
+    assertEquals(
+      PhaseModelDirective("cli-model", "high"),
+      FeatureTaskRuntimeModelResolver.resolve("plan", "claude", assignment),
+    )
+  }
+
+  @Test
+  fun `matrix directive resolves against each phases actual agent`() {
+    val assignment = FeatureTaskRuntimeModelAssignment(matrix = matrix())
+
+    assertEquals(
+      PhaseModelDirective("claude-opus", "high"),
+      FeatureTaskRuntimeModelResolver.resolve("review", "claude", assignment),
+    )
+    assertEquals(
+      PhaseModelDirective("gpt-sol", "xhigh"),
+      FeatureTaskRuntimeModelResolver.resolve("review", "codex", assignment),
+    )
+  }
+
+  @Test
+  fun `no matrix or unknown agent resolves no directive`() {
+    assertNull(
+      FeatureTaskRuntimeModelResolver.resolve(
+        "plan",
+        "claude",
+        FeatureTaskRuntimeModelAssignment(),
+      ),
+    )
+    assertNull(
+      FeatureTaskRuntimeModelResolver.resolve(
+        "plan",
+        "unknown",
+        FeatureTaskRuntimeModelAssignment(matrix = matrix()),
+      ),
+    )
+  }
+
+  private fun matrix(): ExecutionMatrix = ExecutionMatrix(
+    agents = mapOf(
+      InstallAgent.CLAUDE to mapOf(ExecutionTier.REASONING to PhaseModelDirective("claude-opus", "high")),
+      InstallAgent.CODEX to mapOf(ExecutionTier.REASONING to PhaseModelDirective("gpt-sol", "xhigh")),
+    ),
+  )
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/ModelDirectiveRefusal.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/ModelDirectiveRefusal.kt
@@ -1,0 +1,31 @@
+package skillbill.cli.core
+
+import com.github.ajalt.clikt.core.UsageError
+import skillbill.config.model.PhaseModelDirective
+import skillbill.install.model.MODEL_DIRECTIVE_CAPABLE_AGENTS
+import skillbill.install.model.supportsModelDirective
+
+fun refuseUnsupportedModelDirectives(
+  directivesByPhase: Map<String, PhaseModelDirective>,
+  resolvedAgentIdByPhase: Map<String, String>,
+) {
+  directivesByPhase.entries.firstOrNull { (phaseId, _) ->
+    !supportsModelDirective(resolvedAgentIdByPhase.getValue(phaseId))
+  }?.let { (phaseId, directive) ->
+    val agentId = resolvedAgentIdByPhase.getValue(phaseId)
+    throw UsageError(
+      "--phase-model/execution_matrix: phase '$phaseId' resolves to agent '$agentId', which cannot honor a " +
+        "model/effort directive (${directiveText(directive)}). Capable agents: " +
+        MODEL_DIRECTIVE_CAPABLE_AGENTS.joinToString(", ") { it.id } + ".",
+    )
+  }
+}
+
+private fun directiveText(directive: PhaseModelDirective): String = buildString {
+  append("model=")
+  append(directive.model)
+  directive.effort?.let {
+    append(", effort=")
+    append(it)
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
@@ -12,10 +12,14 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.restrictTo
 import me.tatarka.inject.annotations.Inject
+import skillbill.application.config.ConfigResolutionService
+import skillbill.application.featuretask.FeatureTaskRuntimeAgentResolver
+import skillbill.application.featuretask.FeatureTaskRuntimeModelResolver
 import skillbill.application.featuretask.FeatureTaskRuntimeRunner
 import skillbill.application.featuretask.FeatureTaskRuntimeStatusService
 import skillbill.application.model.FeatureTaskRuntimeAgentAssignment
 import skillbill.application.model.FeatureTaskRuntimeGoalContinuationContext
+import skillbill.application.model.FeatureTaskRuntimeModelAssignment
 import skillbill.application.model.FeatureTaskRuntimePhaseStatus
 import skillbill.application.model.FeatureTaskRuntimeRunEvent
 import skillbill.application.model.FeatureTaskRuntimeRunEventSink
@@ -29,6 +33,8 @@ import skillbill.application.workflow.WorkflowService
 import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
 import skillbill.cli.core.refuseRuntimeRefusedAgents
+import skillbill.cli.core.refuseUnsupportedModelDirectives
+import skillbill.config.model.PhaseModelDirective
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InvokingAgentContextResolver
 import skillbill.ports.featurespec.FeatureSpecPathResolverPort
@@ -48,6 +54,7 @@ data class FeatureTaskRuntimeRunDependencies(
   val runner: FeatureTaskRuntimeRunner,
   val runInvariantsSource: FeatureTaskRuntimeRunInvariantsSource,
   val specPathResolver: FeatureSpecPathResolverPort,
+  val configResolutionService: ConfigResolutionService,
   val state: CliRunState,
 )
 
@@ -77,6 +84,11 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
   protected val phaseAgents by option(
     "--phase-agent",
     help = "Per-phase agent assignment as phase=agent (e.g. --phase-agent plan=claude). Repeatable.",
+  ).multiple()
+  protected val phaseModels by option(
+    "--phase-model",
+    help = "Per-phase model directive as phase=model or phase=model@effort " +
+      "(e.g. --phase-model plan=claude-opus-4-8@high). Wins over the config execution_matrix. Repeatable.",
   ).multiple()
   protected val goalParentIssueKey by option(
     "--goal-parent-issue-key",
@@ -135,23 +147,22 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
     deps: FeatureTaskRuntimeRunDependencies,
     issueKey: String,
     specPath: String,
-    workflowId: String,
+    workflowId: () -> String,
   ) {
     val state = deps.state
+    val prepared = prepareRuntimeRun(deps)
     val report = deps.runner.run(
       FeatureTaskRuntimeRunRequest(
         issueKey = issueKey,
-        workflowId = workflowId,
+        workflowId = workflowId(),
         sessionId = "${FeatureTaskRuntimePhaseWorkflowDefinition.definition.defaultSessionPrefix}-$issueKey",
         runInvariants = deps.runInvariantsSource.read(Path.of(specPath)),
-        invokedAgentId = resolveInvokedRuntimeAgentId(agent, state.environment),
-        agentAssignment = FeatureTaskRuntimeAgentAssignment(
-          perPhaseAgentIds = parsePhaseAgents(phaseAgents),
-          override = agentOverride?.takeIf(String::isNotBlank),
-        ),
+        invokedAgentId = prepared.invokedAgentId,
+        agentAssignment = prepared.agentAssignment,
+        modelAssignment = prepared.modelAssignment,
         environment = state.environment,
         dbPathOverride = state.dbOverride,
-        repoRoot = repoRoot?.let(Path::of) ?: Path.of("").toAbsolutePath().normalize(),
+        repoRoot = prepared.repoRoot,
         timeout = maxWallClockMinutes?.minutes,
         parallelReviewAgent = parallelReviewAgent?.takeIf(String::isNotBlank),
         goalContinuation = parseGoalContinuationContext(),
@@ -160,6 +171,31 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
     )
     val payload = report.toRuntimeRunCliMap()
     state.completeText(runtimeRunText(payload), payload, exitCode = payload.runtimeRunExitCode())
+  }
+
+  private fun prepareRuntimeRun(deps: FeatureTaskRuntimeRunDependencies): PreparedRuntimeRun {
+    val environment = deps.state.environment
+    refuseUnsupportedRuntimeAgent(environment)
+    val repoRoot = repoRoot?.let(Path::of) ?: Path.of("").toAbsolutePath().normalize()
+    val invokedAgentId = resolveInvokedRuntimeAgentId(agent, environment)
+    val agentAssignment = FeatureTaskRuntimeAgentAssignment(
+      perPhaseAgentIds = parsePhaseAgents(phaseAgents),
+      override = agentOverride?.takeIf(String::isNotBlank),
+    )
+    val modelAssignment = FeatureTaskRuntimeModelAssignment(
+      perPhaseDirectives = parsePhaseModels(phaseModels),
+      matrix = deps.configResolutionService.resolveExecutionMatrix(repoRoot),
+    )
+    val resolvedAgentIds = FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds.associateWith { phaseId ->
+      FeatureTaskRuntimeAgentResolver.resolve(phaseId, agentAssignment, invokedAgentId).resolvedAgentId
+    }
+    val directives = resolvedAgentIds.mapNotNull { (phaseId, resolvedAgentId) ->
+      FeatureTaskRuntimeModelResolver.resolve(phaseId, resolvedAgentId, modelAssignment)?.let { directive ->
+        phaseId to directive
+      }
+    }.toMap()
+    refuseUnsupportedModelDirectives(directives, resolvedAgentIds)
+    return PreparedRuntimeRun(repoRoot, invokedAgentId, agentAssignment, modelAssignment)
   }
 
   protected fun resolveSpecPath(
@@ -240,14 +276,13 @@ class FeatureTaskRuntimeRunCommand(
     if (currentContext.invokedSubcommand != null) {
       return
     }
-    refuseUnsupportedRuntimeAgent(deps.state.environment)
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for feature-task run.")
     val runSpecPath = resolveSpecPath(deps, runIssueKey, specPath)
     executeRuntimeRun(
       deps = deps,
       issueKey = runIssueKey,
       specPath = runSpecPath,
-      workflowId = resolveRunWorkflowId(workflowService, deps.state),
+      workflowId = { resolveRunWorkflowId(workflowService, deps.state) },
     )
   }
 }
@@ -269,12 +304,11 @@ class FeatureTaskRuntimeExplicitRunCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.").optional()
 
   override fun run() {
-    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
       specPath = resolveSpecPath(deps, issueKey, specPath),
-      workflowId = resolveRunWorkflowId(workflowService, deps.state),
+      workflowId = { resolveRunWorkflowId(workflowService, deps.state) },
     )
   }
 }
@@ -307,12 +341,11 @@ class FeatureTaskRuntimeResumeCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.")
 
   override fun run() {
-    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
       specPath = specPath,
-      workflowId = workflowId,
+      workflowId = { workflowId },
     )
   }
 }
@@ -359,14 +392,13 @@ class FeatureTaskRuntimeDeprecatedRunCommand(
     if (currentContext.invokedSubcommand != null) {
       return
     }
-    refuseUnsupportedRuntimeAgent(deps.state.environment)
     val runIssueKey = issueKey ?: throw UsageError("issue_key is required for feature-task run.")
     val runSpecPath = resolveSpecPath(deps, runIssueKey, specPath)
     executeRuntimeRun(
       deps = deps,
       issueKey = runIssueKey,
       specPath = runSpecPath,
-      workflowId = openRuntimeWorkflowId(workflowService, deps.state),
+      workflowId = { openRuntimeWorkflowId(workflowService, deps.state) },
     )
   }
 }
@@ -383,12 +415,11 @@ class FeatureTaskRuntimeDeprecatedExplicitRunCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.").optional()
 
   override fun run() {
-    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
       specPath = resolveSpecPath(deps, issueKey, specPath),
-      workflowId = openRuntimeWorkflowId(workflowService, deps.state),
+      workflowId = { openRuntimeWorkflowId(workflowService, deps.state) },
     )
   }
 }
@@ -421,12 +452,11 @@ class FeatureTaskRuntimeDeprecatedResumeCommand(
   private val specPath by argument(help = "Path to the governed spec the run implements.")
 
   override fun run() {
-    refuseUnsupportedRuntimeAgent(deps.state.environment)
     executeRuntimeRun(
       deps = deps,
       issueKey = issueKey,
       specPath = specPath,
-      workflowId = workflowId,
+      workflowId = { workflowId },
     )
   }
 }
@@ -456,7 +486,10 @@ private fun FeatureTaskRuntimeRunEvent.runtimeProgressLine(): String = when (thi
     "feature-task-runtime $workflowId: branch setup blocked at phase $phaseId: $blockedReason\n"
   is FeatureTaskRuntimeRunEvent.PhaseStarted ->
     "feature-task-runtime $workflowId: phase $phaseId ${if (resumed) "resumed" else "started"} " +
-      "agent=$resolvedAgentId attempt=$attemptCount\n"
+      "agent=$resolvedAgentId attempt=$attemptCount" +
+      model?.let { " model=$it" }.orEmpty() +
+      effort?.let { " effort=$it" }.orEmpty() +
+      "\n"
   is FeatureTaskRuntimeRunEvent.PhaseFixLoopIteration ->
     "feature-task-runtime $workflowId: phase $phaseId fix_loop attempt=$attemptCount iteration=$fixLoopIteration\n"
   is FeatureTaskRuntimeRunEvent.PhaseCompleted ->
@@ -487,6 +520,47 @@ private fun parsePhaseAgents(rawAssignments: List<String>): Map<String, String> 
   }
   return parsed
 }
+
+private fun parsePhaseModels(rawAssignments: List<String>): Map<String, PhaseModelDirective> {
+  val parsed = LinkedHashMap<String, PhaseModelDirective>()
+  rawAssignments.forEach { assignment ->
+    val separatorIndex = assignment.indexOf('=')
+    if (separatorIndex <= 0 || separatorIndex == assignment.length - 1) {
+      invalidPhaseModel(
+        "--phase-model must be phase=model[@effort], e.g. --phase-model plan=claude-opus-4-8@high " +
+          "(got '$assignment').",
+      )
+    }
+    val phaseId = assignment.substring(0, separatorIndex).trim()
+    val modelAndEffort = assignment.substring(separatorIndex + 1).trim()
+    if (phaseId !in FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds) {
+      invalidPhaseModel(
+        "--phase-model phase '$phaseId' is not a runtime phase " +
+          "(${FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds.joinToString()}).",
+      )
+    }
+    if (modelAndEffort.count { it == '@' } > 1) {
+      invalidPhaseModel("--phase-model allows at most one @ separating model and effort (got '$assignment').")
+    }
+    val effortSeparator = modelAndEffort.indexOf('@')
+    val model = modelAndEffort.substringBefore('@').trim()
+    val effort = if (effortSeparator == -1) null else modelAndEffort.substring(effortSeparator + 1).trim()
+    if (model.isBlank() || effort?.isBlank() == true) {
+      invalidPhaseModel("--phase-model requires non-blank model and effort segments (got '$assignment').")
+    }
+    parsed[phaseId] = PhaseModelDirective(model = model, effort = effort)
+  }
+  return parsed
+}
+
+private fun invalidPhaseModel(message: String): Nothing = throw UsageError(message)
+
+private data class PreparedRuntimeRun(
+  val repoRoot: Path,
+  val invokedAgentId: String,
+  val agentAssignment: FeatureTaskRuntimeAgentAssignment,
+  val modelAssignment: FeatureTaskRuntimeModelAssignment,
+)
 
 private fun resolveInvokedRuntimeAgentId(explicitAgent: String?, environment: Map<String, String>): String =
   explicitAgent?.takeIf(String::isNotBlank)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 
@@ -37,6 +38,7 @@ class CliFeatureTaskRuntimeRuntimeTest {
     // The documented explicit `run` form is a real subcommand, not a misparsed positional.
     assertContains(help.stdout, "explicit form")
     assertContains(help.stdout, "--phase-agent")
+    assertContains(help.stdout, "--phase-model")
     assertContains(help.stdout, "--agent-override")
     assertContains(help.stdout, "--monitor")
     assertContains(help.stdout, "--max-wall-clock-minutes")
@@ -824,6 +826,207 @@ class CliFeatureTaskRuntimeZcodeRefusalTest {
     assertEquals(1, result.exitCode, result.stdout)
     assertContains(result.stdout, "Runtime mode is not supported on opencode or zcode")
     assertEquals(emptyList(), launcher.requests, result.stdout)
+  }
+}
+
+class CliFeatureTaskRuntimeModelDirectiveTest {
+  @Test
+  fun `feature-task runtime applies a cli phase model directive`() {
+    val fixture = runtimeFixture()
+    val launcher = RecordingPhaseLauncher()
+    val monitor = StringBuilder()
+
+    val result = CliRuntime.run(
+      fixture.runCommand(extra = listOf("--agent", "codex", "--phase-model", "plan=gpt-sol@high", "--monitor")),
+      fixture.context(launcher, liveStdout = { monitor.append(it) }),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    val plan = launcher.requests[ALL_PHASES.indexOf("plan")].skillRunRequest
+    assertEquals("gpt-sol", plan.modelOverride)
+    assertEquals("high", plan.effortOverride)
+    assertTrue(
+      launcher.requests.filterIndexed { index, _ -> ALL_PHASES[index] != "plan" }.all { request ->
+        request.skillRunRequest.modelOverride == null && request.skillRunRequest.effortOverride == null
+      },
+    )
+    assertContains(monitor.toString(), "phase plan started agent=codex attempt=1 model=gpt-sol effort=high")
+  }
+
+  @Test
+  fun `feature-task runtime uses the final repeated phase model assignment`() {
+    val fixture = runtimeFixture()
+    val launcher = RecordingPhaseLauncher()
+
+    val result = CliRuntime.run(
+      fixture.runCommand(
+        extra = listOf("--agent", "codex", "--phase-model", "plan=first", "--phase-model", "plan=second@high"),
+      ),
+      fixture.context(launcher),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    val plan = launcher.requests[ALL_PHASES.indexOf("plan")].skillRunRequest
+    assertEquals("second", plan.modelOverride)
+    assertEquals("high", plan.effortOverride)
+  }
+
+  @Test
+  fun `feature-task runtime applies a model only cli phase directive`() {
+    val fixture = runtimeFixture()
+    val launcher = RecordingPhaseLauncher()
+
+    val result = CliRuntime.run(
+      fixture.runCommand(extra = listOf("--agent", "codex", "--phase-model", "plan=gpt-sol")),
+      fixture.context(launcher),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    val plan = launcher.requests[ALL_PHASES.indexOf("plan")].skillRunRequest
+    assertEquals("gpt-sol", plan.modelOverride)
+    assertNull(plan.effortOverride)
+  }
+
+  @Test
+  fun `feature-task runtime reads phase directives from the repo local execution matrix`() {
+    val fixture = runtimeFixture()
+    val config = fixture.tempDir.resolve(".skill-bill/config.yaml")
+    Files.createDirectories(config.parent)
+    Files.writeString(
+      config,
+      """
+      execution_matrix:
+        agents:
+          codex:
+            reasoning:
+              model: gpt-sol
+              effort: high
+      """.trimIndent(),
+    )
+    val launcher = RecordingPhaseLauncher()
+
+    val result = CliRuntime.run(
+      fixture.runCommand(extra = listOf("--agent", "codex")),
+      fixture.context(launcher),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    val plan = launcher.requests[ALL_PHASES.indexOf("plan")].skillRunRequest
+    assertEquals("gpt-sol", plan.modelOverride)
+    assertEquals("high", plan.effortOverride)
+  }
+
+  @Test
+  fun `goal continuation re-resolves execution matrix directives for child phase launches`() {
+    val fixture = runtimeFixture(specFileName = "spec_subtask_5_runtime.md")
+    val config = fixture.tempDir.resolve(".skill-bill/config.yaml")
+    Files.createDirectories(config.parent)
+    Files.writeString(
+      config,
+      """
+      execution_matrix:
+        agents:
+          codex:
+            reasoning:
+              model: gpt-sol
+              effort: high
+      """.trimIndent(),
+    )
+    val directLauncher = RecordingPhaseLauncher()
+    val direct = CliRuntime.run(
+      fixture.runCommand(extra = listOf("--agent", "codex")),
+      fixture.context(directLauncher),
+    )
+    val childLauncher = RecordingPhaseLauncher()
+    val child = CliRuntime.run(
+      fixture.runCommand(
+        extra = listOf(
+          "--agent",
+          "codex",
+          "--goal-parent-issue-key",
+          "SKILL-650",
+          "--goal-subtask-id",
+          "5",
+          "--goal-branch",
+          "feat/existing-runtime-branch",
+          "--suppress-pr",
+        ),
+      ),
+      fixture.context(childLauncher),
+    )
+
+    assertEquals(0, direct.exitCode, direct.stdout)
+    assertEquals(0, child.exitCode, child.stdout)
+    val directPlan = directLauncher.requests[ALL_PHASES.indexOf("plan")].skillRunRequest
+    val childPlan = childLauncher.requests[ALL_PHASES.indexOf("plan")].skillRunRequest
+    assertEquals(directPlan.modelOverride, childPlan.modelOverride)
+    assertEquals(directPlan.effortOverride, childPlan.effortOverride)
+    assertEquals("gpt-sol", childPlan.modelOverride)
+    assertEquals("high", childPlan.effortOverride)
+  }
+
+  @Test
+  fun `feature-task runtime rejects malformed phase model directives before workflow opening`() {
+    listOf("plan", "=model", "plan=", "unknown=model", "plan=model@high@xhigh", "plan=@high", "plan=model@").forEach {
+        assignment ->
+      val fixture = runtimeFixture()
+      val launcher = RecordingPhaseLauncher()
+
+      val result = CliRuntime.run(
+        fixture.runCommand(extra = listOf("--agent", "codex", "--phase-model", assignment)),
+        fixture.context(launcher),
+      )
+
+      assertEquals(1, result.exitCode, "expected rejection for $assignment: ${result.stdout}")
+      assertContains(result.stdout, "--phase-model")
+      assertEquals(emptyList(), launcher.requests, result.stdout)
+      assertFalse(result.stdout.contains("workflow_id:"), result.stdout)
+    }
+  }
+
+  @Test
+  fun `feature-task run and resume refuse a directive that resolves to junie before launching`() {
+    val runFixture = runtimeFixture()
+    val runLauncher = RecordingPhaseLauncher()
+    val run = CliRuntime.run(
+      runFixture.runCommand(
+        extra = listOf("--agent", "codex", "--phase-agent", "plan=junie", "--phase-model", "plan=model"),
+      ),
+      runFixture.context(runLauncher),
+    )
+
+    assertEquals(1, run.exitCode, run.stdout)
+    assertContains(run.stdout, "phase 'plan'")
+    assertContains(run.stdout, "agent 'junie'")
+    assertEquals(emptyList(), runLauncher.requests)
+    assertFalse(run.stdout.contains("workflow_id:"), run.stdout)
+
+    val resumeFixture = runtimeFixture()
+    val resumeLauncher = RecordingPhaseLauncher()
+    val resume = CliRuntime.run(
+      listOf(
+        "--db",
+        resumeFixture.dbPath.toString(),
+        "feature-task",
+        "resume",
+        "wftr-model-directive",
+        "SKILL-650",
+        resumeFixture.specPath.toString(),
+        "--repo-root",
+        resumeFixture.tempDir.toString(),
+        "--agent",
+        "codex",
+        "--phase-agent",
+        "plan=junie",
+        "--phase-model",
+        "plan=model",
+      ),
+      resumeFixture.context(resumeLauncher),
+    )
+
+    assertEquals(1, resume.exitCode, resume.stdout)
+    assertContains(resume.stdout, "agent 'junie'")
+    assertEquals(emptyList(), resumeLauncher.requests)
   }
 }
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/ExecutionMatrixModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/ExecutionMatrixModels.kt
@@ -1,0 +1,176 @@
+package skillbill.config.model
+
+import skillbill.install.model.InstallAgent
+import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
+
+const val EXECUTION_MATRIX_KEY: String = "execution_matrix"
+
+enum class ExecutionTier(
+  val id: String,
+) {
+  REASONING("reasoning"),
+  IMPLEMENTATION("implementation"),
+  ;
+
+  companion object {
+    fun fromId(id: String): ExecutionTier? = entries.firstOrNull { it.id == id }
+  }
+}
+
+val DEFAULT_PHASE_TIERS: Map<String, ExecutionTier> = mapOf(
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN to ExecutionTier.IMPLEMENTATION,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN to ExecutionTier.REASONING,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT to ExecutionTier.IMPLEMENTATION,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT_FIX to ExecutionTier.IMPLEMENTATION,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW to ExecutionTier.REASONING,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_AUDIT to ExecutionTier.REASONING,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE to ExecutionTier.REASONING,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_WRITE_HISTORY to ExecutionTier.IMPLEMENTATION,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH to ExecutionTier.IMPLEMENTATION,
+  FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PR to ExecutionTier.IMPLEMENTATION,
+)
+
+data class PhaseModelDirective(
+  val model: String,
+  val effort: String? = null,
+) {
+  init {
+    require(model.isNotBlank()) { "PhaseModelDirective.model must be non-blank." }
+    effort?.let { require(it.isNotBlank()) { "PhaseModelDirective.effort must be non-blank when provided." } }
+  }
+}
+
+data class ExecutionMatrix(
+  val phaseTiers: Map<String, ExecutionTier> = emptyMap(),
+  val agents: Map<InstallAgent, Map<ExecutionTier, PhaseModelDirective>> = emptyMap(),
+) {
+  fun tierOf(phaseId: String): ExecutionTier = phaseTiers[phaseId] ?: DEFAULT_PHASE_TIERS.getValue(phaseId)
+
+  fun directiveFor(agentId: String, phaseId: String): PhaseModelDirective? {
+    val agent = InstallAgent.entries.firstOrNull { it.id == agentId.trim().lowercase() } ?: return null
+    return agents[agent]?.get(tierOf(phaseId))
+  }
+}
+
+sealed interface ExecutionMatrixParse {
+  data class Valid(val matrix: ExecutionMatrix) : ExecutionMatrixParse
+
+  data class Invalid(
+    val keyPath: String,
+    val value: String,
+    val reason: String,
+  ) : ExecutionMatrixParse
+}
+
+fun parseExecutionMatrix(raw: Any?): ExecutionMatrixParse = try {
+  ExecutionMatrixParse.Valid(parseExecutionMatrixMapping(raw))
+} catch (failure: InvalidExecutionMatrix) {
+  failure.invalid
+}
+
+private fun parseExecutionMatrixMapping(raw: Any?): ExecutionMatrix {
+  val matrix = raw as? Map<*, *> ?: invalidExecutionMatrix(EXECUTION_MATRIX_KEY, raw, "must be a mapping.")
+  val fields = matrix.entries.associate { (key, value) -> key.toString() to value }
+  fields.entries.firstOrNull { (key, _) -> key !in EXECUTION_MATRIX_FIELDS }?.let { (key, value) ->
+    invalidExecutionMatrix("$EXECUTION_MATRIX_KEY.$key", value, "is not a supported execution_matrix field.")
+  }
+  val phaseTiers = if (PHASE_TIERS_KEY in fields) parsePhaseTiers(fields[PHASE_TIERS_KEY]) else emptyMap()
+  return ExecutionMatrix(phaseTiers = phaseTiers, agents = parseAgents(fields[AGENTS_KEY]))
+}
+
+private fun parsePhaseTiers(raw: Any?): Map<String, ExecutionTier> {
+  val phaseTiers = raw as? Map<*, *> ?: invalidExecutionMatrix(
+    "$EXECUTION_MATRIX_KEY.$PHASE_TIERS_KEY",
+    raw,
+    "must be a mapping.",
+  )
+  return phaseTiers.entries.associate { (rawPhaseId, rawTier) ->
+    val phaseId = rawPhaseId as? String ?: invalidExecutionMatrix(
+      "$EXECUTION_MATRIX_KEY.$PHASE_TIERS_KEY.$rawPhaseId",
+      rawTier,
+      "is not a runtime phase.",
+    )
+    if (phaseId !in FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds) {
+      invalidExecutionMatrix("$EXECUTION_MATRIX_KEY.$PHASE_TIERS_KEY.$phaseId", rawTier, "is not a runtime phase.")
+    }
+    val tier = ExecutionTier.fromId(rawTier as? String ?: "") ?: invalidExecutionMatrix(
+      "$EXECUTION_MATRIX_KEY.$PHASE_TIERS_KEY.$phaseId",
+      rawTier,
+      "must be reasoning or implementation.",
+    )
+    phaseId to tier
+  }
+}
+
+private fun parseAgents(raw: Any?): Map<InstallAgent, Map<ExecutionTier, PhaseModelDirective>> {
+  val agents = raw as? Map<*, *> ?: invalidExecutionMatrix(
+    "$EXECUTION_MATRIX_KEY.$AGENTS_KEY",
+    raw,
+    "must be a mapping.",
+  )
+  return agents.entries.associate { (rawAgentId, rawTiers) ->
+    val agentId = rawAgentId as? String ?: invalidExecutionMatrix(
+      "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$rawAgentId",
+      rawTiers,
+      "is not a supported install agent.",
+    )
+    val agent = InstallAgent.entries.firstOrNull { it.id == agentId } ?: invalidExecutionMatrix(
+      "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId",
+      rawTiers,
+      "is not a supported install agent.",
+    )
+    agent to parseAgentTiers(agentId, rawTiers)
+  }
+}
+
+private fun parseAgentTiers(agentId: String, raw: Any?): Map<ExecutionTier, PhaseModelDirective> {
+  val tiers = raw as? Map<*, *> ?: invalidExecutionMatrix(
+    "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId",
+    raw,
+    "must be a mapping.",
+  )
+  return tiers.entries.associate { (rawTierId, rawDirective) ->
+    val tierId = rawTierId as? String
+    val tier = tierId?.let(ExecutionTier::fromId) ?: invalidExecutionMatrix(
+      "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId.$rawTierId",
+      rawDirective,
+      "must be reasoning or implementation.",
+    )
+    tier to parseDirective(agentId, tier, rawDirective)
+  }
+}
+
+private fun parseDirective(agentId: String, tier: ExecutionTier, raw: Any?): PhaseModelDirective {
+  val path = "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId.${tier.id}"
+  val directive = raw as? Map<*, *> ?: invalidExecutionMatrix(path, raw, "must be a mapping.")
+  val fields = directive.entries.associate { (key, value) -> key.toString() to value }
+  if (MODEL_KEY !in fields) invalidExecutionMatrix("$path.$MODEL_KEY", "<missing>", "is required.")
+  val model = fields[MODEL_KEY] as? String
+  if (model.isNullOrBlank()) {
+    invalidExecutionMatrix("$path.$MODEL_KEY", fields[MODEL_KEY], "must be a non-blank string.")
+  }
+  val effort = fields[EFFORT_KEY]
+  if (EFFORT_KEY in fields && (effort !is String || effort.isBlank())) {
+    invalidExecutionMatrix("$path.$EFFORT_KEY", effort, "must be a non-blank string when provided.")
+  }
+  fields.entries.firstOrNull { (key, _) -> key !in DIRECTIVE_FIELDS }?.let { (key, value) ->
+    invalidExecutionMatrix("$path.$key", value, "is not a supported tier field.")
+  }
+  return PhaseModelDirective(model = model, effort = effort as? String)
+}
+
+private fun invalidExecutionMatrix(keyPath: String, value: Any?, reason: String): Nothing =
+  throw InvalidExecutionMatrix(
+    ExecutionMatrixParse.Invalid(keyPath = keyPath, value = value?.toString() ?: "null", reason = reason),
+  )
+
+private class InvalidExecutionMatrix(
+  val invalid: ExecutionMatrixParse.Invalid,
+) : RuntimeException()
+
+private const val PHASE_TIERS_KEY: String = "phase_tiers"
+private const val AGENTS_KEY: String = "agents"
+private const val MODEL_KEY: String = "model"
+private const val EFFORT_KEY: String = "effort"
+private val EXECUTION_MATRIX_FIELDS: Set<String> = setOf(PHASE_TIERS_KEY, AGENTS_KEY)
+private val DIRECTIVE_FIELDS: Set<String> = setOf(MODEL_KEY, EFFORT_KEY)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/RepoLocalConfigModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/RepoLocalConfigModels.kt
@@ -41,6 +41,7 @@ enum class RepoLocalConfigKey(
 data class RepoLocalConfig(
   val specType: SpecType,
   val codeReviewParallelAgent: String,
+  val executionMatrix: ExecutionMatrix? = null,
 ) {
   companion object {
     const val NO_PARALLEL_AGENT: String = "none"

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallModels.kt
@@ -43,6 +43,14 @@ fun isRuntimeRefusedAgent(agentId: String?): Boolean {
   return RUNTIME_REFUSED_AGENTS.any { refused -> refused.id == normalized }
 }
 
+val MODEL_DIRECTIVE_CAPABLE_AGENTS: Set<InstallAgent> = setOf(InstallAgent.CLAUDE, InstallAgent.CODEX)
+
+fun supportsModelDirective(agentId: String?): Boolean {
+  if (agentId == null) return false
+  val normalized = agentId.trim().lowercase()
+  return MODEL_DIRECTIVE_CAPABLE_AGENTS.any { capable -> capable.id == normalized }
+}
+
 // Shared, agent-neutral refusal reason. Documents the observed harness failure mode for every
 // refused agent so the CLI preflight, the spawn-boundary backstop, and the governed skill gates
 // all carry the same actionable prose. opencode is hard-killed at the 120s Bash ceiling; zcode's

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/config/model/ExecutionMatrixModelsTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/config/model/ExecutionMatrixModelsTest.kt
@@ -1,0 +1,161 @@
+package skillbill.config.model
+
+import skillbill.install.model.InstallAgent
+import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class ExecutionMatrixModelsTest {
+  @Test
+  fun `parses a full matrix with phase tier override`() {
+    val parsed = assertIs<ExecutionMatrixParse.Valid>(
+      parseExecutionMatrix(
+        mapOf(
+          "phase_tiers" to mapOf("plan" to "implementation"),
+          "agents" to mapOf(
+            "claude" to mapOf(
+              "reasoning" to mapOf("model" to "claude-opus", "effort" to "high"),
+              "implementation" to mapOf("model" to "claude-sonnet"),
+            ),
+            "codex" to mapOf("reasoning" to mapOf("model" to "gpt-reasoning", "effort" to "xhigh")),
+          ),
+        ),
+      ),
+    )
+
+    assertEquals(ExecutionTier.IMPLEMENTATION, parsed.matrix.tierOf("plan"))
+    assertEquals(
+      PhaseModelDirective("claude-sonnet"),
+      parsed.matrix.directiveFor("claude", "plan"),
+    )
+    assertEquals(
+      PhaseModelDirective("gpt-reasoning", "xhigh"),
+      parsed.matrix.directiveFor("codex", "review"),
+    )
+  }
+
+  @Test
+  fun `parses a single agent single tier matrix with omitted effort`() {
+    val parsed = assertIs<ExecutionMatrixParse.Valid>(
+      parseExecutionMatrix(
+        mapOf("agents" to mapOf("claude" to mapOf("implementation" to mapOf("model" to "sonnet")))),
+      ),
+    )
+
+    assertEquals(PhaseModelDirective("sonnet"), parsed.matrix.directiveFor("claude", "implement"))
+    assertNull(parsed.matrix.directiveFor("claude", "review"))
+  }
+
+  @Test
+  fun `rejects every malformed matrix layer with its dotted key path`() {
+    val cases = listOf(
+      "root" to Pair(listOf("not", "a", "map"), "execution_matrix"),
+      "top-level field" to Pair(
+        mapOf("unknown" to "value", "agents" to emptyMap<String, Any?>()),
+        "execution_matrix.unknown",
+      ),
+      "phase tier" to Pair(
+        mapOf("phase_tiers" to mapOf("unknown_phase" to "reasoning"), "agents" to emptyMap<String, Any?>()),
+        "execution_matrix.phase_tiers.unknown_phase",
+      ),
+      "agents map" to Pair(mapOf("agents" to "claude"), "execution_matrix.agents"),
+      "agent tier" to Pair(
+        mapOf("agents" to mapOf("unknown-agent" to emptyMap<String, Any?>())),
+        "execution_matrix.agents.unknown-agent",
+      ),
+      "directive" to Pair(
+        mapOf("agents" to mapOf("claude" to mapOf("reasoning" to mapOf("effort" to "high")))),
+        "execution_matrix.agents.claude.reasoning.model",
+      ),
+    )
+
+    cases.forEach { (_, case) ->
+      val invalid = assertIs<ExecutionMatrixParse.Invalid>(parseExecutionMatrix(case.first))
+      assertEquals(case.second, invalid.keyPath)
+    }
+  }
+
+  @Test
+  fun `rejects invalid tier entry fields and values at their dotted paths`() {
+    val cases = listOf(
+      Pair(mapOf("model" to ""), "execution_matrix.agents.claude.reasoning.model"),
+      Pair(mapOf("model" to "m", "effort" to ""), "execution_matrix.agents.claude.reasoning.effort"),
+      Pair(mapOf("model" to "m", "other" to "x"), "execution_matrix.agents.claude.reasoning.other"),
+    )
+
+    cases.forEach { (directive, path) ->
+      val invalid = assertIs<ExecutionMatrixParse.Invalid>(
+        parseExecutionMatrix(
+          mapOf("agents" to mapOf("claude" to mapOf("reasoning" to directive))),
+        ),
+      )
+      assertEquals(path, invalid.keyPath)
+    }
+  }
+
+  @Test
+  fun `rejects every remaining malformed nested shape at its dotted path`() {
+    val cases = listOf(
+      Pair(
+        mapOf("phase_tiers" to null, "agents" to emptyMap<String, Any?>()),
+        "execution_matrix.phase_tiers",
+      ),
+      Pair(
+        mapOf("phase_tiers" to mapOf("plan" to "other"), "agents" to emptyMap<String, Any?>()),
+        "execution_matrix.phase_tiers.plan",
+      ),
+      Pair(mapOf("agents" to mapOf("claude" to "not-a-map")), "execution_matrix.agents.claude"),
+      Pair(
+        mapOf("agents" to mapOf("claude" to mapOf("other" to emptyMap<String, Any?>()))),
+        "execution_matrix.agents.claude.other",
+      ),
+      Pair(
+        mapOf("agents" to mapOf("claude" to mapOf("reasoning" to "not-a-map"))),
+        "execution_matrix.agents.claude.reasoning",
+      ),
+      Pair(
+        mapOf("agents" to mapOf("claude" to mapOf("reasoning" to mapOf("model" to 1)))),
+        "execution_matrix.agents.claude.reasoning.model",
+      ),
+      Pair(
+        mapOf("agents" to mapOf("claude" to mapOf("reasoning" to mapOf("model" to "m", "effort" to 1)))),
+        "execution_matrix.agents.claude.reasoning.effort",
+      ),
+    )
+
+    cases.forEach { (raw, path) ->
+      val invalid = assertIs<ExecutionMatrixParse.Invalid>(parseExecutionMatrix(raw))
+      assertEquals(path, invalid.keyPath)
+    }
+  }
+
+  @Test
+  fun `tier defaults cover every runtime phase`() {
+    val matrix = ExecutionMatrix()
+
+    FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds.forEach { phaseId ->
+      assertEquals(DEFAULT_PHASE_TIERS.getValue(phaseId), matrix.tierOf(phaseId))
+    }
+    assertEquals(ExecutionTier.REASONING, matrix.tierOf("plan"))
+    assertEquals(ExecutionTier.REASONING, matrix.tierOf("review"))
+    assertEquals(ExecutionTier.REASONING, matrix.tierOf("audit"))
+    assertEquals(ExecutionTier.REASONING, matrix.tierOf("validate"))
+    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("preplan"))
+    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("implement"))
+    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("implement_fix"))
+    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("write_history"))
+    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("commit_push"))
+    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("pr"))
+  }
+
+  @Test
+  fun `unknown agents stay inert when resolving directives`() {
+    val matrix = ExecutionMatrix(
+      agents = mapOf(InstallAgent.CLAUDE to mapOf(ExecutionTier.REASONING to PhaseModelDirective("opus"))),
+    )
+
+    assertNull(matrix.directiveFor("unknown", "plan"))
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfig.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfig.kt
@@ -3,9 +3,12 @@ package skillbill.infrastructure.fs
 import com.fasterxml.jackson.core.JacksonException
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import me.tatarka.inject.annotations.Inject
+import skillbill.config.model.EXECUTION_MATRIX_KEY
+import skillbill.config.model.ExecutionMatrixParse
 import skillbill.config.model.RepoLocalConfig
 import skillbill.config.model.RepoLocalConfigKey
 import skillbill.config.model.parseCodeReviewParallelAgent
+import skillbill.config.model.parseExecutionMatrix
 import skillbill.config.model.parseSpecType
 import skillbill.error.MalformedRepoLocalConfigError
 import skillbill.error.UnreadableRepoLocalConfigError
@@ -36,7 +39,21 @@ class FileSystemRepoLocalConfig : RepoLocalConfigPort {
     codeReviewParallelAgent = parseKnownKey(path, raw, RepoLocalConfigKey.CODE_REVIEW_PARALLEL_AGENT) { value ->
       parseCodeReviewParallelAgent(value)
     } ?: RepoLocalConfig.defaults().codeReviewParallelAgent,
+    executionMatrix = parseExecutionMatrix(path, raw),
   )
+
+  private fun parseExecutionMatrix(path: Path, raw: Map<String, Any?>) = when {
+    !raw.containsKey(EXECUTION_MATRIX_KEY) -> null
+    else -> when (val parsed = parseExecutionMatrix(raw[EXECUTION_MATRIX_KEY])) {
+      is ExecutionMatrixParse.Valid -> parsed.matrix
+      is ExecutionMatrixParse.Invalid -> throw MalformedRepoLocalConfigError(
+        path = path.toString(),
+        key = parsed.keyPath,
+        value = parsed.value,
+        reason = parsed.reason,
+      )
+    }
+  }
 
   private fun <T> parseKnownKey(
     path: Path,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
@@ -53,6 +53,10 @@ class ClaudeAgentRunCommandBuilder : AgentRunCommandBuilder {
           add("--model")
           add(it)
         }
+        request.effortOverride?.let {
+          add("--effort")
+          add(it)
+        }
         add("--dangerously-skip-permissions")
         add("--add-dir")
         add(request.repoRoot.toString())
@@ -81,6 +85,10 @@ class CodexAgentRunCommandBuilder : AgentRunCommandBuilder {
           add("--model")
           add(it)
         }
+        request.effortOverride?.let {
+          add("--config")
+          add("model_reasoning_effort=$it")
+        }
       },
       workingDirectory = request.repoRoot,
       timeout = request.timeout,
@@ -95,6 +103,9 @@ class JunieAgentRunCommandBuilder : AgentRunCommandBuilder {
   override fun build(request: SkillRunRequest): AgentRunCommand =
     goalContinuationCommand(request, agent) ?: AgentRunCommand(
       command = buildList {
+        require(request.modelOverride == null && request.effortOverride == null) {
+          "junie cannot honor a model/effort directive; remove its execution_matrix entry or --phase-model assignment."
+        }
         add("junie")
         add("--project")
         add(request.repoRoot.toString())

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfigTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfigTest.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs
 
+import skillbill.config.model.ExecutionTier
+import skillbill.config.model.PhaseModelDirective
 import skillbill.config.model.RepoLocalConfig
 import skillbill.config.model.SpecType
 import skillbill.error.MalformedRepoLocalConfigError
@@ -120,6 +122,52 @@ class FileSystemRepoLocalConfigTest {
 
     assertEquals(SpecType.LINEAR, config.specType)
     assertEquals(RepoLocalConfig.NO_PARALLEL_AGENT, config.codeReviewParallelAgent)
+  }
+
+  @Test
+  fun `reads execution matrix beside the existing flat config keys`() {
+    val repoRoot = writeConfig(
+      """
+      spec_type: linear
+      execution_matrix:
+        phase_tiers:
+          plan: implementation
+        agents:
+          codex:
+            implementation:
+              model: gpt-terra
+              effort: high
+      """.trimIndent(),
+    )
+
+    val config = adapter.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot)).config
+    val matrix = requireNotNull(config.executionMatrix)
+
+    assertEquals(SpecType.LINEAR, config.specType)
+    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("plan"))
+    assertEquals(
+      PhaseModelDirective("gpt-terra", "high"),
+      matrix.directiveFor("codex", "plan"),
+    )
+  }
+
+  @Test
+  fun `malformed execution matrix names the dotted config key`() {
+    val repoRoot = writeConfig(
+      """
+      execution_matrix:
+        agents:
+          claude:
+            reasoning:
+              effort: high
+      """.trimIndent(),
+    )
+
+    val error = assertFailsWith<MalformedRepoLocalConfigError> {
+      adapter.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot))
+    }
+
+    assertEquals("execution_matrix.agents.claude.reasoning.model", error.key)
   }
 
   private fun writeConfig(content: String): Path {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunCommandBuildersTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunCommandBuildersTest.kt
@@ -1,0 +1,147 @@
+package skillbill.launcher
+
+import skillbill.install.model.InstallAgent
+import skillbill.install.model.MODEL_DIRECTIVE_CAPABLE_AGENTS
+import skillbill.launcher.agentrun.ClaudeAgentRunCommandBuilder
+import skillbill.launcher.agentrun.CodexAgentRunCommandBuilder
+import skillbill.launcher.agentrun.JunieAgentRunCommandBuilder
+import skillbill.ports.agentrun.model.SkillRunRequest
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AgentRunCommandBuildersTest {
+  @Test
+  fun `claude renders exact commands for each directive shape`() {
+    val builder = ClaudeAgentRunCommandBuilder()
+
+    assertEquals(
+      listOf(
+        "claude",
+        "--print",
+        "--output-format",
+        "text",
+        "--model",
+        "claude-opus",
+        "--effort",
+        "high",
+        "--dangerously-skip-permissions",
+        "--add-dir",
+        "/tmp/skillbill-agent-run",
+      ),
+      builder.build(request(model = "claude-opus", effort = "high")).command,
+    )
+    assertEquals(
+      listOf(
+        "claude",
+        "--print",
+        "--output-format",
+        "text",
+        "--model",
+        "claude-opus",
+        "--dangerously-skip-permissions",
+        "--add-dir",
+        "/tmp/skillbill-agent-run",
+      ),
+      builder.build(request(model = "claude-opus")).command,
+    )
+    assertEquals(
+      listOf(
+        "claude",
+        "--print",
+        "--output-format",
+        "text",
+        "--dangerously-skip-permissions",
+        "--add-dir",
+        "/tmp/skillbill-agent-run",
+      ),
+      builder.build(request()).command,
+    )
+  }
+
+  @Test
+  fun `codex renders exact commands for each directive shape`() {
+    val builder = CodexAgentRunCommandBuilder()
+
+    assertEquals(
+      listOf(
+        "codex",
+        "exec",
+        "--cd",
+        "/tmp/skillbill-agent-run",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--config",
+        "shell_environment_policy.inherit=all",
+        "--model",
+        "gpt-sol",
+        "--config",
+        "model_reasoning_effort=xhigh",
+      ),
+      builder.build(request(model = "gpt-sol", effort = "xhigh")).command,
+    )
+    assertEquals(
+      listOf(
+        "codex",
+        "exec",
+        "--cd",
+        "/tmp/skillbill-agent-run",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--config",
+        "shell_environment_policy.inherit=all",
+        "--model",
+        "gpt-sol",
+      ),
+      builder.build(request(model = "gpt-sol")).command,
+    )
+    assertEquals(
+      listOf(
+        "codex",
+        "exec",
+        "--cd",
+        "/tmp/skillbill-agent-run",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--config",
+        "shell_environment_policy.inherit=all",
+      ),
+      builder.build(request()).command,
+    )
+  }
+
+  @Test
+  fun `directive capable agents have builders that render their directives`() {
+    val builders = listOf(ClaudeAgentRunCommandBuilder(), CodexAgentRunCommandBuilder())
+
+    assertEquals(MODEL_DIRECTIVE_CAPABLE_AGENTS, builders.map { it.agent }.toSet())
+    builders.forEach { builder ->
+      val command = builder.build(request(model = "model", effort = "high")).command
+      assertTrue(command.contains("--model"))
+      assertTrue(command.any { it == "high" || it == "model_reasoning_effort=high" })
+    }
+  }
+
+  @Test
+  fun `junie rejects model and effort directives`() {
+    assertFailsWith<IllegalArgumentException> {
+      JunieAgentRunCommandBuilder().build(request(model = "model", effort = "high"))
+    }
+  }
+
+  @Test
+  fun `junie accepts a directive free request`() {
+    val command = JunieAgentRunCommandBuilder().build(
+      request(),
+    ).command
+
+    assertEquals(InstallAgent.JUNIE.id, command.first())
+  }
+
+  private fun request(model: String? = null, effort: String? = null): SkillRunRequest = SkillRunRequest(
+    issueKey = "SKILL-113",
+    repoRoot = Path.of("/tmp/skillbill-agent-run"),
+    promptOverride = "Phase: implement",
+    modelOverride = model,
+    effortOverride = effort,
+  )
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunGoalContinuationCommandTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunGoalContinuationCommandTest.kt
@@ -149,6 +149,19 @@ class AgentRunGoalContinuationCommandTest {
     assertContains(runner.requests.single().command, "--suppress-pr")
   }
 
+  @Test
+  fun `goal-continuation wrapper never receives model or effort flags`() {
+    val runner = RecordingAgentRunProcessRunner()
+    requireNotNull(headlessAgentRunAdapters(runner)[InstallAgent.CODEX]).launch(
+      skillRunRequest().copy(modelOverride = "gpt-sol", effortOverride = "high"),
+    )
+
+    val command = runner.requests.single().command
+    assertFalse(command.contains("--model"))
+    assertFalse(command.contains("--effort"))
+    assertFalse(command.any { it.startsWith("model_reasoning_effort=") })
+  }
+
   private fun skillRunRequest(
     goalContinuation: SkillRunGoalContinuationContext? = goalContinuationContext(),
   ): SkillRunRequest = SkillRunRequest(

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
@@ -21,12 +21,14 @@ data class SkillRunRequest(
   val outputSink: AgentRunOutputSink = AgentRunOutputSink.NONE,
   val promptOverride: String? = null,
   val modelOverride: String? = null,
+  val effortOverride: String? = null,
   val goalContinuation: SkillRunGoalContinuationContext? = null,
 ) {
   init {
     require(issueKey.isNotBlank()) { "issueKey is required." }
     promptOverride?.let { prompt -> require(prompt.isNotBlank()) { "promptOverride must be non-blank when provided." } }
     modelOverride?.let { model -> require(model.isNotBlank()) { "modelOverride must be non-blank when provided." } }
+    effortOverride?.let { effort -> require(effort.isNotBlank()) { "effortOverride must be non-blank when provided." } }
     subtaskId?.let { id -> require(id > 0) { "subtaskId must be positive when provided." } }
     timeout?.let { maxWallClockTimeout ->
       require(maxWallClockTimeout.isPositive()) { "timeout must be positive when provided." }

--- a/runtime-kotlin/runtime-ports/src/test/kotlin/skillbill/ports/agentrun/AgentRunLauncherModelsTest.kt
+++ b/runtime-kotlin/runtime-ports/src/test/kotlin/skillbill/ports/agentrun/AgentRunLauncherModelsTest.kt
@@ -23,6 +23,20 @@ class AgentRunLauncherModelsTest {
   }
 
   @Test
+  fun `skill run request validates non-blank model and effort overrides`() {
+    SkillRunRequest(
+      issueKey = "SKILL-56",
+      repoRoot = Path.of("."),
+      modelOverride = "gpt-sol",
+      effortOverride = "high",
+    )
+
+    assertFailsWith<IllegalArgumentException> {
+      SkillRunRequest(issueKey = "SKILL-56", repoRoot = Path.of("."), effortOverride = " ")
+    }
+  }
+
+  @Test
   fun `launch facts do not allow terminal process status on timeout or spawn failure`() {
     assertFailsWith<IllegalArgumentException> {
       AgentRunLaunchFacts(


### PR DESCRIPTION
# Summary

Implements SKILL-113’s declarative execution matrix so the feature-task runtime can select per-phase model and effort settings by agent and tier, while preserving current launches when configuration is absent.

- Adds config parsing and validation, CLI `--phase-model` overrides, per-phase resolution, capability gates, directive-aware agent commands, and monitor observability.
- Covers parsing, resolver precedence, CLI validation/refusal, command-builder behavior, continuation wrappers, and baseline parity.

## Feature Flags

N/A

# How Has This Been Tested?

- `skill-bill validate`
- `(cd runtime-kotlin && ./gradlew check)`
- `npx --yes agnix --strict .`
- `scripts/validate_agent_configs`

1. Add an `execution_matrix` to `.skill-bill/config.yaml` for Claude or Codex.
2. Run `skill-bill feature-task run` or resume with selected `--phase-model phase=model[@effort]` overrides.
3. Verify directives resolve per phase, compatible agents receive model/effort flags, unsupported directives fail before workflow work, and no configured matrix preserves existing commands.