### PR TITLE
SKILL-113: use machine-global execution matrix

### DIFF
--- a/.feature-specs/SKILL-113-execution-matrix/spec.md
+++ b/.feature-specs/SKILL-113-execution-matrix/spec.md
@@ -2,7 +2,9 @@
 
 ## Outcome
 
-The feature-task runtime can run its high-leverage phases (plan, code review, completeness audit, quality validation) on a stronger model and its mechanical phases (implement, fix loops, history, commit, PR) on a cheaper one, driven by a declarative `execution_matrix` in the repo-local `.skill-bill/config.yaml`. The matrix is keyed by agent id and named tier, carries `model` and `effort` as separate fields, resolves per phase with the precedence `CLI arg > config > none`, and loud-fails on any combination an agent's command builder cannot honor.
+The feature-task runtime can run its high-leverage phases (plan, code review, completeness audit, quality validation) on a stronger model and its mechanical phases (implement, fix loops, history, commit, PR) on a cheaper one, driven by a declarative `execution_matrix` in the machine-global `~/.config/skill-bill/config.json`. The matrix is keyed by agent id and named tier, carries `model` and `effort` as separate fields, resolves per phase with the precedence `CLI arg > config > none`, and loud-fails on any combination an agent's command builder cannot honor.
+
+> User-directed revision: model and effort preferences apply to the whole machine, not an individual repository. `execution_matrix` shares the durable global JSON config with telemetry and external add-on sources; the prior repo-local `.skill-bill/config.yaml` location is superseded.
 
 Example target config:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,6 +100,8 @@ Installed skills are symlinks to rendered staging directories under `~/.skill-bi
 
 Your `config.json` (telemetry choices, `install_id`, and `external_addon_sources`) lives at the durable path **`~/.config/skill-bill/config.json`**. That location is **outside** the `~/.skill-bill/` tree that installs wipe, so it survives every `./install.sh` and update automatically — no environment variable required.
 
+Feature-task model and effort preferences also belong in this machine-wide JSON file under `execution_matrix`; they apply to every repository you run on this machine.
+
 - **Fresh installs** write there by default.
 - **Existing installs** are migrated automatically: the installer moves a legacy `~/.skill-bill/config.json` to the durable path before the pre-install cleanup, so nothing is lost on upgrade.
 - **Custom location**: set `SKILL_BILL_CONFIG_PATH` to pin the config anywhere (this override always wins, for both the installer and the runtime). If you exported this in an earlier version just to relocate the config to `~/.config/skill-bill/`, you can drop it — the durable default now covers that automatically.

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,6 +1,6 @@
 ## [2026-07-12] SKILL-113 execution matrix per-phase model and effort tiers
 Areas: runtime-kotlin/runtime-domain config/install, runtime-application feature-task/config, runtime-cli feature-task/core, runtime-infra-fs config/launcher, runtime-ports agent-run
-- Repo-local `execution_matrix` now maps per-agent reasoning/implementation tiers to model and optional effort, with default phase tiers, per-phase overrides, typed dotted-path validation failures, and unchanged behavior when absent. reusable
+- Machine-global `execution_matrix` in `~/.config/skill-bill/config.json` maps per-agent reasoning/implementation tiers to model and optional effort, with default phase tiers, per-phase overrides, typed dotted-path validation failures, and unchanged behavior when absent. reusable
 - Runtime resolves each phase as CLI directive > matrix directive for its resolved agent > none, carries the directive into launch and phase-start telemetry, and preserves goal-continuation wrapper commands without model flags.
 - Pattern: declare CLI capability beside agent support in the domain, reject incompatible resolved phase/directive pairs before workflow or branch work, then retain a command-builder `require` as a defensive backstop. reusable
 - Claude and Codex render effort through their native command forms; Junie deliberately refuses directives, while parallel code-review `--model` behavior remains independent.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/config/ConfigResolutionService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/config/ConfigResolutionService.kt
@@ -1,27 +1,52 @@
 package skillbill.application.config
 
 import me.tatarka.inject.annotations.Inject
-import skillbill.application.workflow.repoRoot
+import skillbill.config.model.EXECUTION_MATRIX_KEY
 import skillbill.config.model.ExecutionMatrix
+import skillbill.config.model.ExecutionMatrixParse
 import skillbill.config.model.RepoLocalConfig
 import skillbill.config.model.RepoLocalConfigResolution
 import skillbill.config.model.SpecType
+import skillbill.config.model.parseExecutionMatrix
+import skillbill.error.MalformedMachineConfigError
 import skillbill.ports.config.RepoLocalConfigPort
 import skillbill.ports.config.model.ReadRepoLocalConfigRequest
+import skillbill.ports.telemetry.TelemetryConfigStore
 import java.nio.file.Path
 
 /**
- * Surfaces the repo-local config precedence points (`explicit arg > config value > built-in
- * default`) over [RepoLocalConfigPort]. A malformed config propagates the typed
- * [skillbill.error.MalformedRepoLocalConfigError] unchanged so callers loud-fail instead
- * of silently defaulting.
+ * Resolves repository-local workflow settings and machine-wide model directives through their
+ * respective configuration ports. Malformed values fail loudly with typed errors.
  */
 @Inject
 class ConfigResolutionService(
   private val repoLocalConfigPort: RepoLocalConfigPort,
+  private val machineConfigStore: TelemetryConfigStore,
 ) {
-  fun resolveExecutionMatrix(repoRoot: Path): ExecutionMatrix? =
-    repoLocalConfigPort.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot)).config.executionMatrix
+  fun resolveExecutionMatrix(): ExecutionMatrix? {
+    val configPath = machineConfigStore.configPath()
+    val payload = try {
+      machineConfigStore.read()?.payload
+    } catch (error: IllegalArgumentException) {
+      throw MalformedMachineConfigError(
+        path = configPath.toString(),
+        key = "",
+        value = "<document>",
+        reason = "is not valid JSON.",
+        cause = error,
+      )
+    } ?: return null
+    if (!payload.containsKey(EXECUTION_MATRIX_KEY)) return null
+    return when (val parsed = parseExecutionMatrix(payload[EXECUTION_MATRIX_KEY])) {
+      is ExecutionMatrixParse.Valid -> parsed.matrix
+      is ExecutionMatrixParse.Invalid -> throw MalformedMachineConfigError(
+        path = configPath.toString(),
+        key = parsed.keyPath,
+        value = parsed.value,
+        reason = parsed.reason,
+      )
+    }
+  }
 
   fun resolveSpecType(repoRoot: Path, explicit: SpecType?): SpecType {
     val config = repoLocalConfigPort.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot)).config

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
@@ -184,7 +184,7 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
     )
     val modelAssignment = FeatureTaskRuntimeModelAssignment(
       perPhaseDirectives = parsePhaseModels(phaseModels),
-      matrix = deps.configResolutionService.resolveExecutionMatrix(repoRoot),
+      matrix = deps.configResolutionService.resolveExecutionMatrix(),
     )
     val resolvedAgentIds = FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds.associateWith { phaseId ->
       FeatureTaskRuntimeAgentResolver.resolve(phaseId, agentAssignment, invokedAgentId).resolvedAgentId

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -2,6 +2,7 @@ package skillbill.cli
 
 import skillbill.cli.core.CliRuntime
 import skillbill.cli.model.CliRuntimeContext
+import skillbill.error.MalformedMachineConfigError
 import skillbill.install.model.InstallAgent
 import skillbill.ports.agentrun.AgentRunLauncher
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
@@ -20,6 +21,7 @@ import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -888,19 +890,25 @@ class CliFeatureTaskRuntimeModelDirectiveTest {
   }
 
   @Test
-  fun `feature-task runtime reads phase directives from the repo local execution matrix`() {
+  fun `feature-task runtime reads phase directives from the machine execution matrix`() {
     val fixture = runtimeFixture()
-    val config = fixture.tempDir.resolve(".skill-bill/config.yaml")
+    val config = fixture.tempDir.resolve(".config/skill-bill/config.json")
     Files.createDirectories(config.parent)
     Files.writeString(
       config,
       """
-      execution_matrix:
-        agents:
-          codex:
-            reasoning:
-              model: gpt-sol
-              effort: high
+      {
+        "execution_matrix": {
+          "agents": {
+            "codex": {
+              "reasoning": {
+                "model": "gpt-sol",
+                "effort": "high"
+              }
+            }
+          }
+        }
+      }
       """.trimIndent(),
     )
     val launcher = RecordingPhaseLauncher()
@@ -917,19 +925,60 @@ class CliFeatureTaskRuntimeModelDirectiveTest {
   }
 
   @Test
-  fun `goal continuation re-resolves execution matrix directives for child phase launches`() {
-    val fixture = runtimeFixture(specFileName = "spec_subtask_5_runtime.md")
-    val config = fixture.tempDir.resolve(".skill-bill/config.yaml")
+  fun `feature-task runtime rejects a malformed machine execution matrix`() {
+    val fixture = runtimeFixture()
+    val config = fixture.tempDir.resolve(".config/skill-bill/config.json")
     Files.createDirectories(config.parent)
     Files.writeString(
       config,
       """
-      execution_matrix:
-        agents:
-          codex:
-            reasoning:
-              model: gpt-sol
-              effort: high
+      {
+        "execution_matrix": {
+          "agents": {
+            "codex": {
+              "reasoning": {
+                "effort": "high"
+              }
+            }
+          }
+        }
+      }
+      """.trimIndent(),
+    )
+    val launcher = RecordingPhaseLauncher()
+
+    val error = assertFailsWith<MalformedMachineConfigError> {
+      CliRuntime.run(
+        fixture.runCommand(extra = listOf("--agent", "codex")),
+        fixture.context(launcher),
+      )
+    }
+
+    assertContains(error.message.orEmpty(), "Machine config")
+    assertContains(error.message.orEmpty(), "execution_matrix.agents.codex.reasoning.model")
+    assertEquals(emptyList(), launcher.requests)
+  }
+
+  @Test
+  fun `goal continuation re-resolves execution matrix directives for child phase launches`() {
+    val fixture = runtimeFixture(specFileName = "spec_subtask_5_runtime.md")
+    val config = fixture.tempDir.resolve(".config/skill-bill/config.json")
+    Files.createDirectories(config.parent)
+    Files.writeString(
+      config,
+      """
+      {
+        "execution_matrix": {
+          "agents": {
+            "codex": {
+              "reasoning": {
+                "model": "gpt-sol",
+                "effort": "high"
+              }
+            }
+          }
+        }
+      }
       """.trimIndent(),
     )
     val directLauncher = RecordingPhaseLauncher()

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/error/ShellContentContractErrors.kt
@@ -273,6 +273,18 @@ class MalformedRepoLocalConfigError(
   cause,
 )
 
+class MalformedMachineConfigError(
+  val path: String,
+  val key: String,
+  val value: String,
+  val reason: String,
+  cause: Throwable? = null,
+) : ShellContentContractException(
+  "Machine config at '${path.ifBlank { "<unknown>" }}' is malformed: " +
+    "key '${key.ifBlank { "<root>" }}' value '$value' $reason",
+  cause,
+)
+
 class ContractVersionMismatchError(
   message: String,
   cause: Throwable? = null,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/RepoLocalConfigModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/RepoLocalConfigModels.kt
@@ -41,7 +41,6 @@ enum class RepoLocalConfigKey(
 data class RepoLocalConfig(
   val specType: SpecType,
   val codeReviewParallelAgent: String,
-  val executionMatrix: ExecutionMatrix? = null,
 ) {
   companion object {
     const val NO_PARALLEL_AGENT: String = "none"

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfig.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfig.kt
@@ -3,12 +3,9 @@ package skillbill.infrastructure.fs
 import com.fasterxml.jackson.core.JacksonException
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import me.tatarka.inject.annotations.Inject
-import skillbill.config.model.EXECUTION_MATRIX_KEY
-import skillbill.config.model.ExecutionMatrixParse
 import skillbill.config.model.RepoLocalConfig
 import skillbill.config.model.RepoLocalConfigKey
 import skillbill.config.model.parseCodeReviewParallelAgent
-import skillbill.config.model.parseExecutionMatrix
 import skillbill.config.model.parseSpecType
 import skillbill.error.MalformedRepoLocalConfigError
 import skillbill.error.UnreadableRepoLocalConfigError
@@ -39,21 +36,7 @@ class FileSystemRepoLocalConfig : RepoLocalConfigPort {
     codeReviewParallelAgent = parseKnownKey(path, raw, RepoLocalConfigKey.CODE_REVIEW_PARALLEL_AGENT) { value ->
       parseCodeReviewParallelAgent(value)
     } ?: RepoLocalConfig.defaults().codeReviewParallelAgent,
-    executionMatrix = parseExecutionMatrix(path, raw),
   )
-
-  private fun parseExecutionMatrix(path: Path, raw: Map<String, Any?>) = when {
-    !raw.containsKey(EXECUTION_MATRIX_KEY) -> null
-    else -> when (val parsed = parseExecutionMatrix(raw[EXECUTION_MATRIX_KEY])) {
-      is ExecutionMatrixParse.Valid -> parsed.matrix
-      is ExecutionMatrixParse.Invalid -> throw MalformedRepoLocalConfigError(
-        path = path.toString(),
-        key = parsed.keyPath,
-        value = parsed.value,
-        reason = parsed.reason,
-      )
-    }
-  }
 
   private fun <T> parseKnownKey(
     path: Path,

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfigTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemRepoLocalConfigTest.kt
@@ -1,7 +1,5 @@
 package skillbill.infrastructure.fs
 
-import skillbill.config.model.ExecutionTier
-import skillbill.config.model.PhaseModelDirective
 import skillbill.config.model.RepoLocalConfig
 import skillbill.config.model.SpecType
 import skillbill.error.MalformedRepoLocalConfigError
@@ -125,49 +123,19 @@ class FileSystemRepoLocalConfigTest {
   }
 
   @Test
-  fun `reads execution matrix beside the existing flat config keys`() {
+  fun `ignores execution matrix because it belongs to the machine config`() {
     val repoRoot = writeConfig(
       """
       spec_type: linear
       execution_matrix:
-        phase_tiers:
-          plan: implementation
-        agents:
-          codex:
-            implementation:
-              model: gpt-terra
-              effort: high
+        invalid: repo-local matrices are ignored
       """.trimIndent(),
     )
 
     val config = adapter.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot)).config
-    val matrix = requireNotNull(config.executionMatrix)
 
     assertEquals(SpecType.LINEAR, config.specType)
-    assertEquals(ExecutionTier.IMPLEMENTATION, matrix.tierOf("plan"))
-    assertEquals(
-      PhaseModelDirective("gpt-terra", "high"),
-      matrix.directiveFor("codex", "plan"),
-    )
-  }
-
-  @Test
-  fun `malformed execution matrix names the dotted config key`() {
-    val repoRoot = writeConfig(
-      """
-      execution_matrix:
-        agents:
-          claude:
-            reasoning:
-              effort: high
-      """.trimIndent(),
-    )
-
-    val error = assertFailsWith<MalformedRepoLocalConfigError> {
-      adapter.readRepoLocalConfig(ReadRepoLocalConfigRequest(repoRoot))
-    }
-
-    assertEquals("execution_matrix.agents.claude.reasoning.model", error.key)
+    assertEquals(RepoLocalConfig.NO_PARALLEL_AGENT, config.codeReviewParallelAgent)
   }
 
   private fun writeConfig(content: String): Path {


### PR DESCRIPTION
## Summary

Moves execution_matrix from repository-local YAML to the existing durable machine config at ~/.config/skill-bill/config.json.

- Preserves repository-local workflow settings and existing global telemetry/add-on settings.
- Applies the same matrix to feature-task runs in every repository on the machine.
- Fails loudly with a typed error for malformed matrix JSON.

## Validation

- (cd runtime-kotlin && ./gradlew check)
- skill-bill validate
- npx --yes agnix --strict .
- scripts/validate_agent_configs