### PR TITLE
fix: [SKILL-117] Harden local work-list workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,11 @@ Bundled skills and packs are defaults, not the framework boundary. Teams may rep
 
 ## Subagent Policy
 
-Use subagents only when the user explicitly requests subagents, delegation, or
-parallel agent work. Do not infer that permission from task size, review mode,
-runtime defaults, or model preference. A model must never autonomously decide
-to spawn subagents; otherwise complete the task in the current agent context or
-ask the user whether delegation is desired.
+Use subagents only when the user explicitly requests them or an invoked skill's
+governed contract selects delegated execution. For `bill-code-review`,
+`mode:auto` may choose inline or delegated; explicit `mode:inline` or
+`mode:delegated` wins. Otherwise do not infer permission from task size,
+runtime defaults, or model preference; work inline or ask the user.
 
 ## Taxonomy
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptComposer.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptComposer.kt
@@ -258,9 +258,8 @@ object FeatureTaskRuntimePhasePromptComposer {
     }.orEmpty()
     return """
       ## Review execution mode
-      Run `bill-code-review mode:${codeReviewMode.wireValue}` for this review. The initial pass uses the run-selected
-      mode; every later pass is explicitly INLINE and must fail with the existing eligibility reason rather than
-      substituting delegated mode. Never launch a third review pass.
+      Run `bill-code-review mode:${codeReviewMode.wireValue}` for this review. Every pass uses the run-selected mode;
+      AUTO applies the shared policy independently to the current review scope. Never launch a third review pass.
       AUTO keeps the shared policy's existing selection; INLINE must reject an ineligible scope instead of substituting
       delegated mode; DELEGATED must use normal routed delegation and fail if workers cannot start.$parallel$goalScope
     """.trimIndent()

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -1135,11 +1135,7 @@ internal class FeatureTaskRuntimeRunLoop(
             suppressDecomposition = isGoalContinuationRun(run.request),
             parallelReviewAgent = run.request.parallelReviewAgent
               ?.takeIf { run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW },
-            codeReviewMode = if (reviewPassNumber(run, state) == 2) {
-              skillbill.workflow.model.CodeReviewExecutionMode.INLINE
-            } else {
-              run.request.runInvariants.codeReviewMode
-            },
+            codeReviewMode = run.request.runInvariants.codeReviewMode,
             goalSubtaskReviewInput = run.goalReviewInput,
             specSource = run.specSource,
             priorSchemaFailure = priorSchemaFailure,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerWorkflowStores.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerWorkflowStores.kt
@@ -8,12 +8,14 @@ import skillbill.application.decomposition.DecompositionManifestWriter
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.decomposition.encodeDecompositionManifestMap
 import skillbill.application.decomposition.loadManifestOrNull
+import skillbill.application.normalizeRequiredIssueKey
 import skillbill.application.workflow.WorkflowFamily
 import skillbill.application.workflow.decompositionRuntime
 import skillbill.application.workflow.findDecomposedParentWorkflow
 import skillbill.application.workflow.generateWorkflowId
 import skillbill.application.workflow.isActiveGoalRuntime
 import skillbill.application.workflow.repoRoot
+import skillbill.application.workflow.toRecord
 import skillbill.application.workflow.toSnapshot
 import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
@@ -163,7 +165,10 @@ class WorkflowGoalRunnerManifestStore(
   ): SavedGoalChildWorkflow {
     val parentUpdated = updateParentForChildWorkflow(unitOfWork, state)
     val childUpdated = openGoalChildWorkflow(unitOfWork, state, setup, parentUpdated.workflowId)
-    WorkflowFamily.TASK_RUNTIME.save(unitOfWork.workflowStates, childUpdated)
+    WorkflowFamily.TASK_RUNTIME.saveRecord(
+      unitOfWork.workflowStates,
+      childUpdated.toRecord().copy(issueKey = normalizeRequiredIssueKey(state.manifest.issueKey)),
+    )
     val refreshedParent =
       WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, parentUpdated.workflowId) ?: parentUpdated
     return SavedGoalChildWorkflow(
@@ -426,7 +431,10 @@ class WorkflowGoalRunnerManifestStore(
           sessionId = opened.sessionId.orEmpty(),
         ),
       )
-      WorkflowFamily.IMPLEMENT.save(unitOfWork.workflowStates, imported)
+      WorkflowFamily.IMPLEMENT.saveRecord(
+        unitOfWork.workflowStates,
+        imported.toRecord().copy(issueKey = normalizeRequiredIssueKey(manifest.issueKey)),
+      )
       val saved = WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, workflowId) ?: imported
       GoalRunnerManifestState(
         parentWorkflowId = saved.workflowId,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
@@ -6,6 +6,7 @@ import skillbill.application.decomposition.DECOMPOSITION_RUNTIME_ARTIFACT_KEY
 import skillbill.application.decomposition.encodeDecompositionManifestMap
 import skillbill.application.decomposition.loadManifestOrNull
 import skillbill.application.decomposition.withBlockedSubtask
+import skillbill.application.normalizeRequiredIssueKey
 import skillbill.application.model.GoalContinuationOutcome
 import skillbill.application.model.WorkflowContinueResult
 import skillbill.ports.persistence.UnitOfWork
@@ -111,7 +112,10 @@ internal class DecompositionWorkflowContinuation(
         sessionId = opened.sessionId.orEmpty(),
       ),
     )
-    WorkflowFamily.IMPLEMENT.save(unitOfWork.workflowStates, imported)
+    WorkflowFamily.IMPLEMENT.saveRecord(
+      unitOfWork.workflowStates,
+      imported.toRecord().copy(issueKey = normalizeRequiredIssueKey(manifest.issueKey)),
+    )
     return WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, workflowId) ?: imported
   }
 
@@ -257,7 +261,10 @@ internal class DecompositionWorkflowContinuation(
         sessionId = parentRecord.sessionId.orEmpty(),
       ),
     )
-    WorkflowFamily.IMPLEMENT.save(unitOfWork.workflowStates, started)
+    WorkflowFamily.IMPLEMENT.saveRecord(
+      unitOfWork.workflowStates,
+      started.toRecord().copy(issueKey = normalizeRequiredIssueKey(manifest.issueKey)),
+    )
     engine.persistParentDecompositionRuntime(parentRecord, updatedManifest, unitOfWork, validator)
     val saved = WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, workflowId) ?: started
     return engine.continueExistingWorkflow(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
@@ -6,9 +6,9 @@ import skillbill.application.decomposition.DECOMPOSITION_RUNTIME_ARTIFACT_KEY
 import skillbill.application.decomposition.encodeDecompositionManifestMap
 import skillbill.application.decomposition.loadManifestOrNull
 import skillbill.application.decomposition.withBlockedSubtask
-import skillbill.application.normalizeRequiredIssueKey
 import skillbill.application.model.GoalContinuationOutcome
 import skillbill.application.model.WorkflowContinueResult
+import skillbill.application.normalizeRequiredIssueKey
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.workflow.DecompositionManifestFileStore
 import skillbill.ports.workflow.UnavailableDecompositionManifestFileStore
@@ -194,11 +194,12 @@ internal class DecompositionWorkflowContinuation(
     selection: DecompositionContinuationSelection.Start,
     unitOfWork: UnitOfWork,
   ): ContinuationStepResult {
+    val issueKey = normalizeRequiredIssueKey(manifest.issueKey)
     val branchError = checkoutAndValidateBranch(parentRecord, manifest, selection, unitOfWork)
     return if (branchError != null) {
       ContinuationStepResult(branchError)
     } else {
-      openSubtaskWorkflow(parentRecord, manifest, selection, unitOfWork)
+      openSubtaskWorkflow(parentRecord, manifest, selection, issueKey, unitOfWork)
     }
   }
 
@@ -236,6 +237,7 @@ internal class DecompositionWorkflowContinuation(
     parentRecord: WorkflowStateSnapshot,
     manifest: DecompositionManifest,
     selection: DecompositionContinuationSelection.Start,
+    issueKey: String,
     unitOfWork: UnitOfWork,
   ): ContinuationStepResult {
     val workflowId = generateWorkflowId(WorkflowFamily.IMPLEMENT.definition.workflowIdPrefix)
@@ -263,7 +265,7 @@ internal class DecompositionWorkflowContinuation(
     )
     WorkflowFamily.IMPLEMENT.saveRecord(
       unitOfWork.workflowStates,
-      started.toRecord().copy(issueKey = normalizeRequiredIssueKey(manifest.issueKey)),
+      started.toRecord().copy(issueKey = issueKey),
     )
     engine.persistParentDecompositionRuntime(parentRecord, updatedManifest, unitOfWork, validator)
     val saved = WorkflowFamily.IMPLEMENT.get(unitOfWork.workflowStates, workflowId) ?: started

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeAuditGapLoopTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeAuditGapLoopTest.kt
@@ -66,7 +66,7 @@ class FeatureTaskRuntimeAuditGapLoopTest {
   }
 
   @Test
-  fun `m2 audit re-entry uses selected mode once then inline`() {
+  fun `m2 audit re-entry retains the selected review mode`() {
     val harness = runnerHarness(launcher = auditGapLauncher(convergeOnAudit = 2))
 
     val report = harness.runner.run(
@@ -79,7 +79,7 @@ class FeatureTaskRuntimeAuditGapLoopTest {
       .filter { it.contains("Phase: review") }
     assertEquals(2, reviewPrompts.size)
     assertContains(reviewPrompts[0], "bill-code-review mode:delegated")
-    assertContains(reviewPrompts[1], "bill-code-review mode:inline")
+    assertContains(reviewPrompts[1], "bill-code-review mode:delegated")
   }
 
   // (c) AC2: convergence on the last allowed (2nd) iteration still advances.

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -1937,7 +1937,7 @@ class FeatureTaskRuntimeReviewFixLoopTest {
       .filter { it.contains("Phase: review") }
     assertEquals(2, reviewPrompts.size)
     assertContains(reviewPrompts[0], "bill-code-review mode:delegated")
-    assertContains(reviewPrompts[1], "bill-code-review mode:inline")
+    assertContains(reviewPrompts[1], "bill-code-review mode:delegated")
     assertEquals(
       CodeReviewExecutionMode.DELEGATED,
       requireNotNull(harness.runInvariantsStore.resolve(WORKFLOW_ID)).codeReviewMode,
@@ -1978,7 +1978,7 @@ class FeatureTaskRuntimeReviewFixLoopTest {
   }
 
   @Test
-  fun `failed second review resumes the same durably reserved inline pass`() {
+  fun `failed second review resumes the same durably reserved selected-mode pass`() {
     var reviewLaunches = 0
     val harness = runnerHarness(
       launcher = RuntimeRecordingLauncher { request ->
@@ -2015,7 +2015,7 @@ class FeatureTaskRuntimeReviewFixLoopTest {
       "the failed launch retries the same reserved pass rather than reserving pass three",
     )
     assertContains(reviewPrompts[0], "bill-code-review mode:delegated")
-    reviewPrompts.drop(1).forEach { prompt -> assertContains(prompt, "bill-code-review mode:inline") }
+    reviewPrompts.drop(1).forEach { prompt -> assertContains(prompt, "bill-code-review mode:delegated") }
     val completedReview = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID).orEmpty()["review"])
     assertEquals("completed", completedReview.status)
     assertEquals(2, completedReview.reviewPassNumber)
@@ -2038,7 +2038,7 @@ class FeatureTaskRuntimeReviewFixLoopTest {
     assertEquals(launchCount, harness.launcher.requests.size)
   }
 
-  // (c) AC3/AC10: convergence on the only allowed inline re-review still advances to audit.
+  // (c) AC3/AC10: convergence on the only allowed re-review still advances to audit.
   @Test
   fun `m1 converges on the last allowed iteration and advances`() {
     val harness = runnerHarness(launcher = reviewFixLauncher(convergeOnReview = 2))
@@ -2054,7 +2054,7 @@ class FeatureTaskRuntimeReviewFixLoopTest {
     assertEquals(listOf(1), loopEdges.mapNotNull { it.edgeIteration })
   }
 
-  // (d) AC4/AC10: an unresolved inline re-review exhausts the two-pass budget and blocks loudly.
+  // (d) AC4/AC10: an unresolved re-review exhausts the two-pass budget and blocks loudly.
   @Test
   fun `m1 cap exhaustion blocks loudly with review_fix iteration and unresolved findings`() {
     // convergeOnReview above the cap => review never approves; the edge fires to the cap then blocks.

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
@@ -2169,6 +2169,54 @@ internal class InMemoryWorkflowStates : WorkflowStateRepository {
 
 class DecompositionDiskBootstrapTest {
   @Test
+  fun `invalid decomposition issue key fails before branch checkout`() {
+    val invalidIssueKey = "S".repeat(129)
+    val manifest = DecompositionManifest(
+      issueKey = invalidIssueKey,
+      featureName = "invalid-issue-key",
+      parentSpecPath = ".feature-specs/invalid/spec.md",
+      status = "in_progress",
+      executionModel = DecompositionExecutionModel.SAME_BRANCH_COMMIT_PER_SUBTASK,
+      baseBranch = "main",
+      featureBranch = "feat/invalid-issue-key",
+      currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 1, action = "implement"),
+      subtasks = listOf(
+        DecompositionSubtask(
+          id = 1,
+          name = "first-subtask",
+          specPath = ".feature-specs/invalid/spec_subtask_1.md",
+          status = "pending",
+        ),
+      ),
+    )
+    val workflows = InMemoryWorkflowStates()
+    workflows.saveFeatureImplementWorkflow(
+      workflowRecord(
+        workflowId = "wfl-invalid-issue-key",
+        artifactsPatch = mapOf(
+          "plan" to mapOf("mode" to "decompose"),
+          DECOMPOSITION_RUNTIME_ARTIFACT_KEY to
+            encodeDecompositionManifestMap(manifest, testDecompositionManifestValidator),
+        ),
+      ),
+    )
+    val gitOperations = RecordingWorkflowGitOperations()
+    val continuation = DecompositionWorkflowContinuation(
+      engine = testWorkflowEngine,
+      gitOperations = gitOperations,
+      validator = testDecompositionManifestValidator,
+    )
+
+    assertFailsWith<IllegalArgumentException> {
+      FakeDatabaseSessionFactory(workflows).transaction<ContinuationStepResult>(null) { unitOfWork ->
+        continuation.continueDecomposedParentByIssueKey(invalidIssueKey, unitOfWork)
+      }
+    }
+
+    assertTrue(gitOperations.checkoutCalls.isEmpty())
+  }
+
+  @Test
   fun `continueDecomposedParentByIssueKey bootstraps from disk when no DB parent row exists`() {
     val repoRoot = Files.createTempDirectory("skillbill-disk-bootstrap")
     val manifestPath = repoRoot.resolve(".feature-specs/SKILL-TEST-feature/decomposition-manifest.yaml")

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
@@ -74,16 +74,23 @@ internal object DatabaseColumnMigrations {
   }
 
   fun healWorkListMetadata(connection: Connection) {
-    applyWorkListMetadata(connection, recoverIssueKeys = false)
+    connection.inImmediateTransaction {
+      applyWorkListMetadata(this, recoverIssueKeys = false)
+    }
   }
 
   private fun applyWorkListMetadata(connection: Connection, recoverIssueKeys: Boolean) {
     val workflowColumnsHealed = ensureWorkListWorkflowColumns(connection)
     val goalColumnsHealed = ensureGoalWorkListColumns(connection)
     if (recoverIssueKeys || workflowColumnsHealed || goalColumnsHealed) {
-      recoverRuntimeWorkflowIssueKeys(connection)
-      recoverGoalContinuationWorkflowIssueKeys(connection)
+      recoverWorkListIssueKeys(connection)
     }
+  }
+
+  fun recoverWorkListIssueKeys(connection: Connection) {
+    recoverRuntimeWorkflowIssueKeys(connection)
+    recoverGoalContinuationWorkflowIssueKeys(connection)
+    recoverDecompositionWorkflowIssueKeys(connection)
   }
 
   private fun ensureWorkListWorkflowColumns(connection: Connection): Boolean {
@@ -198,6 +205,22 @@ internal object DatabaseColumnMigrations {
               OR (mode = 'prose' AND json_type(artifacts_json, '$.goal_continuation.enabled') = 'true')
             )
           ELSE 0 END
+        """.trimIndent(),
+      )
+    }
+  }
+
+  private fun recoverDecompositionWorkflowIssueKeys(connection: Connection) {
+    connection.createStatement().use { statement ->
+      statement.execute(
+        """
+        UPDATE feature_task_workflows
+        SET issue_key = trim(json_extract(artifacts_json, '$.decomposition_runtime.issue_key'))
+        WHERE (issue_key IS NULL OR issue_key = '')
+          AND json_valid(artifacts_json)
+          AND json_type(artifacts_json, '$.decomposition_runtime') = 'object'
+          AND json_type(artifacts_json, '$.decomposition_runtime.issue_key') = 'text'
+          AND NULLIF(trim(json_extract(artifacts_json, '$.decomposition_runtime.issue_key')), '') IS NOT NULL
         """.trimIndent(),
       )
     }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
@@ -74,19 +74,7 @@ internal object DatabaseColumnMigrations {
   }
 
   fun healWorkListMetadata(connection: Connection) {
-    if (workListMetadataRequiresHealing(connection)) {
-      applyWorkListMetadata(connection, recoverIssueKeys = true)
-    }
-  }
-
-  private fun workListMetadataRequiresHealing(connection: Connection): Boolean {
-    val workflowTables = listOf("feature_task_workflows", "feature_verify_workflows")
-    val requiredColumns = setOf("issue_key", "state_entered_at", "state_entered_at_estimated")
-    return workflowTables.any { tableName -> !tableColumnNames(connection, tableName).containsAll(requiredColumns) } ||
-      (
-        tableExists(connection, "goal_issue_progress") &&
-          !tableColumnNames(connection, "goal_issue_progress").containsAll(requiredColumns - "issue_key")
-        )
+    applyWorkListMetadata(connection, recoverIssueKeys = false)
   }
 
   private fun applyWorkListMetadata(connection: Connection, recoverIssueKeys: Boolean) {

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseMigrations.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseMigrations.kt
@@ -28,6 +28,11 @@ internal object DatabaseMigrations {
         name = "add-work-list-state-metadata",
         operation = DatabaseColumnMigrations::applyWorkListMetadata,
       ),
+      DatabaseMigration(
+        version = 5,
+        name = "recover-work-list-issue-keys",
+        operation = DatabaseColumnMigrations::recoverWorkListIssueKeys,
+      ),
     ).also(::requireDeterministicMigrations)
 
   fun apply(connection: Connection) {

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
@@ -59,6 +59,7 @@ class DatabaseMigrationsTest {
         2 to "normalize-feedback-event-outcomes",
         3 to "add-goal-telemetry-tables",
         4 to "add-work-list-state-metadata",
+        5 to "recover-work-list-issue-keys",
       ),
       migrationDefinitions,
     )
@@ -467,6 +468,37 @@ class DatabaseMigrationsTest {
         null,
         nullableTableColumnValue(connection, "feature_task_workflows", "workflow_id", "wftr-number-key", "issue_key"),
       )
+    }
+  }
+
+  @Test
+  fun `migration after v4 recovers imported decomposition parent issue keys`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-v5-issue-key-recovery").resolve("metrics.db")
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      connection.createStatement().use { statement ->
+        statement.executeUpdate("DELETE FROM schema_migrations WHERE version = 5")
+        statement.executeUpdate(
+          """
+          INSERT INTO feature_task_workflows (
+            workflow_id, mode, contract_version, workflow_status, artifacts_json,
+            started_at, state_entered_at, state_entered_at_estimated
+          ) VALUES (
+            'wfl-imported-parent', 'prose', '0.1', 'abandoned',
+            '{"decomposition_runtime":{"issue_key":" SKILL-117 ","status":"in_progress"}}',
+            '2026-05-01T10:00:00Z', '2026-05-01T10:00:00Z', 0
+          )
+          """.trimIndent(),
+        )
+      }
+    }
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      assertEquals(
+        "SKILL-117",
+        tableColumnValue(connection, "feature_task_workflows", "workflow_id", "wfl-imported-parent", "issue_key"),
+      )
+      assertNotNull(migrationRows(connection).singleOrNull { row -> row.version == 5 })
     }
   }
 

--- a/skills/bill-feature-task-runtime/content.md
+++ b/skills/bill-feature-task-runtime/content.md
@@ -123,10 +123,10 @@ Blocker/Major finding.
   `implement_fix` phase, which addresses the carried review findings on the
   current working tree as incremental reconciliation (not a plan re-application),
   then re-runs `review`. This `review` → `implement_fix` → `review` cycle is
-  capped at one remediation iteration via a durable per-edge counter: the
-  initial review may use the selected mode, while the only re-review is reserved
-  before launch and always invokes `bill-code-review mode:inline`. The first
-  `approved` verdict advances the run to `audit`.
+  capped at one remediation iteration via a durable per-edge counter. The
+  initial review and the only re-review both use the run-selected mode, so
+  `auto` applies the shared review policy independently to each review scope.
+  The first `approved` verdict advances the run to `audit`.
 - If the loop exhausts its cap without an `approved` verdict, the run blocks
   loudly rather than advancing: it records a durable terminal blocked phase plus
   an observability/ledger event carrying the loop id `review_fix`, the iteration
@@ -168,9 +168,9 @@ correct phase and iteration, preserving the `audit_gap` watermark and re-blockin
 a cap-exhausted loop on resume rather than re-entering past the cap.
 
 The two loops compose under one durable two-pass review budget. The initial
-review may use the selected mode. The first later review reached by either a
-review-fix or audit-gap path consumes pass two and runs inline. Later audit-gap
-iterations reuse the completed pass-two result rather than launching a third
+review and the first later review reached by either a review-fix or audit-gap
+path use the run-selected mode. That later review consumes pass two; later
+audit-gap iterations reuse its completed result rather than launching a third
 review. Each backward edge carries the `audit_gap` loop id and iteration in the
 ledger and status output, and finished telemetry reflects the audit-gap
 iteration count alongside the review-fix count.


### PR DESCRIPTION
# Summary

Completes SKILL-117 hardening after review of the local durable-work inventory. This recovers issue keys for existing databases, prevents invalid decomposition inputs from mutating Git state, and preserves automatic review-mode selection during remediation.

- add append-only migration v5 for authoritative workflow issue-key recovery, including imported decomposition parents
- persist normalized issue keys when goal-runner workflows create parent and child records
- validate decomposition issue keys before branch checkout or creation
- let `bill-code-review` automatic mode choose an eligible strategy on every review pass

## Feature Flags

N/A

# How Has This Been Tested?

Focused migration, workflow-continuation, and review-loop tests plus the complete repository validation suite.

1. Run `skill-bill validate`.
2. Run `(cd runtime-kotlin && ./gradlew check)`.
3. Run `npx --yes agnix --strict .`.
4. Run `scripts/validate_agent_configs`.
5. Verify all commands pass and the migration and invalid-key regression tests remain green.
