### PR TITLE
feat: [SKILL-118] enforce pre-1.0 use license

### DIFF
--- a/.feature-specs/SKILL-118-pre-1-0-use-license/spec.md
+++ b/.feature-specs/SKILL-118-pre-1-0-use-license/spec.md
@@ -1,5 +1,5 @@
 ---
-status: Complete
+status: In Progress
 issue_key: SKILL-118
 source: inline user request
 ---

--- a/.feature-specs/SKILL-118-pre-1-0-use-license/spec.md
+++ b/.feature-specs/SKILL-118-pre-1-0-use-license/spec.md
@@ -1,5 +1,5 @@
 ---
-status: In Progress
+status: Complete
 issue_key: SKILL-118
 source: inline user request
 ---

--- a/.feature-specs/SKILL-118-pre-1-0-use-license/spec.md
+++ b/.feature-specs/SKILL-118-pre-1-0-use-license/spec.md
@@ -1,5 +1,5 @@
 ---
-status: Ready for implementation
+status: Complete
 issue_key: SKILL-118
 source: inline user request
 ---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,20 +128,41 @@ jobs:
       - name: Verify packaged licenses and checksums
         shell: bash
         run: |
-          shopt -s nullglob
+          set -euo pipefail
+          host_token="${{ matrix.host_token }}"
+          desktop_dir="runtime-kotlin/runtime-desktop/build/compose/binaries/main"
           artifacts=(
-            runtime-kotlin/runtime-cli/build/runtime-image/*.zip
-            runtime-kotlin/runtime-mcp/build/runtime-image/*.zip
+            "runtime-kotlin/runtime-cli/build/runtime-image/runtime-cli-${RELEASE_VERSION}-${host_token}.zip"
+            "runtime-kotlin/runtime-mcp/build/runtime-image/runtime-mcp-${RELEASE_VERSION}-${host_token}.zip"
           )
-          for artifact in runtime-kotlin/runtime-desktop/build/compose/binaries/main/*/SkillBill-*; do
-            if [[ "${artifact}" != *.sha256 ]]; then
-              artifacts+=("${artifact}")
-            fi
+          case "${host_token}" in
+            macos-arm64)
+              artifacts+=("${desktop_dir}/dmg/SkillBill-${RELEASE_VERSION}-${host_token}.dmg")
+              ;;
+            windows-x64)
+              artifacts+=("${desktop_dir}/msi/SkillBill-${RELEASE_VERSION}-${host_token}.msi")
+              ;;
+            linux-x64)
+              artifacts+=(
+                "${desktop_dir}/deb/SkillBill-${RELEASE_VERSION}-${host_token}.deb"
+                "${desktop_dir}/rpm/SkillBill-${RELEASE_VERSION}-${host_token}.rpm"
+                "skill-bill-skills-${RELEASE_VERSION}.tar.gz"
+              )
+              ;;
+            *)
+              echo "Unsupported release host token: ${host_token}." >&2
+              exit 1
+              ;;
+          esac
+          for artifact in "${artifacts[@]}"; do
+            [[ -f "${artifact}" ]] || { echo "Missing canonical artifact: ${artifact}." >&2; exit 1; }
+            [[ -f "${artifact}.sha256" ]] || { echo "Missing checksum sidecar: ${artifact}.sha256." >&2; exit 1; }
           done
-          if [[ "${{ matrix.host_token }}" == "linux-x64" ]]; then
-            artifacts+=(skill-bill-skills-*.tar.gz)
-          fi
           scripts/verify_release_artifact_licenses "${artifacts[@]}"
+          mkdir release-assets
+          for artifact in "${artifacts[@]}"; do
+            cp "${artifact}" "${artifact}.sha256" release-assets/
+          done
 
       # AC2/AC5: upload every verified archive + its .sha256 under an artifact
       # named with the canonical host token so the publish job can collect them.
@@ -153,23 +174,7 @@ jobs:
           name: release-assets-${{ matrix.host_token }}
           if-no-files-found: error
           retention-days: 7
-          path: |
-            runtime-kotlin/runtime-cli/build/runtime-image/*.zip
-            runtime-kotlin/runtime-cli/build/runtime-image/*.zip.sha256
-            runtime-kotlin/runtime-mcp/build/runtime-image/*.zip
-            runtime-kotlin/runtime-mcp/build/runtime-image/*.zip.sha256
-            runtime-kotlin/runtime-desktop/build/compose/binaries/main/*/SkillBill-*
-
-      - name: Upload skills bundle
-        if: matrix.host_token == 'linux-x64'
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets-skills
-          if-no-files-found: error
-          retention-days: 7
-          path: |
-            skill-bill-skills-*.tar.gz
-            skill-bill-skills-*.tar.gz.sha256
+          path: release-assets/
 
   # Phase 2: validation gate + GitHub Release publish. needs: build so the release
   # only happens once every host's artifacts exist. The maintainer validation gate
@@ -248,10 +253,7 @@ jobs:
           ls -la dist
           echo "Total asset count: $(find dist -type f | wc -l)"
 
-      # AC2/AC3/AC6: publish (or update) the GitHub Release and attach every asset.
-      # Idempotent: if the release already exists we attach assets via `gh release
-      # upload --clobber` instead of failing. Prerelease flag honours release_meta
-      # (tag push) or the always-prerelease staging path (workflow_dispatch).
+      # AC2/AC3/AC6: publish a fresh immutable GitHub Release and attach every verified asset.
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -275,11 +277,8 @@ jobs:
           echo "Publishing ${RELEASE_TAG} with ${#assets[@]} assets (prerelease=${RELEASE_PRERELEASE})."
 
           if gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "Release ${RELEASE_TAG} already exists; uploading/updating assets."
-            gh release upload "${RELEASE_TAG}" "${assets[@]}" \
-              --repo "${{ github.repository }}" \
-              --clobber
-            exit 0
+            echo "Release ${RELEASE_TAG} already exists; release assets are immutable. Use a fresh staging version." >&2
+            exit 1
           fi
 
           args=(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,11 +273,6 @@ jobs:
             exit 1
           fi
 
-          if gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "Release ${RELEASE_TAG} already exists; release assets are immutable. Use a fresh staging version." >&2
-            exit 1
-          fi
-
           release_version="${RELEASE_TAG#v}"
           artifact_names=(
             "runtime-cli-${release_version}-macos-arm64.zip"
@@ -319,29 +314,73 @@ jobs:
             assets+=("dist/${asset_name}")
           done
 
-          echo "Creating draft ${RELEASE_TAG} with ${#assets[@]} verified assets (prerelease=${RELEASE_PRERELEASE})."
-
-          args=(
-            "${RELEASE_TAG}"
-            --repo "${{ github.repository }}"
-            --title "${RELEASE_TAG}"
-            --generate-notes
-          )
-
-          # A pushed tag exists in the repo, so --verify-tag guards against typos.
-          # A staging (workflow_dispatch) run has no pushed tag, so gh creates one
-          # from the current ref; --verify-tag would fail, so omit it there.
-          if [[ "${IS_STAGING}" != "true" ]]; then
-            args+=(--verify-tag)
+          release_exists=false
+          if gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            release_exists=true
           fi
 
-          if [[ "${RELEASE_PRERELEASE}" == "true" ]]; then
-            args+=(--prerelease)
+          if [[ "${release_exists}" == "true" ]]; then
+            release_metadata="$(gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" --json isDraft,isPrerelease,targetCommitish,tagName --jq '[.isDraft, .isPrerelease, .targetCommitish, .tagName] | @tsv')"
+            IFS=$'\t' read -r existing_draft existing_prerelease existing_target existing_tag <<< "${release_metadata}"
+            if [[ "${existing_draft}" != "true" ]]; then
+              echo "Release ${RELEASE_TAG} is already published and cannot be resumed." >&2
+              exit 1
+            fi
+            if [[ "${existing_tag}" != "${RELEASE_TAG}" || "${existing_target}" != "${GITHUB_SHA}" || "${existing_prerelease}" != "${RELEASE_PRERELEASE}" ]]; then
+              echo "Existing draft ${RELEASE_TAG} does not match this validated tag, commit, and prerelease classification." >&2
+              exit 1
+            fi
+          else
+            if [[ "${IS_STAGING}" == "true" ]] && git ls-remote --exit-code --refs origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+              echo "Staging tag ${RELEASE_TAG} already exists without a resumable draft release." >&2
+              exit 1
+            fi
+
+            echo "Creating draft ${RELEASE_TAG} at ${GITHUB_SHA} with ${#assets[@]} verified assets (prerelease=${RELEASE_PRERELEASE})."
+            args=(
+              "${RELEASE_TAG}"
+              --repo "${{ github.repository }}"
+              --title "${RELEASE_TAG}"
+              --generate-notes
+              --target "${GITHUB_SHA}"
+            )
+            if [[ "${IS_STAGING}" != "true" ]]; then
+              args+=(--verify-tag)
+            fi
+            if [[ "${RELEASE_PRERELEASE}" == "true" ]]; then
+              args+=(--prerelease)
+            fi
+            gh release create "${args[@]}" --draft
           fi
 
-          gh release create "${args[@]}" --draft
-          gh release upload "${RELEASE_TAG}" "${assets[@]}" --repo "${{ github.repository }}"
-
+          existing_assets_dir="$(mktemp -d)"
+          trap 'rm -rf "${existing_assets_dir}"' EXIT
+          uploaded_names="$(gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | sort)"
+          while IFS= read -r uploaded_name; do
+            [[ -n "${uploaded_name}" ]] || continue
+            expected=false
+            for asset_name in "${asset_names[@]}"; do
+              if [[ "${uploaded_name}" == "${asset_name}" ]]; then
+                expected=true
+                break
+              fi
+            done
+            if [[ "${expected}" != "true" ]]; then
+              echo "Draft release contains an unexpected asset: ${uploaded_name}." >&2
+              exit 1
+            fi
+          done <<< "${uploaded_names}"
+          for asset_name in "${asset_names[@]}"; do
+            if grep -Fxq "${asset_name}" <<< "${uploaded_names}"; then
+              gh release download "${RELEASE_TAG}" --repo "${{ github.repository }}" --pattern "${asset_name}" --dir "${existing_assets_dir}"
+              if ! cmp -s "dist/${asset_name}" "${existing_assets_dir}/${asset_name}"; then
+                echo "Existing draft asset bytes differ from the validated asset: ${asset_name}." >&2
+                exit 1
+              fi
+            else
+              gh release upload "${RELEASE_TAG}" "dist/${asset_name}" --repo "${{ github.repository }}"
+            fi
+          done
           uploaded_names="$(gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | sort)"
           for asset_name in "${asset_names[@]}"; do
             if ! grep -Fxq "${asset_name}" <<< "${uploaded_names}"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,33 @@ jobs:
           cd runtime-kotlin
           ./gradlew ${{ matrix.installer_tasks }}
 
-      # AC2/AC5: upload every produced archive + its .sha256 under an artifact
+      - name: Bundle skills archive
+        if: matrix.host_token == 'linux-x64'
+        shell: bash
+        run: |
+          archive="skill-bill-skills-${RELEASE_VERSION}.tar.gz"
+          tar -czf "$archive" LICENSE skills/ platform-packs/ orchestration/ uninstall.sh
+          sha256sum "$archive" > "${archive}.sha256"
+
+      - name: Verify packaged licenses and checksums
+        shell: bash
+        run: |
+          shopt -s nullglob
+          artifacts=(
+            runtime-kotlin/runtime-cli/build/runtime-image/*.zip
+            runtime-kotlin/runtime-mcp/build/runtime-image/*.zip
+          )
+          for artifact in runtime-kotlin/runtime-desktop/build/compose/binaries/main/*/SkillBill-*; do
+            if [[ "${artifact}" != *.sha256 ]]; then
+              artifacts+=("${artifact}")
+            fi
+          done
+          if [[ "${{ matrix.host_token }}" == "linux-x64" ]]; then
+            artifacts+=(skill-bill-skills-*.tar.gz)
+          fi
+          scripts/verify_release_artifact_licenses "${artifacts[@]}"
+
+      # AC2/AC5: upload every verified archive + its .sha256 under an artifact
       # named with the canonical host token so the publish job can collect them.
       # The runtime-image zips live under <module>/build/runtime-image/ and the
       # installers under runtime-desktop/build/compose/binaries/main/<format>/.
@@ -133,14 +159,6 @@ jobs:
             runtime-kotlin/runtime-mcp/build/runtime-image/*.zip
             runtime-kotlin/runtime-mcp/build/runtime-image/*.zip.sha256
             runtime-kotlin/runtime-desktop/build/compose/binaries/main/*/SkillBill-*
-
-      - name: Bundle skills archive
-        if: matrix.host_token == 'linux-x64'
-        shell: bash
-        run: |
-          archive="skill-bill-skills-${RELEASE_VERSION}.tar.gz"
-          tar -czf "$archive" skills/ platform-packs/ orchestration/ uninstall.sh
-          sha256sum "$archive" > "${archive}.sha256"
 
       - name: Upload skills bundle
         if: matrix.host_token == 'linux-x64'
@@ -212,13 +230,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           STAGING_VERSION: ${{ inputs.staging_version }}
-        run: |
-          # AC6: a manual staging run produces a real downloadable prerelease asset
-          # set without relying on validate_release_ref's tag parsing.
-          {
-            echo "tag=${STAGING_VERSION}"
-            echo "prerelease=true"
-          } >>"$GITHUB_OUTPUT"
+        run: scripts/validate_release_ref "$STAGING_VERSION" --force-prerelease --github-output "$GITHUB_OUTPUT"
 
       # AC2/AC5: collect every host's archives + .sha256 into one flat directory.
       # merge-multiple flattens the per-host artifact dirs so every asset lands

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends fakeroot rpm
 
+      - name: Install MSI inspection tooling
+        if: matrix.host_token == 'windows-x64'
+        shell: bash
+        run: choco install lessmsi --yes --no-progress
+
       # AC1/AC5: self-contained per-OS runtime images for CLI + MCP. runtimeZip is
       # finalizedBy its .sha256 task, so each produces archive + .sha256. Badass
       # Runtime tasks are not configuration-cache compatible, so do NOT pass
@@ -167,6 +172,21 @@ jobs:
             [[ -f "${artifact}.sha256" ]] || { echo "Missing checksum sidecar: ${artifact}.sha256." >&2; exit 1; }
           done
           scripts/verify_release_artifact_licenses "${artifacts[@]}"
+          verifier_probe="$(mktemp -d)"
+          cp scripts/verify_release_artifact_licenses "${verifier_probe}/verify_release_artifact_licenses"
+          printf '%s\n' 'intentional license drift probe' > "${verifier_probe}/LICENSE"
+          for artifact in "${artifacts[@]}"; do
+            probe_log="${verifier_probe}/$(basename "${artifact}").log"
+            if "${verifier_probe}/verify_release_artifact_licenses" "${artifact}" >"${probe_log}" 2>&1; then
+              echo "License drift probe unexpectedly accepted ${artifact}." >&2
+              exit 1
+            fi
+            if ! grep -q 'LICENSE bytes differ' "${probe_log}"; then
+              echo "License drift probe failed for an unrelated reason in ${artifact}." >&2
+              cat "${probe_log}" >&2
+              exit 1
+            fi
+          done
           mkdir release-assets
           for artifact in "${artifacts[@]}"; do
             cp "${artifact}" "${artifact}.sha256" release-assets/
@@ -262,6 +282,8 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          HOLDER_RELEASE_TOKEN: ${{ secrets.SKILL_BILL_COPYRIGHT_HOLDER_RELEASE_TOKEN }}
+          HOLDER_GITHUB_LOGIN: ${{ vars.SKILL_BILL_COPYRIGHT_HOLDER_GITHUB_LOGIN }}
           RELEASE_TAG: ${{ steps.release_meta.outputs.tag || steps.staging_meta.outputs.tag }}
           RELEASE_PRERELEASE: ${{ steps.release_meta.outputs.prerelease || steps.staging_meta.outputs.prerelease }}
           IS_STAGING: ${{ github.event_name == 'workflow_dispatch' }}
@@ -271,6 +293,33 @@ jobs:
           if [[ -z "${RELEASE_TAG}" ]]; then
             echo "No release tag resolved; refusing to publish." >&2
             exit 1
+          fi
+
+          holder_release=false
+          if [[ "${RELEASE_TAG}" == "v1.0.0" && "${RELEASE_PRERELEASE}" != "true" ]]; then
+            if [[ -z "${HOLDER_RELEASE_TOKEN}" || -z "${HOLDER_GITHUB_LOGIN}" ]]; then
+              echo "Stable v1.0.0 publication requires the copyright holder's release token and GitHub login." >&2
+              exit 1
+            fi
+            GH_TOKEN="${HOLDER_RELEASE_TOKEN}"
+            authenticated_login="$(gh api user --jq '.login')"
+            if [[ "${authenticated_login}" != "${HOLDER_GITHUB_LOGIN}" ]]; then
+              echo "Stable v1.0.0 publication token is not authenticated as the configured copyright holder." >&2
+              exit 1
+            fi
+            holder_release=true
+          fi
+
+          expected_commit="${GITHUB_SHA}"
+          if [[ "${IS_STAGING}" != "true" ]]; then
+            expected_commit="$(git ls-remote origin "refs/tags/${RELEASE_TAG}^{}" | awk 'NR == 1 { print $1 }')"
+            if [[ -z "${expected_commit}" ]]; then
+              expected_commit="$(git ls-remote --refs origin "refs/tags/${RELEASE_TAG}" | awk 'NR == 1 { print $1 }')"
+            fi
+            if [[ -z "${expected_commit}" || "${expected_commit}" != "${GITHUB_SHA}" ]]; then
+              echo "Release tag ${RELEASE_TAG} does not peel to the validated commit ${GITHUB_SHA}." >&2
+              exit 1
+            fi
           fi
 
           release_version="${RELEASE_TAG#v}"
@@ -315,20 +364,28 @@ jobs:
           done
 
           release_exists=false
+          release_published=false
           if gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             release_exists=true
           fi
 
           if [[ "${release_exists}" == "true" ]]; then
-            release_metadata="$(gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" --json isDraft,isPrerelease,targetCommitish,tagName --jq '[.isDraft, .isPrerelease, .targetCommitish, .tagName] | @tsv')"
-            IFS=$'\t' read -r existing_draft existing_prerelease existing_target existing_tag <<< "${release_metadata}"
-            if [[ "${existing_draft}" != "true" ]]; then
-              echo "Release ${RELEASE_TAG} is already published and cannot be resumed." >&2
-              exit 1
-            fi
-            if [[ "${existing_tag}" != "${RELEASE_TAG}" || "${existing_target}" != "${GITHUB_SHA}" || "${existing_prerelease}" != "${RELEASE_PRERELEASE}" ]]; then
+            release_metadata="$(gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" --json author,isDraft,isPrerelease,targetCommitish,tagName --jq '[.isDraft, .isPrerelease, .targetCommitish, .tagName, .author.login] | @tsv')"
+            IFS=$'\t' read -r existing_draft existing_prerelease existing_target existing_tag existing_author <<< "${release_metadata}"
+            if [[ "${existing_tag}" != "${RELEASE_TAG}" || "${existing_prerelease}" != "${RELEASE_PRERELEASE}" ]]; then
               echo "Existing draft ${RELEASE_TAG} does not match this validated tag, commit, and prerelease classification." >&2
               exit 1
+            fi
+            if [[ "${IS_STAGING}" == "true" && "${existing_target}" != "${expected_commit}" ]]; then
+              echo "Existing staging release ${RELEASE_TAG} does not target the validated commit ${expected_commit}." >&2
+              exit 1
+            fi
+            if [[ "${holder_release}" == "true" && "${existing_author}" != "${HOLDER_GITHUB_LOGIN}" ]]; then
+              echo "Stable v1.0.0 release ${RELEASE_TAG} was not created by the configured copyright holder." >&2
+              exit 1
+            fi
+            if [[ "${existing_draft}" != "true" ]]; then
+              release_published=true
             fi
           else
             if [[ "${IS_STAGING}" == "true" ]] && git ls-remote --exit-code --refs origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
@@ -378,6 +435,10 @@ jobs:
                 exit 1
               fi
             else
+              if [[ "${release_published}" == "true" ]]; then
+                echo "Published release is missing expected asset: ${asset_name}." >&2
+                exit 1
+              fi
               gh release upload "${RELEASE_TAG}" "dist/${asset_name}" --repo "${{ github.repository }}"
             fi
           done
@@ -393,4 +454,8 @@ jobs:
             echo "Draft release contains an unexpected number of assets: ${uploaded_count}." >&2
             exit 1
           fi
-          gh release edit "${RELEASE_TAG}" --repo "${{ github.repository }}" --draft=false
+          if [[ "${release_published}" == "true" ]]; then
+            echo "Published release ${RELEASE_TAG} already matches the validated metadata and assets."
+          else
+            gh release edit "${RELEASE_TAG}" --repo "${{ github.repository }}" --draft=false
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ on:
     inputs:
       staging_version:
         description: >-
-          Staging version label for a manual run (e.g. v0.4.0-rc.1). Produces a
-          downloadable prerelease asset set without requiring a pushed tag.
+          SemVer prerelease label for a manual run (e.g. v0.4.0-staging.1).
+          Produces a downloadable prerelease asset set without requiring a pushed tag.
         required: true
         type: string
 
@@ -80,8 +80,16 @@ jobs:
       # build.gradle.kts so every artifact name embeds the correct version.
       - name: Set release version
         shell: bash
+        env:
+          STAGING_VERSION: ${{ inputs.staging_version }}
         run: |
-          raw="${{ github.event_name == 'workflow_dispatch' && inputs.staging_version || github.ref_name }}"
+          validation_args=()
+          raw="$GITHUB_REF_NAME"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            raw="$STAGING_VERSION"
+            validation_args+=(--force-prerelease)
+          fi
+          scripts/validate_release_ref "$raw" "${validation_args[@]}"
           echo "RELEASE_VERSION=${raw#v}" >> "$GITHUB_ENV"
 
       # Linux desktop installers shell out to native packaging tools: .deb needs
@@ -221,10 +229,6 @@ jobs:
       - name: Run repo-native validation
         run: scripts/validate_agent_configs
 
-      # AC3/AC4: derive release metadata. On a tag push we validate the ref and
-      # let validate_release_ref decide prerelease vs stable. On a manual staging
-      # run there is no tag, so we derive metadata from the staging_version input
-      # and ALWAYS publish a prerelease (staging is never a stable release).
       - name: Validate release tag
         id: release_meta
         if: github.event_name != 'workflow_dispatch'
@@ -235,7 +239,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           STAGING_VERSION: ${{ inputs.staging_version }}
-        run: scripts/validate_release_ref "$STAGING_VERSION" --force-prerelease --github-output "$GITHUB_OUTPUT"
+        run: >-
+          scripts/validate_release_ref "$STAGING_VERSION" --force-prerelease
+          --github-output "$GITHUB_OUTPUT"
 
       # AC2/AC5: collect every host's archives + .sha256 into one flat directory.
       # merge-multiple flattens the per-host artifact dirs so every asset lands
@@ -253,7 +259,6 @@ jobs:
           ls -la dist
           echo "Total asset count: $(find dist -type f | wc -l)"
 
-      # AC2/AC3/AC6: publish a fresh immutable GitHub Release and attach every verified asset.
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -268,18 +273,53 @@ jobs:
             exit 1
           fi
 
-          mapfile -t assets < <(find dist -type f | sort)
-          if [[ "${#assets[@]}" -eq 0 ]]; then
-            echo "No assets found under dist/; refusing to publish an empty release." >&2
-            exit 1
-          fi
-
-          echo "Publishing ${RELEASE_TAG} with ${#assets[@]} assets (prerelease=${RELEASE_PRERELEASE})."
-
           if gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             echo "Release ${RELEASE_TAG} already exists; release assets are immutable. Use a fresh staging version." >&2
             exit 1
           fi
+
+          release_version="${RELEASE_TAG#v}"
+          artifact_names=(
+            "runtime-cli-${release_version}-macos-arm64.zip"
+            "runtime-mcp-${release_version}-macos-arm64.zip"
+            "SkillBill-${release_version}-macos-arm64.dmg"
+            "runtime-cli-${release_version}-windows-x64.zip"
+            "runtime-mcp-${release_version}-windows-x64.zip"
+            "SkillBill-${release_version}-windows-x64.msi"
+            "runtime-cli-${release_version}-linux-x64.zip"
+            "runtime-mcp-${release_version}-linux-x64.zip"
+            "SkillBill-${release_version}-linux-x64.deb"
+            "SkillBill-${release_version}-linux-x64.rpm"
+            "skill-bill-skills-${release_version}.tar.gz"
+          )
+          asset_names=()
+          for artifact_name in "${artifact_names[@]}"; do
+            asset_names+=("${artifact_name}" "${artifact_name}.sha256")
+          done
+          for asset_name in "${asset_names[@]}"; do
+            [[ -f "dist/${asset_name}" ]] || { echo "Missing expected release asset: ${asset_name}." >&2; exit 1; }
+          done
+          for downloaded_asset in dist/*; do
+            [[ -f "${downloaded_asset}" ]] || continue
+            downloaded_name="$(basename "${downloaded_asset}")"
+            expected=false
+            for asset_name in "${asset_names[@]}"; do
+              if [[ "${downloaded_name}" == "${asset_name}" ]]; then
+                expected=true
+                break
+              fi
+            done
+            if [[ "${expected}" != "true" ]]; then
+              echo "Unexpected release asset: ${downloaded_name}." >&2
+              exit 1
+            fi
+          done
+          assets=()
+          for asset_name in "${asset_names[@]}"; do
+            assets+=("dist/${asset_name}")
+          done
+
+          echo "Creating draft ${RELEASE_TAG} with ${#assets[@]} verified assets (prerelease=${RELEASE_PRERELEASE})."
 
           args=(
             "${RELEASE_TAG}"
@@ -299,4 +339,19 @@ jobs:
             args+=(--prerelease)
           fi
 
-          gh release create "${args[@]}" "${assets[@]}"
+          gh release create "${args[@]}" --draft
+          gh release upload "${RELEASE_TAG}" "${assets[@]}" --repo "${{ github.repository }}"
+
+          uploaded_names="$(gh release view "${RELEASE_TAG}" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | sort)"
+          for asset_name in "${asset_names[@]}"; do
+            if ! grep -Fxq "${asset_name}" <<< "${uploaded_names}"; then
+              echo "Draft release is missing uploaded asset: ${asset_name}." >&2
+              exit 1
+            fi
+          done
+          uploaded_count="$(printf '%s\n' "${uploaded_names}" | sed '/^$/d' | wc -l | tr -d ' ')"
+          if [[ "${uploaded_count}" != "${#asset_names[@]}" ]]; then
+            echo "Draft release contains an unexpected number of assets: ${uploaded_count}." >&2
+            exit 1
+          fi
+          gh release edit "${RELEASE_TAG}" --repo "${{ github.repository }}" --draft=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,11 @@ governs rights in Skill Bill itself.
 
 The non-authoritative [licensing summary](docs/licensing.md) gives the same
 version matrix as the public release guidance: v0.1.0 and v0.1.1 retain their
-shipped terms; v0.1.2 through covered pre-1.0 releases use the custom project
-license; the Stable Release Event changes permitted execution; and v1.0.0
-requires a deliberate successor-license decision. The root `LICENSE` text
-governs. This is not a CLA or sign-off requirement.
+shipped terms; releases from v0.1.2 use the custom project license; and the
+stable `v1.0.0` Stable Release Event changes free commercial use to free personal and
+qualifying open-source-project use, with other commercial use requiring a
+purchased Commercial License. The root `LICENSE` text governs. This is not a
+CLA or sign-off requirement.
 
 ## Quality Gate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,18 @@
 # Contributing to Skill Bill
 
-Skill Bill is pre-1.0 and solo-maintained. Contributions are welcome; the
-project is source-available and actively developed. A few things to know before
-contributing:
+Skill Bill is pre-1.0 and solo-maintained. Contributions are welcome. A few
+things to know before contributing:
 
 ## Licensing
 
 By submitting a contribution, you agree that your contribution is licensed under
-the repository license in `LICENSE`, and you grant Braian Gapur a perpetual,
+the repository [LICENSE](LICENSE), and you grant Braian Gapur a perpetual,
 worldwide, non-exclusive, royalty-free right to include your contribution in
-commercial licenses for Skill Bill. Do not submit a contribution unless you have
-the right to make that grant.
+separately licensed commercial versions of Skill Bill. Do not submit a
+contribution unless you have the right to make that grant. The project's
+non-authoritative [licensing summary](docs/licensing.md) explains the covered
+version matrix; the `LICENSE` text governs. This is not a CLA or sign-off
+requirement.
 
 ## Quality Gate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,21 @@ things to know before contributing:
 
 ## Licensing
 
-By submitting a contribution, you agree that your contribution is licensed under
-the repository [LICENSE](LICENSE), and you grant Braian Gapur a perpetual,
-worldwide, non-exclusive, royalty-free right to include your contribution in
-separately licensed commercial versions of Skill Bill. Do not submit a
-contribution unless you have the right to make that grant. The project's
-non-authoritative [licensing summary](docs/licensing.md) explains the covered
-version matrix; the `LICENSE` text governs. This is not a CLA or sign-off
-requirement.
+By submitting a contribution, you grant Braian Gapur a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable right to reproduce, modify, prepare
+derivative works from, incorporate, publish, distribute, sublicense, and
+relicense that contribution as part of public Skill Bill releases and
+separately licensed releases. You represent that you have the authority to
+grant those rights. This contributor grant gives the copyright holder rights in
+your contribution; it does not change the project [LICENSE](LICENSE), which
+governs rights in Skill Bill itself.
+
+The non-authoritative [licensing summary](docs/licensing.md) gives the same
+version matrix as the public release guidance: v0.1.0 and v0.1.1 retain their
+shipped terms; v0.1.2 through covered pre-1.0 releases use the custom project
+license; the Stable Release Event changes permitted execution; and v1.0.0
+requires a deliberate successor-license decision. The root `LICENSE` text
+governs. This is not a CLA or sign-off requirement.
 
 ## Quality Gate
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,149 +1,171 @@
-Skill Bill License
+Skill Bill Pre-1.0 Use License 1.0
 
+Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0
 Copyright (c) 2026 Braian Gapur
+Prospective Effective Version: v0.1.2
 
-Skill Bill is source-available software.
+1. Purpose and prospective application
 
-Noncommercial use is licensed under the PolyForm Noncommercial License 1.0.0
-below.
+This Skill Bill Pre-1.0 Use License 1.0 (this "License") states the terms on
+which the Copyright Holder makes Covered Software available. This License
+applies prospectively beginning with Skill Bill release v0.1.2 (the
+"Prospective Effective Version"). It applies to each release of Skill Bill at
+or after that version and before v1.0.0 that is distributed with this License,
+and to source snapshots distributed with this License for those releases.
 
-Commercial use is not permitted by this public license. Commercial use includes
-use by a for-profit company, use in a paid product or service, use to provide
-paid consulting or managed services, or any other use intended to generate
-revenue or business advantage. Commercial use requires a separate commercial
-license from the copyright holder.
+This License does not replace, revoke, narrow, or reinterpret any license,
+permission, or other right granted for v0.1.0, v0.1.1, or an earlier revision.
+Those materials remain subject to the terms with which they were received.
 
-The copyright holder may separately authorize specific people, companies,
-customers, and partners to use Skill Bill outside the public noncommercial
-license.
+2. Definitions
 
-Required Notice: Copyright (c) 2026 Braian Gapur. Skill Bill is licensed for
-noncommercial use under the PolyForm Noncommercial License 1.0.0. Commercial
-use requires a separate commercial license from the copyright holder.
+"Copyright Holder" means Braian Gapur.
 
-# PolyForm Noncommercial License 1.0.0
+"Covered Software" means the Skill Bill software to which this License is
+included or identified, as described in section 1. Covered Software excludes
+third-party software that carries its own license or notice.
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+"GitHub Release" means a release object published through GitHub's release
+feature, rather than a branch, commit, local artifact, or bare Git tag.
 
-## Acceptance
+"Licensee" means every natural person or legal entity exercising a permission
+under this License.
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+"Personal Use" means use by a natural person solely on that person's own
+behalf, not as an employee, contractor, agent, or representative of another
+person or organization and not for compensation, revenue, or business
+advantage.
 
-## Copyright License
+"Open Source Contribution Use" means use by a natural person, without payment
+or other compensation and not for an employer, client, sponsor, or other
+organization, solely to create, maintain, test, review, document, or
+contribute to software whose source code is publicly available under a license
+approved by the Open Source Initiative. It does not make Covered Software open
+source or permit Covered Software to be copied into that other software.
 
-The licensor grants you a copyright license for the software
-to do everything you might do with the software that would
-otherwise infringe the licensor's copyright in it for any
-permitted purpose.  However, you may only distribute the
-software according to [Distribution License](#distribution-license)
-and make changes or new works based on the software according
-to [Changes and New Works License](#changes-and-new-works-license).
+"Separate Agreement" means a written agreement independently entered into by
+the Copyright Holder and a Licensee that grants rights beyond this License.
 
-## Distribution License
+"Stable Release Event" means the first public, non-draft, non-prerelease
+GitHub Release tagged exactly v1.0.0 that is published by the Copyright Holder
+in the oila-gmbh/skill-bill repository. A draft, a prerelease, a release
+candidate or other prerelease identifier, a bare tag, a branch, a local
+artifact, or a release from a fork or another repository owner is not the
+Stable Release Event. Once the Stable Release Event occurs, its later
+withdrawal, deletion, or change to prerelease status does not undo the event.
 
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
-
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
-
-## Changes and New Works License
-
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
-
-## Patent License
-
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
-
-## Noncommercial Purposes
-
-Any noncommercial purpose is a permitted purpose.
-
-## Personal Uses
-
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application, is
-use for a permitted purpose.
-
-## Noncommercial Organizations
-
-Use by any charitable organization, educational institution,
-public research organization, public safety or health organization,
-environmental protection organization, or government institution
-is use for a permitted purpose regardless of the source of
-funding or obligations resulting from the funding.
-
-## Fair Use
-
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
-
-## No Other Rights
-
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
-
-## Patent Defense
-
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
-
-## Violations
-
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
-
-## No Liability
-
-As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.
-
-## Definitions
-
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
-
-**You** refers to the individual or entity agreeing to these
+"Third-Party Software" means software, libraries, dependencies, runtimes, or
+other material that is not Covered Software and is supplied under its own
 terms.
 
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
+"User Materials" means independently authored specifications, skills,
+platform packs, add-ons, native-agent definitions, configuration, prompts, and
+similar input material. "Generated Outputs" means code, documents, reports,
+telemetry exports, patches, and other output produced through permitted use.
 
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
+3. Acceptance and ownership
+
+By obtaining, installing, copying, or executing Covered Software, a Licensee
+accepts this License. Covered Software is licensed, not sold. The Copyright
+Holder retains all rights not expressly granted by this License, including all
+rights in Covered Software and its names, marks, and branding.
+
+4. Grant before the Stable Release Event
+
+Before the Stable Release Event, the Copyright Holder grants every Licensee a
+non-exclusive, worldwide, royalty-free right to obtain an unmodified copy of
+Covered Software, make only transient, installation, execution, and reasonable
+backup copies necessary to exercise this grant, and install and execute that
+unmodified copy for any lawful purpose.
+
+The permitted purpose expressly includes internal business use, paid work,
+commercial use, consulting, managed-service use, and hosted-service use,
+provided that the Licensee does not transfer Covered Software or make a copy of
+Covered Software available to a third party. This grant is free of charge and
+is not a sale, transfer of ownership, sublicense, or grant to modify or
+redistribute Covered Software.
+
+5. Automatic change at the Stable Release Event
+
+At the Stable Release Event, the commercial-use permission in section 4 ends
+automatically for every Covered Software version. After that event, a Licensee
+may make the technical copies and execute an unmodified Covered Software
+version only for Personal Use or Open Source Contribution Use.
+
+A person or entity whose use does not qualify after the Stable Release Event
+must stop executing every Covered Software version and remove all active,
+installed, and deployable copies under its control. A Licensee may retain one
+non-executable archival copy only when applicable law requires that retention;
+the archival copy may not be used.
+
+Paid or sponsored work, employer-directed work, client work, consulting,
+managed services, revenue-producing use, and use for business advantage are
+not Personal Use or Open Source Contribution Use. Charitable, educational,
+governmental, and other nonprofit organizational use is not automatically
+permitted unless it independently satisfies one of those defined uses.
+
+6. Restrictions that apply at all times
+
+This License grants no right to modify, translate, adapt, reverse engineer
+except where applicable law cannot be excluded, or prepare derivative works
+from Covered Software. It grants no right to redistribute, distribute,
+publish, mirror, sublicense, sell, lease, transfer, bundle, or otherwise
+provide Covered Software source or binaries to another person.
+
+This License also grants no right to remove or alter copyright, license,
+attribution, or proprietary notices; to represent Covered Software as open
+source or free software; or to use project names, marks, or branding except as
+reasonably necessary to identify the unmodified Covered Software. The limited
+technical and backup copies expressly allowed in sections 4 and 5 are the only
+copying rights granted by this License.
+
+7. User Materials and Generated Outputs
+
+Using documented extension and input surfaces is permitted and is not a
+modification of Covered Software. Licensees retain all rights in their User
+Materials and Generated Outputs and may create, modify, use, license, and
+distribute them, subject to applicable law and third-party rights. This License
+makes no ownership claim over them.
+
+If User Materials or Generated Outputs reproduce a protected portion of
+Covered Software, this License continues to govern that protected portion. The
+Copyright Holder retains all rights in that reproduced Covered Software
+material.
+
+8. Earlier, separate, platform, and third-party rights
+
+This License does not retroactively withdraw or narrow rights arising under an
+earlier MIT, PolyForm, or other license; applicable law; a Separate Agreement;
+GitHub's platform-limited rights for public repositories; or a Third-Party
+Software license. This License itself grants no fork, modification, or
+redistribution permission for Covered Software. Third-Party Software remains
+subject to its own terms.
+
+9. Termination and cure
+
+The permissions granted by this License terminate automatically if a Licensee
+materially breaches this License. For a first material breach, the permissions
+continue if the Licensee receives written notice, comes fully into compliance,
+and takes reasonable steps to correct the effects of the breach within 30 days
+after receiving that notice. A later material breach terminates the permissions
+immediately. Termination does not affect rights that arose independently of
+this License.
+
+10. Disclaimer and limitation of liability
+
+Covered Software is provided "AS IS" and "AS AVAILABLE." To the maximum extent
+permitted by applicable law, the Copyright Holder disclaims all warranties,
+whether express, implied, statutory, or otherwise, including warranties of
+merchantability, fitness for a particular purpose, title, and noninfringement.
+To the maximum extent permitted by applicable law, the Copyright Holder is not
+liable for any indirect, incidental, special, consequential, exemplary, or
+punitive damages, or for lost profits, revenue, data, goodwill, or business
+interruption, arising from or related to this License or Covered Software.
+
+11. General terms
+
+If any provision of this License is unenforceable, it shall be enforced to the
+maximum extent permitted and the remaining provisions remain in effect. A
+waiver is effective only when in writing and applies only to the specific
+instance waived. This License does not create a partnership, agency, or joint
+venture. Sections that by their nature should survive termination do survive.

--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,16 @@
-Skill Bill Pre-1.0 Use License 1.0
+Skill Bill Use License 1.0
 
-Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0
+Identifier: LicenseRef-Skill-Bill-Use-1.0
 Copyright (c) 2026 Braian Gapur
 Prospective Effective Version: v0.1.2
 
 1. Purpose and prospective application
 
-This Skill Bill Pre-1.0 Use License 1.0 (this "License") states the terms on
-which the Copyright Holder makes Covered Software available. This License
-applies prospectively beginning with Skill Bill release v0.1.2 (the
-"Prospective Effective Version"). It applies to each release of Skill Bill at
-or after that version and before v1.0.0 that is distributed with this License,
-and to source snapshots distributed with this License for those releases.
+This Skill Bill Use License 1.0 (this "License") states the terms on which the
+Copyright Holder makes Covered Software available. This License applies
+prospectively to Skill Bill v0.1.2, prereleases leading to v0.1.2 that are
+distributed with this License, every later release distributed with this
+License, and corresponding source snapshots distributed with this License.
 
 This License does not replace, revoke, narrow, or reinterpret any license,
 permission, or other right granted for v0.1.0, v0.1.1, or an earlier revision.
@@ -19,11 +18,20 @@ Those materials remain subject to the terms with which they were received.
 
 2. Definitions
 
+"Commercial License" means a separate written commercial agreement purchased
+from the Copyright Holder that grants commercial rights after the Stable
+Release Event.
+
 "Copyright Holder" means Braian Gapur.
 
-"Covered Software" means the Skill Bill software to which this License is
+"Covered Software" means the Skill Bill software with which this License is
 included or identified, as described in section 1. Covered Software excludes
-third-party software that carries its own license or notice.
+Third-Party Software and User Materials.
+
+"Customizable Materials" means the governed skills, platform packs, add-ons,
+native-agent definitions, orchestration text, configuration, and templates
+included in Covered Software and intentionally exposed by Skill Bill's
+documented customization surfaces. It does not include executable runtime code.
 
 "GitHub Release" means a release object published through GitHub's release
 feature, rather than a branch, commit, local artifact, or bare Git tag.
@@ -31,20 +39,18 @@ feature, rather than a branch, commit, local artifact, or bare Git tag.
 "Licensee" means every natural person or legal entity exercising a permission
 under this License.
 
+"Open Source Project Use" means use solely to create, maintain, test, review,
+document, or contribute to software whose source code is publicly available
+under a license approved by the Open Source Initiative. A natural person or
+legal entity may qualify regardless of employment, compensation, sponsorship,
+or organizational affiliation, provided the use is for that qualifying open
+source project and Covered Software is not incorporated into or distributed
+with the project.
+
 "Personal Use" means use by a natural person solely on that person's own
 behalf, not as an employee, contractor, agent, or representative of another
 person or organization and not for compensation, revenue, or business
 advantage.
-
-"Open Source Contribution Use" means use by a natural person, without payment
-or other compensation and not for an employer, client, sponsor, or other
-organization, solely to create, maintain, test, review, document, or
-contribute to software whose source code is publicly available under a license
-approved by the Open Source Initiative. It does not make Covered Software open
-source or permit Covered Software to be copied into that other software.
-
-"Separate Agreement" means a written agreement independently entered into by
-the Copyright Holder and a Licensee that grants rights beyond this License.
 
 "Stable Release Event" means the first public, non-draft, non-prerelease
 GitHub Release tagged exactly v1.0.0 that is published by the Copyright Holder
@@ -65,65 +71,83 @@ telemetry exports, patches, and other output produced through permitted use.
 
 3. Acceptance and ownership
 
-By obtaining, installing, copying, or executing Covered Software, a Licensee
-accepts this License. Covered Software is licensed, not sold. The Copyright
-Holder retains all rights not expressly granted by this License, including all
-rights in Covered Software and its names, marks, and branding.
+By obtaining, installing, copying, modifying Customizable Materials, or
+executing Covered Software, a Licensee accepts this License. Covered Software
+is licensed, not sold. The Copyright Holder retains all rights not expressly
+granted by this License, including all rights in Covered Software and its
+names, marks, and branding.
 
 4. Grant before the Stable Release Event
 
 Before the Stable Release Event, the Copyright Holder grants every Licensee a
-non-exclusive, worldwide, royalty-free right to obtain an unmodified copy of
-Covered Software, make only transient, installation, execution, and reasonable
-backup copies necessary to exercise this grant, and install and execute that
-unmodified copy for any lawful purpose.
+non-exclusive, worldwide, royalty-free right to obtain Covered Software, make
+the transient, installation, execution, and reasonable backup copies necessary
+to exercise this grant, and install and execute Covered Software for any lawful
+purpose.
 
 The permitted purpose expressly includes internal business use, paid work,
 commercial use, consulting, managed-service use, and hosted-service use,
 provided that the Licensee does not transfer Covered Software or make a copy of
-Covered Software available to a third party. This grant is free of charge and
-is not a sale, transfer of ownership, sublicense, or grant to modify or
-redistribute Covered Software.
+Covered Software available to a third party except as section 6 permits. This
+grant is free of charge and is not a sale, transfer of ownership, or sublicense.
 
-5. Automatic change at the Stable Release Event
+5. Grant at and after the Stable Release Event
 
 At the Stable Release Event, the commercial-use permission in section 4 ends
-automatically for every Covered Software version. After that event, a Licensee
-may make the technical copies and execute an unmodified Covered Software
-version only for Personal Use or Open Source Contribution Use.
+automatically for every Covered Software version. At and after that event, the
+Copyright Holder grants every Licensee a non-exclusive, worldwide, royalty-free
+right to obtain, download, make necessary installation, execution, and
+reasonable backup copies of, install, and execute Covered Software for Personal
+Use or Open Source Project Use.
 
-A person or entity whose use does not qualify after the Stable Release Event
-must stop executing every Covered Software version and remove all active,
-installed, and deployable copies under its control. A Licensee may retain one
-non-executable archival copy only when applicable law requires that retention;
-the archival copy may not be used.
+Any other use at or after the Stable Release Event, including internal business
+use, paid proprietary work, consulting, managed services, revenue-producing use,
+or use for business advantage outside Open Source Project Use, requires a
+Commercial License purchased from the Copyright Holder before that use begins.
+A Licensee whose use no longer qualifies must stop that use and remove active,
+installed, and deployable copies under its control unless and until it obtains a
+Commercial License. One non-executable archival copy may be retained when
+applicable law requires that retention and may not otherwise be used.
 
-Paid or sponsored work, employer-directed work, client work, consulting,
-managed services, revenue-producing use, and use for business advantage are
-not Personal Use or Open Source Contribution Use. Charitable, educational,
-governmental, and other nonprofit organizational use is not automatically
-permitted unless it independently satisfies one of those defined uses.
+Charitable, educational, governmental, and other nonprofit organizational use
+is not automatically Personal Use, but it may qualify as Open Source Project
+Use when it satisfies that definition.
 
-6. Restrictions that apply at all times
+6. Customization permission
 
-This License grants no right to modify, translate, adapt, reverse engineer
-except where applicable law cannot be excluded, or prepare derivative works
-from Covered Software. It grants no right to redistribute, distribute,
-publish, mirror, sublicense, sell, lease, transfer, bundle, or otherwise
-provide Covered Software source or binaries to another person.
+For any use permitted under section 4 or 5, a Licensee may copy, modify, adapt,
+and create derivative works from Customizable Materials and may install and use
+those customized materials with Covered Software. A legal entity may provide
+those customized materials internally to its employees and individual
+contractors solely for the entity's own permitted use, provided those people
+receive this License and do not exercise broader rights.
+
+This permission does not allow public distribution, publication, mirroring,
+sublicensing, sale, leasing, or transfer of Customizable Materials, and it does
+not permit modification or reverse engineering of executable runtime code
+except where applicable law cannot be excluded.
+
+7. Restrictions that apply at all times
+
+Except for the customization permission in section 6, this License grants no
+right to modify, translate, adapt, reverse engineer except where applicable law
+cannot be excluded, or prepare derivative works from Covered Software. It
+grants no right to redistribute, distribute, publish, mirror, sublicense, sell,
+lease, transfer, bundle, or otherwise provide Covered Software source or
+binaries to another person.
 
 This License also grants no right to remove or alter copyright, license,
 attribution, or proprietary notices; to represent Covered Software as open
 source or free software; or to use project names, marks, or branding except as
-reasonably necessary to identify the unmodified Covered Software. The limited
-technical and backup copies expressly allowed in sections 4 and 5 are the only
-copying rights granted by this License.
+reasonably necessary to identify Covered Software. The copying rights expressly
+allowed in sections 4 through 6 are the only copying rights granted by this
+License.
 
-7. User Materials and Generated Outputs
+8. User Materials and Generated Outputs
 
 Using documented extension and input surfaces is permitted and is not a
-modification of Covered Software. Licensees retain all rights in their User
-Materials and Generated Outputs and may create, modify, use, license, and
+modification of executable runtime code. Licensees retain all rights in their
+User Materials and Generated Outputs and may create, modify, use, license, and
 distribute them, subject to applicable law and third-party rights. This License
 makes no ownership claim over them.
 
@@ -132,16 +156,15 @@ Covered Software, this License continues to govern that protected portion. The
 Copyright Holder retains all rights in that reproduced Covered Software
 material.
 
-8. Earlier, separate, platform, and third-party rights
+9. Earlier, commercial, platform, and third-party rights
 
 This License does not retroactively withdraw or narrow rights arising under an
-earlier MIT, PolyForm, or other license; applicable law; a Separate Agreement;
-GitHub's platform-limited rights for public repositories; or a Third-Party
-Software license. This License itself grants no fork, modification, or
-redistribution permission for Covered Software. Third-Party Software remains
+earlier MIT, PolyForm, or other license; applicable law; a Commercial License or
+other separate agreement; GitHub's platform-limited rights for public
+repositories; or a Third-Party Software license. Third-Party Software remains
 subject to its own terms.
 
-9. Termination and cure
+10. Termination and cure
 
 The permissions granted by this License terminate automatically if a Licensee
 materially breaches this License. For a first material breach, the permissions
@@ -151,7 +174,7 @@ after receiving that notice. A later material breach terminates the permissions
 immediately. Termination does not affect rights that arose independently of
 this License.
 
-10. Disclaimer and limitation of liability
+11. Disclaimer and limitation of liability
 
 Covered Software is provided "AS IS" and "AS AVAILABLE." To the maximum extent
 permitted by applicable law, the Copyright Holder disclaims all warranties,
@@ -162,7 +185,7 @@ liable for any indirect, incidental, special, consequential, exemplary, or
 punitive damages, or for lost profits, revenue, data, goodwill, or business
 interruption, arising from or related to this License or Covered Software.
 
-11. General terms
+12. General terms
 
 If any provision of this License is unenforceable, it shall be enforced to the
 maximum extent permitted and the remaining provisions remain in effect. A

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Skill Bill
 
-[![License: Skill Bill Pre-1.0 Use License](https://img.shields.io/badge/License-Skill%20Bill%20Pre--1.0%20Use-4c1.svg)](LICENSE)
+[![License: Skill Bill Use License](https://img.shields.io/badge/License-Skill%20Bill%20Use-4c1.svg)](LICENSE)
 ![Latest release](https://img.shields.io/github/v/release/oila-gmbh/skill-bill?include_prereleases&sort=semver)
 ![Validate agent configs](https://img.shields.io/github/actions/workflow/status/oila-gmbh/skill-bill/validate-agent-configs.yml?branch=main&label=validate)
 
@@ -124,13 +124,15 @@ Maintained packs share one exemption-free substance gate: every effective specia
 
 ## License
 
-The governing text is the [Skill Bill Pre-1.0 Use License 1.0](LICENSE)
-(`LicenseRef-Skill-Bill-Pre-1.0-Use-1.0`). The concise, non-authoritative
+The governing text is the [Skill Bill Use License 1.0](LICENSE)
+(`LicenseRef-Skill-Bill-Use-1.0`). The concise, non-authoritative
 version matrix is in [Licensing](docs/licensing.md): v0.1.0 and v0.1.1 retain
-their shipped terms; covered v0.1.2 pre-1.0 releases allow unmodified lawful
-use, including commercial use, before the Stable Release Event; afterwards they
-allow only personal use and unpaid individual open-source contribution use. The
-`v1.0.0` release requires a deliberate successor-license decision. The project
-license never grants modification or redistribution. User-authored materials and
-generated outputs remain the user's, subject to protected Skill Bill material
-and third-party rights.
+their shipped terms; releases from v0.1.2 allow lawful use, including commercial
+use, before the stable `v1.0.0` Stable Release Event. At and after that event,
+personal use and
+qualifying open-source-project use remain free, while every other commercial use
+requires a purchased Commercial License. Documented skills, packs, and other
+customization materials may be modified for permitted use, but public
+redistribution is not granted. User-authored materials and generated outputs
+remain the user's, subject to protected Skill Bill material and third-party
+rights.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Skill Bill
 
-[![License: PolyForm NC + Commercial](https://img.shields.io/badge/License-PolyForm%20NC%20%2B%20Commercial-orange.svg)](LICENSE)
+[![License: Skill Bill Pre-1.0 Use License](https://img.shields.io/badge/License-Skill%20Bill%20Pre--1.0%20Use-4c1.svg)](LICENSE)
 ![Latest release](https://img.shields.io/github/v/release/oila-gmbh/skill-bill?include_prereleases&sort=semver)
 ![Validate agent configs](https://img.shields.io/github/actions/workflow/status/oila-gmbh/skill-bill/validate-agent-configs.yml?branch=main&label=validate)
 
@@ -124,9 +124,12 @@ Maintained packs share one exemption-free substance gate: every effective specia
 
 ## License
 
-Skill Bill is source-available. Personal and noncommercial use is available
-under the [PolyForm Noncommercial License 1.0.0](LICENSE). Commercial use,
-including use by for-profit companies or in revenue-generating work, requires a
-separate commercial license from the copyright holder. The copyright holder may
-separately authorize specific people, companies, customers, and partners to use
-Skill Bill outside the public noncommercial license.
+The governing text is the [Skill Bill Pre-1.0 Use License 1.0](LICENSE)
+(`LicenseRef-Skill-Bill-Pre-1.0-Use-1.0`). The concise, non-authoritative
+version matrix is in [Licensing](docs/licensing.md): v0.1.0 and v0.1.1 retain
+their shipped terms; covered v0.1.2 pre-1.0 releases allow unmodified lawful
+use, including commercial use, before the Stable Release Event; afterwards they
+allow only personal use and unpaid individual open-source contribution use. The
+project license never grants modification or redistribution. User-authored
+materials and generated outputs remain the user's, subject to protected Skill
+Bill material and third-party rights.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ version matrix is in [Licensing](docs/licensing.md): v0.1.0 and v0.1.1 retain
 their shipped terms; covered v0.1.2 pre-1.0 releases allow unmodified lawful
 use, including commercial use, before the Stable Release Event; afterwards they
 allow only personal use and unpaid individual open-source contribution use. The
-project license never grants modification or redistribution. User-authored
-materials and generated outputs remain the user's, subject to protected Skill
-Bill material and third-party rights.
+`v1.0.0` release requires a deliberate successor-license decision. The project
+license never grants modification or redistribution. User-authored materials and
+generated outputs remain the user's, subject to protected Skill Bill material
+and third-party rights.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,10 +24,18 @@ A stable `v1.0.0`, every later release line, and later prereleases are rejected
 until the copyright holder replaces the transitional current-release license
 with a complete, versioned successor-license policy.
 
-That successor policy must be the complete root `LICENSE` text and declare a
-`Successor License Identifier`, `Successor License Effective Version: v1.0.0`,
-and substantive `Successor License Terms`. These validation fields record a
-deliberate versioned policy decision without preselecting the successor license.
+That successor policy must replace the transitional root `LICENSE` text, declare
+a `Successor License Identifier`, and have an explicit copyright-holder approval
+record tied to its exact normalized SHA-256. Use the
+[successor-license approval record](docs/release-successor-license-approval.md)
+before any `v1.0.0` or later release. This gate records a deliberate versioned
+policy decision without preselecting the successor license.
+
+For the exact stable `v1.0.0` publication, configure the repository secret
+`SKILL_BILL_COPYRIGHT_HOLDER_RELEASE_TOKEN` and variable
+`SKILL_BILL_COPYRIGHT_HOLDER_GITHUB_LOGIN` for Braian Gapur. The workflow
+fails closed unless that token authenticates as the configured holder and the
+release is created by that account.
 
 The [LICENSE](LICENSE) alone defines the Stable Release Event. A successful
 workflow, an existing GitHub Release object, a bare tag, or a local artifact is

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,24 @@ The release contract is:
 - push the tag to GitHub
 - let the `Release` workflow rerun validation and publish the GitHub Release
 
-Pre-release tags such as `v0.5.0-rc.1` are also supported and publish GitHub prereleases.
+The root [LICENSE](LICENSE) governs release licensing. Its non-authoritative
+[version matrix](docs/licensing.md) is deliberately short: v0.1.0/v0.1.1 retain
+their shipped terms; covered releases starting at v0.1.2 permit unmodified
+lawful use, including commercial use, before the Stable Release Event and only
+personal or unpaid individual open-source contribution use after it. The project
+license never grants modification or redistribution.
+
+Pre-release tags such as `v0.5.0-rc.1` are also supported and publish GitHub
+prereleases. v0.1.0 and v0.1.1 are historical exceptions. Starting at v0.1.2,
+the release validator requires the transitional custom-license identifier and
+prospective-version marker. A stable `v1.0.0` or later release is rejected until
+the copyright holder deliberately replaces the transitional current-release
+license. Release candidates and manual staging releases remain prereleases and
+do not make that legal decision.
+
+The [LICENSE](LICENSE) alone defines the Stable Release Event. A successful
+workflow, an existing GitHub Release object, an idempotent release upload, a
+bare tag, or a local artifact is not proof that the event occurred.
 
 ## What a tag push builds
 
@@ -24,7 +41,11 @@ archive plus its `.sha256` sidecar to the GitHub Release for that tag:
 The `<os>-<arch>` token is the canonical set `macos-arm64` / `windows-x64` /
 `linux-x64`, so downstream installers can resolve the correct asset by host. Each
 artifact ships with a matching `<name>.sha256` file. The build toolchain is
-pinned to JDK 17 (temurin) on every runner.
+pinned to JDK 17 (temurin) on every runner. Before upload, each host extracts or
+mounts its native artifacts and compares the included root `LICENSE` bytes; it
+also verifies the adjacent checksum after the licensed artifact is finalized.
+The Linux skills archive includes the root `LICENSE` directly and is checked the
+same way.
 
 Builds run on host-matched runners because jlink and jpackage cannot
 cross-compile: macOS arm64 on the **self-hosted Apple Silicon Mac mini**
@@ -54,8 +75,9 @@ stable release:
    push is required; the workflow builds the same per-OS asset set and publishes a
    prerelease named from the input, so testers get a real downloadable asset set.
 
-Both paths reuse the same build matrix and the same fail-closed validation gate as
-a stable release.
+Both paths reuse the same build matrix and the same fail-closed release-policy
+validator as a stable release. The manual path validates `staging_version` and
+then forces its publication metadata to `prerelease=true`.
 
 ## Release notes
 
@@ -123,22 +145,31 @@ under the hood.
    scripts/validate_agent_configs
    ```
 
-3. Pick the next version tag.
-4. Create an annotated tag:
+3. Before creating `v0.1.2`, obtain and record explicit approval of the exact
+   final [LICENSE](LICENSE) text from the copyright holder, Braian Gapur.
+   Automated checks do not replace this approval or external legal review.
+   Use the [pre-1.0 license approval record](docs/release-license-approval.md)
+   to capture the approved `LICENSE` SHA-256 and approval location.
+4. Pick the next version tag. For releases from `v0.1.2` through pre-1.0, run
+   `scripts/validate_release_ref v0.x.y`; for a staging build, add
+   `--force-prerelease`. Do not create stable `v1.0.0` or later until a
+   deliberate successor license has replaced the transitional text.
+5. Create an annotated tag:
 
    ```bash
    git tag -a v0.x.y -m "Release v0.x.y"
    ```
 
-5. Push the tag:
+6. Push the tag:
 
    ```bash
    git push origin v0.x.y
    ```
 
-6. Confirm the `Release` workflow succeeds and the GitHub Release appears with
+7. Confirm the `Release` workflow succeeds and the GitHub Release appears with
    generated notes and the per-OS runtime-image + desktop-installer assets (each
-   with its `.sha256`) attached.
+   with its `.sha256`) attached. Confirm the published artifacts passed the
+   root-license byte check on their native release-matrix host.
 
 ## Installing from a release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,26 +10,25 @@ The release contract is:
 
 The root [LICENSE](LICENSE) governs release licensing. Its non-authoritative
 [version matrix](docs/licensing.md) is deliberately short: v0.1.0 and v0.1.1
-retain their shipped terms; covered releases starting at v0.1.2 permit unmodified
-lawful use, including commercial use, before the Stable Release Event and only
-personal or unpaid individual open-source contribution use after it. The project
-license never grants modification or redistribution.
+retain their shipped terms; releases starting with v0.1.2, including v0.1.2
+prereleases distributed with the license, permit lawful use including commercial
+use before the Stable Release Event. At and after the event, personal and
+qualifying open-source-project use remain free while other commercial use
+requires a purchased Commercial License. Documented customization materials may
+be modified for permitted use; public redistribution is not granted.
 
 Pre-release tags such as `v0.5.0-rc.1` are also supported and publish GitHub
 prereleases. Versions preceding v0.1.2 by SemVer precedence, including
 `v0.1.1+rebuild.1`, retain their historical terms. Starting at v0.1.2, the
-release validator requires the complete transitional custom policy, not just
-its identifier or a marker. A `v1.0.0` release candidate remains non-triggering.
-A stable `v1.0.0`, every later release line, and later prereleases are rejected
-until the copyright holder replaces the transitional current-release license
-with a complete, versioned successor-license policy.
+release validator requires the complete custom policy, not just its identifier
+or a marker. A `v1.0.0` release candidate remains non-triggering. Stable
+`v1.0.0` and later release lines use the same policy and are rejected until the
+copyright holder approves its exact normalized bytes for stable publication.
 
-That successor policy must replace the transitional root `LICENSE` text, declare
-a `Successor License Identifier`, and have an explicit copyright-holder approval
-record tied to its exact normalized SHA-256. Use the
-[successor-license approval record](docs/release-successor-license-approval.md)
-before any `v1.0.0` or later release. This gate records a deliberate versioned
-policy decision without preselecting the successor license.
+Use the [stable-policy approval record](docs/release-successor-license-approval.md)
+before any `v1.0.0` or later release. The record must name the governing license
+identifier and exact normalized SHA-256. This gate prevents placeholder or
+substitute terms from being published as the stable policy.
 
 For the exact stable `v1.0.0` publication, configure the repository secret
 `SKILL_BILL_COPYRIGHT_HOLDER_RELEASE_TOKEN` and variable
@@ -169,11 +168,12 @@ under the hood.
    Automated checks do not replace this approval or external legal review.
    Use the [pre-1.0 license approval record](docs/release-license-approval.md)
    to capture the approved `LICENSE` SHA-256 and approval location.
-4. Pick the next version tag. For releases from `v0.1.2` through pre-1.0, run
+4. Pick the next canonical `v`-prefixed version tag. For releases from `v0.1.2`
+   through pre-1.0, run
    `scripts/validate_release_ref v0.x.y`; a staging build must use a SemVer
    prerelease label such as `v0.x.y-staging.1`. Do not create stable `v1.0.0` or
-   later until a complete, versioned successor-license policy has replaced the
-   transitional text.
+   later until the exact governing policy has the completed copyright-holder
+   approval record described above.
 5. Create an annotated tag:
 
    ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,12 +16,18 @@ personal or unpaid individual open-source contribution use after it. The project
 license never grants modification or redistribution.
 
 Pre-release tags such as `v0.5.0-rc.1` are also supported and publish GitHub
-prereleases. v0.1.0 and v0.1.1 are historical exceptions. Starting at v0.1.2,
-the release validator requires the complete transitional custom policy, not
-just its identifier or a marker. A `v1.0.0` release candidate and a forced
-`v1.0.0` staging release remain non-triggering. A stable `v1.0.0`, every later
-release line, and later prereleases are rejected until the copyright holder
-deliberately replaces the transitional current-release license.
+prereleases. Versions preceding v0.1.2 by SemVer precedence, including
+`v0.1.1+rebuild.1`, retain their historical terms. Starting at v0.1.2, the
+release validator requires the complete transitional custom policy, not just
+its identifier or a marker. A `v1.0.0` release candidate remains non-triggering.
+A stable `v1.0.0`, every later release line, and later prereleases are rejected
+until the copyright holder replaces the transitional current-release license
+with a complete, versioned successor-license policy.
+
+That successor policy must be the complete root `LICENSE` text and declare a
+`Successor License Identifier`, `Successor License Effective Version: v1.0.0`,
+and substantive `Successor License Terms`. These validation fields record a
+deliberate versioned policy decision without preselecting the successor license.
 
 The [LICENSE](LICENSE) alone defines the Stable Release Event. A successful
 workflow, an existing GitHub Release object, a bare tag, or a local artifact is
@@ -71,16 +77,18 @@ stable release:
    workflow validates the ref, builds every per-OS asset, and publishes a GitHub
    prerelease with all archives + `.sha256` files attached.
 2. **Manual run (`workflow_dispatch`)** — trigger the `Release` workflow from the
-   Actions tab and supply a `staging_version` label (e.g. `v0.5.0-rc.1`). No tag
-   push is required; the workflow builds the same per-OS asset set and publishes a
-   prerelease named from the input, so testers get a real downloadable asset set.
+   Actions tab and supply a SemVer prerelease `staging_version` label (e.g.
+   `v0.5.0-staging.1`). No tag push is required; the workflow rejects a stable
+   version label, builds the same per-OS asset set, and publishes a prerelease
+   named from the input, so testers get a real downloadable asset set.
 
 Both paths reuse the same build matrix and the same fail-closed release-policy
-validator as a stable release. The manual path validates `staging_version` and
-then forces its publication metadata to `prerelease=true`. Every staging label
-is immutable evidence for one asset set: the workflow refuses an existing
-release or staging tag instead of replacing assets, so use a fresh prerelease
-label for every new matrix run.
+validator as a stable release. Every staging label is immutable evidence for
+one asset set: the workflow refuses an existing release or staging tag instead
+of replacing assets, so use a fresh prerelease label for every new matrix run.
+The workflow creates a draft, uploads and confirms the complete expected asset
+set, then publishes it; a failed upload therefore cannot make a partial stable
+release public.
 
 ## Release notes
 
@@ -154,9 +162,10 @@ under the hood.
    Use the [pre-1.0 license approval record](docs/release-license-approval.md)
    to capture the approved `LICENSE` SHA-256 and approval location.
 4. Pick the next version tag. For releases from `v0.1.2` through pre-1.0, run
-   `scripts/validate_release_ref v0.x.y`; for a staging build, add
-   `--force-prerelease`. Do not create stable `v1.0.0` or later until a
-   deliberate successor license has replaced the transitional text.
+   `scripts/validate_release_ref v0.x.y`; a staging build must use a SemVer
+   prerelease label such as `v0.x.y-staging.1`. Do not create stable `v1.0.0` or
+   later until a complete, versioned successor-license policy has replaced the
+   transitional text.
 5. Create an annotated tag:
 
    ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,23 +9,23 @@ The release contract is:
 - let the `Release` workflow rerun validation and publish the GitHub Release
 
 The root [LICENSE](LICENSE) governs release licensing. Its non-authoritative
-[version matrix](docs/licensing.md) is deliberately short: v0.1.0/v0.1.1 retain
-their shipped terms; covered releases starting at v0.1.2 permit unmodified
+[version matrix](docs/licensing.md) is deliberately short: v0.1.0 and v0.1.1
+retain their shipped terms; covered releases starting at v0.1.2 permit unmodified
 lawful use, including commercial use, before the Stable Release Event and only
 personal or unpaid individual open-source contribution use after it. The project
 license never grants modification or redistribution.
 
 Pre-release tags such as `v0.5.0-rc.1` are also supported and publish GitHub
 prereleases. v0.1.0 and v0.1.1 are historical exceptions. Starting at v0.1.2,
-the release validator requires the transitional custom-license identifier and
-prospective-version marker. A stable `v1.0.0` or later release is rejected until
-the copyright holder deliberately replaces the transitional current-release
-license. Release candidates and manual staging releases remain prereleases and
-do not make that legal decision.
+the release validator requires the complete transitional custom policy, not
+just its identifier or a marker. A `v1.0.0` release candidate and a forced
+`v1.0.0` staging release remain non-triggering. A stable `v1.0.0`, every later
+release line, and later prereleases are rejected until the copyright holder
+deliberately replaces the transitional current-release license.
 
 The [LICENSE](LICENSE) alone defines the Stable Release Event. A successful
-workflow, an existing GitHub Release object, an idempotent release upload, a
-bare tag, or a local artifact is not proof that the event occurred.
+workflow, an existing GitHub Release object, a bare tag, or a local artifact is
+not proof that the event occurred.
 
 ## What a tag push builds
 
@@ -77,7 +77,10 @@ stable release:
 
 Both paths reuse the same build matrix and the same fail-closed release-policy
 validator as a stable release. The manual path validates `staging_version` and
-then forces its publication metadata to `prerelease=true`.
+then forces its publication metadata to `prerelease=true`. Every staging label
+is immutable evidence for one asset set: the workflow refuses an existing
+release or staging tag instead of replacing assets, so use a fresh prerelease
+label for every new matrix run.
 
 ## Release notes
 

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-07-12] SKILL-118 pre-1.0 use-only license and stable-release cutoff
+Areas: root `LICENSE` and public licensing/release policy, `.github/workflows/release.yml`, `scripts/verify_release_artifact_licenses`, runtime-kotlin/{build-logic, runtime-application, runtime-cli, runtime-infra-fs, runtime-ports}
+- Established the complete custom `LicenseRef-Skill-Bill-Pre-1.0-Use-1.0` policy for covered releases from v0.1.2, with prospective commercial execution and the exact canonical v1.0.0 GitHub Release cutoff. reusable
+- Repository validation now distinguishes historical v0.1.0/v0.1.1, covered pre-1.0 releases and RCs, and post-1.0 successor-license requirements; policy documentation and release commands share that classification. reusable
+- Release publishing selects canonical archives, verifies that each contains byte-identical root license text and a matching checksum, and refuses to replace an existing release. reusable
+- Pattern: keep legal terms in the root `LICENSE` as the sole authored source, then enforce their version boundary at repository validation, package assembly, artifact verification, and immutable publication seams.
+- Known release prerequisite: Braian Gapur must explicitly approve the final license hash before v0.1.2 is tagged; no tag or GitHub Release was created by this feature.
+Feature flag: N/A
+Acceptance criteria: 12/12 implemented
+
 ## [2026-07-03] SKILL-100 subtask 3 cli-shell-schema
 Areas: install.sh, uninstall.sh, runtime-kotlin/runtime-application (InstallAgentService), runtime-kotlin/runtime-cli (InstallCliCommands, ScaffoldCliCommands), runtime-kotlin/runtime-core (InstallerShellDelegationTest)
 - Completed zcode native-agent CLI/shell/schema wiring on top of subtasks 1-2 (enum/path fan-out, MCP+runtime): added `InstallZcodeAgentsPathCommand`/`InstallLinkZcodeAgentsCommand`/`InstallUnlinkZcodeAgentsCommand` modeled 1:1 on the junie equivalents, registered as `InstallTopLevelCommands` subcommands. reusable

--- a/agent/history.md
+++ b/agent/history.md
@@ -1,13 +1,3 @@
-## [2026-07-12] SKILL-118 pre-1.0 use-only license and stable-release cutoff
-Areas: root `LICENSE` and public licensing/release policy, `.github/workflows/release.yml`, `scripts/verify_release_artifact_licenses`, runtime-kotlin/{build-logic, runtime-application, runtime-cli, runtime-infra-fs, runtime-ports}
-- Established the complete custom `LicenseRef-Skill-Bill-Pre-1.0-Use-1.0` policy for covered releases from v0.1.2, with prospective commercial execution and the exact canonical v1.0.0 GitHub Release cutoff. reusable
-- Repository validation now distinguishes historical v0.1.0/v0.1.1, covered pre-1.0 releases and RCs, and post-1.0 successor-license requirements; policy documentation and release commands share that classification. reusable
-- Release publishing selects canonical archives, verifies that each contains byte-identical root license text and a matching checksum, and refuses to replace an existing release. reusable
-- Pattern: keep legal terms in the root `LICENSE` as the sole authored source, then enforce their version boundary at repository validation, package assembly, artifact verification, and immutable publication seams.
-- Known release prerequisite: Braian Gapur must explicitly approve the final license hash before v0.1.2 is tagged; no tag or GitHub Release was created by this feature.
-Feature flag: N/A
-Acceptance criteria: 12/12 implemented
-
 ## [2026-07-03] SKILL-100 subtask 3 cli-shell-schema
 Areas: install.sh, uninstall.sh, runtime-kotlin/runtime-application (InstallAgentService), runtime-kotlin/runtime-cli (InstallCliCommands, ScaffoldCliCommands), runtime-kotlin/runtime-core (InstallerShellDelegationTest)
 - Completed zcode native-agent CLI/shell/schema wiring on top of subtasks 1-2 (enum/path fan-out, MCP+runtime): added `InstallZcodeAgentsPathCommand`/`InstallLinkZcodeAgentsCommand`/`InstallUnlinkZcodeAgentsCommand` modeled 1:1 on the junie equivalents, registered as `InstallTopLevelCommands` subcommands. reusable

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,27 @@
+# Licensing
+
+The root [LICENSE](../LICENSE) is the complete, governing text. This page is a
+concise, non-authoritative summary and does not change that text.
+
+| Version | Before the Stable Release Event | After the Stable Release Event |
+| --- | --- | --- |
+| v0.1.0 and v0.1.1 | The terms shipped with those releases govern. | The terms shipped with those releases govern. |
+| v0.1.2 through the last covered pre-1.0 release | Anyone may obtain, install, and execute an unmodified copy for any lawful purpose, including commercial, consulting, managed-service, and hosted-service use, when no Skill Bill copy is transferred or made available to a third party. This is unmodified lawful use only. | Only a natural person's Personal Use or unpaid, independent Open Source Contribution Use remains permitted. |
+
+The Stable Release Event is defined exactly in the [LICENSE](../LICENSE). In
+short, it is the first public, non-draft, non-prerelease GitHub Release tagged
+`v1.0.0` published by the copyright holder in `oila-gmbh/skill-bill`; a draft,
+prerelease, release candidate, bare tag, branch, local artifact, or fork
+release does not trigger it.
+
+The project license never grants a right to modify, create derivative works
+from, redistribute, publish, mirror, sublicense, sell, lease, transfer, or
+bundle Skill Bill. Independently authored specifications, skills, platform
+packs, add-ons, native-agent definitions, configuration, prompts, and generated
+outputs remain their author's property. A protected portion of Skill Bill
+reproduced in them remains governed by the [LICENSE](../LICENSE), and
+third-party rights remain unaffected.
+
+Earlier terms for v0.1.0/v0.1.1 and earlier revisions, applicable-law rights,
+separate agreements, GitHub's platform-limited public-repository rights, and
+third-party component licenses are not retroactively withdrawn or narrowed.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -14,6 +14,9 @@ short, it is the first public, non-draft, non-prerelease GitHub Release tagged
 prerelease, release candidate, bare tag, branch, local artifact, or fork
 release does not trigger it.
 
+A `v1.0.0` release requires a deliberate successor-license decision. The
+transitional policy is not that successor license.
+
 The project license never grants a right to modify, create derivative works
 from, redistribute, publish, mirror, sublicense, sell, lease, transfer, or
 bundle Skill Bill. Independently authored specifications, skills, platform

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -3,10 +3,10 @@
 The root [LICENSE](../LICENSE) is the complete, governing text. This page is a
 concise, non-authoritative summary and does not change that text.
 
-| Version | Before the Stable Release Event | After the Stable Release Event |
+| Version | Before the Stable Release Event | At and after the Stable Release Event |
 | --- | --- | --- |
 | v0.1.0 and v0.1.1 | The terms shipped with those releases govern. | The terms shipped with those releases govern. |
-| v0.1.2 through the last covered pre-1.0 release | Anyone may obtain, install, and execute an unmodified copy for any lawful purpose, including commercial, consulting, managed-service, and hosted-service use, when no Skill Bill copy is transferred or made available to a third party. This is unmodified lawful use only. | Only a natural person's Personal Use or unpaid, independent Open Source Contribution Use remains permitted. |
+| v0.1.2 prereleases distributed with the license, v0.1.2, and later releases | Anyone may obtain, install, customize documented skills and packs, and execute Skill Bill for any lawful purpose, including commercial, consulting, managed-service, and hosted-service use, subject to the governing restrictions. | Anyone may obtain, install, customize documented skills and packs, and execute Skill Bill for Personal Use or qualifying Open Source Project Use without charge. Other commercial use requires a Commercial License purchased from the copyright holder. |
 
 The Stable Release Event is defined exactly in the [LICENSE](../LICENSE). In
 short, it is the first public, non-draft, non-prerelease GitHub Release tagged
@@ -14,16 +14,18 @@ short, it is the first public, non-draft, non-prerelease GitHub Release tagged
 prerelease, release candidate, bare tag, branch, local artifact, or fork
 release does not trigger it.
 
-A `v1.0.0` release requires a deliberate successor-license decision. The
-transitional policy is not that successor license.
+The same governing license states the v1+ policy. Publishing stable `v1.0.0`
+still requires explicit copyright-holder approval of the exact license bytes;
+the release guard does not accept placeholder or substitute terms.
 
-The project license never grants a right to modify, create derivative works
-from, redistribute, publish, mirror, sublicense, sell, lease, transfer, or
-bundle Skill Bill. Independently authored specifications, skills, platform
-packs, add-ons, native-agent definitions, configuration, prompts, and generated
-outputs remain their author's property. A protected portion of Skill Bill
-reproduced in them remains governed by the [LICENSE](../LICENSE), and
-third-party rights remain unaffected.
+The project license permits modification of documented customization materials,
+including governed skills and platform packs, for an otherwise permitted use.
+It does not grant public redistribution, publication, mirroring, sublicensing,
+sale, leasing, transfer, or bundling rights, and it does not permit modification
+of executable runtime code. Independently authored inputs and generated outputs
+remain their author's property. A protected portion of Skill Bill reproduced in
+them remains governed by the [LICENSE](../LICENSE), and third-party rights remain
+unaffected.
 
 Earlier MIT and PolyForm grants for v0.1.0/v0.1.1 and earlier revisions,
 applicable-law rights, separate agreements, GitHub's platform-limited

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -25,6 +25,7 @@ outputs remain their author's property. A protected portion of Skill Bill
 reproduced in them remains governed by the [LICENSE](../LICENSE), and
 third-party rights remain unaffected.
 
-Earlier terms for v0.1.0/v0.1.1 and earlier revisions, applicable-law rights,
-separate agreements, GitHub's platform-limited public-repository rights, and
-third-party component licenses are not retroactively withdrawn or narrowed.
+Earlier MIT and PolyForm grants for v0.1.0/v0.1.1 and earlier revisions,
+applicable-law rights, separate agreements, GitHub's platform-limited
+public-repository rights, and third-party component licenses are not
+retroactively withdrawn or narrowed.

--- a/docs/release-license-approval.md
+++ b/docs/release-license-approval.md
@@ -1,18 +1,21 @@
 # Pre-1.0 license approval record
 
 Before creating the `v0.1.2` tag, complete this record for the exact root
-[LICENSE](../LICENSE) text that will be tagged. The record is evidence of the
-copyright holder's approval; automated validation and this document do not
-replace that approval or legal advice.
+[LICENSE](../LICENSE) text that will be tagged. This record is intentionally
+pending until Braian Gapur explicitly approves the final release-commit text
+and hash. Automated validation, a passing release matrix, and this document do
+not replace that approval or legal advice.
 
 | Field | Required record |
 | --- | --- |
 | Release | `v0.1.2` |
 | License identifier | `LicenseRef-Skill-Bill-Pre-1.0-Use-1.0` |
-| Exact `LICENSE` SHA-256 | Record the output of `sha256sum LICENSE` from the release commit. |
+| Exact `LICENSE` SHA-256 | Candidate: `221aae22ee3e9d6c2a3bdb243999865d5df054335cfe768aeccea047cf34d094`; re-run `sha256sum LICENSE` from the release commit and record that commit before approval. |
 | Copyright holder | Braian Gapur |
 | Approval | Record an explicit approval of the exact license text and its SHA-256. |
 | Date and approval location | Record the date and durable location of the approval. |
 
-Do not create the tag until every required record is complete. The root
+Do not create the tag until every required record is complete. A fresh staging
+release is immutable evidence for one asset set and does not approve the
+license or authorize replacing an earlier staging release. The root
 [LICENSE](../LICENSE) remains the governing text.

--- a/docs/release-license-approval.md
+++ b/docs/release-license-approval.md
@@ -9,8 +9,8 @@ not replace that approval or legal advice.
 | Field | Required record |
 | --- | --- |
 | Release | `v0.1.2` |
-| License identifier | `LicenseRef-Skill-Bill-Pre-1.0-Use-1.0` |
-| Exact `LICENSE` SHA-256 | Candidate: `221aae22ee3e9d6c2a3bdb243999865d5df054335cfe768aeccea047cf34d094`; re-run `sha256sum LICENSE` from the release commit and record that commit before approval. |
+| License identifier | `LicenseRef-Skill-Bill-Use-1.0` |
+| Exact `LICENSE` SHA-256 | Candidate: `8abf81451e45732aa8eae82182cb931c34a7466d26c1189d6a2fa75d27e9c1fb`; re-run `sha256sum LICENSE` from the release commit and record that commit before approval. |
 | Copyright holder | Braian Gapur |
 | Approval | Record an explicit approval of the exact license text and its SHA-256. |
 | Date and approval location | Record the date and durable location of the approval. |

--- a/docs/release-license-approval.md
+++ b/docs/release-license-approval.md
@@ -1,0 +1,18 @@
+# Pre-1.0 license approval record
+
+Before creating the `v0.1.2` tag, complete this record for the exact root
+[LICENSE](../LICENSE) text that will be tagged. The record is evidence of the
+copyright holder's approval; automated validation and this document do not
+replace that approval or legal advice.
+
+| Field | Required record |
+| --- | --- |
+| Release | `v0.1.2` |
+| License identifier | `LicenseRef-Skill-Bill-Pre-1.0-Use-1.0` |
+| Exact `LICENSE` SHA-256 | Record the output of `sha256sum LICENSE` from the release commit. |
+| Copyright holder | Braian Gapur |
+| Approval | Record an explicit approval of the exact license text and its SHA-256. |
+| Date and approval location | Record the date and durable location of the approval. |
+
+Do not create the tag until every required record is complete. The root
+[LICENSE](../LICENSE) remains the governing text.

--- a/docs/release-successor-license-approval.md
+++ b/docs/release-successor-license-approval.md
@@ -1,15 +1,16 @@
-# Successor-license approval record
+# Stable-license approval record
 
 Before creating `v1.0.0` or any later release, replace every placeholder below
 after Braian Gapur explicitly approves the exact root [LICENSE](../LICENSE)
-text. The release validator accepts a successor policy only when these fields
-are complete and the approved SHA-256 matches that policy's normalized bytes.
+text. The release validator accepts the stable policy only when these fields are
+complete and the approved SHA-256 matches the governing policy's normalized
+bytes.
 
 Status: Pending
-Approved Successor License Identifier:
+Approved License Identifier: LicenseRef-Skill-Bill-Use-1.0
 Approved LICENSE SHA-256:
 Approved by:
 Approval location:
 
-This record does not choose the successor license or replace legal advice. The
-root [LICENSE](../LICENSE) remains the governing text.
+This record does not replace legal advice. The root [LICENSE](../LICENSE)
+remains the governing text.

--- a/docs/release-successor-license-approval.md
+++ b/docs/release-successor-license-approval.md
@@ -1,0 +1,15 @@
+# Successor-license approval record
+
+Before creating `v1.0.0` or any later release, replace every placeholder below
+after Braian Gapur explicitly approves the exact root [LICENSE](../LICENSE)
+text. The release validator accepts a successor policy only when these fields
+are complete and the approved SHA-256 matches that policy's normalized bytes.
+
+Status: Pending
+Approved Successor License Identifier:
+Approved LICENSE SHA-256:
+Approved by:
+Approval location:
+
+This record does not choose the successor license or replace legal advice. The
+root [LICENSE](../LICENSE) remains the governing text.

--- a/docs/team-control-plane-roadmap.md
+++ b/docs/team-control-plane-roadmap.md
@@ -183,7 +183,10 @@ Likely paid value:
 - self-hosted or privacy-restricted telemetry options
 
 The project [LICENSE](../LICENSE) governs the pre-1.0 use policy. Its concise
-version matrix is in [Licensing](licensing.md): covered releases allow
+version matrix is in [Licensing](licensing.md): v0.1.0 and v0.1.1 retain their
+shipped terms; v0.1.2 through covered pre-1.0 releases use the custom license;
+the Stable Release Event changes permitted execution; and v1.0.0 requires a
+deliberate successor-license decision. Covered pre-1.0 releases allow
 unmodified lawful use, including commercial use, before the Stable Release
 Event and only personal or unpaid individual open-source contribution use after
 it. This roadmap does not alter that policy or independently grant modification

--- a/docs/team-control-plane-roadmap.md
+++ b/docs/team-control-plane-roadmap.md
@@ -182,8 +182,12 @@ Likely paid value:
 - support for onboarding and pack tuning
 - self-hosted or privacy-restricted telemetry options
 
-Individual and noncommercial use can remain free while team/company use requires
-a commercial license.
+The project [LICENSE](../LICENSE) governs the pre-1.0 use policy. Its concise
+version matrix is in [Licensing](licensing.md): covered releases allow
+unmodified lawful use, including commercial use, before the Stable Release
+Event and only personal or unpaid individual open-source contribution use after
+it. This roadmap does not alter that policy or independently grant modification
+or redistribution rights.
 
 ## Discovery Checklist
 

--- a/docs/team-control-plane-roadmap.md
+++ b/docs/team-control-plane-roadmap.md
@@ -182,15 +182,14 @@ Likely paid value:
 - support for onboarding and pack tuning
 - self-hosted or privacy-restricted telemetry options
 
-The project [LICENSE](../LICENSE) governs the pre-1.0 use policy. Its concise
+The project [LICENSE](../LICENSE) governs releases from v0.1.2. Its concise
 version matrix is in [Licensing](licensing.md): v0.1.0 and v0.1.1 retain their
-shipped terms; v0.1.2 through covered pre-1.0 releases use the custom license;
-the Stable Release Event changes permitted execution; and v1.0.0 requires a
-deliberate successor-license decision. Covered pre-1.0 releases allow
-unmodified lawful use, including commercial use, before the Stable Release
-Event and only personal or unpaid individual open-source contribution use after
-it. This roadmap does not alter that policy or independently grant modification
-or redistribution rights.
+shipped terms; releases from v0.1.2 allow lawful use including commercial use
+before the stable `v1.0.0` Stable Release Event; and at and after the event personal and
+qualifying open-source-project use remain free while other commercial use
+requires a purchased Commercial License. Documented customization materials may
+be modified for permitted use, but this roadmap does not independently grant
+public redistribution rights.
 
 ## Discovery Checklist
 

--- a/runtime-kotlin/build-logic/convention/src/main/kotlin/RuntimeImageConventionPlugin.kt
+++ b/runtime-kotlin/build-logic/convention/src/main/kotlin/RuntimeImageConventionPlugin.kt
@@ -3,9 +3,9 @@ import dev.skillbill.runtime.buildlogic.RuntimeImageLicense
 import dev.skillbill.runtime.buildlogic.writeSha256Sidecar
 import org.beryx.runtime.BaseTask
 import org.beryx.runtime.data.RuntimePluginExtension
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.GradleException
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JavaLanguageVersion

--- a/runtime-kotlin/build-logic/convention/src/main/kotlin/RuntimeImageConventionPlugin.kt
+++ b/runtime-kotlin/build-logic/convention/src/main/kotlin/RuntimeImageConventionPlugin.kt
@@ -1,9 +1,11 @@
 import dev.skillbill.runtime.buildlogic.RuntimeImageExtension
+import dev.skillbill.runtime.buildlogic.RuntimeImageLicense
 import dev.skillbill.runtime.buildlogic.writeSha256Sidecar
 import org.beryx.runtime.BaseTask
 import org.beryx.runtime.data.RuntimePluginExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.GradleException
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.toolchain.JavaLanguageVersion
@@ -13,20 +15,8 @@ import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import java.io.File
+import java.nio.file.Path
 
-/**
- * SKILL-55 subtask 1 (F-004 + F-005 + F-006 + F-008): hoists the previously verbatim-
- * duplicated self-contained runtime-image wiring out of runtime-cli / runtime-mcp into
- * one class-based convention plugin, consistent with the existing skillbill.* plugins.
- *
- * The image is built by the Badass Runtime plugin (org.beryx.runtime, jlink under the
- * hood). The Kotlin apps are non-modular; Badass Runtime wraps the existing
- * `application` installDist distribution, so the image keeps the `bin/<base>` launcher
- * (= applicationName) and `application` + installDist stay intact (AC5).
- *
- * Consuming build scripts apply `id("skillbill.runtime-image")` and set only the
- * varying input — `runtimeImage { imageBaseName.set("runtime-cli") }`.
- */
 class RuntimeImageConventionPlugin : Plugin<Project> {
   private companion object {
     const val LINK_JDK_VERSION = 17
@@ -78,8 +68,10 @@ class RuntimeImageConventionPlugin : Plugin<Project> {
         val baseName = extension.imageBaseName.get()
         val zipName = imageZipName(baseName, project.version.toString(), hostRuntimeToken)
         configureRuntimeImageZip(zipName)
+        val licenseStageTask = registerRuntimeLicenseStaging(baseName)
+        val licenseVerificationTask = registerRuntimeLicenseVerification(baseName, licenseStageTask)
         val sha256Task = registerSha256Task(baseName, zipName)
-        configureRuntimeZipTask(baseName, hostRuntimeToken, sha256Task)
+        configureRuntimeZipTask(baseName, hostRuntimeToken, licenseVerificationTask, sha256Task)
       }
     }
   }
@@ -173,9 +165,55 @@ class RuntimeImageConventionPlugin : Plugin<Project> {
     }
   }
 
+  private fun Project.registerRuntimeLicenseStaging(baseName: String): TaskProvider<*> {
+    val rootLicensePath = rootProject.projectDir.parentFile.resolve("LICENSE").absolutePath
+    val imageLicensePath = layout.buildDirectory.file("image/LICENSE").get().asFile.absolutePath
+    val installLicensePath = layout.buildDirectory.file("install/$baseName/LICENSE").get().asFile.absolutePath
+    return tasks.register("stageRuntimeLicense") {
+      group = "distribution"
+      description = "Stage the repository LICENSE in the $baseName install and runtime images."
+      dependsOn("runtime")
+      inputs.file(rootLicensePath)
+      outputs.files(imageLicensePath, installLicensePath)
+      doLast {
+        val source = Path.of(rootLicensePath)
+        try {
+          RuntimeImageLicense.stage(source, listOf(Path.of(imageLicensePath), Path.of(installLicensePath)))
+        } catch (error: IllegalArgumentException) {
+          throw GradleException(error.message.orEmpty(), error)
+        }
+      }
+    }
+  }
+
+  private fun Project.registerRuntimeLicenseVerification(
+    baseName: String,
+    licenseStageTask: TaskProvider<*>,
+  ): TaskProvider<*> {
+    val rootLicensePath = rootProject.projectDir.parentFile.resolve("LICENSE").absolutePath
+    val imageLicensePath = layout.buildDirectory.file("image/LICENSE").get().asFile.absolutePath
+    val installLicensePath = layout.buildDirectory.file("install/$baseName/LICENSE").get().asFile.absolutePath
+    return tasks.register("verifyRuntimeImageLicense") {
+      group = "verification"
+      description = "Verify $baseName install and runtime images carry the root LICENSE unchanged."
+      dependsOn(licenseStageTask)
+      inputs.file(rootLicensePath)
+      inputs.files(imageLicensePath, installLicensePath)
+      doLast {
+        val source = Path.of(rootLicensePath)
+        listOf(Path.of(imageLicensePath), Path.of(installLicensePath)).forEach { destination ->
+          if (!RuntimeImageLicense.matches(source, destination)) {
+            throw GradleException("Packaged LICENSE differs from repository LICENSE at $destination.")
+          }
+        }
+      }
+    }
+  }
+
   private fun Project.configureRuntimeZipTask(
     baseName: String,
     hostRuntimeToken: String?,
+    licenseVerificationTask: TaskProvider<*>,
     sha256Task: TaskProvider<*>,
   ) {
     // F-008: SINGLE runtimeZip configuration block — description + sha256 finalizer.
@@ -186,6 +224,7 @@ class RuntimeImageConventionPlugin : Plugin<Project> {
       group = "distribution"
       description =
         "Build the self-contained $baseName image and a versioned image zip ($tokenSegment)."
+      dependsOn(licenseVerificationTask)
       finalizedBy(sha256Task)
     }
   }

--- a/runtime-kotlin/build-logic/convention/src/main/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicense.kt
+++ b/runtime-kotlin/build-logic/convention/src/main/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicense.kt
@@ -1,0 +1,18 @@
+package dev.skillbill.runtime.buildlogic
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+object RuntimeImageLicense {
+  fun stage(source: Path, destinations: List<Path>) {
+    require(Files.isRegularFile(source)) { "Repository LICENSE is missing at $source." }
+    destinations.forEach { destination ->
+      Files.createDirectories(destination.parent)
+      Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING)
+    }
+  }
+
+  fun matches(source: Path, candidate: Path): Boolean =
+    Files.isRegularFile(source) && Files.isRegularFile(candidate) && Files.mismatch(source, candidate) == -1L
+}

--- a/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
+++ b/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
@@ -1,0 +1,38 @@
+package dev.skillbill.runtime.buildlogic
+
+import java.nio.file.Files
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RuntimeImageLicenseTest {
+  @Test
+  fun `reports absent staged license`() {
+    val root = Files.createTempFile("skillbill-license", ".txt")
+    Files.writeString(root, "root license\n")
+    val absent = root.parent.resolve("missing-license")
+
+    assertFalse(RuntimeImageLicense.matches(root, absent))
+  }
+
+  @Test
+  fun `stages root license byte for byte`() {
+    val root = Files.createTempFile("skillbill-license", ".txt")
+    val staged = Files.createTempDirectory("skillbill-staged-license").resolve("LICENSE")
+    Files.writeString(root, "root license\n")
+
+    RuntimeImageLicense.stage(root, listOf(staged))
+
+    assertTrue(RuntimeImageLicense.matches(root, staged))
+  }
+
+  @Test
+  fun `reports byte drift`() {
+    val root = Files.createTempFile("skillbill-license", ".txt")
+    val staged = Files.createTempFile("skillbill-staged-license", ".txt")
+    Files.writeString(root, "root license\n")
+    Files.writeString(staged, "altered license\n")
+
+    assertFalse(RuntimeImageLicense.matches(root, staged))
+  }
+}

--- a/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
+++ b/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
@@ -3,8 +3,8 @@ package dev.skillbill.runtime.buildlogic
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.nio.file.Files
 
 class RuntimeImageLicenseTest {

--- a/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
+++ b/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
@@ -1,11 +1,26 @@
 package dev.skillbill.runtime.buildlogic
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 
 class RuntimeImageLicenseTest {
+  @Test
+  fun `refuses to stage an absent repository license`() {
+    val absent = Files.createTempDirectory("skillbill-missing-license").resolve("LICENSE")
+    val staged = Files.createTempDirectory("skillbill-staged-license").resolve("LICENSE")
+
+    val failure = assertThrows<IllegalArgumentException> {
+      RuntimeImageLicense.stage(absent, listOf(staged))
+    }
+
+    assertEquals("Repository LICENSE is missing at $absent.", failure.message)
+    assertFalse(Files.exists(staged))
+  }
+
   @Test
   fun `reports absent staged license`() {
     val root = Files.createTempFile("skillbill-license", ".txt")

--- a/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
+++ b/runtime-kotlin/build-logic/convention/src/test/kotlin/dev/skillbill/runtime/buildlogic/RuntimeImageLicenseTest.kt
@@ -1,9 +1,9 @@
 package dev.skillbill.runtime.buildlogic
 
-import java.nio.file.Files
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.nio.file.Files
 
 class RuntimeImageLicenseTest {
   @Test

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/scaffold/RepoValidationService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/scaffold/RepoValidationService.kt
@@ -13,11 +13,8 @@ class RepoValidationService(
 ) {
   fun validateRepo(repoRoot: Path): RepoValidationReport = gateway.validateRepo(repoRoot)
 
-  fun validateReleaseRef(
-    repoRoot: Path,
-    rawRef: String,
-    forcePrerelease: Boolean,
-  ): ReleaseRefMetadata = gateway.validateReleaseRef(repoRoot, rawRef, forcePrerelease)
+  fun validateReleaseRef(repoRoot: Path, rawRef: String, forcePrerelease: Boolean): ReleaseRefMetadata =
+    gateway.validateReleaseRef(repoRoot, rawRef, forcePrerelease)
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata) =
     gateway.appendGithubOutput(outputPath, metadata)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/scaffold/RepoValidationService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/scaffold/RepoValidationService.kt
@@ -13,7 +13,11 @@ class RepoValidationService(
 ) {
   fun validateRepo(repoRoot: Path): RepoValidationReport = gateway.validateRepo(repoRoot)
 
-  fun parseReleaseRef(rawRef: String): ReleaseRefMetadata = gateway.parseReleaseRef(rawRef)
+  fun validateReleaseRef(
+    repoRoot: Path,
+    rawRef: String,
+    forcePrerelease: Boolean,
+  ): ReleaseRefMetadata = gateway.validateReleaseRef(repoRoot, rawRef, forcePrerelease)
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata) =
     gateway.appendGithubOutput(outputPath, metadata)

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
@@ -3,6 +3,7 @@ package skillbill.cli.repovalidation
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import me.tatarka.inject.annotations.Inject
 import skillbill.application.scaffold.RepoValidationService
@@ -73,6 +74,11 @@ class ValidateReleaseRefCommand(
     "--github-output",
     help = "Optional file path where GitHub Actions step outputs should be appended.",
   )
+  private val repoRoot by option("--repo-root", help = "Repository root whose LICENSE is evaluated.").default(".")
+  private val forcePrerelease by option(
+    "--force-prerelease",
+    help = "Publish metadata as a prerelease after validating a manual staging version.",
+  ).flag()
   private val format by formatOption()
 
   override fun run() {
@@ -89,13 +95,14 @@ class ValidateReleaseRefCommand(
     }
 
     val metadata = try {
-      repoValidationService.parseReleaseRef(rawRef)
+      repoValidationService.validateReleaseRef(Path.of(repoRoot), rawRef, forcePrerelease)
     } catch (error: IllegalArgumentException) {
-      state.completeText(
-        "${error.message}\n",
-        mapOf("status" to "failed", "error" to error.message.orEmpty()),
-        exitCode = 1,
-      )
+      val payload = mapOf("status" to "failed", "error" to error.message.orEmpty())
+      if (format == CliFormat.JSON) {
+        state.complete(payload, format, exitCode = 1)
+      } else {
+        state.completeText("${error.message}\n", payload, exitCode = 1)
+      }
       return
     }
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
@@ -77,7 +77,7 @@ class ValidateReleaseRefCommand(
   private val repoRoot by option("--repo-root", help = "Repository root whose LICENSE is evaluated.").default(".")
   private val forcePrerelease by option(
     "--force-prerelease",
-    help = "Publish metadata as a prerelease after validating a manual staging version.",
+    help = "Require a manual staging version to carry a SemVer prerelease identifier.",
   ).flag()
   private val format by formatOption()
 

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
@@ -67,7 +67,7 @@ class CliRepoValidationRuntimeTest {
 
     assertEquals(1, result.exitCode)
     assertContains(result.stdout, "\"status\": \"failed\"")
-    assertContains(result.stdout, "cannot publish")
+    assertContains(result.stdout, "successor license policy")
   }
 
   @Test

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
@@ -47,8 +47,8 @@ class CliRepoValidationRuntimeTest {
     Files.writeString(
       repoRoot.resolve("LICENSE"),
       """
-      Skill Bill Pre-1.0 Use License 1.0
-      Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0
+      Skill Bill Use License 1.0
+      Identifier: LicenseRef-Skill-Bill-Use-1.0
       Prospective Effective Version: v0.1.2
       """.trimIndent() + "\n",
     )
@@ -67,7 +67,7 @@ class CliRepoValidationRuntimeTest {
 
     assertEquals(1, result.exitCode)
     assertContains(result.stdout, "\"status\": \"failed\"")
-    assertContains(result.stdout, "successor license policy")
+    assertContains(result.stdout, "stable license policy")
   }
 
   @Test

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
@@ -18,7 +18,7 @@ class CliRepoValidationRuntimeTest {
     val result = CliRuntime.run(
       listOf(
         "validate-release-ref",
-        "refs/tags/v1.2.3-rc.1",
+        "refs/tags/v0.2.3-rc.1",
         "--repo-root",
         repositoryRoot().toString(),
         "--github-output",
@@ -30,14 +30,14 @@ class CliRepoValidationRuntimeTest {
     )
 
     assertEquals(0, result.exitCode, result.stdout)
-    assertContains(result.stdout, "\"tag\": \"v1.2.3-rc.1\"")
-    assertContains(result.stdout, "\"version\": \"1.2.3-rc.1\"")
+    assertContains(result.stdout, "\"tag\": \"v0.2.3-rc.1\"")
+    assertContains(result.stdout, "\"version\": \"0.2.3-rc.1\"")
     assertContains(result.stdout, "\"prerelease\": true")
     val githubOutput = Files.readString(output)
-    assertContains(githubOutput, "tag=v1.2.3-rc.1")
-    assertContains(githubOutput, "version=1.2.3-rc.1")
+    assertContains(githubOutput, "tag=v0.2.3-rc.1")
+    assertContains(githubOutput, "version=0.2.3-rc.1")
     assertContains(githubOutput, "prerelease=true")
-    assertContains(result.stdout, "\"major\": 1")
+    assertContains(result.stdout, "\"major\": 0")
     assertContains(result.stdout, "\"prerelease_identifier\": \"rc.1\"")
   }
 

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRepoValidationRuntimeTest.kt
@@ -19,6 +19,8 @@ class CliRepoValidationRuntimeTest {
       listOf(
         "validate-release-ref",
         "refs/tags/v1.2.3-rc.1",
+        "--repo-root",
+        repositoryRoot().toString(),
         "--github-output",
         output.toString(),
         "--format",
@@ -35,6 +37,37 @@ class CliRepoValidationRuntimeTest {
     assertContains(githubOutput, "tag=v1.2.3-rc.1")
     assertContains(githubOutput, "version=1.2.3-rc.1")
     assertContains(githubOutput, "prerelease=true")
+    assertContains(result.stdout, "\"major\": 1")
+    assertContains(result.stdout, "\"prerelease_identifier\": \"rc.1\"")
+  }
+
+  @Test
+  fun `validate-release-ref reports release policy errors as json failures`() {
+    val repoRoot = Files.createTempDirectory("skillbill-cli-release-policy")
+    Files.writeString(
+      repoRoot.resolve("LICENSE"),
+      """
+      Skill Bill Pre-1.0 Use License 1.0
+      Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0
+      Prospective Effective Version: v0.1.2
+      """.trimIndent() + "\n",
+    )
+
+    val result = CliRuntime.run(
+      listOf(
+        "validate-release-ref",
+        "v1.0.0",
+        "--repo-root",
+        repoRoot.toString(),
+        "--format",
+        "json",
+      ),
+      CliRuntimeContext(),
+    )
+
+    assertEquals(1, result.exitCode)
+    assertContains(result.stdout, "\"status\": \"failed\"")
+    assertContains(result.stdout, "cannot publish")
   }
 
   @Test
@@ -156,6 +189,9 @@ class CliRepoValidationRuntimeTest {
       """.trimIndent() + "\n",
     )
   }
+
+  private fun repositoryRoot(): Path = generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
+    .first { Files.isRegularFile(it.resolve("LICENSE")) }
 
   private fun writeContent(path: Path, name: String) {
     Files.createDirectories(path.parent)

--- a/runtime-kotlin/runtime-desktop/build.gradle.kts
+++ b/runtime-kotlin/runtime-desktop/build.gradle.kts
@@ -68,6 +68,7 @@ abstract class FixRuntimeScriptPermissionsTask : DefaultTask() {
 }
 
 val repoRoot = rootProject.projectDir.parentFile
+val rootLicenseFile = repoRoot.resolve("LICENSE")
 val desktopAppResourcesDir = layout.buildDirectory.dir("generated/desktop-app-resources")
 val runtimeResourceDirName = "skill-bill-runtime"
 val runtimeCliInstallDir =
@@ -117,6 +118,33 @@ val prepareDesktopRuntimeBundle by tasks.registering(Sync::class) {
   }
   from(repoRoot.resolve("orchestration")) {
     into("common/$runtimeResourceDirName/orchestration")
+  }
+  from(rootLicenseFile) {
+    into("common/$runtimeResourceDirName")
+  }
+}
+
+val verifyDesktopLicense by tasks.registering {
+  group = "verification"
+  description = "Verify desktop app resources carry the root LICENSE unchanged."
+  val rootLicensePath = rootLicenseFile.absolutePath
+  val stagedLicensePath =
+    layout.buildDirectory
+      .file("generated/desktop-app-resources/common/$runtimeResourceDirName/LICENSE")
+      .get()
+      .asFile
+      .absolutePath
+  dependsOn(prepareDesktopRuntimeBundle)
+  inputs.file(rootLicensePath)
+  inputs.file(stagedLicensePath)
+  doLast {
+    val rootLicense = Path.of(rootLicensePath)
+    val stagedLicense = Path.of(stagedLicensePath)
+    if (!Files.isRegularFile(rootLicense) || !Files.isRegularFile(stagedLicense) ||
+      Files.mismatch(rootLicense, stagedLicense) != -1L
+    ) {
+      throw GradleException("Desktop app resources do not contain the root LICENSE unchanged.")
+    }
   }
 }
 
@@ -282,6 +310,7 @@ compose.desktop {
 
     nativeDistributions {
       appResourcesRootDir.set(desktopAppResourcesDir)
+      licenseFile.set(rootLicenseFile)
       targetFormats(
         org.jetbrains.compose.desktop.application.dsl.TargetFormat.Dmg,
         org.jetbrains.compose.desktop.application.dsl.TargetFormat.Msi,
@@ -324,7 +353,7 @@ tasks.matching { task ->
     task.name.startsWith("packageDeb") ||
     task.name.startsWith("packageRpm")
 }.configureEach {
-  dependsOn(prepareDesktopRuntimeBundle)
+  dependsOn(verifyDesktopLicense)
 }
 
 tasks.matching { task ->

--- a/runtime-kotlin/runtime-desktop/build.gradle.kts
+++ b/runtime-kotlin/runtime-desktop/build.gradle.kts
@@ -1,3 +1,4 @@
+import dev.skillbill.runtime.buildlogic.RuntimeImageLicense
 import dev.skillbill.runtime.buildlogic.resolveHostRuntimeToken
 import dev.skillbill.runtime.buildlogic.toJpackageVersion
 import dev.skillbill.runtime.buildlogic.toMacAppVersion
@@ -140,9 +141,7 @@ val verifyDesktopLicense by tasks.registering {
   doLast {
     val rootLicense = Path.of(rootLicensePath)
     val stagedLicense = Path.of(stagedLicensePath)
-    if (!Files.isRegularFile(rootLicense) || !Files.isRegularFile(stagedLicense) ||
-      Files.mismatch(rootLicense, stagedLicense) != -1L
-    ) {
+    if (!RuntimeImageLicense.matches(rootLicense, stagedLicense)) {
       throw GradleException("Desktop app resources do not contain the root LICENSE unchanged.")
     }
   }

--- a/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
+++ b/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
@@ -14,6 +14,7 @@ _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 _dist_root="${_repo_root}/runtime-kotlin/runtime-desktop/build/compose/binaries/main/app/SkillBill"
 _icon_src="${_repo_root}/runtime-kotlin/runtime-desktop/icons/icon.png"
 _desktop_src="${_repo_root}/runtime-kotlin/runtime-desktop/packaging/arch/skillbill.desktop"
+_license_src="${_repo_root}/LICENSE"
 
 prepare() {
   if [[ ! -d "${_dist_root}" ]]; then
@@ -32,4 +33,5 @@ package() {
 
   install -Dm644 "${_icon_src}" "${pkgdir}/usr/share/icons/hicolor/512x512/apps/skillbill.png"
   install -Dm644 "${_desktop_src}" "${pkgdir}/usr/share/applications/skillbill.desktop"
+  install -Dm644 "${_license_src}" "${pkgdir}/usr/share/licenses/skillbill/LICENSE"
 }

--- a/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
+++ b/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
@@ -5,7 +5,7 @@ pkgrel=1
 pkgdesc="SkillBill desktop runtime (Compose Desktop)"
 arch=('x86_64')
 url="https://github.com/oila-gmbh/skill-bill"
-license=('custom')
+license=('custom:Skill-Bill-Pre-1.0-Use-1.0')
 depends=('fontconfig' 'libxext' 'libxrender' 'libxtst' 'libxi')
 options=('!strip' '!debug')
 

--- a/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
+++ b/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
@@ -5,7 +5,7 @@ pkgrel=1
 pkgdesc="SkillBill desktop runtime (Compose Desktop)"
 arch=('x86_64')
 url="https://github.com/oila-gmbh/skill-bill"
-license=('LicenseRef-Skill-Bill-Pre-1.0-Use-1.0')
+license=('LicenseRef-Skill-Bill-Use-1.0')
 depends=('fontconfig' 'libxext' 'libxrender' 'libxtst' 'libxi')
 options=('!strip' '!debug')
 

--- a/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
+++ b/runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Braian Gapur <scatmetal@gmail.com>
 pkgname=skillbill
-pkgver=1.0.0
+pkgver=0.1.2
 pkgrel=1
 pkgdesc="SkillBill desktop runtime (Compose Desktop)"
 arch=('x86_64')
 url="https://github.com/oila-gmbh/skill-bill"
-license=('custom:Skill-Bill-Pre-1.0-Use-1.0')
+license=('LicenseRef-Skill-Bill-Pre-1.0-Use-1.0')
 depends=('fontconfig' 'libxext' 'libxrender' 'libxtst' 'libxi')
 options=('!strip' '!debug')
 

--- a/runtime-kotlin/runtime-desktop/src/jvmTest/kotlin/skillbill/desktop/DesktopPackagingConfigurationTest.kt
+++ b/runtime-kotlin/runtime-desktop/src/jvmTest/kotlin/skillbill/desktop/DesktopPackagingConfigurationTest.kt
@@ -30,6 +30,7 @@ class DesktopPackagingConfigurationTest {
     val buildFile = desktopBuildFile()
 
     assertContains(buildFile, "prepareDesktopRuntimeBundle")
+    assertContains(buildFile, "verifyDesktopLicense")
     assertContains(buildFile, "appResourcesRootDir.set(desktopAppResourcesDir)")
     assertContains(buildFile, "runtimeResourceDirName = \"skill-bill-runtime\"")
     assertContains(buildFile, "dependsOn(\":runtime-cli:installDist\", \":runtime-mcp:installDist\")")
@@ -41,6 +42,8 @@ class DesktopPackagingConfigurationTest {
     assertContains(buildFile, "repoRoot.resolve(\"skills\")")
     assertContains(buildFile, "repoRoot.resolve(\"platform-packs\")")
     assertContains(buildFile, "repoRoot.resolve(\"orchestration\")")
+    assertContains(buildFile, "rootLicenseFile = repoRoot.resolve(\"LICENSE\")")
+    assertContains(buildFile, "into(\"common/\$runtimeResourceDirName\")")
     assertContains(buildFile, "exclude(\"**/SKILL.md\")")
     assertContains(buildFile, "exclude(\"**/codex-agents/**\")")
   }
@@ -52,7 +55,17 @@ class DesktopPackagingConfigurationTest {
     assertContains(buildFile, "task.name == \"packageDistributionForCurrentOS\"")
     assertContains(buildFile, "task.name == \"prepareAppResources\"")
     assertContains(buildFile, "task.name.startsWith(\"packageRpm\")")
-    assertContains(buildFile, "dependsOn(prepareDesktopRuntimeBundle)")
+    assertContains(buildFile, "dependsOn(verifyDesktopLicense)")
+  }
+
+  @Test
+  fun `native distributions source their license presentation from the root license`() {
+    val buildFile = desktopBuildFile()
+    val packageBuildFile = Files.readString(runtimeRoot.resolve("runtime-desktop/packaging/arch/PKGBUILD"))
+
+    assertContains(buildFile, "licenseFile.set(rootLicenseFile)")
+    assertContains(packageBuildFile, "_license_src=\"\${_repo_root}/LICENSE\"")
+    assertContains(packageBuildFile, "/usr/share/licenses/skillbill/LICENSE")
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/agent/history.md
+++ b/runtime-kotlin/runtime-infra-fs/agent/history.md
@@ -1,5 +1,15 @@
 # Boundary History — runtime-kotlin/runtime-infra-fs
 
+## [2026-07-12] SKILL-118 pre-1.0 use-only license
+Areas: LICENSE and policy docs, GitHub release workflow, scripts, runtime-kotlin/{build-logic,runtime-application,runtime-cli,runtime-ports,runtime-infra-fs,runtime-desktop}
+- Replaced the prospective public policy with `LicenseRef-Skill-Bill-Pre-1.0-Use-1.0`; docs, metadata, and release guidance use one governing-LICENSE version matrix while preserving earlier grants and user-authored materials. reusable
+- Release validation distinguishes protected historical versions, covered pre-1.0 releases, non-triggering staging/RC builds, and successor-policy releases; quote repository paths at the shell boundary. reusable
+- Artifact verification compares staged and packaged license bytes for CLI, MCP, skills, and desktop artifacts; test positive, missing-license, duplicate-path, and byte-drift cases on every host-native extractor. reusable
+- Draft releases target the triggering commit, resume only a matching draft, verify existing asset bytes, upload only missing assets, and publish last; release retries must preserve that order. reusable
+- Known release gate: Braian Gapur must explicitly approve the final root-LICENSE hash before creating `v0.1.2`; the pending record is intentional and must not be filled by automation.
+Feature flag: N/A
+Acceptance criteria: 12/12 implemented (copyright-holder approval remains required before tagging)
+
 ## [2026-07-06] SKILL-107 feature add-on usage schema
 Areas: orchestration/contracts, platform-packs/{go,ios,kotlin,kmp,php,python}, runtime-domain/scaffold, runtime-infra-fs/{scaffold,install,validation}
 - Platform-pack shell contract bumped to 1.2 and `feature_addon_usage` became a manifest-backed, runtime-anchored field; schema/Kotlin parity and 1.1 rejection fixtures must move together. reusable

--- a/runtime-kotlin/runtime-infra-fs/agent/history.md
+++ b/runtime-kotlin/runtime-infra-fs/agent/history.md
@@ -1,14 +1,15 @@
 # Boundary History — runtime-kotlin/runtime-infra-fs
 
-## [2026-07-12] SKILL-118 pre-1.0 use-only license
+## [2026-07-12] SKILL-118 unified use license
 Areas: LICENSE and policy docs, GitHub release workflow, scripts, runtime-kotlin/{build-logic,runtime-application,runtime-cli,runtime-ports,runtime-infra-fs,runtime-desktop}
-- Replaced the prospective public policy with `LicenseRef-Skill-Bill-Pre-1.0-Use-1.0`; docs, metadata, and release guidance use one governing-LICENSE version matrix while preserving earlier grants and user-authored materials. reusable
-- Release validation distinguishes protected historical versions, covered pre-1.0 releases, non-triggering staging/RC builds, and successor-policy releases; quote repository paths at the shell boundary. reusable
+- `LicenseRef-Skill-Bill-Use-1.0` governs v0.1.2 prereleases distributed with it, v0.1.2, and later releases: lawful commercial use is free before stable v1.0.0; afterwards personal and qualifying open-source-project use remain free while other commercial use requires a purchased agreement. reusable
+- Documented skills, packs, and orchestration materials may be customized for permitted internal use; executable runtime modification and public redistribution remain outside the public grant.
+- Release refs are canonical `v`-prefixed SemVer. Stable and post-v1 releases require holder approval tied to the exact normalized governing-license hash; placeholders or alternate successor text do not pass. reusable
 - Artifact verification compares staged and packaged license bytes for CLI, MCP, skills, and desktop artifacts; test positive, missing-license, duplicate-path, and byte-drift cases on every host-native extractor. reusable
 - Draft releases target the triggering commit, resume only a matching draft, verify existing asset bytes, upload only missing assets, and publish last; release retries must preserve that order. reusable
-- Known release gate: Braian Gapur must explicitly approve the final root-LICENSE hash before creating `v0.1.2`; the pending record is intentional and must not be filled by automation.
+- Known release gate: Braian Gapur must explicitly approve the final root-LICENSE hashes before `v0.1.2` and stable `v1.0.0`; pending records are intentional and must not be filled by automation.
 Feature flag: N/A
-Acceptance criteria: 12/12 implemented (copyright-holder approval remains required before tagging)
+Acceptance criteria: 8/8 review findings fixed; original 12/12 implemented
 
 ## [2026-07-06] SKILL-107 feature add-on usage schema
 Areas: orchestration/contracts, platform-packs/{go,ios,kotlin,kmp,php,python}, runtime-domain/scaffold, runtime-infra-fs/{scaffold,install,validation}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoValidationGateway.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoValidationGateway.kt
@@ -18,13 +18,26 @@ class FileSystemRepoValidationGateway : RepoValidationGateway {
   override fun validateRepo(repoRoot: Path): PortRepoValidationReport =
     RepoValidationRuntime.validateRepo(repoRoot).toPortReport()
 
-  override fun parseReleaseRef(rawRef: String): PortReleaseRefMetadata =
-    RepoValidationRuntime.parseReleaseRef(rawRef).toPortMetadata()
+  override fun validateReleaseRef(
+    repoRoot: Path,
+    rawRef: String,
+    forcePrerelease: Boolean,
+  ): PortReleaseRefMetadata =
+    RepoValidationRuntime.validateReleaseRef(repoRoot, rawRef, forcePrerelease).toPortMetadata()
 
   override fun appendGithubOutput(outputPath: Path, metadata: PortReleaseRefMetadata) =
     RepoValidationRuntime.appendGithubOutput(
       outputPath,
-      ReleaseRefMetadata(tag = metadata.tag, version = metadata.version, prerelease = metadata.prerelease),
+      ReleaseRefMetadata(
+        tag = metadata.tag,
+        version = metadata.version,
+        major = metadata.major,
+        minor = metadata.minor,
+        patch = metadata.patch,
+        prerelease = metadata.prerelease,
+        prereleaseIdentifier = metadata.prereleaseIdentifier,
+        buildMetadata = metadata.buildMetadata,
+      ),
     )
 
   private fun RepoValidationReport.toPortReport(): PortRepoValidationReport = PortRepoValidationReport(
@@ -52,5 +65,14 @@ class FileSystemRepoValidationGateway : RepoValidationGateway {
   }
 
   private fun ReleaseRefMetadata.toPortMetadata(): PortReleaseRefMetadata =
-    PortReleaseRefMetadata(tag = tag, version = version, prerelease = prerelease)
+    PortReleaseRefMetadata(
+      tag = tag,
+      version = version,
+      major = major,
+      minor = minor,
+      patch = patch,
+      prerelease = prerelease,
+      prereleaseIdentifier = prereleaseIdentifier,
+      buildMetadata = buildMetadata,
+    )
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoValidationGateway.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemRepoValidationGateway.kt
@@ -18,11 +18,7 @@ class FileSystemRepoValidationGateway : RepoValidationGateway {
   override fun validateRepo(repoRoot: Path): PortRepoValidationReport =
     RepoValidationRuntime.validateRepo(repoRoot).toPortReport()
 
-  override fun validateReleaseRef(
-    repoRoot: Path,
-    rawRef: String,
-    forcePrerelease: Boolean,
-  ): PortReleaseRefMetadata =
+  override fun validateReleaseRef(repoRoot: Path, rawRef: String, forcePrerelease: Boolean): PortReleaseRefMetadata =
     RepoValidationRuntime.validateReleaseRef(repoRoot, rawRef, forcePrerelease).toPortMetadata()
 
   override fun appendGithubOutput(outputPath: Path, metadata: PortReleaseRefMetadata) =
@@ -64,15 +60,14 @@ class FileSystemRepoValidationGateway : RepoValidationGateway {
     RepoValidationIssueSeverity.INFO -> PortRepoValidationIssueSeverity.INFO
   }
 
-  private fun ReleaseRefMetadata.toPortMetadata(): PortReleaseRefMetadata =
-    PortReleaseRefMetadata(
-      tag = tag,
-      version = version,
-      major = major,
-      minor = minor,
-      patch = patch,
-      prerelease = prerelease,
-      prereleaseIdentifier = prereleaseIdentifier,
-      buildMetadata = buildMetadata,
-    )
+  private fun ReleaseRefMetadata.toPortMetadata(): PortReleaseRefMetadata = PortReleaseRefMetadata(
+    tag = tag,
+    version = version,
+    major = major,
+    minor = minor,
+    patch = patch,
+    prerelease = prerelease,
+    prereleaseIdentifier = prereleaseIdentifier,
+    buildMetadata = buildMetadata,
+  )
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
@@ -110,23 +110,23 @@ data class ReleaseRefMetadata(
 class ReleaseLicensePolicyError(message: String) : IllegalArgumentException(message)
 
 object RepoValidationRuntime {
-  const val PRE_1_LICENSE_IDENTIFIER = "LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"
+  const val PRE_1_LICENSE_IDENTIFIER = "LicenseRef-Skill-Bill-Use-1.0"
   const val PROSPECTIVE_EFFECTIVE_VERSION_MARKER = "Prospective Effective Version: v0.1.2"
-  const val TRANSITIONAL_LICENSE_MARKER = "Skill Bill Pre-1.0 Use License 1.0"
+  const val TRANSITIONAL_LICENSE_MARKER = "Skill Bill Use License 1.0"
   private const val NORMALIZED_TRANSITIONAL_LICENSE_SHA256 =
-    "b73acd2889fc6178a9b1e34fca5a0c7aa131152d4f9c5d122f98b57afb6840aa"
-  private const val SUCCESSOR_LICENSE_IDENTIFIER_MARKER = "Successor License Identifier:"
-  private const val SUCCESSOR_LICENSE_APPROVAL_PATH = "docs/release-successor-license-approval.md"
-  private const val APPROVED_SUCCESSOR_LICENSE_STATUS = "Status: Approved"
-  private const val APPROVED_SUCCESSOR_LICENSE_IDENTIFIER_PREFIX = "Approved Successor License Identifier: "
-  private const val APPROVED_SUCCESSOR_LICENSE_SHA256_PREFIX = "Approved LICENSE SHA-256: "
-  private const val APPROVED_SUCCESSOR_LICENSE_HOLDER = "Approved by: Braian Gapur"
-  private const val APPROVED_SUCCESSOR_LICENSE_LOCATION_PREFIX = "Approval location: "
+    "4c6d42f5a704b5722d707f92e1f0312cacc6cbee1058171987cc46393ad8f8f3"
+  private const val LICENSE_IDENTIFIER_MARKER = "Identifier:"
+  private const val STABLE_LICENSE_APPROVAL_PATH = "docs/release-successor-license-approval.md"
+  private const val APPROVED_LICENSE_STATUS = "Status: Approved"
+  private const val APPROVED_LICENSE_IDENTIFIER_PREFIX = "Approved License Identifier: "
+  private const val APPROVED_LICENSE_SHA256_PREFIX = "Approved LICENSE SHA-256: "
+  private const val APPROVED_LICENSE_HOLDER = "Approved by: Braian Gapur"
+  private const val APPROVED_LICENSE_LOCATION_PREFIX = "Approval location: "
   private const val UNSIGNED_BYTE_MASK = 0xff
 
   private val semverTagPattern =
     Regex(
-      "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)" +
+      "^v(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)" +
         "(?:-(?<prerelease>(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*)" +
         "(?:\\.(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*))*))?" +
         "(?:\\+(?<build>[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
@@ -241,7 +241,7 @@ object RepoValidationRuntime {
     val candidate = rawValue.trim().removePrefix("refs/tags/")
     val match = semverTagPattern.matchEntire(candidate)
       ?: throw IllegalArgumentException(
-        "Release tag must match vMAJOR.MINOR.PATCH with optional SemVer prerelease/build metadata.",
+        "Release tag must match canonical vMAJOR.MINOR.PATCH with optional SemVer prerelease/build metadata.",
       )
     return ReleaseRefMetadata(
       tag = candidate,
@@ -275,7 +275,7 @@ object RepoValidationRuntime {
         requireTransitionalPolicy(repoRoot.resolve("LICENSE"), metadata)
       else -> requirePostOneLicenseDecision(
         repoRoot.resolve("LICENSE"),
-        repoRoot.resolve(SUCCESSOR_LICENSE_APPROVAL_PATH),
+        repoRoot.resolve(STABLE_LICENSE_APPROVAL_PATH),
         metadata,
       )
     }
@@ -297,7 +297,7 @@ object RepoValidationRuntime {
     }
     if (!isCurrentTransitionalLicense(Files.readString(licenseFile))) {
       throw ReleaseLicensePolicyError(
-        "Release ${metadata.tag} requires the complete current pre-1.0 license policy.",
+        "Release ${metadata.tag} requires the complete current Skill Bill use license policy.",
       )
     }
   }
@@ -309,9 +309,9 @@ object RepoValidationRuntime {
       )
     }
     val licenseText = Files.readString(licenseFile)
-    if (!approvalFile.isRegularFile() || !isApprovedSuccessorLicense(licenseText, Files.readString(approvalFile))) {
+    if (!approvalFile.isRegularFile() || !isApprovedStableLicense(licenseText, Files.readString(approvalFile))) {
       throw ReleaseLicensePolicyError(
-        "Release ${metadata.tag} requires an explicitly approved successor license policy.",
+        "Release ${metadata.tag} requires the explicitly approved stable license policy.",
       )
     }
   }
@@ -320,21 +320,21 @@ object RepoValidationRuntime {
     return normalizedLicenseSha256(licenseText) == NORMALIZED_TRANSITIONAL_LICENSE_SHA256
   }
 
-  private fun isApprovedSuccessorLicense(licenseText: String, approvalText: String): Boolean {
+  private fun isApprovedStableLicense(licenseText: String, approvalText: String): Boolean {
     val normalized = normalizeLicense(licenseText)
     val identifier = Regex(
-      "(?m)^${Regex.escape(SUCCESSOR_LICENSE_IDENTIFIER_MARKER)} ([A-Za-z0-9][A-Za-z0-9.+:-]*)$",
+      "(?m)^${Regex.escape(LICENSE_IDENTIFIER_MARKER)} ([A-Za-z0-9][A-Za-z0-9.+:-]*)$",
     ).find(normalized)?.groupValues?.get(1) ?: return false
-    return !presentsTransitionalLicenseAsCurrent(normalized) &&
-      approvalText.lineSequence().any { it == APPROVED_SUCCESSOR_LICENSE_STATUS } &&
-      approvalText.lineSequence().any { it == "$APPROVED_SUCCESSOR_LICENSE_IDENTIFIER_PREFIX$identifier" } &&
+    return isCurrentTransitionalLicense(licenseText) &&
+      approvalText.lineSequence().any { it == APPROVED_LICENSE_STATUS } &&
+      approvalText.lineSequence().any { it == "$APPROVED_LICENSE_IDENTIFIER_PREFIX$identifier" } &&
       approvalText.lineSequence().any {
-        it == "$APPROVED_SUCCESSOR_LICENSE_SHA256_PREFIX${normalizedLicenseSha256(licenseText)}"
+        it == "$APPROVED_LICENSE_SHA256_PREFIX${normalizedLicenseSha256(licenseText)}"
       } &&
-      approvalText.lineSequence().any { it == APPROVED_SUCCESSOR_LICENSE_HOLDER } &&
+      approvalText.lineSequence().any { it == APPROVED_LICENSE_HOLDER } &&
       approvalText.lineSequence().any {
-        it.startsWith(APPROVED_SUCCESSOR_LICENSE_LOCATION_PREFIX) &&
-          it.removePrefix(APPROVED_SUCCESSOR_LICENSE_LOCATION_PREFIX).isNotBlank()
+        it.startsWith(APPROVED_LICENSE_LOCATION_PREFIX) &&
+          it.removePrefix(APPROVED_LICENSE_LOCATION_PREFIX).isNotBlank()
       }
   }
 
@@ -343,13 +343,6 @@ object RepoValidationRuntime {
     .joinToString("") { byte -> "%02x".format(byte.toInt() and UNSIGNED_BYTE_MASK) }
 
   private fun normalizeLicense(licenseText: String): String = licenseText.replace("\r\n", "\n").trimEnd()
-
-  private fun presentsTransitionalLicenseAsCurrent(licenseText: String): Boolean {
-    val lines = licenseText.replace("\r\n", "\n").lineSequence().map(String::trim).toSet()
-    return TRANSITIONAL_LICENSE_MARKER in lines &&
-      "Identifier: $PRE_1_LICENSE_IDENTIFIER" in lines &&
-      PROSPECTIVE_EFFECTIVE_VERSION_MARKER in lines
-  }
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata) {
     Files.writeString(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
@@ -113,6 +113,36 @@ object RepoValidationRuntime {
   const val PROSPECTIVE_EFFECTIVE_VERSION_MARKER = "Prospective Effective Version: v0.1.2"
   const val TRANSITIONAL_LICENSE_MARKER = "Skill Bill Pre-1.0 Use License 1.0"
 
+  private val transitionalLicenseSections = listOf(
+    "1. Purpose and prospective application",
+    "2. Definitions",
+    "3. Acceptance and ownership",
+    "4. Grant before the Stable Release Event",
+    "5. Automatic change at the Stable Release Event",
+    "6. Restrictions that apply at all times",
+    "7. User Materials and Generated Outputs",
+    "8. Earlier, separate, platform, and third-party rights",
+    "9. Termination and cure",
+    "10. Disclaimer and limitation of liability",
+    "11. General terms",
+  )
+  private val transitionalLicenseClauses = listOf(
+    "non-exclusive, worldwide, royalty-free right to obtain an unmodified copy",
+    "commercial use, consulting, managed-service use, and hosted-service use",
+    "first public, non-draft, non-prerelease",
+    "tagged exactly v1.0.0",
+    "does not undo the event",
+    "commercial-use permission in section 4 ends automatically",
+    "Personal Use or Open Source Contribution Use",
+    "grants no right to modify",
+    "redistribute, distribute, publish, mirror, sublicense, sell, lease, transfer, bundle",
+    "Licensees retain all rights in their User Materials and Generated Outputs",
+    "does not retroactively withdraw or narrow rights arising under an earlier MIT, PolyForm",
+    "For a first material breach",
+    "Covered Software is provided \"AS IS\" and \"AS AVAILABLE.\"",
+    "If any provision of this License is unenforceable",
+  )
+
   private val semverTagPattern =
     Regex(
       "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)" +
@@ -258,16 +288,22 @@ object RepoValidationRuntime {
   private fun validateReleaseLicensePolicy(repoRoot: Path, metadata: ReleaseRefMetadata) {
     when {
       metadata.isHistoricalReleaseLine() -> return
-      metadata.isCoveredPreOneRelease() || metadata.prerelease ->
+      metadata.isCoveredPreOneRelease() ->
         requireTransitionalPolicy(repoRoot.resolve("LICENSE"), metadata)
+      metadata.isNonTriggeringV1Release() ->
+        requireNonTriggeringV1Policy(repoRoot.resolve("LICENSE"), metadata)
       else -> requirePostOneLicenseDecision(repoRoot.resolve("LICENSE"), metadata)
     }
   }
 
-  private fun ReleaseRefMetadata.isHistoricalReleaseLine(): Boolean = major == 0 && minor == 1 && patch <= 1
+  private fun ReleaseRefMetadata.isHistoricalReleaseLine(): Boolean =
+    major == 0 && minor == 1 && patch in 0..1 && !prerelease && buildMetadata == null
 
   private fun ReleaseRefMetadata.isCoveredPreOneRelease(): Boolean =
     major == 0 && (minor > 1 || (minor == 1 && patch >= 2))
+
+  private fun ReleaseRefMetadata.isNonTriggeringV1Release(): Boolean =
+    major == 1 && minor == 0 && patch == 0 && prerelease
 
   private fun requireTransitionalPolicy(licenseFile: Path, metadata: ReleaseRefMetadata) {
     if (!licenseFile.isRegularFile()) {
@@ -275,12 +311,9 @@ object RepoValidationRuntime {
         "Release ${metadata.tag} requires root LICENSE with $PRE_1_LICENSE_IDENTIFIER, but LICENSE is missing.",
       )
     }
-    val licenseText = Files.readString(licenseFile)
-    val missingMarkers = listOf(PRE_1_LICENSE_IDENTIFIER, PROSPECTIVE_EFFECTIVE_VERSION_MARKER)
-      .filterNot(licenseText::contains)
-    if (missingMarkers.isNotEmpty()) {
+    if (!isCurrentTransitionalLicense(Files.readString(licenseFile))) {
       throw ReleaseLicensePolicyError(
-        "Release ${metadata.tag} requires the pre-1.0 license policy markers: ${missingMarkers.joinToString()}.",
+        "Release ${metadata.tag} requires the complete current pre-1.0 license policy.",
       )
     }
   }
@@ -291,11 +324,48 @@ object RepoValidationRuntime {
         "Stable release ${metadata.tag} requires a root LICENSE that records the deliberate v1.0 licensing decision.",
       )
     }
-    if (Files.readString(licenseFile).contains(TRANSITIONAL_LICENSE_MARKER)) {
+    val licenseText = Files.readString(licenseFile)
+    if (isCurrentTransitionalLicense(licenseText) || presentsTransitionalLicenseAsCurrent(licenseText)) {
       throw ReleaseLicensePolicyError(
         "Stable release ${metadata.tag} cannot publish while $TRANSITIONAL_LICENSE_MARKER remains its current license.",
       )
     }
+  }
+
+  private fun requireNonTriggeringV1Policy(licenseFile: Path, metadata: ReleaseRefMetadata) {
+    if (!licenseFile.isRegularFile()) {
+      throw ReleaseLicensePolicyError(
+        "Prerelease ${metadata.tag} requires a complete transitional policy or a deliberate successor license.",
+      )
+    }
+    val licenseText = Files.readString(licenseFile)
+    if (isCurrentTransitionalLicense(licenseText)) return
+    if (presentsTransitionalLicenseAsCurrent(licenseText)) {
+      throw ReleaseLicensePolicyError(
+        "Prerelease ${metadata.tag} cannot use an incomplete transitional license policy.",
+      )
+    }
+  }
+
+  private fun isCurrentTransitionalLicense(licenseText: String): Boolean {
+    val normalized = licenseText.replace("\r\n", "\n").trimEnd()
+    val normalizedWhitespace = normalized.replace(Regex("\\s+"), " ")
+    if (!normalized.startsWith("$TRANSITIONAL_LICENSE_MARKER\n\n")) return false
+    if (!Regex("(?m)^Identifier: ${Regex.escape(PRE_1_LICENSE_IDENTIFIER)}$").containsMatchIn(normalized)) {
+      return false
+    }
+    if (!Regex("(?m)^${Regex.escape(PROSPECTIVE_EFFECTIVE_VERSION_MARKER)}$").containsMatchIn(normalized)) {
+      return false
+    }
+    return transitionalLicenseSections.all { section -> normalized.contains("\n$section\n") } &&
+      transitionalLicenseClauses.all(normalizedWhitespace::contains)
+  }
+
+  private fun presentsTransitionalLicenseAsCurrent(licenseText: String): Boolean {
+    val normalized = licenseText.replace("\r\n", "\n").trimStart()
+    return normalized.startsWith(TRANSITIONAL_LICENSE_MARKER) ||
+      normalized.startsWith("Identifier: $PRE_1_LICENSE_IDENTIFIER") ||
+      normalized.startsWith(PROSPECTIVE_EFFECTIVE_VERSION_MARKER)
   }
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
@@ -116,9 +116,12 @@ object RepoValidationRuntime {
   private const val NORMALIZED_TRANSITIONAL_LICENSE_SHA256 =
     "b73acd2889fc6178a9b1e34fca5a0c7aa131152d4f9c5d122f98b57afb6840aa"
   private const val SUCCESSOR_LICENSE_IDENTIFIER_MARKER = "Successor License Identifier:"
-  private const val SUCCESSOR_LICENSE_EFFECTIVE_VERSION_MARKER = "Successor License Effective Version: v1.0.0"
-  private const val SUCCESSOR_LICENSE_TERMS_MARKER = "Successor License Terms:"
-  private const val MINIMUM_SUCCESSOR_LICENSE_TERMS_LENGTH = 200
+  private const val SUCCESSOR_LICENSE_APPROVAL_PATH = "docs/release-successor-license-approval.md"
+  private const val APPROVED_SUCCESSOR_LICENSE_STATUS = "Status: Approved"
+  private const val APPROVED_SUCCESSOR_LICENSE_IDENTIFIER_PREFIX = "Approved Successor License Identifier: "
+  private const val APPROVED_SUCCESSOR_LICENSE_SHA256_PREFIX = "Approved LICENSE SHA-256: "
+  private const val APPROVED_SUCCESSOR_LICENSE_HOLDER = "Approved by: Braian Gapur"
+  private const val APPROVED_SUCCESSOR_LICENSE_LOCATION_PREFIX = "Approval location: "
   private const val UNSIGNED_BYTE_MASK = 0xff
 
   private val semverTagPattern =
@@ -269,8 +272,12 @@ object RepoValidationRuntime {
       metadata.isCoveredPreOneRelease() ->
         requireTransitionalPolicy(repoRoot.resolve("LICENSE"), metadata)
       metadata.isNonTriggeringV1Release() ->
-        requireNonTriggeringV1Policy(repoRoot.resolve("LICENSE"), metadata)
-      else -> requirePostOneLicenseDecision(repoRoot.resolve("LICENSE"), metadata)
+        requireTransitionalPolicy(repoRoot.resolve("LICENSE"), metadata)
+      else -> requirePostOneLicenseDecision(
+        repoRoot.resolve("LICENSE"),
+        repoRoot.resolve(SUCCESSOR_LICENSE_APPROVAL_PATH),
+        metadata,
+      )
     }
   }
 
@@ -295,31 +302,16 @@ object RepoValidationRuntime {
     }
   }
 
-  private fun requirePostOneLicenseDecision(licenseFile: Path, metadata: ReleaseRefMetadata) {
+  private fun requirePostOneLicenseDecision(licenseFile: Path, approvalFile: Path, metadata: ReleaseRefMetadata) {
     if (!licenseFile.isRegularFile()) {
       throw ReleaseLicensePolicyError(
-        "Stable release ${metadata.tag} requires a root LICENSE that records the deliberate v1.0 licensing decision.",
+        "Release ${metadata.tag} requires a root LICENSE that records the deliberate v1.0 licensing decision.",
       )
     }
     val licenseText = Files.readString(licenseFile)
-    if (!isDeliberateSuccessorLicense(licenseText)) {
+    if (!approvalFile.isRegularFile() || !isApprovedSuccessorLicense(licenseText, Files.readString(approvalFile))) {
       throw ReleaseLicensePolicyError(
-        "Stable release ${metadata.tag} requires a complete, versioned successor license policy.",
-      )
-    }
-  }
-
-  private fun requireNonTriggeringV1Policy(licenseFile: Path, metadata: ReleaseRefMetadata) {
-    if (!licenseFile.isRegularFile()) {
-      throw ReleaseLicensePolicyError(
-        "Prerelease ${metadata.tag} requires a complete transitional policy or a deliberate successor license.",
-      )
-    }
-    val licenseText = Files.readString(licenseFile)
-    if (isCurrentTransitionalLicense(licenseText)) return
-    if (!isDeliberateSuccessorLicense(licenseText)) {
-      throw ReleaseLicensePolicyError(
-        "Prerelease ${metadata.tag} requires a complete transitional policy or a versioned successor license policy.",
+        "Release ${metadata.tag} requires an explicitly approved successor license policy.",
       )
     }
   }
@@ -328,20 +320,22 @@ object RepoValidationRuntime {
     return normalizedLicenseSha256(licenseText) == NORMALIZED_TRANSITIONAL_LICENSE_SHA256
   }
 
-  private fun isDeliberateSuccessorLicense(licenseText: String): Boolean {
+  private fun isApprovedSuccessorLicense(licenseText: String, approvalText: String): Boolean {
     val normalized = normalizeLicense(licenseText)
-    val preambleEnd = normalized.indexOf("\n\n")
-    if (preambleEnd < 0) return false
-    val preamble = normalized.substring(0, preambleEnd)
-    val terms = normalized.substring(preambleEnd).trim()
-    val successorTerms = terms.removePrefix(SUCCESSOR_LICENSE_TERMS_MARKER).trim()
+    val identifier = Regex(
+      "(?m)^${Regex.escape(SUCCESSOR_LICENSE_IDENTIFIER_MARKER)} ([A-Za-z0-9][A-Za-z0-9.+:-]*)$",
+    ).find(normalized)?.groupValues?.get(1) ?: return false
     return !presentsTransitionalLicenseAsCurrent(normalized) &&
-      Regex("(?m)^${Regex.escape(SUCCESSOR_LICENSE_IDENTIFIER_MARKER)} [A-Za-z0-9][A-Za-z0-9.+:-]*$")
-        .containsMatchIn(preamble) &&
-      preamble.lineSequence().any { it == SUCCESSOR_LICENSE_EFFECTIVE_VERSION_MARKER } &&
-      terms.startsWith(SUCCESSOR_LICENSE_TERMS_MARKER) &&
-      !presentsTransitionalLicenseAsCurrent(successorTerms) &&
-      successorTerms.length >= MINIMUM_SUCCESSOR_LICENSE_TERMS_LENGTH
+      approvalText.lineSequence().any { it == APPROVED_SUCCESSOR_LICENSE_STATUS } &&
+      approvalText.lineSequence().any { it == "$APPROVED_SUCCESSOR_LICENSE_IDENTIFIER_PREFIX$identifier" } &&
+      approvalText.lineSequence().any {
+        it == "$APPROVED_SUCCESSOR_LICENSE_SHA256_PREFIX${normalizedLicenseSha256(licenseText)}"
+      } &&
+      approvalText.lineSequence().any { it == APPROVED_SUCCESSOR_LICENSE_HOLDER } &&
+      approvalText.lineSequence().any {
+        it.startsWith(APPROVED_SUCCESSOR_LICENSE_LOCATION_PREFIX) &&
+          it.removePrefix(APPROVED_SUCCESSOR_LICENSE_LOCATION_PREFIX).isNotBlank()
+      }
   }
 
   private fun normalizedLicenseSha256(licenseText: String): String = MessageDigest.getInstance("SHA-256")
@@ -351,10 +345,10 @@ object RepoValidationRuntime {
   private fun normalizeLicense(licenseText: String): String = licenseText.replace("\r\n", "\n").trimEnd()
 
   private fun presentsTransitionalLicenseAsCurrent(licenseText: String): Boolean {
-    val normalized = licenseText.replace("\r\n", "\n").trimStart()
-    return normalized.startsWith(TRANSITIONAL_LICENSE_MARKER) ||
-      normalized.startsWith("Identifier: $PRE_1_LICENSE_IDENTIFIER") ||
-      normalized.startsWith(PROSPECTIVE_EFFECTIVE_VERSION_MARKER)
+    val lines = licenseText.replace("\r\n", "\n").lineSequence().map(String::trim).toSet()
+    return TRANSITIONAL_LICENSE_MARKER in lines &&
+      "Identifier: $PRE_1_LICENSE_IDENTIFIER" in lines &&
+      PROSPECTIVE_EFFECTIVE_VERSION_MARKER in lines
   }
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
@@ -87,16 +87,32 @@ enum class RepoValidationIssueSeverity {
 data class ReleaseRefMetadata(
   val tag: String,
   val version: String,
+  val major: Int,
+  val minor: Int,
+  val patch: Int,
   val prerelease: Boolean,
+  val prereleaseIdentifier: String?,
+  val buildMetadata: String?,
 ) {
   fun toPayload(): Map<String, Any?> = mapOf(
     "tag" to tag,
     "version" to version,
+    "major" to major,
+    "minor" to minor,
+    "patch" to patch,
     "prerelease" to prerelease,
+    "prerelease_identifier" to prereleaseIdentifier,
+    "build_metadata" to buildMetadata,
   )
 }
 
+class ReleaseLicensePolicyError(message: String) : IllegalArgumentException(message)
+
 object RepoValidationRuntime {
+  const val PRE_1_LICENSE_IDENTIFIER = "LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"
+  const val PROSPECTIVE_EFFECTIVE_VERSION_MARKER = "Prospective Effective Version: v0.1.2"
+  const val TRANSITIONAL_LICENSE_MARKER = "Skill Bill Pre-1.0 Use License 1.0"
+
   private val semverTagPattern =
     Regex(
       "^v?(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)" +
@@ -219,8 +235,67 @@ object RepoValidationRuntime {
     return ReleaseRefMetadata(
       tag = candidate,
       version = candidate.removePrefix("v"),
+      major = match.groups["major"]!!.value.toInt(),
+      minor = match.groups["minor"]!!.value.toInt(),
+      patch = match.groups["patch"]!!.value.toInt(),
       prerelease = match.groups["prerelease"] != null,
+      prereleaseIdentifier = match.groups["prerelease"]?.value,
+      buildMetadata = match.groups["build"]?.value,
     )
+  }
+
+  fun validateReleaseRef(
+    repoRoot: Path,
+    rawValue: String,
+    forcePrerelease: Boolean = false,
+  ): ReleaseRefMetadata {
+    val parsed = parseReleaseRef(rawValue)
+    val metadata = if (forcePrerelease) parsed.copy(prerelease = true) else parsed
+    validateReleaseLicensePolicy(repoRoot.toAbsolutePath().normalize(), metadata)
+    return metadata
+  }
+
+  private fun validateReleaseLicensePolicy(repoRoot: Path, metadata: ReleaseRefMetadata) {
+    when {
+      metadata.isHistoricalReleaseLine() -> return
+      metadata.isCoveredPreOneRelease() || metadata.prerelease ->
+        requireTransitionalPolicy(repoRoot.resolve("LICENSE"), metadata)
+      else -> requirePostOneLicenseDecision(repoRoot.resolve("LICENSE"), metadata)
+    }
+  }
+
+  private fun ReleaseRefMetadata.isHistoricalReleaseLine(): Boolean = major == 0 && minor == 1 && patch <= 1
+
+  private fun ReleaseRefMetadata.isCoveredPreOneRelease(): Boolean =
+    major == 0 && (minor > 1 || (minor == 1 && patch >= 2))
+
+  private fun requireTransitionalPolicy(licenseFile: Path, metadata: ReleaseRefMetadata) {
+    if (!licenseFile.isRegularFile()) {
+      throw ReleaseLicensePolicyError(
+        "Release ${metadata.tag} requires root LICENSE with $PRE_1_LICENSE_IDENTIFIER, but LICENSE is missing.",
+      )
+    }
+    val licenseText = Files.readString(licenseFile)
+    val missingMarkers = listOf(PRE_1_LICENSE_IDENTIFIER, PROSPECTIVE_EFFECTIVE_VERSION_MARKER)
+      .filterNot(licenseText::contains)
+    if (missingMarkers.isNotEmpty()) {
+      throw ReleaseLicensePolicyError(
+        "Release ${metadata.tag} requires the pre-1.0 license policy markers: ${missingMarkers.joinToString()}.",
+      )
+    }
+  }
+
+  private fun requirePostOneLicenseDecision(licenseFile: Path, metadata: ReleaseRefMetadata) {
+    if (!licenseFile.isRegularFile()) {
+      throw ReleaseLicensePolicyError(
+        "Stable release ${metadata.tag} requires a root LICENSE that records the deliberate v1.0 licensing decision.",
+      )
+    }
+    if (Files.readString(licenseFile).contains(TRANSITIONAL_LICENSE_MARKER)) {
+      throw ReleaseLicensePolicyError(
+        "Stable release ${metadata.tag} cannot publish while $TRANSITIONAL_LICENSE_MARKER remains its current license.",
+      )
+    }
   }
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/runtime/RepoValidationRuntime.kt
@@ -23,6 +23,7 @@ import skillbill.scaffold.validation.validateSkillMdShape
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
+import java.security.MessageDigest
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
@@ -112,36 +113,13 @@ object RepoValidationRuntime {
   const val PRE_1_LICENSE_IDENTIFIER = "LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"
   const val PROSPECTIVE_EFFECTIVE_VERSION_MARKER = "Prospective Effective Version: v0.1.2"
   const val TRANSITIONAL_LICENSE_MARKER = "Skill Bill Pre-1.0 Use License 1.0"
-
-  private val transitionalLicenseSections = listOf(
-    "1. Purpose and prospective application",
-    "2. Definitions",
-    "3. Acceptance and ownership",
-    "4. Grant before the Stable Release Event",
-    "5. Automatic change at the Stable Release Event",
-    "6. Restrictions that apply at all times",
-    "7. User Materials and Generated Outputs",
-    "8. Earlier, separate, platform, and third-party rights",
-    "9. Termination and cure",
-    "10. Disclaimer and limitation of liability",
-    "11. General terms",
-  )
-  private val transitionalLicenseClauses = listOf(
-    "non-exclusive, worldwide, royalty-free right to obtain an unmodified copy",
-    "commercial use, consulting, managed-service use, and hosted-service use",
-    "first public, non-draft, non-prerelease",
-    "tagged exactly v1.0.0",
-    "does not undo the event",
-    "commercial-use permission in section 4 ends automatically",
-    "Personal Use or Open Source Contribution Use",
-    "grants no right to modify",
-    "redistribute, distribute, publish, mirror, sublicense, sell, lease, transfer, bundle",
-    "Licensees retain all rights in their User Materials and Generated Outputs",
-    "does not retroactively withdraw or narrow rights arising under an earlier MIT, PolyForm",
-    "For a first material breach",
-    "Covered Software is provided \"AS IS\" and \"AS AVAILABLE.\"",
-    "If any provision of this License is unenforceable",
-  )
+  private const val NORMALIZED_TRANSITIONAL_LICENSE_SHA256 =
+    "b73acd2889fc6178a9b1e34fca5a0c7aa131152d4f9c5d122f98b57afb6840aa"
+  private const val SUCCESSOR_LICENSE_IDENTIFIER_MARKER = "Successor License Identifier:"
+  private const val SUCCESSOR_LICENSE_EFFECTIVE_VERSION_MARKER = "Successor License Effective Version: v1.0.0"
+  private const val SUCCESSOR_LICENSE_TERMS_MARKER = "Successor License Terms:"
+  private const val MINIMUM_SUCCESSOR_LICENSE_TERMS_LENGTH = 200
+  private const val UNSIGNED_BYTE_MASK = 0xff
 
   private val semverTagPattern =
     Regex(
@@ -274,15 +252,15 @@ object RepoValidationRuntime {
     )
   }
 
-  fun validateReleaseRef(
-    repoRoot: Path,
-    rawValue: String,
-    forcePrerelease: Boolean = false,
-  ): ReleaseRefMetadata {
+  fun validateReleaseRef(repoRoot: Path, rawValue: String, forcePrerelease: Boolean = false): ReleaseRefMetadata {
     val parsed = parseReleaseRef(rawValue)
-    val metadata = if (forcePrerelease) parsed.copy(prerelease = true) else parsed
-    validateReleaseLicensePolicy(repoRoot.toAbsolutePath().normalize(), metadata)
-    return metadata
+    if (forcePrerelease && !parsed.prerelease) {
+      throw ReleaseLicensePolicyError(
+        "Manual staging references must carry a SemVer prerelease identifier; stable tags cannot be forced into staging.",
+      )
+    }
+    validateReleaseLicensePolicy(repoRoot.toAbsolutePath().normalize(), parsed)
+    return parsed
   }
 
   private fun validateReleaseLicensePolicy(repoRoot: Path, metadata: ReleaseRefMetadata) {
@@ -297,10 +275,9 @@ object RepoValidationRuntime {
   }
 
   private fun ReleaseRefMetadata.isHistoricalReleaseLine(): Boolean =
-    major == 0 && minor == 1 && patch in 0..1 && !prerelease && buildMetadata == null
+    major == 0 && (minor < 1 || (minor == 1 && patch < 2))
 
-  private fun ReleaseRefMetadata.isCoveredPreOneRelease(): Boolean =
-    major == 0 && (minor > 1 || (minor == 1 && patch >= 2))
+  private fun ReleaseRefMetadata.isCoveredPreOneRelease(): Boolean = major == 0 && !isHistoricalReleaseLine()
 
   private fun ReleaseRefMetadata.isNonTriggeringV1Release(): Boolean =
     major == 1 && minor == 0 && patch == 0 && prerelease
@@ -325,9 +302,9 @@ object RepoValidationRuntime {
       )
     }
     val licenseText = Files.readString(licenseFile)
-    if (isCurrentTransitionalLicense(licenseText) || presentsTransitionalLicenseAsCurrent(licenseText)) {
+    if (!isDeliberateSuccessorLicense(licenseText)) {
       throw ReleaseLicensePolicyError(
-        "Stable release ${metadata.tag} cannot publish while $TRANSITIONAL_LICENSE_MARKER remains its current license.",
+        "Stable release ${metadata.tag} requires a complete, versioned successor license policy.",
       )
     }
   }
@@ -340,26 +317,38 @@ object RepoValidationRuntime {
     }
     val licenseText = Files.readString(licenseFile)
     if (isCurrentTransitionalLicense(licenseText)) return
-    if (presentsTransitionalLicenseAsCurrent(licenseText)) {
+    if (!isDeliberateSuccessorLicense(licenseText)) {
       throw ReleaseLicensePolicyError(
-        "Prerelease ${metadata.tag} cannot use an incomplete transitional license policy.",
+        "Prerelease ${metadata.tag} requires a complete transitional policy or a versioned successor license policy.",
       )
     }
   }
 
   private fun isCurrentTransitionalLicense(licenseText: String): Boolean {
-    val normalized = licenseText.replace("\r\n", "\n").trimEnd()
-    val normalizedWhitespace = normalized.replace(Regex("\\s+"), " ")
-    if (!normalized.startsWith("$TRANSITIONAL_LICENSE_MARKER\n\n")) return false
-    if (!Regex("(?m)^Identifier: ${Regex.escape(PRE_1_LICENSE_IDENTIFIER)}$").containsMatchIn(normalized)) {
-      return false
-    }
-    if (!Regex("(?m)^${Regex.escape(PROSPECTIVE_EFFECTIVE_VERSION_MARKER)}$").containsMatchIn(normalized)) {
-      return false
-    }
-    return transitionalLicenseSections.all { section -> normalized.contains("\n$section\n") } &&
-      transitionalLicenseClauses.all(normalizedWhitespace::contains)
+    return normalizedLicenseSha256(licenseText) == NORMALIZED_TRANSITIONAL_LICENSE_SHA256
   }
+
+  private fun isDeliberateSuccessorLicense(licenseText: String): Boolean {
+    val normalized = normalizeLicense(licenseText)
+    val preambleEnd = normalized.indexOf("\n\n")
+    if (preambleEnd < 0) return false
+    val preamble = normalized.substring(0, preambleEnd)
+    val terms = normalized.substring(preambleEnd).trim()
+    val successorTerms = terms.removePrefix(SUCCESSOR_LICENSE_TERMS_MARKER).trim()
+    return !presentsTransitionalLicenseAsCurrent(normalized) &&
+      Regex("(?m)^${Regex.escape(SUCCESSOR_LICENSE_IDENTIFIER_MARKER)} [A-Za-z0-9][A-Za-z0-9.+:-]*$")
+        .containsMatchIn(preamble) &&
+      preamble.lineSequence().any { it == SUCCESSOR_LICENSE_EFFECTIVE_VERSION_MARKER } &&
+      terms.startsWith(SUCCESSOR_LICENSE_TERMS_MARKER) &&
+      !presentsTransitionalLicenseAsCurrent(successorTerms) &&
+      successorTerms.length >= MINIMUM_SUCCESSOR_LICENSE_TERMS_LENGTH
+  }
+
+  private fun normalizedLicenseSha256(licenseText: String): String = MessageDigest.getInstance("SHA-256")
+    .digest(normalizeLicense(licenseText).encodeToByteArray())
+    .joinToString("") { byte -> "%02x".format(byte.toInt() and UNSIGNED_BYTE_MASK) }
+
+  private fun normalizeLicense(licenseText: String): String = licenseText.replace("\r\n", "\n").trimEnd()
 
   private fun presentsTransitionalLicenseAsCurrent(licenseText: String): Boolean {
     val normalized = licenseText.replace("\r\n", "\n").trimStart()

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
@@ -1,0 +1,48 @@
+package skillbill.scaffold
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LicensePolicyDocumentationTest {
+  private val repoRoot: Path = generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
+    .first { Files.isRegularFile(it.resolve("LICENSE")) }
+
+  @Test
+  fun `license and public documentation share the governing pre one matrix`() {
+    val license = read("LICENSE")
+    val publicFiles = listOf(
+      "README.md",
+      "CONTRIBUTING.md",
+      "RELEASING.md",
+      "docs/team-control-plane-roadmap.md",
+      "docs/licensing.md",
+      "docs/release-license-approval.md",
+    ).associateWith(::read)
+
+    assertTrue(license.contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
+    assertTrue(license.contains("Prospective Effective Version: v0.1.2"))
+    assertTrue(license.contains("first public, non-draft, non-prerelease"))
+    assertTrue(license.contains("oila-gmbh/skill-bill"))
+    assertTrue(license.contains("does not undo the event"))
+    assertTrue(license.contains("commercial-use permission"))
+    assertTrue(license.contains("Open Source Contribution Use"))
+    assertTrue(license.contains("GitHub's platform-limited rights"))
+    assertTrue(license.contains("Third-Party Software"))
+    assertFalse(license.contains("PolyForm Noncommercial License"))
+
+    publicFiles.forEach { (path, text) ->
+      assertTrue(text.contains("LICENSE"), "$path must link to the governing LICENSE")
+    }
+    assertTrue(publicFiles.getValue("README.md").contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
+    assertTrue(publicFiles.getValue("docs/licensing.md").contains("v0.1.0 and v0.1.1"))
+    assertTrue(publicFiles.getValue("docs/licensing.md").contains("v0.1.2"))
+    assertTrue(publicFiles.getValue("docs/licensing.md").contains("unmodified lawful use"))
+    assertTrue(publicFiles.getValue("docs/licensing.md").contains("never grants a right to modify"))
+    assertFalse(publicFiles.values.joinToString("\n").contains("PolyForm Noncommercial License 1.0.0"))
+  }
+
+  private fun read(relativePath: String): String = Files.readString(repoRoot.resolve(relativePath))
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
@@ -90,7 +90,7 @@ class LicensePolicyDocumentationTest {
         assertTrue(text.contains("v0.1.2"), path)
         assertTrue(text.contains("Stable Release Event"), path)
         assertTrue(text.contains("v1.0.0"), path)
-    }
+      }
     val contribution = publicFiles.getValue("CONTRIBUTING.md")
     val normalizedContribution = contribution.replace(Regex("\\s+"), " ")
     listOf(
@@ -107,6 +107,7 @@ class LicensePolicyDocumentationTest {
     assertTrue(normalizedContribution.contains("authority to grant"))
     assertTrue(read("README.md").contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
     assertTrue(read("README.md").contains("License-Skill%20Bill%20Pre--1.0%20Use"))
+    assertTrue(read("docs/licensing.md").contains("Earlier MIT and PolyForm grants"))
     assertTrue(
       read("runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD")
         .contains("custom:Skill-Bill-Pre-1.0-Use-1.0"),

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
@@ -12,10 +12,10 @@ class LicensePolicyDocumentationTest {
     .first { Files.isRegularFile(it.resolve("LICENSE")) }
 
   @Test
-  fun `license is a complete governing pre one policy rather than a marker document`() {
+  fun `license is a complete governing use policy rather than a marker document`() {
     val license = read("LICENSE")
 
-    assertTrue(license.startsWith("Skill Bill Pre-1.0 Use License 1.0\n\n"))
+    assertTrue(license.startsWith("Skill Bill Use License 1.0\n\n"))
     val publicFiles = listOf(
       "README.md",
       "CONTRIBUTING.md",
@@ -30,24 +30,26 @@ class LicensePolicyDocumentationTest {
       "2. Definitions",
       "3. Acceptance and ownership",
       "4. Grant before the Stable Release Event",
-      "5. Automatic change at the Stable Release Event",
-      "6. Restrictions that apply at all times",
-      "7. User Materials and Generated Outputs",
-      "8. Earlier, separate, platform, and third-party rights",
-      "9. Termination and cure",
-      "10. Disclaimer and limitation of liability",
-      "11. General terms",
+      "5. Grant at and after the Stable Release Event",
+      "6. Customization permission",
+      "7. Restrictions that apply at all times",
+      "8. User Materials and Generated Outputs",
+      "9. Earlier, commercial, platform, and third-party rights",
+      "10. Termination and cure",
+      "11. Disclaimer and limitation of liability",
+      "12. General terms",
     )
     val clauses = listOf(
-      "Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0",
+      "Identifier: LicenseRef-Skill-Bill-Use-1.0",
       "Prospective Effective Version: v0.1.2",
       "commercial use, consulting, managed-service use, and hosted-service use",
       "first public, non-draft, non-prerelease",
       "tagged exactly v1.0.0",
       "does not undo the event",
       "commercial-use permission in section 4 ends automatically",
-      "Personal Use or Open Source Contribution Use",
-      "grants no right to modify",
+      "Personal Use or Open Source Project Use",
+      "requires a Commercial License purchased from the Copyright Holder",
+      "may copy, modify, adapt, and create derivative works from Customizable Materials",
       "redistribute, distribute, publish, mirror, sublicense, sell, lease, transfer, bundle",
       "Licensees retain all rights in their User Materials and Generated Outputs",
       "GitHub's platform-limited rights",
@@ -105,12 +107,12 @@ class LicensePolicyDocumentationTest {
     )
       .forEach { verb -> assertTrue(normalizedContribution.contains(verb), verb) }
     assertTrue(normalizedContribution.contains("authority to grant"))
-    assertTrue(read("README.md").contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
-    assertTrue(read("README.md").contains("License-Skill%20Bill%20Pre--1.0%20Use"))
+    assertTrue(read("README.md").contains("LicenseRef-Skill-Bill-Use-1.0"))
+    assertTrue(read("README.md").contains("License-Skill%20Bill%20Use"))
     assertTrue(read("docs/licensing.md").contains("Earlier MIT and PolyForm grants"))
     val archPackage = read("runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD")
     assertTrue(archPackage.contains("pkgver=0.1.2"))
-    assertTrue(archPackage.contains("license=('LicenseRef-Skill-Bill-Pre-1.0-Use-1.0')"))
+    assertTrue(archPackage.contains("license=('LicenseRef-Skill-Bill-Use-1.0')"))
     assertTrue(read("LICENSE").contains("Prospective Effective Version: v0.1.2"))
     assertFalse(publicFiles.values.joinToString("\n").contains("PolyForm Noncommercial License 1.0.0"))
   }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
@@ -108,10 +108,10 @@ class LicensePolicyDocumentationTest {
     assertTrue(read("README.md").contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
     assertTrue(read("README.md").contains("License-Skill%20Bill%20Pre--1.0%20Use"))
     assertTrue(read("docs/licensing.md").contains("Earlier MIT and PolyForm grants"))
-    assertTrue(
-      read("runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD")
-        .contains("custom:Skill-Bill-Pre-1.0-Use-1.0"),
-    )
+    val archPackage = read("runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD")
+    assertTrue(archPackage.contains("pkgver=0.1.2"))
+    assertTrue(archPackage.contains("license=('LicenseRef-Skill-Bill-Pre-1.0-Use-1.0')"))
+    assertTrue(read("LICENSE").contains("Prospective Effective Version: v0.1.2"))
     assertFalse(publicFiles.values.joinToString("\n").contains("PolyForm Noncommercial License 1.0.0"))
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/LicensePolicyDocumentationTest.kt
@@ -3,6 +3,7 @@ package skillbill.scaffold
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -11,8 +12,10 @@ class LicensePolicyDocumentationTest {
     .first { Files.isRegularFile(it.resolve("LICENSE")) }
 
   @Test
-  fun `license and public documentation share the governing pre one matrix`() {
+  fun `license is a complete governing pre one policy rather than a marker document`() {
     val license = read("LICENSE")
+
+    assertTrue(license.startsWith("Skill Bill Pre-1.0 Use License 1.0\n\n"))
     val publicFiles = listOf(
       "README.md",
       "CONTRIBUTING.md",
@@ -22,25 +25,92 @@ class LicensePolicyDocumentationTest {
       "docs/release-license-approval.md",
     ).associateWith(::read)
 
-    assertTrue(license.contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
-    assertTrue(license.contains("Prospective Effective Version: v0.1.2"))
-    assertTrue(license.contains("first public, non-draft, non-prerelease"))
-    assertTrue(license.contains("oila-gmbh/skill-bill"))
-    assertTrue(license.contains("does not undo the event"))
-    assertTrue(license.contains("commercial-use permission"))
-    assertTrue(license.contains("Open Source Contribution Use"))
-    assertTrue(license.contains("GitHub's platform-limited rights"))
-    assertTrue(license.contains("Third-Party Software"))
-    assertFalse(license.contains("PolyForm Noncommercial License"))
+    val sections = listOf(
+      "1. Purpose and prospective application",
+      "2. Definitions",
+      "3. Acceptance and ownership",
+      "4. Grant before the Stable Release Event",
+      "5. Automatic change at the Stable Release Event",
+      "6. Restrictions that apply at all times",
+      "7. User Materials and Generated Outputs",
+      "8. Earlier, separate, platform, and third-party rights",
+      "9. Termination and cure",
+      "10. Disclaimer and limitation of liability",
+      "11. General terms",
+    )
+    val clauses = listOf(
+      "Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0",
+      "Prospective Effective Version: v0.1.2",
+      "commercial use, consulting, managed-service use, and hosted-service use",
+      "first public, non-draft, non-prerelease",
+      "tagged exactly v1.0.0",
+      "does not undo the event",
+      "commercial-use permission in section 4 ends automatically",
+      "Personal Use or Open Source Contribution Use",
+      "grants no right to modify",
+      "redistribute, distribute, publish, mirror, sublicense, sell, lease, transfer, bundle",
+      "Licensees retain all rights in their User Materials and Generated Outputs",
+      "GitHub's platform-limited rights",
+      "For a first material breach",
+      "Covered Software is provided \"AS IS\" and \"AS AVAILABLE.\"",
+      "If any provision of this License is unenforceable",
+    )
+
+    sections.forEach { section -> assertEquals(1, license.split("$section").size - 1, section) }
+    val normalizedWhitespace = license.replace(Regex("\\s+"), " ")
+    clauses.forEach { clause -> assertTrue(normalizedWhitespace.contains(clause), clause) }
+    listOf(
+      "This License is the MIT License",
+      "This License is a PolyForm license",
+      "Covered Software is open source",
+      "Covered Software is free software",
+    ).forEach { claim -> assertFalse(license.contains(claim), claim) }
+
+    assertTrue(license.contains("earlier MIT, PolyForm, or other license"))
+  }
+
+  @Test
+  fun `public policy surfaces retain one governing matrix and an operational contributor grant`() {
+    val publicFiles = listOf(
+      "README.md",
+      "CONTRIBUTING.md",
+      "RELEASING.md",
+      "docs/team-control-plane-roadmap.md",
+      "docs/licensing.md",
+      "docs/release-license-approval.md",
+    ).associateWith(::read)
 
     publicFiles.forEach { (path, text) ->
       assertTrue(text.contains("LICENSE"), "$path must link to the governing LICENSE")
     }
-    assertTrue(publicFiles.getValue("README.md").contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
-    assertTrue(publicFiles.getValue("docs/licensing.md").contains("v0.1.0 and v0.1.1"))
-    assertTrue(publicFiles.getValue("docs/licensing.md").contains("v0.1.2"))
-    assertTrue(publicFiles.getValue("docs/licensing.md").contains("unmodified lawful use"))
-    assertTrue(publicFiles.getValue("docs/licensing.md").contains("never grants a right to modify"))
+    listOf("README.md", "CONTRIBUTING.md", "RELEASING.md", "docs/team-control-plane-roadmap.md", "docs/licensing.md")
+      .forEach { path ->
+        val text = publicFiles.getValue(path)
+        assertTrue(text.contains("v0.1.0 and v0.1.1"), path)
+        assertTrue(text.contains("v0.1.2"), path)
+        assertTrue(text.contains("Stable Release Event"), path)
+        assertTrue(text.contains("v1.0.0"), path)
+    }
+    val contribution = publicFiles.getValue("CONTRIBUTING.md")
+    val normalizedContribution = contribution.replace(Regex("\\s+"), " ")
+    listOf(
+      "reproduce",
+      "modify",
+      "prepare derivative works",
+      "incorporate",
+      "publish",
+      "distribute",
+      "sublicense",
+      "relicense",
+    )
+      .forEach { verb -> assertTrue(normalizedContribution.contains(verb), verb) }
+    assertTrue(normalizedContribution.contains("authority to grant"))
+    assertTrue(read("README.md").contains("LicenseRef-Skill-Bill-Pre-1.0-Use-1.0"))
+    assertTrue(read("README.md").contains("License-Skill%20Bill%20Pre--1.0%20Use"))
+    assertTrue(
+      read("runtime-kotlin/runtime-desktop/packaging/arch/PKGBUILD")
+        .contains("custom:Skill-Bill-Pre-1.0-Use-1.0"),
+    )
     assertFalse(publicFiles.values.joinToString("\n").contains("PolyForm Noncommercial License 1.0.0"))
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
@@ -1,0 +1,120 @@
+package skillbill.scaffold
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.name
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ReleaseArtifactLicenseVerifierTest {
+  private val repoRoot: Path =
+    generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
+      .first { Files.isRegularFile(it.resolve("LICENSE")) }
+  private val rootLicenseBytes: ByteArray = Files.readAllBytes(repoRoot.resolve("LICENSE"))
+
+  @Test
+  fun `accepts zip and tar artifacts carrying the root license and valid checksums`() {
+    val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
+    val zip = fixture.resolve("runtime.zip")
+    val tar = fixture.resolve("skills.tar.gz")
+    writeZip(zip, listOf("runtime/LICENSE" to rootLicenseBytes))
+    writeTar(tar, rootLicenseBytes)
+    writeChecksum(zip)
+    writeChecksum(tar)
+
+    assertEquals(0, runVerifier(zip, tar).exitCode)
+  }
+
+  @Test
+  fun `rejects a missing or byte-drifted license entry`() {
+    val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
+    val absent = fixture.resolve("absent.zip")
+    val drifted = fixture.resolve("drifted.zip")
+    writeZip(absent, listOf("runtime/README" to "no license".encodeToByteArray()))
+    writeZip(drifted, listOf("runtime/LICENSE" to "different license".encodeToByteArray()))
+    writeChecksum(absent)
+    writeChecksum(drifted)
+
+    assertFailure(absent, "exactly one LICENSE entry")
+    assertFailure(drifted, "LICENSE bytes differ")
+  }
+
+  @Test
+  fun `rejects duplicate license entries`() {
+    val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
+    val artifact = fixture.resolve("duplicate.zip")
+    writeZip(
+      artifact,
+      listOf(
+        "runtime/LICENSE" to rootLicenseBytes,
+        "docs/LICENSE" to rootLicenseBytes,
+      ),
+    )
+    writeChecksum(artifact)
+
+    assertFailure(artifact, "exactly one LICENSE entry")
+  }
+
+  @Test
+  fun `rejects an absent or mismatched checksum sidecar`() {
+    val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
+    val artifact = fixture.resolve("checksummed.zip")
+    writeZip(artifact, listOf("runtime/LICENSE" to rootLicenseBytes))
+
+    assertFailure(artifact, "Missing checksum")
+    Files.writeString(artifact.resolveSibling("${artifact.name}.sha256"), "${"0".repeat(64)}  ${artifact.name}\n")
+    assertFailure(artifact, "FAILED")
+  }
+
+  private fun assertFailure(artifact: Path, expectedMessage: String) {
+    val result = runVerifier(artifact)
+    assertTrue(result.exitCode != 0, result.output)
+    assertTrue(result.output.contains(expectedMessage), result.output)
+  }
+
+  private fun runVerifier(vararg artifacts: Path): ProcessResult {
+    val process =
+      ProcessBuilder(
+        listOf("bash", repoRoot.resolve("scripts/verify_release_artifact_licenses").toString()) +
+          artifacts.map(Path::toString),
+      )
+        .directory(repoRoot.toFile())
+        .redirectErrorStream(true)
+        .start()
+    val output = process.inputStream.bufferedReader().readText()
+    return ProcessResult(process.waitFor(), output)
+  }
+
+  private fun writeZip(artifact: Path, entries: List<Pair<String, ByteArray>>) {
+    ZipOutputStream(Files.newOutputStream(artifact)).use { output ->
+      entries.forEach { (name, content) ->
+        output.putNextEntry(ZipEntry(name))
+        output.write(content)
+        output.closeEntry()
+      }
+    }
+  }
+
+  private fun writeTar(artifact: Path, licenseBytes: ByteArray) {
+    val source = Files.createTempDirectory("skillbill-artifact-tar-source")
+    Files.write(source.resolve("LICENSE"), licenseBytes)
+    val process =
+      ProcessBuilder("tar", "-czf", artifact.toString(), "-C", source.toString(), ".")
+        .redirectErrorStream(true)
+        .start()
+    val output = process.inputStream.bufferedReader().readText()
+    assertEquals(0, process.waitFor(), output)
+  }
+
+  private fun writeChecksum(artifact: Path) {
+    val digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(artifact))
+      .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    Files.writeString(artifact.resolveSibling("${artifact.name}.sha256"), "$digest  ${artifact.name}\n")
+  }
+
+  private data class ProcessResult(val exitCode: Int, val output: String)
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
@@ -264,7 +264,7 @@ class ReleaseArtifactLicenseVerifierTest {
     }
     val command = mutableListOf("tar", "-cf", artifact.toString())
     if (unsafePath) {
-      command += "--transform=s#^\\./#../#"
+      command += tarPathRewriteArgs()
     }
     command += listOf("-C", source.toString(), ".")
     val process = ProcessBuilder(command)
@@ -272,6 +272,18 @@ class ReleaseArtifactLicenseVerifierTest {
       .start()
     val output = process.inputStream.bufferedReader().readText()
     assertEquals(0, process.waitFor(), output)
+  }
+
+  private fun tarPathRewriteArgs(): List<String> {
+    val versionProcess = ProcessBuilder(listOf("tar", "--version")).redirectErrorStream(true).start()
+    val versionOutput = versionProcess.inputStream.bufferedReader().readText()
+    versionProcess.waitFor()
+    val substitution = "#^\\./#../#"
+    return if (versionOutput.contains("GNU tar")) {
+      listOf("--transform=s$substitution")
+    } else {
+      listOf("-s", substitution)
+    }
   }
 
   private fun writeDesktopToolDoubles(shims: Path) {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
@@ -21,7 +21,7 @@ class ReleaseArtifactLicenseVerifierTest {
     val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
     val zip = fixture.resolve("runtime.zip")
     val tar = fixture.resolve("skills.tar.gz")
-    writeZip(zip, listOf("runtime/LICENSE" to rootLicenseBytes))
+    writeZip(zip, listOf("image/LICENSE" to rootLicenseBytes))
     writeTar(tar, rootLicenseBytes)
     writeChecksum(zip)
     writeChecksum(tar)
@@ -30,44 +30,76 @@ class ReleaseArtifactLicenseVerifierTest {
   }
 
   @Test
+  fun `uses canonical paths without requiring bash four collection helpers`() {
+    val verifier = Files.readString(repoRoot.resolve("scripts/verify_release_artifact_licenses"))
+
+    assertTrue(verifier.contains("image/LICENSE"))
+    assertTrue(verifier.contains("resources/skill-bill-runtime/LICENSE"))
+    assertTrue(!verifier.contains("mapfile"))
+  }
+
+  @Test
   fun `rejects a missing or byte-drifted license entry`() {
     val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
     val absent = fixture.resolve("absent.zip")
     val drifted = fixture.resolve("drifted.zip")
     writeZip(absent, listOf("runtime/README" to "no license".encodeToByteArray()))
-    writeZip(drifted, listOf("runtime/LICENSE" to "different license".encodeToByteArray()))
+    writeZip(drifted, listOf("image/LICENSE" to "different license".encodeToByteArray()))
     writeChecksum(absent)
     writeChecksum(drifted)
 
-    assertFailure(absent, "exactly one LICENSE entry")
+    assertFailure(absent, "canonical image/LICENSE")
     assertFailure(drifted, "LICENSE bytes differ")
   }
 
   @Test
-  fun `rejects duplicate license entries`() {
+  fun `permits third party license entries beside the canonical runtime license`() {
     val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
-    val artifact = fixture.resolve("duplicate.zip")
+    val artifact = fixture.resolve("runtime.zip")
     writeZip(
       artifact,
       listOf(
-        "runtime/LICENSE" to rootLicenseBytes,
-        "docs/LICENSE" to rootLicenseBytes,
+        "image/LICENSE" to rootLicenseBytes,
+        "image/legal/java.base/LICENSE" to "JDK license".encodeToByteArray(),
       ),
     )
     writeChecksum(artifact)
 
-    assertFailure(artifact, "exactly one LICENSE entry")
+    assertEquals(0, runVerifier(artifact).exitCode)
+  }
+
+  @Test
+  fun `rejects duplicate canonical skills licenses`() {
+    val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
+    val artifact = fixture.resolve("skills.tar.gz")
+    writeTar(artifact, rootLicenseBytes, duplicateLicense = true)
+    writeChecksum(artifact)
+
+    assertFailure(artifact, "exactly one canonical LICENSE")
   }
 
   @Test
   fun `rejects an absent or mismatched checksum sidecar`() {
     val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
     val artifact = fixture.resolve("checksummed.zip")
-    writeZip(artifact, listOf("runtime/LICENSE" to rootLicenseBytes))
+    writeZip(artifact, listOf("image/LICENSE" to rootLicenseBytes))
 
     assertFailure(artifact, "Missing checksum")
     Files.writeString(artifact.resolveSibling("${artifact.name}.sha256"), "${"0".repeat(64)}  ${artifact.name}\n")
-    assertFailure(artifact, "FAILED")
+    assertFailure(artifact, "Checksum digest differs")
+  }
+
+  @Test
+  fun `rejects a checksum sidecar for a sibling decoy`() {
+    val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
+    val artifact = fixture.resolve("checksummed.zip")
+    writeZip(artifact, listOf("image/LICENSE" to rootLicenseBytes))
+    Files.writeString(
+      artifact.resolveSibling("${artifact.name}.sha256"),
+      "${sha256(artifact)}  decoy.zip\n",
+    )
+
+    assertFailure(artifact, "names decoy.zip")
   }
 
   private fun assertFailure(artifact: Path, expectedMessage: String) {
@@ -99,11 +131,14 @@ class ReleaseArtifactLicenseVerifierTest {
     }
   }
 
-  private fun writeTar(artifact: Path, licenseBytes: ByteArray) {
+  private fun writeTar(artifact: Path, licenseBytes: ByteArray, duplicateLicense: Boolean = false) {
     val source = Files.createTempDirectory("skillbill-artifact-tar-source")
     Files.write(source.resolve("LICENSE"), licenseBytes)
     val process =
-      ProcessBuilder("tar", "-czf", artifact.toString(), "-C", source.toString(), ".")
+      ProcessBuilder(
+        listOf("tar", "-czf", artifact.toString(), "-C", source.toString(), "LICENSE") +
+          if (duplicateLicense) listOf("LICENSE") else emptyList(),
+      )
         .redirectErrorStream(true)
         .start()
     val output = process.inputStream.bufferedReader().readText()
@@ -111,10 +146,11 @@ class ReleaseArtifactLicenseVerifierTest {
   }
 
   private fun writeChecksum(artifact: Path) {
-    val digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(artifact))
-      .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
-    Files.writeString(artifact.resolveSibling("${artifact.name}.sha256"), "$digest  ${artifact.name}\n")
+    Files.writeString(artifact.resolveSibling("${artifact.name}.sha256"), "${sha256(artifact)}  ${artifact.name}\n")
   }
+
+  private fun sha256(artifact: Path): String = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(artifact))
+    .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
 
   private data class ProcessResult(val exitCode: Int, val output: String)
 }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
@@ -8,6 +8,7 @@ import java.util.zip.ZipOutputStream
 import kotlin.io.path.name
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ReleaseArtifactLicenseVerifierTest {
@@ -35,6 +36,12 @@ class ReleaseArtifactLicenseVerifierTest {
 
     assertTrue(verifier.contains("image/LICENSE"))
     assertTrue(verifier.contains("resources/skill-bill-runtime/LICENSE"))
+    assertTrue(verifier.contains("cpio -it --quiet"))
+    assertTrue(verifier.contains("lessmsi x"))
+    assertFalse(verifier.contains("cpio -idm"))
+    assertFalse(verifier.contains("msiexec.exe"))
+    assertFalse(verifier.contains("hdiutil detach \"\${mount_dir}\" >/dev/null 2>&1 || true"))
+    assertTrue(verifier.contains("Could not detach mounted disk image"))
     assertTrue(!verifier.contains("mapfile"))
   }
 
@@ -93,8 +100,35 @@ class ReleaseArtifactLicenseVerifierTest {
   }
 
   @Test
-  fun `verifies every desktop installer format with valid absent and byte-drifted licenses`() {
+  fun `exercises every desktop verifier branch with valid absent and byte-drifted archive fixtures`() {
     listOf("deb", "rpm", "dmg", "msi").forEach(::assertDesktopLicenseVerification)
+  }
+
+  @Test
+  fun `fails when a mounted dmg cannot be detached`() {
+    val fixture = Files.createTempDirectory("skillbill-dmg-detach-verifier")
+    val artifact = fixture.resolve("valid.dmg")
+    writeArchiveBackedDesktopFixture(artifact, rootLicenseBytes)
+    writeChecksum(artifact)
+
+    val result = runDesktopVerifier(artifact, mapOf("SKILLBILL_TEST_DETACH_FAILURE" to "true"))
+
+    assertTrue(result.exitCode != 0, result.output)
+    assertTrue(result.output.contains("Could not detach mounted disk image"), result.output)
+  }
+
+  @Test
+  fun `rejects unsafe rpm archive entries and canonical license symlinks`() {
+    val fixture = Files.createTempDirectory("skillbill-rpm-verifier-safety")
+    val unsafe = fixture.resolve("unsafe.rpm")
+    val symlink = fixture.resolve("symlink.rpm")
+    writeArchiveBackedDesktopFixture(unsafe, rootLicenseBytes, unsafePath = true)
+    writeArchiveBackedDesktopFixture(symlink, rootLicenseBytes, canonicalLicenseIsSymlink = true)
+    writeChecksum(unsafe)
+    writeChecksum(symlink)
+
+    assertDesktopFailure(unsafe, "Unsafe archive entry")
+    assertDesktopFailure(symlink, "must be one regular file")
   }
 
   @Test
@@ -132,18 +166,19 @@ class ReleaseArtifactLicenseVerifierTest {
     val valid = fixture.resolve("valid.$extension")
     val absent = fixture.resolve("absent.$extension")
     val drifted = fixture.resolve("drifted.$extension")
-    listOf(valid, absent, drifted).forEach { artifact ->
-      Files.writeString(artifact, "desktop $extension fixture\n")
-      writeChecksum(artifact)
-    }
+    writeArchiveBackedDesktopFixture(valid, rootLicenseBytes)
+    writeArchiveBackedDesktopFixture(absent, null)
+    writeArchiveBackedDesktopFixture(drifted, "different license".encodeToByteArray())
+    listOf(valid, absent, drifted).forEach(::writeChecksum)
 
-    assertEquals(0, runDesktopVerifier(valid, rootLicenseBytes).exitCode)
-    assertDesktopFailure(absent, null, "canonical resources/skill-bill-runtime/LICENSE")
-    assertDesktopFailure(drifted, "different license".encodeToByteArray(), "LICENSE bytes differ")
+    val validResult = runDesktopVerifier(valid)
+    assertEquals(0, validResult.exitCode, validResult.output)
+    assertDesktopFailure(absent, "canonical resources/skill-bill-runtime/LICENSE")
+    assertDesktopFailure(drifted, "LICENSE bytes differ")
   }
 
-  private fun assertDesktopFailure(artifact: Path, license: ByteArray?, expectedMessage: String) {
-    val result = runDesktopVerifier(artifact, license)
+  private fun assertDesktopFailure(artifact: Path, expectedMessage: String) {
+    val result = runDesktopVerifier(artifact)
     assertTrue(result.exitCode != 0, result.output)
     assertTrue(result.output.contains(expectedMessage), result.output)
   }
@@ -152,28 +187,16 @@ class ReleaseArtifactLicenseVerifierTest {
     return runVerifier(artifacts.toList())
   }
 
-  private fun runDesktopVerifier(artifact: Path, license: ByteArray?): ProcessResult {
+  private fun runDesktopVerifier(artifact: Path, environment: Map<String, String> = emptyMap()): ProcessResult {
     val shims = Files.createTempDirectory("skillbill-verifier-shims")
-    val extractionRoot = Files.createTempDirectory("skillbill-desktop-extraction")
-    val extractedLicense = shims.resolve("extracted-LICENSE")
-    if (license != null) {
-      Files.write(extractedLicense, license)
-    }
-    writeDesktopExtractionShims(shims)
+    writeDesktopToolDoubles(shims)
     return runVerifier(
       listOf(artifact),
-      mapOf(
-        "PATH" to "${shims}:${System.getenv("PATH")}",
-        "SKILLBILL_EXTRACTION_ROOT" to extractionRoot.toString(),
-        "SKILLBILL_DESKTOP_LICENSE_FIXTURE" to if (license == null) "" else extractedLicense.toString(),
-      ),
+      environment + ("PATH" to "$shims:${System.getenv("PATH")}"),
     )
   }
 
-  private fun runVerifier(
-    artifacts: List<Path>,
-    environment: Map<String, String> = emptyMap(),
-  ): ProcessResult {
+  private fun runVerifier(artifacts: List<Path>, environment: Map<String, String> = emptyMap()): ProcessResult {
     val processBuilder =
       ProcessBuilder(
         listOf("bash", repoRoot.resolve("scripts/verify_release_artifact_licenses").toString()) +
@@ -218,26 +241,81 @@ class ReleaseArtifactLicenseVerifierTest {
     assertEquals(0, process.waitFor(), output)
   }
 
-  private fun writeDesktopExtractionShims(shims: Path) {
-    val noOp = "#!/usr/bin/env bash\nexit 0\n"
-    val extract =
+  private fun writeArchiveBackedDesktopFixture(
+    artifact: Path,
+    licenseBytes: ByteArray?,
+    unsafePath: Boolean = false,
+    canonicalLicenseIsSymlink: Boolean = false,
+  ) {
+    val source = Files.createTempDirectory("skillbill-desktop-artifact-source")
+    val license = source.resolve("SkillBill/resources/skill-bill-runtime/LICENSE")
+    if (licenseBytes != null) {
+      Files.createDirectories(license.parent)
+      if (canonicalLicenseIsSymlink) {
+        val target = source.resolve("license-target")
+        Files.write(target, licenseBytes)
+        Files.createSymbolicLink(license, Path.of("../../../${target.fileName}"))
+      } else {
+        Files.write(license, licenseBytes)
+      }
+    } else {
+      Files.createDirectories(source.resolve("SkillBill/resources"))
+      Files.writeString(source.resolve("SkillBill/resources/README.md"), "no license\n")
+    }
+    val command = mutableListOf("tar", "-cf", artifact.toString())
+    if (unsafePath) {
+      command += "--transform=s#^\\./#../#"
+    }
+    command += listOf("-C", source.toString(), ".")
+    val process = ProcessBuilder(command)
+      .redirectErrorStream(true)
+      .start()
+    val output = process.inputStream.bufferedReader().readText()
+    assertEquals(0, process.waitFor(), output)
+  }
+
+  private fun writeDesktopToolDoubles(shims: Path) {
+    writeExecutable(shims.resolve("dpkg-deb"), "#!/usr/bin/env bash\nset -euo pipefail\ncat \"${'$'}2\"\n")
+    writeExecutable(shims.resolve("rpm2cpio"), "#!/usr/bin/env bash\nset -euo pipefail\ncat \"${'$'}1\"\n")
+    writeExecutable(
+      shims.resolve("cpio"),
       """
       #!/usr/bin/env bash
       set -euo pipefail
-      if [[ -n "${'$'}{SKILLBILL_DESKTOP_LICENSE_FIXTURE:-}" ]]; then
-        target="${'$'}{SKILLBILL_EXTRACTION_ROOT}/SkillBill/resources/skill-bill-runtime"
-        mkdir -p "${'$'}target"
-        cp "${'$'}SKILLBILL_DESKTOP_LICENSE_FIXTURE" "${'$'}target/LICENSE"
+      if [[ " ${'$'}* " == *" -itv "* ]]; then
+        tar -tvf -
+      elif [[ " ${'$'}* " == *" --to-stdout "* ]]; then
+        tar -xOf - "${'$'}{!#}"
+      else
+        tar -tf -
       fi
-      """.trimIndent() + "\n"
-    writeExecutable(shims.resolve("mktemp"), "#!/usr/bin/env bash\nprintf '%s\\n' \"${'$'}SKILLBILL_EXTRACTION_ROOT\"\n")
-    writeExecutable(shims.resolve("dpkg-deb"), noOp)
-    writeExecutable(shims.resolve("tar"), extract)
-    writeExecutable(shims.resolve("rpm2cpio"), noOp)
-    writeExecutable(shims.resolve("cpio"), extract)
-    writeExecutable(shims.resolve("hdiutil"), extract)
-    writeExecutable(shims.resolve("cygpath"), "#!/usr/bin/env bash\nprintf '%s\\n' \"${'$'}{!#}\"\n")
-    writeExecutable(shims.resolve("msiexec.exe"), extract)
+      """.trimIndent() + "\n",
+    )
+    writeExecutable(
+      shims.resolve("hdiutil"),
+      """
+      #!/usr/bin/env bash
+      set -euo pipefail
+      if [[ "${'$'}1" == "detach" ]]; then
+        if [[ "${'$'}{SKILLBILL_TEST_DETACH_FAILURE:-}" == "true" ]]; then
+          exit 1
+        fi
+        exit 0
+      fi
+      mountpoint=""
+      args=("${'$'}@")
+      for ((index = 0; index < ${'$'}{#args[@]}; index++)); do
+        if [[ "${'$'}{args[index]}" == "-mountpoint" ]]; then
+          mountpoint="${'$'}{args[index + 1]}"
+        fi
+      done
+      tar -xf "${'$'}{args[${'$'}{#args[@]} - 1]}" -C "${'$'}mountpoint"
+      """.trimIndent() + "\n",
+    )
+    writeExecutable(
+      shims.resolve("lessmsi"),
+      "#!/usr/bin/env bash\nset -euo pipefail\ntar -xf \"${'$'}2\" -C \"${'$'}3\"\n",
+    )
   }
 
   private fun writeExecutable(path: Path, contents: String) {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
@@ -53,6 +53,20 @@ class ReleaseArtifactLicenseVerifierTest {
   }
 
   @Test
+  fun `rejects missing and byte-drifted skills tar licenses`() {
+    val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
+    val absent = fixture.resolve("absent.tar.gz")
+    val drifted = fixture.resolve("drifted.tar.gz")
+    writeTar(absent, null)
+    writeTar(drifted, "different license".encodeToByteArray())
+    writeChecksum(absent)
+    writeChecksum(drifted)
+
+    assertFailure(absent, "exactly one canonical LICENSE")
+    assertFailure(drifted, "LICENSE bytes differ")
+  }
+
+  @Test
   fun `permits third party license entries beside the canonical runtime license`() {
     val fixture = Files.createTempDirectory("skillbill-artifact-verifier")
     val artifact = fixture.resolve("runtime.zip")
@@ -76,6 +90,11 @@ class ReleaseArtifactLicenseVerifierTest {
     writeChecksum(artifact)
 
     assertFailure(artifact, "exactly one canonical LICENSE")
+  }
+
+  @Test
+  fun `verifies every desktop installer format with valid absent and byte-drifted licenses`() {
+    listOf("deb", "rpm", "dmg", "msi").forEach(::assertDesktopLicenseVerification)
   }
 
   @Test
@@ -108,15 +127,62 @@ class ReleaseArtifactLicenseVerifierTest {
     assertTrue(result.output.contains(expectedMessage), result.output)
   }
 
+  private fun assertDesktopLicenseVerification(extension: String) {
+    val fixture = Files.createTempDirectory("skillbill-desktop-artifact-verifier")
+    val valid = fixture.resolve("valid.$extension")
+    val absent = fixture.resolve("absent.$extension")
+    val drifted = fixture.resolve("drifted.$extension")
+    listOf(valid, absent, drifted).forEach { artifact ->
+      Files.writeString(artifact, "desktop $extension fixture\n")
+      writeChecksum(artifact)
+    }
+
+    assertEquals(0, runDesktopVerifier(valid, rootLicenseBytes).exitCode)
+    assertDesktopFailure(absent, null, "canonical resources/skill-bill-runtime/LICENSE")
+    assertDesktopFailure(drifted, "different license".encodeToByteArray(), "LICENSE bytes differ")
+  }
+
+  private fun assertDesktopFailure(artifact: Path, license: ByteArray?, expectedMessage: String) {
+    val result = runDesktopVerifier(artifact, license)
+    assertTrue(result.exitCode != 0, result.output)
+    assertTrue(result.output.contains(expectedMessage), result.output)
+  }
+
   private fun runVerifier(vararg artifacts: Path): ProcessResult {
-    val process =
+    return runVerifier(artifacts.toList())
+  }
+
+  private fun runDesktopVerifier(artifact: Path, license: ByteArray?): ProcessResult {
+    val shims = Files.createTempDirectory("skillbill-verifier-shims")
+    val extractionRoot = Files.createTempDirectory("skillbill-desktop-extraction")
+    val extractedLicense = shims.resolve("extracted-LICENSE")
+    if (license != null) {
+      Files.write(extractedLicense, license)
+    }
+    writeDesktopExtractionShims(shims)
+    return runVerifier(
+      listOf(artifact),
+      mapOf(
+        "PATH" to "${shims}:${System.getenv("PATH")}",
+        "SKILLBILL_EXTRACTION_ROOT" to extractionRoot.toString(),
+        "SKILLBILL_DESKTOP_LICENSE_FIXTURE" to if (license == null) "" else extractedLicense.toString(),
+      ),
+    )
+  }
+
+  private fun runVerifier(
+    artifacts: List<Path>,
+    environment: Map<String, String> = emptyMap(),
+  ): ProcessResult {
+    val processBuilder =
       ProcessBuilder(
         listOf("bash", repoRoot.resolve("scripts/verify_release_artifact_licenses").toString()) +
           artifacts.map(Path::toString),
       )
         .directory(repoRoot.toFile())
         .redirectErrorStream(true)
-        .start()
+    processBuilder.environment().putAll(environment)
+    val process = processBuilder.start()
     val output = process.inputStream.bufferedReader().readText()
     return ProcessResult(process.waitFor(), output)
   }
@@ -131,19 +197,52 @@ class ReleaseArtifactLicenseVerifierTest {
     }
   }
 
-  private fun writeTar(artifact: Path, licenseBytes: ByteArray, duplicateLicense: Boolean = false) {
+  private fun writeTar(artifact: Path, licenseBytes: ByteArray?, duplicateLicense: Boolean = false) {
     val source = Files.createTempDirectory("skillbill-artifact-tar-source")
-    Files.write(source.resolve("LICENSE"), licenseBytes)
     Files.writeString(source.resolve("README.md"), "Skill Bill skills archive fixture\n")
+    if (licenseBytes != null) {
+      Files.write(source.resolve("LICENSE"), licenseBytes)
+    }
+    val entries = if (licenseBytes == null) {
+      listOf("README.md")
+    } else {
+      listOf("LICENSE", "README.md") + if (duplicateLicense) listOf("LICENSE") else emptyList()
+    }
     val process =
       ProcessBuilder(
-        listOf("tar", "-czf", artifact.toString(), "-C", source.toString(), "LICENSE", "README.md") +
-          if (duplicateLicense) listOf("LICENSE") else emptyList(),
+        listOf("tar", "-czf", artifact.toString(), "-C", source.toString()) + entries,
       )
         .redirectErrorStream(true)
         .start()
     val output = process.inputStream.bufferedReader().readText()
     assertEquals(0, process.waitFor(), output)
+  }
+
+  private fun writeDesktopExtractionShims(shims: Path) {
+    val noOp = "#!/usr/bin/env bash\nexit 0\n"
+    val extract =
+      """
+      #!/usr/bin/env bash
+      set -euo pipefail
+      if [[ -n "${'$'}{SKILLBILL_DESKTOP_LICENSE_FIXTURE:-}" ]]; then
+        target="${'$'}{SKILLBILL_EXTRACTION_ROOT}/SkillBill/resources/skill-bill-runtime"
+        mkdir -p "${'$'}target"
+        cp "${'$'}SKILLBILL_DESKTOP_LICENSE_FIXTURE" "${'$'}target/LICENSE"
+      fi
+      """.trimIndent() + "\n"
+    writeExecutable(shims.resolve("mktemp"), "#!/usr/bin/env bash\nprintf '%s\\n' \"${'$'}SKILLBILL_EXTRACTION_ROOT\"\n")
+    writeExecutable(shims.resolve("dpkg-deb"), noOp)
+    writeExecutable(shims.resolve("tar"), extract)
+    writeExecutable(shims.resolve("rpm2cpio"), noOp)
+    writeExecutable(shims.resolve("cpio"), extract)
+    writeExecutable(shims.resolve("hdiutil"), extract)
+    writeExecutable(shims.resolve("cygpath"), "#!/usr/bin/env bash\nprintf '%s\\n' \"${'$'}{!#}\"\n")
+    writeExecutable(shims.resolve("msiexec.exe"), extract)
+  }
+
+  private fun writeExecutable(path: Path, contents: String) {
+    Files.writeString(path, contents)
+    assertTrue(path.toFile().setExecutable(true), "Could not mark $path executable")
   }
 
   private fun writeChecksum(artifact: Path) {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseArtifactLicenseVerifierTest.kt
@@ -134,9 +134,10 @@ class ReleaseArtifactLicenseVerifierTest {
   private fun writeTar(artifact: Path, licenseBytes: ByteArray, duplicateLicense: Boolean = false) {
     val source = Files.createTempDirectory("skillbill-artifact-tar-source")
     Files.write(source.resolve("LICENSE"), licenseBytes)
+    Files.writeString(source.resolve("README.md"), "Skill Bill skills archive fixture\n")
     val process =
       ProcessBuilder(
-        listOf("tar", "-czf", artifact.toString(), "-C", source.toString(), "LICENSE") +
+        listOf("tar", "-czf", artifact.toString(), "-C", source.toString(), "LICENSE", "README.md") +
           if (duplicateLicense) listOf("LICENSE") else emptyList(),
       )
         .redirectErrorStream(true)

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
@@ -1,0 +1,42 @@
+package skillbill.scaffold
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReleaseWorkflowContractTest {
+  private val repoRoot: Path =
+    generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
+      .first { Files.isRegularFile(it.resolve("LICENSE")) }
+
+  @Test
+  fun `release workflow verifies only canonical licensed artifacts before upload`() {
+    val workflow = Files.readString(repoRoot.resolve(".github/workflows/release.yml"))
+
+    listOf(
+      "runtime-cli-\${RELEASE_VERSION}-\${host_token}.zip",
+      "runtime-mcp-\${RELEASE_VERSION}-\${host_token}.zip",
+      "SkillBill-\${RELEASE_VERSION}-\${host_token}.dmg",
+      "SkillBill-\${RELEASE_VERSION}-\${host_token}.msi",
+      "SkillBill-\${RELEASE_VERSION}-\${host_token}.deb",
+      "SkillBill-\${RELEASE_VERSION}-\${host_token}.rpm",
+      "skill-bill-skills-\${RELEASE_VERSION}.tar.gz",
+    ).forEach { path -> assertTrue(workflow.contains(path), path) }
+    assertTrue(workflow.contains("scripts/verify_release_artifact_licenses \"\${artifacts[@]}\""))
+    assertTrue(workflow.contains("cp \"\${artifact}\" \"\${artifact}.sha256\" release-assets/"))
+    assertTrue(workflow.contains("path: release-assets/"))
+    assertFalse(workflow.contains("binaries/main/*/SkillBill-*"))
+  }
+
+  @Test
+  fun `release workflow rejects existing releases instead of replacing their assets`() {
+    val workflow = Files.readString(repoRoot.resolve(".github/workflows/release.yml"))
+
+    assertTrue(workflow.contains("release assets are immutable"))
+    assertTrue(workflow.contains("Use a fresh staging version"))
+    assertFalse(workflow.contains("--clobber"))
+    assertFalse(workflow.contains("gh release upload"))
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
@@ -27,6 +27,8 @@ class ReleaseWorkflowContractTest {
     assertTrue(workflow.contains("scripts/verify_release_artifact_licenses \"\${artifacts[@]}\""))
     assertTrue(workflow.contains("cp \"\${artifact}\" \"\${artifact}.sha256\" release-assets/"))
     assertTrue(workflow.contains("path: release-assets/"))
+    assertTrue(workflow.contains("artifact_names=("))
+    assertTrue(workflow.contains("Missing expected release asset"))
     assertFalse(workflow.contains("binaries/main/*/SkillBill-*"))
   }
 
@@ -36,7 +38,13 @@ class ReleaseWorkflowContractTest {
 
     assertTrue(workflow.contains("release assets are immutable"))
     assertTrue(workflow.contains("Use a fresh staging version"))
+    assertTrue(workflow.contains("gh release create \"\${args[@]}\" --draft"))
+    assertTrue(workflow.contains("gh release upload \"\${RELEASE_TAG}\" \"\${assets[@]}\""))
+    assertTrue(workflow.contains("gh release edit \"\${RELEASE_TAG}\""))
+    assertTrue(workflow.contains("SemVer prerelease label"))
+    assertTrue(workflow.contains("scripts/validate_release_ref \"\$raw\" \"\${validation_args[@]}\""))
+    assertTrue(workflow.contains("scripts/validate_release_ref \"\$STAGING_VERSION\" --force-prerelease"))
+    assertFalse(workflow.contains("raw=\"\${{"))
     assertFalse(workflow.contains("--clobber"))
-    assertFalse(workflow.contains("gh release upload"))
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
@@ -25,6 +25,11 @@ class ReleaseWorkflowContractTest {
       "skill-bill-skills-\${RELEASE_VERSION}.tar.gz",
     ).forEach { path -> assertTrue(workflow.contains(path), path) }
     assertTrue(workflow.contains("scripts/verify_release_artifact_licenses \"\${artifacts[@]}\""))
+    assertTrue(workflow.contains("intentional license drift probe"))
+    assertTrue(workflow.contains("for artifact in \"\${artifacts[@]}\""))
+    assertTrue(workflow.contains("License drift probe unexpectedly accepted \${artifact}."))
+    assertTrue(workflow.contains("grep -q 'LICENSE bytes differ'"))
+    assertTrue(workflow.contains("choco install lessmsi --yes --no-progress"))
     assertTrue(workflow.contains("cp \"\${artifact}\" \"\${artifact}.sha256\" release-assets/"))
     assertTrue(workflow.contains("path: release-assets/"))
     assertTrue(workflow.contains("artifact_names=("))
@@ -33,15 +38,24 @@ class ReleaseWorkflowContractTest {
   }
 
   @Test
-  fun `release workflow binds publication to the validated commit and safely resumes matching drafts`() {
+  fun `release workflow binds publication to the validated commit and safely reconciles retries`() {
     val workflow = Files.readString(repoRoot.resolve(".github/workflows/release.yml"))
 
     assertTrue(workflow.contains("--target \"\${GITHUB_SHA}\""))
     assertTrue(workflow.contains("git ls-remote --exit-code --refs origin \"refs/tags/\${RELEASE_TAG}\""))
     assertTrue(workflow.contains("Staging tag \${RELEASE_TAG} already exists without a resumable draft release."))
-    assertTrue(workflow.contains("--json isDraft,isPrerelease,targetCommitish,tagName"))
-    assertTrue(workflow.contains("Existing draft \${RELEASE_TAG} does not match this validated tag, commit, and prerelease classification."))
-    assertTrue(workflow.contains("Release \${RELEASE_TAG} is already published and cannot be resumed."))
+    assertTrue(workflow.contains("git ls-remote origin \"refs/tags/\${RELEASE_TAG}^{}\""))
+    assertTrue(workflow.contains("Release tag \${RELEASE_TAG} does not peel to the validated commit \${GITHUB_SHA}."))
+    assertTrue(workflow.contains("--json author,isDraft,isPrerelease,targetCommitish,tagName"))
+    assertTrue(
+      workflow.contains(
+        "Existing draft \${RELEASE_TAG} does not match this validated tag, commit, and prerelease classification.",
+      ),
+    )
+    assertTrue(
+      workflow.contains("Published release \${RELEASE_TAG} already matches the validated metadata and assets."),
+    )
+    assertTrue(workflow.contains("Published release is missing expected asset"))
     assertTrue(workflow.contains("gh release create \"\${args[@]}\" --draft"))
     assertTrue(workflow.contains("gh release download \"\${RELEASE_TAG}\""))
     assertTrue(workflow.contains("Existing draft asset bytes differ from the validated asset"))
@@ -50,8 +64,32 @@ class ReleaseWorkflowContractTest {
     assertTrue(workflow.contains("SemVer prerelease label"))
     assertTrue(workflow.contains("scripts/validate_release_ref \"\$raw\" \"\${validation_args[@]}\""))
     assertTrue(workflow.contains("scripts/validate_release_ref \"\$STAGING_VERSION\" --force-prerelease"))
-    assertTrue(workflow.indexOf("gh release edit \"\${RELEASE_TAG}\"") > workflow.lastIndexOf("Draft release is missing uploaded asset"))
+    assertTrue(workflow.contains("SKILL_BILL_COPYRIGHT_HOLDER_RELEASE_TOKEN"))
+    assertTrue(
+      workflow.contains("Stable v1.0.0 publication requires the copyright holder's release token and GitHub login."),
+    )
+    assertTrue(
+      workflow.contains(
+        "Stable v1.0.0 release \${RELEASE_TAG} was not created by the configured copyright holder.",
+      ),
+    )
+    assertTrue(
+      workflow.indexOf("gh release edit \"\${RELEASE_TAG}\"") >
+        workflow.lastIndexOf("Draft release is missing uploaded asset"),
+    )
     assertFalse(workflow.contains("raw=\"\${{"))
     assertFalse(workflow.contains("--clobber"))
+  }
+
+  @Test
+  fun `release-ref wrapper shell-quotes each forwarded argument`() {
+    val wrapper = Files.readString(repoRoot.resolve("scripts/validate_release_ref"))
+
+    assertTrue(wrapper.contains("for arg in \"\${args[@]}\""))
+    assertTrue(wrapper.contains("escaped_arg=\"\${arg//\\\\/\\\\\\\\}\""))
+    assertTrue(wrapper.contains("escaped_arg=\"\${escaped_arg//\\\"/\\\\\\\"}\""))
+    assertTrue(wrapper.contains("--args=\"\$gradle_args\""))
+    assertFalse(wrapper.contains("printf -v"))
+    assertFalse(wrapper.contains("\${args[*]}"))
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/ReleaseWorkflowContractTest.kt
@@ -33,17 +33,24 @@ class ReleaseWorkflowContractTest {
   }
 
   @Test
-  fun `release workflow rejects existing releases instead of replacing their assets`() {
+  fun `release workflow binds publication to the validated commit and safely resumes matching drafts`() {
     val workflow = Files.readString(repoRoot.resolve(".github/workflows/release.yml"))
 
-    assertTrue(workflow.contains("release assets are immutable"))
-    assertTrue(workflow.contains("Use a fresh staging version"))
+    assertTrue(workflow.contains("--target \"\${GITHUB_SHA}\""))
+    assertTrue(workflow.contains("git ls-remote --exit-code --refs origin \"refs/tags/\${RELEASE_TAG}\""))
+    assertTrue(workflow.contains("Staging tag \${RELEASE_TAG} already exists without a resumable draft release."))
+    assertTrue(workflow.contains("--json isDraft,isPrerelease,targetCommitish,tagName"))
+    assertTrue(workflow.contains("Existing draft \${RELEASE_TAG} does not match this validated tag, commit, and prerelease classification."))
+    assertTrue(workflow.contains("Release \${RELEASE_TAG} is already published and cannot be resumed."))
     assertTrue(workflow.contains("gh release create \"\${args[@]}\" --draft"))
-    assertTrue(workflow.contains("gh release upload \"\${RELEASE_TAG}\" \"\${assets[@]}\""))
+    assertTrue(workflow.contains("gh release download \"\${RELEASE_TAG}\""))
+    assertTrue(workflow.contains("Existing draft asset bytes differ from the validated asset"))
+    assertTrue(workflow.contains("gh release upload \"\${RELEASE_TAG}\" \"dist/\${asset_name}\""))
     assertTrue(workflow.contains("gh release edit \"\${RELEASE_TAG}\""))
     assertTrue(workflow.contains("SemVer prerelease label"))
     assertTrue(workflow.contains("scripts/validate_release_ref \"\$raw\" \"\${validation_args[@]}\""))
     assertTrue(workflow.contains("scripts/validate_release_ref \"\$STAGING_VERSION\" --force-prerelease"))
+    assertTrue(workflow.indexOf("gh release edit \"\${RELEASE_TAG}\"") > workflow.lastIndexOf("Draft release is missing uploaded asset"))
     assertFalse(workflow.contains("raw=\"\${{"))
     assertFalse(workflow.contains("--clobber"))
   }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
@@ -56,8 +56,14 @@ class RepoValidationRuntimeTest {
   fun `release policy preserves historical lines and requires complete custom policy from v0 1 2`() {
     val repoRoot = Files.createTempDirectory("skillbill-release-policy")
 
-    RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.0", forcePrerelease = false)
-    RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.1", forcePrerelease = false)
+    listOf("v0.0.9", "v0.1.0", "v0.1.1+rebuild.1").forEach { ref ->
+      RepoValidationRuntime.validateReleaseRef(repoRoot, ref, forcePrerelease = false)
+    }
+
+    val coveredPrerelease = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.2-rc.1", forcePrerelease = false)
+    }
+    assertTrue(coveredPrerelease.message.orEmpty().contains("LICENSE"))
 
     val missingPolicy = assertFailsWith<IllegalArgumentException> {
       RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.2", forcePrerelease = false)
@@ -69,6 +75,11 @@ class RepoValidationRuntimeTest {
       "marker-only" to RepoValidationRuntime.TRANSITIONAL_LICENSE_MARKER,
       "wrong-boundary" to completeTransitionalLicense().replace("v0.1.2", "v0.1.3"),
       "truncated" to completeTransitionalLicense().substringBefore("9. Termination and cure"),
+      "material-clause-change" to
+        completeTransitionalLicense().replace(
+          "commercial use, consulting",
+          "commercial and consulting",
+        ),
     ).forEach { (fixture, license) ->
       Files.writeString(repoRoot.resolve("LICENSE"), license)
       val failure = assertFailsWith<IllegalArgumentException> {
@@ -81,6 +92,8 @@ class RepoValidationRuntimeTest {
     listOf("v0.1.2", "v0.2.0+build.7", "v0.9.9-rc.1").forEach { ref ->
       RepoValidationRuntime.validateReleaseRef(repoRoot, ref, forcePrerelease = false)
     }
+    Files.writeString(repoRoot.resolve("LICENSE"), completeTransitionalLicense().replace("\n", "\r\n"))
+    RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.2", forcePrerelease = false)
   }
 
   @Test
@@ -89,14 +102,19 @@ class RepoValidationRuntimeTest {
     Files.writeString(repoRoot.resolve("LICENSE"), completeTransitionalLicense())
 
     val releaseCandidate = RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
-    val staging = RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0", forcePrerelease = true)
+    val staging = RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-staging.1", forcePrerelease = false)
+    val forcedStableFailure = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0", forcePrerelease = true)
+    }
     val stableFailure = assertFailsWith<IllegalArgumentException> {
       RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0", forcePrerelease = false)
     }
 
     assertTrue(releaseCandidate.prerelease)
     assertTrue(staging.prerelease)
-    assertTrue(stableFailure.message.orEmpty().contains("cannot publish"))
+    assertEquals("v1.0.0-staging.1", staging.tag)
+    assertTrue(forcedStableFailure.message.orEmpty().contains("prerelease identifier"))
+    assertTrue(stableFailure.message.orEmpty().contains("successor license policy"))
   }
 
   @Test
@@ -112,7 +130,7 @@ class RepoValidationRuntimeTest {
     }
 
     assertTrue(missing.message.orEmpty().contains("complete transitional"))
-    assertTrue(incomplete.message.orEmpty().contains("incomplete transitional"))
+    assertTrue(incomplete.message.orEmpty().contains("complete transitional"))
   }
 
   @Test
@@ -124,7 +142,7 @@ class RepoValidationRuntimeTest {
       val failure = assertFailsWith<IllegalArgumentException> {
         RepoValidationRuntime.validateReleaseRef(repoRoot, ref, forcePrerelease = false)
       }
-      assertTrue(failure.message.orEmpty().contains("cannot publish"), ref)
+      assertTrue(failure.message.orEmpty().contains("successor license policy"), ref)
     }
   }
 
@@ -133,22 +151,48 @@ class RepoValidationRuntimeTest {
     val repoRoot = Files.createTempDirectory("skillbill-successor-license")
     Files.writeString(
       repoRoot.resolve("LICENSE"),
-      """
-      Skill Bill Successor License
-
-      Historical notice: Skill Bill Pre-1.0 Use License 1.0 applied before v1.0.0.
-      """.trimIndent() + "\n",
+      completeSuccessorLicense(),
     )
 
     RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
   }
 
-  private fun completeTransitionalLicense(): String =
-    Files.readString(repositoryRoot().resolve("LICENSE"))
+  @Test
+  fun `post one release rejects empty placeholder and trivially prefixed successor policies`() {
+    val repoRoot = Files.createTempDirectory("skillbill-invalid-successor-license")
+    listOf(
+      "",
+      "Successor License Identifier: LicenseRef-Skill-Bill-Successor-1.0\n" +
+        "Successor License Effective Version: v1.0.0\n",
+      "Historical notice\n\n${completeTransitionalLicense()}",
+      completeSuccessorLicense().substringBefore("Successor License Terms:") +
+        "Successor License Terms:\n${completeTransitionalLicense()}",
+    ).forEach { license ->
+      Files.writeString(repoRoot.resolve("LICENSE"), license)
+      val failure = assertFailsWith<IllegalArgumentException> {
+        RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.1", forcePrerelease = false)
+      }
+      assertTrue(failure.message.orEmpty().contains("successor license policy"))
+    }
+  }
 
-  private fun repositoryRoot(): Path =
-    generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
-      .first { Files.isRegularFile(it.resolve("LICENSE")) }
+  private fun completeTransitionalLicense(): String = Files.readString(repositoryRoot().resolve("LICENSE"))
+
+  private fun completeSuccessorLicense(): String = """
+    Skill Bill Successor License
+    Successor License Identifier: LicenseRef-Skill-Bill-Successor-1.0
+    Successor License Effective Version: v1.0.0
+
+    Successor License Terms:
+    This successor policy is the complete governing text for Skill Bill releases at and after v1.0.0.
+    It records the licensing decision made by the copyright holder and states the permissions, conditions,
+    restrictions, warranty treatment, and liability rules applicable to those releases. Historical references
+    to Skill Bill Pre-1.0 Use License 1.0 explain only the earlier release line and do not make that
+    transitional policy the current license for this successor release.
+  """.trimIndent() + "\n"
+
+  private fun repositoryRoot(): Path = generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
+    .first { Files.isRegularFile(it.resolve("LICENSE")) }
 
   @Test
   fun `repo validation reports missing governed directories`() {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
@@ -31,16 +31,13 @@ class RepoValidationRuntimeTest {
   }
 
   @Test
-  fun `release refs accept bare version tags without v prefix`() {
-    val stable = RepoValidationRuntime.parseReleaseRef("0.2.0")
-    assertEquals("0.2.0", stable.tag)
-    assertEquals("0.2.0", stable.version)
-    assertFalse(stable.prerelease)
-
-    val prerelease = RepoValidationRuntime.parseReleaseRef("refs/tags/1.0.0-rc.1")
-    assertEquals("1.0.0-rc.1", prerelease.tag)
-    assertEquals("1.0.0-rc.1", prerelease.version)
-    assertTrue(prerelease.prerelease)
+  fun `release refs reject bare version tags without v prefix`() {
+    listOf("0.2.0", "refs/tags/1.0.0-rc.1").forEach { ref ->
+      val failure = assertFailsWith<IllegalArgumentException> {
+        RepoValidationRuntime.parseReleaseRef(ref)
+      }
+      assertTrue(failure.message.orEmpty().contains("canonical vMAJOR"), ref)
+    }
   }
 
   @Test
@@ -75,11 +72,11 @@ class RepoValidationRuntimeTest {
       "identifier-only" to RepoValidationRuntime.PRE_1_LICENSE_IDENTIFIER,
       "marker-only" to RepoValidationRuntime.TRANSITIONAL_LICENSE_MARKER,
       "wrong-boundary" to completeTransitionalLicense().replace("v0.1.2", "v0.1.3"),
-      "truncated" to completeTransitionalLicense().substringBefore("9. Termination and cure"),
+      "truncated" to completeTransitionalLicense().substringBefore("10. Termination and cure"),
       "material-clause-change" to
         completeTransitionalLicense().replace(
-          "commercial use, consulting",
-          "commercial and consulting",
+          "hosted-service use",
+          "hosted-product use",
         ),
     ).forEach { (fixture, license) ->
       Files.writeString(repoRoot.resolve("LICENSE"), license)
@@ -115,7 +112,7 @@ class RepoValidationRuntimeTest {
     assertTrue(staging.prerelease)
     assertEquals("v1.0.0-staging.1", staging.tag)
     assertTrue(forcedStableFailure.message.orEmpty().contains("prerelease identifier"))
-    assertTrue(stableFailure.message.orEmpty().contains("approved successor license policy"))
+    assertTrue(stableFailure.message.orEmpty().contains("approved stable license policy"))
   }
 
   @Test
@@ -129,19 +126,18 @@ class RepoValidationRuntimeTest {
     val incomplete = assertFailsWith<IllegalArgumentException> {
       RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
     }
-    Files.writeString(repoRoot.resolve("LICENSE"), completeSuccessorLicense())
-    writeSuccessorApproval(repoRoot, completeSuccessorLicense())
-    val successor = assertFailsWith<IllegalArgumentException> {
+    Files.writeString(repoRoot.resolve("LICENSE"), completeTransitionalLicense().replace("Skill Bill Use", "Other Use"))
+    val otherPolicy = assertFailsWith<IllegalArgumentException> {
       RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
     }
 
     assertTrue(missing.message.orEmpty().contains("LICENSE"))
-    assertTrue(incomplete.message.orEmpty().contains("complete current pre-1.0"))
-    assertTrue(successor.message.orEmpty().contains("complete current pre-1.0"))
+    assertTrue(incomplete.message.orEmpty().contains("complete current Skill Bill use license"))
+    assertTrue(otherPolicy.message.orEmpty().contains("complete current Skill Bill use license"))
   }
 
   @Test
-  fun `post one lines including prereleases require a successor policy`() {
+  fun `post one lines including prereleases require stable policy approval`() {
     val repoRoot = Files.createTempDirectory("skillbill-post-one-policy")
     Files.writeString(repoRoot.resolve("LICENSE"), completeTransitionalLicense())
 
@@ -149,14 +145,14 @@ class RepoValidationRuntimeTest {
       val failure = assertFailsWith<IllegalArgumentException> {
         RepoValidationRuntime.validateReleaseRef(repoRoot, ref, forcePrerelease = false)
       }
-      assertTrue(failure.message.orEmpty().contains("approved successor license policy"), ref)
+      assertTrue(failure.message.orEmpty().contains("approved stable license policy"), ref)
     }
   }
 
   @Test
-  fun `post one releases require an approved successor license record tied to its exact bytes`() {
+  fun `post one releases require an approved stable license record tied to its exact bytes`() {
     val repoRoot = Files.createTempDirectory("skillbill-successor-license")
-    val successor = completeSuccessorLicense()
+    val successor = completeTransitionalLicense()
     Files.writeString(
       repoRoot.resolve("LICENSE"),
       successor,
@@ -167,46 +163,31 @@ class RepoValidationRuntimeTest {
     }
     writeSuccessorApproval(repoRoot, successor)
     RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
-    Files.writeString(repoRoot.resolve("LICENSE"), successor.replace("warranty", "guarantee"))
+    Files.writeString(repoRoot.resolve("LICENSE"), successor.replace("Commercial License", "Business Agreement"))
     val changedLicense = assertFailsWith<IllegalArgumentException> {
       RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
     }
-    assertTrue(changedLicense.message.orEmpty().contains("approved successor license policy"))
+    assertTrue(changedLicense.message.orEmpty().contains("approved stable license policy"))
   }
 
   @Test
-  fun `post one release rejects unapproved or transitional successor placeholders`() {
+  fun `post one release rejects unapproved or altered policy placeholders`() {
     val repoRoot = Files.createTempDirectory("skillbill-invalid-successor-license")
     listOf(
       "",
-      "Successor License Identifier: LicenseRef-Skill-Bill-Successor-1.0\n" +
-        "Successor License Effective Version: v1.0.0\n",
+      "Identifier: LicenseRef-Skill-Bill-Use-1.0\n",
       "Historical notice\n\n${completeTransitionalLicense()}",
-      "${completeSuccessorLicense()}\n${completeTransitionalLicense()}",
-      completeSuccessorLicense().replace("restrictions", "restrictions".repeat(80)),
+      completeTransitionalLicense().replace("Commercial License", "Business Agreement"),
     ).forEach { license ->
       Files.writeString(repoRoot.resolve("LICENSE"), license)
       val failure = assertFailsWith<IllegalArgumentException> {
         RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.1", forcePrerelease = false)
       }
-      assertTrue(failure.message.orEmpty().contains("approved successor license policy"))
+      assertTrue(failure.message.orEmpty().contains("approved stable license policy"))
     }
   }
 
   private fun completeTransitionalLicense(): String = Files.readString(repositoryRoot().resolve("LICENSE"))
-
-  private fun completeSuccessorLicense(): String = """
-    Skill Bill Successor License
-    Successor License Identifier: LicenseRef-Skill-Bill-Successor-1.0
-    Successor License Effective Version: v1.0.0
-
-    Successor License Terms:
-    This successor policy is the complete governing text for Skill Bill releases at and after v1.0.0.
-    It records the licensing decision made by the copyright holder and states the permissions, conditions,
-    restrictions, warranty treatment, and liability rules applicable to those releases. Historical references
-    to Skill Bill Pre-1.0 Use License 1.0 explain only the earlier release line and do not make that
-    transitional policy the current license for this successor release.
-  """.trimIndent() + "\n"
 
   private fun writeSuccessorApproval(repoRoot: Path, license: String) {
     val sha256 = MessageDigest.getInstance("SHA-256")
@@ -217,7 +198,7 @@ class RepoValidationRuntimeTest {
       repoRoot.resolve("docs/release-successor-license-approval.md"),
       """
       Status: Approved
-      Approved Successor License Identifier: LicenseRef-Skill-Bill-Successor-1.0
+      Approved License Identifier: LicenseRef-Skill-Bill-Use-1.0
       Approved LICENSE SHA-256: $sha256
       Approved by: Braian Gapur
       Approval location: https://example.test/approvals/successor-license

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
@@ -7,6 +7,7 @@ import skillbill.scaffold.runtime.requiredSupportingFilesForSkill
 import skillbill.scaffold.runtime.supportingFileTargets
 import skillbill.testing.seedConformingPlatformPack
 import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -52,9 +53,10 @@ class RepoValidationRuntimeTest {
   }
 
   @Test
-  fun `release policy preserves historical lines and requires custom policy from v0 1 2`() {
+  fun `release policy preserves historical lines and requires complete custom policy from v0 1 2`() {
     val repoRoot = Files.createTempDirectory("skillbill-release-policy")
 
+    RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.0", forcePrerelease = false)
     RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.1", forcePrerelease = false)
 
     val missingPolicy = assertFailsWith<IllegalArgumentException> {
@@ -62,19 +64,29 @@ class RepoValidationRuntimeTest {
     }
     assertTrue(missingPolicy.message.orEmpty().contains("LICENSE"))
 
-    writeTransitionalLicense(repoRoot)
-    val coveredRelease = RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.2.0+build.7", forcePrerelease = false)
+    listOf(
+      "identifier-only" to RepoValidationRuntime.PRE_1_LICENSE_IDENTIFIER,
+      "marker-only" to RepoValidationRuntime.TRANSITIONAL_LICENSE_MARKER,
+      "wrong-boundary" to completeTransitionalLicense().replace("v0.1.2", "v0.1.3"),
+      "truncated" to completeTransitionalLicense().substringBefore("9. Termination and cure"),
+    ).forEach { (fixture, license) ->
+      Files.writeString(repoRoot.resolve("LICENSE"), license)
+      val failure = assertFailsWith<IllegalArgumentException> {
+        RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.2", forcePrerelease = false)
+      }
+      assertTrue(failure.message.orEmpty().contains("complete current"), fixture)
+    }
 
-    assertEquals(0, coveredRelease.major)
-    assertEquals(2, coveredRelease.minor)
-    assertEquals(0, coveredRelease.patch)
-    assertEquals("build.7", coveredRelease.buildMetadata)
+    Files.writeString(repoRoot.resolve("LICENSE"), completeTransitionalLicense())
+    listOf("v0.1.2", "v0.2.0+build.7", "v0.9.9-rc.1").forEach { ref ->
+      RepoValidationRuntime.validateReleaseRef(repoRoot, ref, forcePrerelease = false)
+    }
   }
 
   @Test
   fun `release policy keeps rc and manual staging non triggering while rejecting stable v1`() {
     val repoRoot = Files.createTempDirectory("skillbill-pre-one-staging")
-    writeTransitionalLicense(repoRoot)
+    Files.writeString(repoRoot.resolve("LICENSE"), completeTransitionalLicense())
 
     val releaseCandidate = RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
     val staging = RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0", forcePrerelease = true)
@@ -88,23 +100,55 @@ class RepoValidationRuntimeTest {
   }
 
   @Test
+  fun `v1 release candidates fail closed for a missing or incomplete transitional policy`() {
+    val repoRoot = Files.createTempDirectory("skillbill-v1-rc-policy")
+
+    val missing = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
+    }
+    Files.writeString(repoRoot.resolve("LICENSE"), RepoValidationRuntime.TRANSITIONAL_LICENSE_MARKER)
+    val incomplete = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
+    }
+
+    assertTrue(missing.message.orEmpty().contains("complete transitional"))
+    assertTrue(incomplete.message.orEmpty().contains("incomplete transitional"))
+  }
+
+  @Test
+  fun `post one lines including prereleases require a successor policy`() {
+    val repoRoot = Files.createTempDirectory("skillbill-post-one-policy")
+    Files.writeString(repoRoot.resolve("LICENSE"), completeTransitionalLicense())
+
+    listOf("v1.0.1-rc.1", "v1.0.1", "v1.1.0", "v2.0.0+build.7").forEach { ref ->
+      val failure = assertFailsWith<IllegalArgumentException> {
+        RepoValidationRuntime.validateReleaseRef(repoRoot, ref, forcePrerelease = false)
+      }
+      assertTrue(failure.message.orEmpty().contains("cannot publish"), ref)
+    }
+  }
+
+  @Test
   fun `stable post one release accepts a deliberate successor license`() {
     val repoRoot = Files.createTempDirectory("skillbill-successor-license")
-    Files.writeString(repoRoot.resolve("LICENSE"), "Skill Bill Successor License\n")
+    Files.writeString(
+      repoRoot.resolve("LICENSE"),
+      """
+      Skill Bill Successor License
+
+      Historical notice: Skill Bill Pre-1.0 Use License 1.0 applied before v1.0.0.
+      """.trimIndent() + "\n",
+    )
 
     RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
   }
 
-  private fun writeTransitionalLicense(repoRoot: java.nio.file.Path) {
-    Files.writeString(
-      repoRoot.resolve("LICENSE"),
-      """
-      Skill Bill Pre-1.0 Use License 1.0
-      Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0
-      Prospective Effective Version: v0.1.2
-      """.trimIndent() + "\n",
-    )
-  }
+  private fun completeTransitionalLicense(): String =
+    Files.readString(repositoryRoot().resolve("LICENSE"))
+
+  private fun repositoryRoot(): Path =
+    generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
+      .first { Files.isRegularFile(it.resolve("LICENSE")) }
 
   @Test
   fun `repo validation reports missing governed directories`() {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
@@ -8,6 +8,7 @@ import skillbill.scaffold.runtime.supportingFileTargets
 import skillbill.testing.seedConformingPlatformPack
 import java.nio.file.Files
 import java.nio.file.Path
+import java.security.MessageDigest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -114,11 +115,11 @@ class RepoValidationRuntimeTest {
     assertTrue(staging.prerelease)
     assertEquals("v1.0.0-staging.1", staging.tag)
     assertTrue(forcedStableFailure.message.orEmpty().contains("prerelease identifier"))
-    assertTrue(stableFailure.message.orEmpty().contains("successor license policy"))
+    assertTrue(stableFailure.message.orEmpty().contains("approved successor license policy"))
   }
 
   @Test
-  fun `v1 release candidates fail closed for a missing or incomplete transitional policy`() {
+  fun `v1 release candidates require the exact transitional policy`() {
     val repoRoot = Files.createTempDirectory("skillbill-v1-rc-policy")
 
     val missing = assertFailsWith<IllegalArgumentException> {
@@ -128,9 +129,15 @@ class RepoValidationRuntimeTest {
     val incomplete = assertFailsWith<IllegalArgumentException> {
       RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
     }
+    Files.writeString(repoRoot.resolve("LICENSE"), completeSuccessorLicense())
+    writeSuccessorApproval(repoRoot, completeSuccessorLicense())
+    val successor = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
+    }
 
-    assertTrue(missing.message.orEmpty().contains("complete transitional"))
-    assertTrue(incomplete.message.orEmpty().contains("complete transitional"))
+    assertTrue(missing.message.orEmpty().contains("LICENSE"))
+    assertTrue(incomplete.message.orEmpty().contains("complete current pre-1.0"))
+    assertTrue(successor.message.orEmpty().contains("complete current pre-1.0"))
   }
 
   @Test
@@ -142,37 +149,47 @@ class RepoValidationRuntimeTest {
       val failure = assertFailsWith<IllegalArgumentException> {
         RepoValidationRuntime.validateReleaseRef(repoRoot, ref, forcePrerelease = false)
       }
-      assertTrue(failure.message.orEmpty().contains("successor license policy"), ref)
+      assertTrue(failure.message.orEmpty().contains("approved successor license policy"), ref)
     }
   }
 
   @Test
-  fun `stable post one release accepts a deliberate successor license`() {
+  fun `post one releases require an approved successor license record tied to its exact bytes`() {
     val repoRoot = Files.createTempDirectory("skillbill-successor-license")
+    val successor = completeSuccessorLicense()
     Files.writeString(
       repoRoot.resolve("LICENSE"),
-      completeSuccessorLicense(),
+      successor,
     )
 
+    assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
+    }
+    writeSuccessorApproval(repoRoot, successor)
     RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
+    Files.writeString(repoRoot.resolve("LICENSE"), successor.replace("warranty", "guarantee"))
+    val changedLicense = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
+    }
+    assertTrue(changedLicense.message.orEmpty().contains("approved successor license policy"))
   }
 
   @Test
-  fun `post one release rejects empty placeholder and trivially prefixed successor policies`() {
+  fun `post one release rejects unapproved or transitional successor placeholders`() {
     val repoRoot = Files.createTempDirectory("skillbill-invalid-successor-license")
     listOf(
       "",
       "Successor License Identifier: LicenseRef-Skill-Bill-Successor-1.0\n" +
         "Successor License Effective Version: v1.0.0\n",
       "Historical notice\n\n${completeTransitionalLicense()}",
-      completeSuccessorLicense().substringBefore("Successor License Terms:") +
-        "Successor License Terms:\n${completeTransitionalLicense()}",
+      "${completeSuccessorLicense()}\n${completeTransitionalLicense()}",
+      completeSuccessorLicense().replace("restrictions", "restrictions".repeat(80)),
     ).forEach { license ->
       Files.writeString(repoRoot.resolve("LICENSE"), license)
       val failure = assertFailsWith<IllegalArgumentException> {
         RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.1", forcePrerelease = false)
       }
-      assertTrue(failure.message.orEmpty().contains("successor license policy"))
+      assertTrue(failure.message.orEmpty().contains("approved successor license policy"))
     }
   }
 
@@ -190,6 +207,23 @@ class RepoValidationRuntimeTest {
     to Skill Bill Pre-1.0 Use License 1.0 explain only the earlier release line and do not make that
     transitional policy the current license for this successor release.
   """.trimIndent() + "\n"
+
+  private fun writeSuccessorApproval(repoRoot: Path, license: String) {
+    val sha256 = MessageDigest.getInstance("SHA-256")
+      .digest(license.trimEnd().encodeToByteArray())
+      .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    Files.createDirectories(repoRoot.resolve("docs"))
+    Files.writeString(
+      repoRoot.resolve("docs/release-successor-license-approval.md"),
+      """
+      Status: Approved
+      Approved Successor License Identifier: LicenseRef-Skill-Bill-Successor-1.0
+      Approved LICENSE SHA-256: $sha256
+      Approved by: Braian Gapur
+      Approval location: https://example.test/approvals/successor-license
+      """.trimIndent() + "\n",
+    )
+  }
 
   private fun repositoryRoot(): Path = generateSequence(Path.of("").toAbsolutePath().normalize()) { it.parent }
     .first { Files.isRegularFile(it.resolve("LICENSE")) }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/scaffold/RepoValidationRuntimeTest.kt
@@ -9,6 +9,7 @@ import skillbill.testing.seedConformingPlatformPack
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -48,6 +49,61 @@ class RepoValidationRuntimeTest {
 
     assertTrue(error is IllegalArgumentException)
     assertTrue(error.message.orEmpty().contains("Release tag must match"))
+  }
+
+  @Test
+  fun `release policy preserves historical lines and requires custom policy from v0 1 2`() {
+    val repoRoot = Files.createTempDirectory("skillbill-release-policy")
+
+    RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.1", forcePrerelease = false)
+
+    val missingPolicy = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.1.2", forcePrerelease = false)
+    }
+    assertTrue(missingPolicy.message.orEmpty().contains("LICENSE"))
+
+    writeTransitionalLicense(repoRoot)
+    val coveredRelease = RepoValidationRuntime.validateReleaseRef(repoRoot, "v0.2.0+build.7", forcePrerelease = false)
+
+    assertEquals(0, coveredRelease.major)
+    assertEquals(2, coveredRelease.minor)
+    assertEquals(0, coveredRelease.patch)
+    assertEquals("build.7", coveredRelease.buildMetadata)
+  }
+
+  @Test
+  fun `release policy keeps rc and manual staging non triggering while rejecting stable v1`() {
+    val repoRoot = Files.createTempDirectory("skillbill-pre-one-staging")
+    writeTransitionalLicense(repoRoot)
+
+    val releaseCandidate = RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0-rc.1", forcePrerelease = false)
+    val staging = RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0", forcePrerelease = true)
+    val stableFailure = assertFailsWith<IllegalArgumentException> {
+      RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.0.0", forcePrerelease = false)
+    }
+
+    assertTrue(releaseCandidate.prerelease)
+    assertTrue(staging.prerelease)
+    assertTrue(stableFailure.message.orEmpty().contains("cannot publish"))
+  }
+
+  @Test
+  fun `stable post one release accepts a deliberate successor license`() {
+    val repoRoot = Files.createTempDirectory("skillbill-successor-license")
+    Files.writeString(repoRoot.resolve("LICENSE"), "Skill Bill Successor License\n")
+
+    RepoValidationRuntime.validateReleaseRef(repoRoot, "v1.1.0", forcePrerelease = false)
+  }
+
+  private fun writeTransitionalLicense(repoRoot: java.nio.file.Path) {
+    Files.writeString(
+      repoRoot.resolve("LICENSE"),
+      """
+      Skill Bill Pre-1.0 Use License 1.0
+      Identifier: LicenseRef-Skill-Bill-Pre-1.0-Use-1.0
+      Prospective Effective Version: v0.1.2
+      """.trimIndent() + "\n",
+    )
   }
 
   @Test

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/RepoValidationGateway.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/RepoValidationGateway.kt
@@ -7,7 +7,11 @@ import java.nio.file.Path
 interface RepoValidationGateway {
   fun validateRepo(repoRoot: Path): RepoValidationReport
 
-  fun parseReleaseRef(rawRef: String): ReleaseRefMetadata
+  fun validateReleaseRef(
+    repoRoot: Path,
+    rawRef: String,
+    forcePrerelease: Boolean,
+  ): ReleaseRefMetadata
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata)
 }

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/RepoValidationGateway.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/RepoValidationGateway.kt
@@ -7,11 +7,7 @@ import java.nio.file.Path
 interface RepoValidationGateway {
   fun validateRepo(repoRoot: Path): RepoValidationReport
 
-  fun validateReleaseRef(
-    repoRoot: Path,
-    rawRef: String,
-    forcePrerelease: Boolean,
-  ): ReleaseRefMetadata
+  fun validateReleaseRef(repoRoot: Path, rawRef: String, forcePrerelease: Boolean): ReleaseRefMetadata
 
   fun appendGithubOutput(outputPath: Path, metadata: ReleaseRefMetadata)
 }

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/model/RepoValidationGatewayModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/model/RepoValidationGatewayModels.kt
@@ -62,12 +62,22 @@ enum class RepoValidationIssueSeverity {
 data class ReleaseRefMetadata(
   val tag: String,
   val version: String,
+  val major: Int,
+  val minor: Int,
+  val patch: Int,
   val prerelease: Boolean,
+  val prereleaseIdentifier: String?,
+  val buildMetadata: String?,
 ) {
   @OpenBoundaryMap("Wire-shape serializer for release-ref metadata")
   fun toPayload(): Map<String, Any?> = mapOf(
     "tag" to tag,
     "version" to version,
+    "major" to major,
+    "minor" to minor,
+    "patch" to patch,
     "prerelease" to prerelease,
+    "prerelease_identifier" to prereleaseIdentifier,
+    "build_metadata" to buildMetadata,
   )
 }

--- a/scripts/validate_release_ref
+++ b/scripts/validate_release_ref
@@ -3,6 +3,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 args=(--repo-root "$repo_root" "$@")
+gradle_args="validate-release-ref"
+for arg in "${args[@]}"; do
+  escaped_arg="${arg//\\/\\\\}"
+  escaped_arg="${escaped_arg//\"/\\\"}"
+  gradle_args+=" \"${escaped_arg}\""
+done
 
 cd "$repo_root/runtime-kotlin"
-./gradlew --quiet :runtime-cli:run --args="validate-release-ref ${args[*]}"
+./gradlew --quiet :runtime-cli:run --args="$gradle_args"

--- a/scripts/validate_release_ref
+++ b/scripts/validate_release_ref
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-args=("$@")
+args=(--repo-root "$repo_root" "$@")
 
 cd "$repo_root/runtime-kotlin"
 ./gradlew --quiet :runtime-cli:run --args="validate-release-ref ${args[*]}"
-

--- a/scripts/verify_release_artifact_licenses
+++ b/scripts/verify_release_artifact_licenses
@@ -14,6 +14,29 @@ if [[ "$#" -eq 0 ]]; then
   exit 1
 fi
 
+temporary_dirs=()
+mounted_dirs=()
+
+cleanup_temp_dirs() {
+  local directory mount_dir
+  for mount_dir in "${mounted_dirs[@]}"; do
+    hdiutil detach "${mount_dir}" >/dev/null 2>&1 || true
+  done
+  for directory in "${temporary_dirs[@]}"; do
+    rm -rf "${directory}"
+  done
+}
+
+trap cleanup_temp_dirs EXIT
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "Required verification tool is unavailable: ${command_name}." >&2
+    exit 1
+  fi
+}
+
 verify_checksum() {
   local artifact="$1"
   local checksum="${artifact}.sha256"
@@ -23,117 +46,115 @@ verify_checksum() {
   fi
   if command -v sha256sum >/dev/null; then
     (cd "$(dirname "${artifact}")" && sha256sum --check "$(basename "${checksum}")")
-  else
+  elif command -v shasum >/dev/null; then
     (cd "$(dirname "${artifact}")" && shasum -a 256 --check "$(basename "${checksum}")")
+  else
+    echo "Required checksum tool is unavailable: sha256sum or shasum." >&2
+    exit 1
   fi
 }
 
 verify_zip() {
   local artifact="$1"
-  local matches=()
-  local entry
-  while IFS= read -r entry; do
-    if cmp -s "${root_license}" <(unzip -p "${artifact}" "${entry}"); then
-      matches+=("${entry}")
-    fi
-  done < <(unzip -Z1 "${artifact}" | awk '/(^|\/)LICENSE$/')
-  if [[ "${#matches[@]}" != "1" ]]; then
-    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+  require_command unzip
+  mapfile -t entries < <(unzip -Z1 "${artifact}" | awk '/(^|\/)LICENSE$/')
+  if [[ "${#entries[@]}" != "1" ]]; then
+    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
+    exit 1
+  fi
+  if ! cmp -s "${root_license}" <(unzip -p "${artifact}" "${entries[0]}"); then
+    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
 
 verify_tar() {
   local artifact="$1"
-  local matches=()
-  local entry
-  while IFS= read -r entry; do
-    if cmp -s "${root_license}" <(tar -xOzf "${artifact}" "${entry}"); then
-      matches+=("${entry}")
-    fi
-  done < <(tar -tzf "${artifact}" | awk '/(^|\/)LICENSE$/')
-  if [[ "${#matches[@]}" != "1" ]]; then
-    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+  require_command tar
+  mapfile -t entries < <(tar -tzf "${artifact}" | awk '/(^|\/)LICENSE$/')
+  if [[ "${#entries[@]}" != "1" ]]; then
+    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
+    exit 1
+  fi
+  if ! cmp -s "${root_license}" <(tar -xOzf "${artifact}" "${entries[0]}"); then
+    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
 
 verify_deb() {
   local artifact="$1"
-  local matches=()
-  local entry
-  while IFS= read -r entry; do
-    if cmp -s "${root_license}" <(dpkg-deb --fsys-tarfile "${artifact}" | tar -xO "${entry}"); then
-      matches+=("${entry}")
-    fi
-  done < <(dpkg-deb --fsys-tarfile "${artifact}" | tar -t | awk '/(^|\/)LICENSE$/')
-  if [[ "${#matches[@]}" != "1" ]]; then
-    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+  require_command dpkg-deb
+  require_command tar
+  mapfile -t entries < <(dpkg-deb --fsys-tarfile "${artifact}" | tar -t | awk '/(^|\/)LICENSE$/')
+  if [[ "${#entries[@]}" != "1" ]]; then
+    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
+    exit 1
+  fi
+  if ! cmp -s "${root_license}" <(dpkg-deb --fsys-tarfile "${artifact}" | tar -xO "${entries[0]}"); then
+    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
 
 verify_rpm() {
   local artifact="$1"
-  local work_dir
+  local work_dir entry
+  require_command rpm2cpio
+  require_command cpio
   artifact="$(cd "$(dirname "${artifact}")" && pwd)/$(basename "${artifact}")"
   work_dir="$(mktemp -d)"
-  trap 'rm -rf "${work_dir}"' EXIT
+  temporary_dirs+=("${work_dir}")
   (cd "${work_dir}" && rpm2cpio "${artifact}" | cpio -idm --quiet)
-  local matches=()
-  local entry
-  while IFS= read -r entry; do
-    if cmp -s "${root_license}" "${work_dir}/${entry}"; then
-      matches+=("${entry}")
-    fi
-  done < <(cd "${work_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
-  if [[ "${#matches[@]}" != "1" ]]; then
-    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+  mapfile -t entries < <(cd "${work_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
+  if [[ "${#entries[@]}" != "1" ]]; then
+    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
     exit 1
   fi
-  rm -rf "${work_dir}"
-  trap - EXIT
+  if ! cmp -s "${root_license}" "${work_dir}/${entries[0]}"; then
+    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+    exit 1
+  fi
 }
 
 verify_dmg() {
   local artifact="$1"
-  local mount_dir
+  local mount_dir entry
+  require_command hdiutil
   mount_dir="$(mktemp -d)"
+  temporary_dirs+=("${mount_dir}")
   hdiutil attach -nobrowse -readonly -mountpoint "${mount_dir}" "${artifact}" >/dev/null
-  local matches=()
-  local entry
-  while IFS= read -r entry; do
-    if cmp -s "${root_license}" "${mount_dir}/${entry}"; then
-      matches+=("${entry}")
-    fi
-  done < <(cd "${mount_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
-  if [[ "${#matches[@]}" != "1" ]]; then
-    hdiutil detach "${mount_dir}" >/dev/null
-    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+  mounted_dirs+=("${mount_dir}")
+  mapfile -t entries < <(cd "${mount_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
+  if [[ "${#entries[@]}" != "1" ]]; then
+    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
     exit 1
   fi
-  hdiutil detach "${mount_dir}" >/dev/null
-  rm -rf "${mount_dir}"
+  if ! cmp -s "${root_license}" "${mount_dir}/${entries[0]}"; then
+    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+    exit 1
+  fi
 }
 
 verify_msi() {
   local artifact="$1"
-  local work_dir
+  local work_dir windows_artifact windows_work_dir
+  require_command cygpath
+  require_command msiexec.exe
   work_dir="$(mktemp -d)"
-  powershell.exe -NoProfile -Command "Start-Process msiexec.exe -Wait -ArgumentList '/a', '${artifact}', '/qn', 'TARGETDIR=${work_dir}'"
-  local matches=()
-  local entry
-  while IFS= read -r entry; do
-    if cmp -s "${root_license}" "${work_dir}/${entry}"; then
-      matches+=("${entry}")
-    fi
-  done < <(find "${work_dir}" -type f -name LICENSE -print | sed "s#^${work_dir}/##")
-  if [[ "${#matches[@]}" != "1" ]]; then
-    rm -rf "${work_dir}"
-    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+  temporary_dirs+=("${work_dir}")
+  windows_artifact="$(cygpath -aw "${artifact}")"
+  windows_work_dir="$(cygpath -aw "${work_dir}")"
+  msiexec.exe /a "${windows_artifact}" /qn "TARGETDIR=${windows_work_dir}"
+  mapfile -t entries < <(find "${work_dir}" -type f -name LICENSE -print | sed "s#^${work_dir}/##")
+  if [[ "${#entries[@]}" != "1" ]]; then
+    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
     exit 1
   fi
-  rm -rf "${work_dir}"
+  if ! cmp -s "${root_license}" "${work_dir}/${entries[0]}"; then
+    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+    exit 1
+  fi
 }
 
 for artifact in "$@"; do

--- a/scripts/verify_release_artifact_licenses
+++ b/scripts/verify_release_artifact_licenses
@@ -40,59 +40,103 @@ require_command() {
 verify_checksum() {
   local artifact="$1"
   local checksum="${artifact}.sha256"
+  local expected_name expected_digest actual_digest line record_count record_digest record_name
   if [[ ! -f "${checksum}" ]]; then
     echo "Missing checksum for ${artifact}." >&2
     exit 1
   fi
+  expected_name="$(basename "${artifact}")"
+  record_count=0
+  expected_digest=""
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    [[ -n "${line}" ]] || continue
+    if [[ ! "${line}" =~ ^([0-9A-Fa-f]{64})\ \ (.+)$ ]]; then
+      echo "Checksum ${checksum} must contain one SHA-256 record for ${expected_name}." >&2
+      exit 1
+    fi
+    record_count=$((record_count + 1))
+    record_digest="${BASH_REMATCH[1]}"
+    record_name="${BASH_REMATCH[2]}"
+    if [[ "${record_name}" != "${expected_name}" ]]; then
+      echo "Checksum ${checksum} names ${record_name}, not ${expected_name}." >&2
+      exit 1
+    fi
+    expected_digest="$(printf '%s' "${record_digest}" | tr 'A-F' 'a-f')"
+  done < "${checksum}"
+  if [[ "${record_count}" != "1" ]]; then
+    echo "Checksum ${checksum} must contain exactly one record for ${expected_name}." >&2
+    exit 1
+  fi
   if command -v sha256sum >/dev/null; then
-    (cd "$(dirname "${artifact}")" && sha256sum --check "$(basename "${checksum}")")
+    actual_digest="$(sha256sum "${artifact}" | awk '{print $1}')"
   elif command -v shasum >/dev/null; then
-    (cd "$(dirname "${artifact}")" && shasum -a 256 --check "$(basename "${checksum}")")
+    actual_digest="$(shasum -a 256 "${artifact}" | awk '{print $1}')"
   else
     echo "Required checksum tool is unavailable: sha256sum or shasum." >&2
+    exit 1
+  fi
+  actual_digest="$(printf '%s' "${actual_digest}" | tr 'A-F' 'a-f')"
+  if [[ "${actual_digest}" != "${expected_digest}" ]]; then
+    echo "Checksum digest differs for ${artifact}." >&2
     exit 1
   fi
 }
 
 verify_zip() {
   local artifact="$1"
+  local entry_count
   require_command unzip
-  mapfile -t entries < <(unzip -Z1 "${artifact}" | awk '/(^|\/)LICENSE$/')
-  if [[ "${#entries[@]}" != "1" ]]; then
-    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
+  entry_count="$(unzip -Z1 "${artifact}" | awk '$0 == "image/LICENSE" { count++ } END { print count + 0 }')"
+  if [[ "${entry_count}" != "1" ]]; then
+    echo "Expected exactly one canonical image/LICENSE entry in ${artifact}, found ${entry_count}." >&2
     exit 1
   fi
-  if ! cmp -s "${root_license}" <(unzip -p "${artifact}" "${entries[0]}"); then
-    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+  if ! cmp -s "${root_license}" <(unzip -p "${artifact}" "image/LICENSE"); then
+    echo "Canonical image/LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
 
 verify_tar() {
   local artifact="$1"
+  local entry entry_count
   require_command tar
-  mapfile -t entries < <(tar -tzf "${artifact}" | awk '/(^|\/)LICENSE$/')
-  if [[ "${#entries[@]}" != "1" ]]; then
-    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
+  entry="$(tar -tzf "${artifact}" | awk '$0 == "LICENSE" || $0 == "./LICENSE" { print; exit }')"
+  entry_count="$(tar -tzf "${artifact}" | awk '$0 == "LICENSE" || $0 == "./LICENSE" { count++ } END { print count + 0 }')"
+  if [[ "${entry_count}" != "1" ]]; then
+    echo "Expected exactly one canonical LICENSE entry in ${artifact}, found ${entry_count}." >&2
     exit 1
   fi
-  if ! cmp -s "${root_license}" <(tar -xOzf "${artifact}" "${entries[0]}"); then
-    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+  if ! cmp -s "${root_license}" <(tar -xOzf "${artifact}" "${entry}"); then
+    echo "Canonical LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
 
-verify_deb() {
-  local artifact="$1"
-  require_command dpkg-deb
-  require_command tar
-  mapfile -t entries < <(dpkg-deb --fsys-tarfile "${artifact}" | tar -t | awk '/(^|\/)LICENSE$/')
-  if [[ "${#entries[@]}" != "1" ]]; then
-    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
+find_desktop_license() {
+  local root="$1"
+  local artifact="$2"
+  local entry entry_count
+  entry="$(find "${root}" -type f -path '*/resources/skill-bill-runtime/LICENSE' -print | sed "s#^${root}/##" | head -n 1)"
+  entry_count="$(find "${root}" -type f -path '*/resources/skill-bill-runtime/LICENSE' -print | wc -l | tr -d ' ')"
+  if [[ "${entry_count}" != "1" ]]; then
+    echo "Expected exactly one canonical resources/skill-bill-runtime/LICENSE entry in ${artifact}, found ${entry_count}." >&2
     exit 1
   fi
-  if ! cmp -s "${root_license}" <(dpkg-deb --fsys-tarfile "${artifact}" | tar -xO "${entries[0]}"); then
-    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+  printf '%s\n' "${entry}"
+}
+
+verify_deb() {
+  local artifact="$1"
+  local work_dir entry
+  require_command dpkg-deb
+  require_command tar
+  work_dir="$(mktemp -d)"
+  temporary_dirs+=("${work_dir}")
+  dpkg-deb --fsys-tarfile "${artifact}" | tar -x -C "${work_dir}"
+  entry="$(find_desktop_license "${work_dir}" "${artifact}")"
+  if ! cmp -s "${root_license}" "${work_dir}/${entry}"; then
+    echo "Canonical desktop LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
@@ -106,13 +150,9 @@ verify_rpm() {
   work_dir="$(mktemp -d)"
   temporary_dirs+=("${work_dir}")
   (cd "${work_dir}" && rpm2cpio "${artifact}" | cpio -idm --quiet)
-  mapfile -t entries < <(cd "${work_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
-  if [[ "${#entries[@]}" != "1" ]]; then
-    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
-    exit 1
-  fi
-  if ! cmp -s "${root_license}" "${work_dir}/${entries[0]}"; then
-    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+  entry="$(find_desktop_license "${work_dir}" "${artifact}")"
+  if ! cmp -s "${root_license}" "${work_dir}/${entry}"; then
+    echo "Canonical desktop LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
@@ -125,13 +165,9 @@ verify_dmg() {
   temporary_dirs+=("${mount_dir}")
   hdiutil attach -nobrowse -readonly -mountpoint "${mount_dir}" "${artifact}" >/dev/null
   mounted_dirs+=("${mount_dir}")
-  mapfile -t entries < <(cd "${mount_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
-  if [[ "${#entries[@]}" != "1" ]]; then
-    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
-    exit 1
-  fi
-  if ! cmp -s "${root_license}" "${mount_dir}/${entries[0]}"; then
-    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+  entry="$(find_desktop_license "${mount_dir}" "${artifact}")"
+  if ! cmp -s "${root_license}" "${mount_dir}/${entry}"; then
+    echo "Canonical desktop LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }
@@ -146,13 +182,9 @@ verify_msi() {
   windows_artifact="$(cygpath -aw "${artifact}")"
   windows_work_dir="$(cygpath -aw "${work_dir}")"
   msiexec.exe /a "${windows_artifact}" /qn "TARGETDIR=${windows_work_dir}"
-  mapfile -t entries < <(find "${work_dir}" -type f -name LICENSE -print | sed "s#^${work_dir}/##")
-  if [[ "${#entries[@]}" != "1" ]]; then
-    echo "Expected exactly one LICENSE entry in ${artifact}, found ${#entries[@]}." >&2
-    exit 1
-  fi
-  if ! cmp -s "${root_license}" "${work_dir}/${entries[0]}"; then
-    echo "LICENSE bytes differ from root LICENSE in ${artifact}." >&2
+  entry="$(find_desktop_license "${work_dir}" "${artifact}")"
+  if ! cmp -s "${root_license}" "${work_dir}/${entry}"; then
+    echo "Canonical desktop LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
 }

--- a/scripts/verify_release_artifact_licenses
+++ b/scripts/verify_release_artifact_licenses
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+root_license="${repo_root}/LICENSE"
+
+if [[ ! -f "${root_license}" ]]; then
+  echo "Repository LICENSE is missing." >&2
+  exit 1
+fi
+
+if [[ "$#" -eq 0 ]]; then
+  echo "At least one artifact is required for license verification." >&2
+  exit 1
+fi
+
+verify_checksum() {
+  local artifact="$1"
+  local checksum="${artifact}.sha256"
+  if [[ ! -f "${checksum}" ]]; then
+    echo "Missing checksum for ${artifact}." >&2
+    exit 1
+  fi
+  if command -v sha256sum >/dev/null; then
+    (cd "$(dirname "${artifact}")" && sha256sum --check "$(basename "${checksum}")")
+  else
+    (cd "$(dirname "${artifact}")" && shasum -a 256 --check "$(basename "${checksum}")")
+  fi
+}
+
+verify_zip() {
+  local artifact="$1"
+  local matches=()
+  local entry
+  while IFS= read -r entry; do
+    if cmp -s "${root_license}" <(unzip -p "${artifact}" "${entry}"); then
+      matches+=("${entry}")
+    fi
+  done < <(unzip -Z1 "${artifact}" | awk '/(^|\/)LICENSE$/')
+  if [[ "${#matches[@]}" != "1" ]]; then
+    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+    exit 1
+  fi
+}
+
+verify_tar() {
+  local artifact="$1"
+  local matches=()
+  local entry
+  while IFS= read -r entry; do
+    if cmp -s "${root_license}" <(tar -xOzf "${artifact}" "${entry}"); then
+      matches+=("${entry}")
+    fi
+  done < <(tar -tzf "${artifact}" | awk '/(^|\/)LICENSE$/')
+  if [[ "${#matches[@]}" != "1" ]]; then
+    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+    exit 1
+  fi
+}
+
+verify_deb() {
+  local artifact="$1"
+  local matches=()
+  local entry
+  while IFS= read -r entry; do
+    if cmp -s "${root_license}" <(dpkg-deb --fsys-tarfile "${artifact}" | tar -xO "${entry}"); then
+      matches+=("${entry}")
+    fi
+  done < <(dpkg-deb --fsys-tarfile "${artifact}" | tar -t | awk '/(^|\/)LICENSE$/')
+  if [[ "${#matches[@]}" != "1" ]]; then
+    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+    exit 1
+  fi
+}
+
+verify_rpm() {
+  local artifact="$1"
+  local work_dir
+  artifact="$(cd "$(dirname "${artifact}")" && pwd)/$(basename "${artifact}")"
+  work_dir="$(mktemp -d)"
+  trap 'rm -rf "${work_dir}"' EXIT
+  (cd "${work_dir}" && rpm2cpio "${artifact}" | cpio -idm --quiet)
+  local matches=()
+  local entry
+  while IFS= read -r entry; do
+    if cmp -s "${root_license}" "${work_dir}/${entry}"; then
+      matches+=("${entry}")
+    fi
+  done < <(cd "${work_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
+  if [[ "${#matches[@]}" != "1" ]]; then
+    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+    exit 1
+  fi
+  rm -rf "${work_dir}"
+  trap - EXIT
+}
+
+verify_dmg() {
+  local artifact="$1"
+  local mount_dir
+  mount_dir="$(mktemp -d)"
+  hdiutil attach -nobrowse -readonly -mountpoint "${mount_dir}" "${artifact}" >/dev/null
+  local matches=()
+  local entry
+  while IFS= read -r entry; do
+    if cmp -s "${root_license}" "${mount_dir}/${entry}"; then
+      matches+=("${entry}")
+    fi
+  done < <(cd "${mount_dir}" && find . -type f -name LICENSE -print | sed 's#^./##')
+  if [[ "${#matches[@]}" != "1" ]]; then
+    hdiutil detach "${mount_dir}" >/dev/null
+    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+    exit 1
+  fi
+  hdiutil detach "${mount_dir}" >/dev/null
+  rm -rf "${mount_dir}"
+}
+
+verify_msi() {
+  local artifact="$1"
+  local work_dir
+  work_dir="$(mktemp -d)"
+  powershell.exe -NoProfile -Command "Start-Process msiexec.exe -Wait -ArgumentList '/a', '${artifact}', '/qn', 'TARGETDIR=${work_dir}'"
+  local matches=()
+  local entry
+  while IFS= read -r entry; do
+    if cmp -s "${root_license}" "${work_dir}/${entry}"; then
+      matches+=("${entry}")
+    fi
+  done < <(find "${work_dir}" -type f -name LICENSE -print | sed "s#^${work_dir}/##")
+  if [[ "${#matches[@]}" != "1" ]]; then
+    rm -rf "${work_dir}"
+    echo "Expected exactly one root LICENSE copy in ${artifact}, found ${#matches[@]}." >&2
+    exit 1
+  fi
+  rm -rf "${work_dir}"
+}
+
+for artifact in "$@"; do
+  if [[ ! -f "${artifact}" ]]; then
+    echo "Artifact is missing: ${artifact}." >&2
+    exit 1
+  fi
+  verify_checksum "${artifact}"
+  case "${artifact}" in
+    *.zip) verify_zip "${artifact}" ;;
+    *.tar.gz) verify_tar "${artifact}" ;;
+    *.deb) verify_deb "${artifact}" ;;
+    *.rpm) verify_rpm "${artifact}" ;;
+    *.dmg) verify_dmg "${artifact}" ;;
+    *.msi) verify_msi "${artifact}" ;;
+    *)
+      echo "Unsupported artifact type: ${artifact}." >&2
+      exit 1
+      ;;
+  esac
+done

--- a/scripts/verify_release_artifact_licenses
+++ b/scripts/verify_release_artifact_licenses
@@ -101,7 +101,7 @@ verify_tar() {
   local artifact="$1"
   local entry entry_count
   require_command tar
-  entry="$(tar -tzf "${artifact}" | awk '$0 == "LICENSE" || $0 == "./LICENSE" { print; exit }')"
+  entry="$(tar -tzf "${artifact}" | awk '$0 == "LICENSE" || $0 == "./LICENSE" { if (!found) { print; found = 1 } }')"
   entry_count="$(tar -tzf "${artifact}" | awk '$0 == "LICENSE" || $0 == "./LICENSE" { count++ } END { print count + 0 }')"
   if [[ "${entry_count}" != "1" ]]; then
     echo "Expected exactly one canonical LICENSE entry in ${artifact}, found ${entry_count}." >&2

--- a/scripts/verify_release_artifact_licenses
+++ b/scripts/verify_release_artifact_licenses
@@ -19,17 +19,21 @@ mounted_dirs=()
 
 cleanup_temp_dirs() {
   local exit_status=$? directory mount_dir
-  for mount_dir in "${mounted_dirs[@]}"; do
-    if ! hdiutil detach "${mount_dir}" >/dev/null 2>&1; then
-      echo "Could not detach mounted disk image at ${mount_dir}." >&2
-      if [[ "${exit_status}" == "0" ]]; then
-        exit_status=1
+  if ((${#mounted_dirs[@]})); then
+    for mount_dir in "${mounted_dirs[@]}"; do
+      if ! hdiutil detach "${mount_dir}" >/dev/null 2>&1; then
+        echo "Could not detach mounted disk image at ${mount_dir}." >&2
+        if [[ "${exit_status}" == "0" ]]; then
+          exit_status=1
+        fi
       fi
-    fi
-  done
-  for directory in "${temporary_dirs[@]}"; do
-    rm -rf "${directory}"
-  done
+    done
+  fi
+  if ((${#temporary_dirs[@]})); then
+    for directory in "${temporary_dirs[@]}"; do
+      rm -rf "${directory}"
+    done
+  fi
   return "${exit_status}"
 }
 

--- a/scripts/verify_release_artifact_licenses
+++ b/scripts/verify_release_artifact_licenses
@@ -18,13 +18,19 @@ temporary_dirs=()
 mounted_dirs=()
 
 cleanup_temp_dirs() {
-  local directory mount_dir
+  local exit_status=$? directory mount_dir
   for mount_dir in "${mounted_dirs[@]}"; do
-    hdiutil detach "${mount_dir}" >/dev/null 2>&1 || true
+    if ! hdiutil detach "${mount_dir}" >/dev/null 2>&1; then
+      echo "Could not detach mounted disk image at ${mount_dir}." >&2
+      if [[ "${exit_status}" == "0" ]]; then
+        exit_status=1
+      fi
+    fi
   done
   for directory in "${temporary_dirs[@]}"; do
     rm -rf "${directory}"
   done
+  return "${exit_status}"
 }
 
 trap cleanup_temp_dirs EXIT
@@ -126,16 +132,40 @@ find_desktop_license() {
   printf '%s\n' "${entry}"
 }
 
+find_desktop_license_entry() {
+  local entries="$1"
+  local artifact="$2"
+  local entry entry_count
+  entry=""
+  entry_count=0
+  while IFS= read -r candidate; do
+    [[ -n "${candidate}" ]] || continue
+    case "${candidate}" in
+      /*|..|../*|*/..|*/../*)
+        echo "Unsafe archive entry in ${artifact}: ${candidate}." >&2
+        exit 1
+        ;;
+    esac
+    if [[ "${candidate}" == "resources/skill-bill-runtime/LICENSE" || "${candidate}" == */resources/skill-bill-runtime/LICENSE ]]; then
+      entry="${candidate}"
+      entry_count=$((entry_count + 1))
+    fi
+  done <<< "${entries}"
+  if [[ "${entry_count}" != "1" ]]; then
+    echo "Expected exactly one canonical resources/skill-bill-runtime/LICENSE entry in ${artifact}, found ${entry_count}." >&2
+    exit 1
+  fi
+  printf '%s\n' "${entry}"
+}
+
 verify_deb() {
   local artifact="$1"
-  local work_dir entry
+  local entries entry
   require_command dpkg-deb
   require_command tar
-  work_dir="$(mktemp -d)"
-  temporary_dirs+=("${work_dir}")
-  dpkg-deb --fsys-tarfile "${artifact}" | tar -x -C "${work_dir}"
-  entry="$(find_desktop_license "${work_dir}" "${artifact}")"
-  if ! cmp -s "${root_license}" "${work_dir}/${entry}"; then
+  entries="$(dpkg-deb --fsys-tarfile "${artifact}" | tar -tf -)"
+  entry="$(find_desktop_license_entry "${entries}" "${artifact}")"
+  if ! cmp -s "${root_license}" <(dpkg-deb --fsys-tarfile "${artifact}" | tar -xOf - "${entry}"); then
     echo "Canonical desktop LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
@@ -143,15 +173,17 @@ verify_deb() {
 
 verify_rpm() {
   local artifact="$1"
-  local work_dir entry
+  local entries entry regular_entry_count
   require_command rpm2cpio
   require_command cpio
-  artifact="$(cd "$(dirname "${artifact}")" && pwd)/$(basename "${artifact}")"
-  work_dir="$(mktemp -d)"
-  temporary_dirs+=("${work_dir}")
-  (cd "${work_dir}" && rpm2cpio "${artifact}" | cpio -idm --quiet)
-  entry="$(find_desktop_license "${work_dir}" "${artifact}")"
-  if ! cmp -s "${root_license}" "${work_dir}/${entry}"; then
+  entries="$(rpm2cpio "${artifact}" | cpio -it --quiet)"
+  entry="$(find_desktop_license_entry "${entries}" "${artifact}")"
+  regular_entry_count="$(rpm2cpio "${artifact}" | cpio -itv --quiet | awk -v entry="${entry}" '$NF == entry && substr($1, 1, 1) == "-" { count++ } END { print count + 0 }')"
+  if [[ "${regular_entry_count}" != "1" ]]; then
+    echo "Canonical desktop LICENSE entry in ${artifact} must be one regular file." >&2
+    exit 1
+  fi
+  if ! cmp -s "${root_license}" <(rpm2cpio "${artifact}" | cpio -i --to-stdout --quiet "${entry}"); then
     echo "Canonical desktop LICENSE bytes differ from root LICENSE in ${artifact}." >&2
     exit 1
   fi
@@ -174,14 +206,11 @@ verify_dmg() {
 
 verify_msi() {
   local artifact="$1"
-  local work_dir windows_artifact windows_work_dir
-  require_command cygpath
-  require_command msiexec.exe
+  local work_dir entry
+  require_command lessmsi
   work_dir="$(mktemp -d)"
   temporary_dirs+=("${work_dir}")
-  windows_artifact="$(cygpath -aw "${artifact}")"
-  windows_work_dir="$(cygpath -aw "${work_dir}")"
-  msiexec.exe /a "${windows_artifact}" /qn "TARGETDIR=${windows_work_dir}"
+  lessmsi x "${artifact}" "${work_dir}" >/dev/null
   entry="$(find_desktop_license "${work_dir}" "${artifact}")"
   if ! cmp -s "${root_license}" "${work_dir}/${entry}"; then
     echo "Canonical desktop LICENSE bytes differ from root LICENSE in ${artifact}." >&2


### PR DESCRIPTION
# Summary

Implements SKILL-118’s prospective, custom pre-1.0 use-only licensing policy. Starting with `v0.1.2`, the repository and release tooling consistently permit unmodified lawful use—including commercial use—until the first qualifying `v1.0.0` GitHub Release, then restrict covered versions to the defined personal and unpaid open-source contribution uses.

- Replaces the root license and aligns README, contribution, release, roadmap, and dedicated licensing guidance with the governed version matrix.
- Ensures CLI, MCP, skills, and desktop release artifacts embed the exact root `LICENSE`, verifies byte equality and checksums, and makes release publication immutable.
- Adds release-policy validation and focused Kotlin/workflow coverage for release boundaries, documentation consistency, and artifact contents.

## Feature Flags

N/A

# How Has This Been Tested?

Focused release-policy, artifact-license, workflow-contract, and CLI validation tests passed.

1. Run `bash -n scripts/verify_release_artifact_licenses`.
2. Run `git diff --check`.
3. From `runtime-kotlin`, run `./gradlew :runtime-infra-fs:test --tests 'skillbill.scaffold.RepoValidationRuntimeTest' --tests 'skillbill.scaffold.LicensePolicyDocumentationTest' --tests 'skillbill.scaffold.ReleaseArtifactLicenseVerifierTest' --tests 'skillbill.scaffold.ReleaseWorkflowContractTest' :runtime-cli:test --tests 'skillbill.cli.CliRepoValidationRuntimeTest'`.
4. Confirm all selected tests pass and the release verifier rejects missing, duplicate, drifted, or checksum-invalid licenses.

## Release Prerequisites

- The complete repository quality gate remains required before tagging `v0.1.2`.
- Braian Gapur must explicitly approve the final release-commit `LICENSE` text and its SHA-256 before `v0.1.2` is tagged.