### PR TITLE
fix(runtime): goal status liveness and phase-output evidence follow-ups for SKILL-135

### DIFF
--- a/.feature-specs/SKILL-135-audit-first-review-gate/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-135-audit-first-review-gate/decomposition-manifest.yaml
@@ -3,14 +3,14 @@ contract_version: "0.5"
 issue_key: "SKILL-135"
 feature_name: "audit-first-review-gate"
 parent_spec_path: ".feature-specs/SKILL-135-audit-first-review-gate/spec.md"
-status: "in_progress"
+status: "complete"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-135-audit-first-review-gate"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 3
-  action: "resume"
+  subtask_id: 0
+  action: "complete"
 subtasks:
 - id: 1
   name: "Audit-first phase reordering"
@@ -44,12 +44,12 @@ subtasks:
 - id: 3
   name: "Goal-wide unaddressed findings ledger"
   spec_path: ".feature-specs/SKILL-135-audit-first-review-gate/spec_subtask_3_findings_ledger.md"
-  status: "in_progress"
+  status: "complete"
   branch: null
   commit_sha: null
   workflow_id: "wftr-20260720-192238-iwxj"
   blocked_reason: null
-  last_resumable_step: "review"
+  last_resumable_step: "commit_push"
   linear_issue_id: null
   finalizing_agent_id: null
   participating_agent_ids: []

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -584,6 +584,7 @@ class FeatureTaskRuntimePhaseRecorder(
       durationMillis = if (request.finished) durationMillis(startedAt, now) else null,
       resolvedAgentId = request.resolvedAgentId,
       outputArtifact = request.outputArtifact,
+      rejectedOutput = request.rejectedOutput,
       blockedReason = request.blockedReason,
       failureDisposition = request.failureDisposition,
       fileManifestBefore = request.fileManifestBefore,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -1263,6 +1263,7 @@ internal class FeatureTaskRuntimeRunLoop(
           FeatureTaskRuntimePhaseFileManifest(it.fileManifestBefore, it.fileManifestAfter)
         },
         outputArtifact = durable?.outputArtifact,
+        rejectedOutput = durable?.rejectedOutput,
       )
     }
   }
@@ -1341,7 +1342,7 @@ internal class FeatureTaskRuntimeRunLoop(
             observability,
             failureDisposition = FeatureTaskRuntimeFailureDisposition.INVALID_OUTPUT,
             fileManifest = attempt.fileManifest,
-            outputArtifact = attempt.rejectedOutput,
+            rejectedOutput = attempt.rejectedOutput,
           )
         }
     }
@@ -1359,6 +1360,7 @@ internal class FeatureTaskRuntimeRunLoop(
     failureDisposition: FeatureTaskRuntimeFailureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
     fileManifest: FeatureTaskRuntimePhaseFileManifest? = null,
     outputArtifact: String? = null,
+    rejectedOutput: String? = null,
   ): PhaseOutcome {
     val phaseState = FeatureTaskRuntimePhaseStateRequest(
       workflowId = run.request.workflowId,
@@ -1368,6 +1370,7 @@ internal class FeatureTaskRuntimeRunLoop(
       resolvedAgentId = run.resolvedAgent.resolvedAgentId,
       finished = false,
       outputArtifact = outputArtifact,
+      rejectedOutput = rejectedOutput,
       blockedReason = reason,
       failureDisposition = failureDisposition,
       fileManifestBefore = fileManifest?.before.orEmpty(),
@@ -1394,6 +1397,7 @@ internal class FeatureTaskRuntimeRunLoop(
     failureDisposition: FeatureTaskRuntimeFailureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
     fileManifest: FeatureTaskRuntimePhaseFileManifest? = null,
     outputArtifact: String? = null,
+    rejectedOutput: String? = null,
   ): PhaseOutcome = blockAndPersist(
     run,
     attemptCount,
@@ -1404,6 +1408,7 @@ internal class FeatureTaskRuntimeRunLoop(
     failureDisposition = failureDisposition,
     fileManifest = fileManifest,
     outputArtifact = outputArtifact,
+    rejectedOutput = rejectedOutput,
   )
 
   @Suppress("LongParameterList")

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunState.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunState.kt
@@ -55,15 +55,17 @@ internal class FeatureTaskRuntimeRunState(
       .filterNot { it.phaseId in gateInvalidatedPhases }
       .toMutableList()
 
-  // A blocked phase deliberately persists its schema-rejected output as diagnostic evidence, so a durable
-  // artifact is not guaranteed to satisfy the phase schema. Re-validating it while hydrating resume state
-  // must not kill the process: an unparseable artifact carries no usable output, and the phase re-runs.
-  // Failing here instead would leave the workflow permanently unresumable.
+  // Records written before rejected_output existed stored schema-rejected evidence in output_artifact, so a
+  // non-completed record's artifact is not guaranteed to satisfy the phase schema. Hydrating resume state
+  // tolerates that: an unparseable artifact carries no usable output and the phase re-runs, whereas failing
+  // here leaves the workflow permanently unresumable. A completed record still loud-fails, because there an
+  // invalid artifact is genuine corruption rather than evidence.
   private fun validatedRecordToOutput(record: FeatureTaskRuntimePhaseRecord): FeatureTaskRuntimePhaseOutput? =
     record.outputArtifact?.let { artifact ->
       val normalized = try {
         outputValidator.normalizePhaseOutput(artifact, record.phaseId)
-      } catch (_: InvalidFeatureTaskRuntimePhaseOutputSchemaError) {
+      } catch (error: InvalidFeatureTaskRuntimePhaseOutputSchemaError) {
+        if (record.status == STATUS_COMPLETED) throw error
         return@let null
       }
       FeatureTaskRuntimePhaseOutput(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
@@ -67,6 +67,7 @@ class GoalRunnerStatusService(
               request.dbPathOverride,
             ),
             currentStepOverride = progress?.currentStepId,
+            currentWorkflowStatus = progress?.workflowStatus,
             latestLivenessSignal = progress?.latestLivenessSignal,
             latestObservabilityEvent = progress?.latestGoalObservabilityEvent?.toStatusMap(),
             requestedDiffStat = request.requestedDiffStat(),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
@@ -16,6 +16,7 @@ data class FeatureTaskRuntimePhaseStateRequest(
   val resolvedAgentId: String,
   val finished: Boolean,
   val outputArtifact: String? = null,
+  val rejectedOutput: String? = null,
   val normalizedOutput: NormalizedFeatureTaskRuntimePhaseOutput? = null,
   val repositoryFingerprint: String? = null,
   /** Present only on a terminal blocked record so blocked-ness survives ledger pruning. */

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeAuditRepairRegressionTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeAuditRepairRegressionTest.kt
@@ -113,7 +113,7 @@ class FeatureTaskRuntimeAuditRepairRegressionTest {
 
     assertEquals("implement", blocked.lastIncompletePhase)
     val implementRecord = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID).orEmpty()["implement"])
-    val persisted = requireNotNull(implementRecord.outputArtifact) {
+    val persisted = requireNotNull(implementRecord.rejectedOutput) {
       "a rejected output must stay on the durable record so the failure is diagnosable"
     }
     assertContains(persisted, marker)

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -105,6 +105,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -2188,8 +2189,40 @@ class FeatureTaskRuntimeRunnerSpecLifecycleTest {
 // topology, kept in a sibling class so the primary runner test class stays within its size
 // budget while sharing the same file-private run harness.
 class FeatureTaskRuntimeReviewFixLoopTest {
-  // The rejected output persisted as diagnostic evidence is not schema-valid by construction. Hydrating
-  // resume state must tolerate it, or the workflow can never be resumed again.
+  @Test
+  fun `schema-rejected evidence is persisted apart from the phase output artifact`() {
+    val harness = runnerHarness(
+      validator = ThrowingValidator(failPhases = setOf("review")),
+      agentAssignment = phasePerAgentAssignment(),
+    )
+
+    assertIs<FeatureTaskRuntimeRunReport.Blocked>(harness.runner.run(harness.request()))
+
+    val reviewRecord = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID).orEmpty()["review"])
+    assertEquals("blocked", reviewRecord.status)
+    assertNotNull(reviewRecord.rejectedOutput)
+    assertNull(
+      reviewRecord.outputArtifact,
+      "rejected evidence must never land in output_artifact, which resume hydration re-validates",
+    )
+  }
+
+  @Test
+  fun `a completed record with an unparseable output artifact still loud-fails on resume`() {
+    val harness = runnerHarness(
+      validator = ThrowingValidator(failPhases = setOf("plan")),
+      agentAssignment = phasePerAgentAssignment(),
+    )
+    harness.seedPhase("preplan", "completed", 1, phaseAgent("preplan"), PREPLAN_OUTPUT)
+    harness.seedPhase("plan", "completed", 1, phaseAgent("plan"), "not a json object")
+
+    assertFailsWith<InvalidFeatureTaskRuntimePhaseOutputSchemaError> {
+      harness.runner.run(harness.request())
+    }
+  }
+
+  // Legacy records stored schema-rejected evidence in output_artifact. Hydrating resume state must tolerate
+  // it, or those workflows can never be resumed again.
   @Test
   fun `a blocked phase carrying schema-rejected output stays resumable`() {
     val harness = runnerHarness(agentAssignment = phasePerAgentAssignment())

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalRunnerTest.kt
@@ -2652,8 +2652,11 @@ class GoalRunnerStatusAttributionTest {
 
     requireNotNull(status)
     assertEquals(1, status.completeCount)
-    assertEquals(1, status.pendingCount)
-    assertEquals(1, status.blockedCount)
+    // Subtask 2 is durably blocked in the manifest but its child workflow is running, so it counts as
+    // in-progress: the manifest projection is only rewritten at reconciliation points and would otherwise
+    // report a relaunched subtask as blocked for the whole run.
+    assertEquals(2, status.pendingCount)
+    assertEquals(0, status.blockedCount)
     assertEquals(2, status.currentSubtaskId)
     assertEquals("implement", status.currentStep)
     assertEquals("zcode", status.activeAgent)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
@@ -250,6 +250,12 @@ data class GoalRunnerStatusProjection(
 data class GoalRunnerStatusProjectionExtras(
   val planning: GoalPlanningStatusSnapshot? = null,
   val currentStepOverride: String? = null,
+  /**
+   * Live workflow status of the current subtask's child. The manifest projection is only rewritten at
+   * reconciliation points, so a subtask relaunched from a durable block still reads `blocked` there for
+   * the whole run; this reports what the child is actually doing.
+   */
+  val currentWorkflowStatus: String? = null,
   val latestLivenessSignal: String? = null,
   @OpenBoundaryMap("Compact latest goal observability event passthrough for goal status rendering")
   val latestObservabilityEvent: Map<String, Any?>? = null,
@@ -265,21 +271,35 @@ object GoalRunnerStatusProjector {
     extras: GoalRunnerStatusProjectionExtras = GoalRunnerStatusProjectionExtras(),
   ): GoalRunnerStatusProjection {
     val currentSubtask = manifest.subtasks.firstOrNull { it.id == manifest.currentSubtaskIntent.subtaskId }
+    val statusOf: (DecompositionSubtask) -> String = { subtask ->
+      if (subtask.id == currentSubtask?.id && extras.currentWorkflowStatus in LIVE_WORKFLOW_STATUSES) {
+        "in_progress"
+      } else {
+        subtask.status
+      }
+    }
+    // Only goal_runner_supervisor events are persisted; the per-tick foreground heartbeats are console-only.
+    // So a block recorded when a prior run stopped stays the newest stored event while a relaunched child
+    // runs, and rendering it would contradict the live workflow status.
+    val staleBlockSignal = extras.currentWorkflowStatus in LIVE_WORKFLOW_STATUSES &&
+      extras.latestObservabilityEvent?.get("liveness_class") == "block"
     return GoalRunnerStatusProjection(
       issueKey = manifest.issueKey,
-      completeCount = manifest.subtasks.count { it.status == "complete" || it.status == "skipped" },
-      pendingCount = manifest.subtasks.count { it.status !in setOf("complete", "skipped", "blocked") },
-      blockedCount = manifest.subtasks.count { it.status == "blocked" },
+      completeCount = manifest.subtasks.count { statusOf(it) == "complete" || statusOf(it) == "skipped" },
+      pendingCount = manifest.subtasks.count { statusOf(it) !in setOf("complete", "skipped", "blocked") },
+      blockedCount = manifest.subtasks.count { statusOf(it) == "blocked" },
       currentSubtaskId = currentSubtask?.id,
       currentStep = extras.currentStepOverride?.takeIf(String::isNotBlank)
         ?: currentSubtask?.lastResumableStep
         ?: currentSubtask?.let { s -> if (s.workflowId.isNullOrBlank()) "pending_launch" else "initializing" },
       activeAgent = activeAgent?.takeIf(String::isNotBlank),
       planning = extras.planning,
-      latestLivenessSignal = extras.latestLivenessSignal?.takeIf(String::isNotBlank),
-      latestObservabilityEvent = extras.latestObservabilityEvent,
+      latestLivenessSignal = extras.latestLivenessSignal?.takeIf { it.isNotBlank() && !staleBlockSignal },
+      latestObservabilityEvent = extras.latestObservabilityEvent?.takeUnless { staleBlockSignal },
       requestedDiffStat = extras.requestedDiffStat,
       selectedDiffHunks = extras.selectedDiffHunks,
     )
   }
+
+  private val LIVE_WORKFLOW_STATUSES = setOf("running", "pending")
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
@@ -200,6 +200,11 @@ data class FeatureTaskRuntimePhaseRecord(
   val executionOrigin: FeatureTaskRuntimePhaseExecutionOrigin =
     FeatureTaskRuntimePhaseExecutionOrigin.AGENT_EXECUTED,
   val outputArtifact: String? = null,
+  /**
+   * Schema-rejected agent output kept as diagnostic evidence. Held apart from [outputArtifact] because it
+   * is invalid by construction: storing it as an output makes resume hydration re-validate and reject it.
+   */
+  val rejectedOutput: String? = null,
   val blockedReason: String? = null,
   val failureDisposition: FeatureTaskRuntimeFailureDisposition? = null,
   val fileManifestBefore: List<String> = emptyList(),
@@ -247,6 +252,7 @@ data class FeatureTaskRuntimePhaseRecord(
     finishedAt?.let { put("finished_at", it) }
     durationMillis?.let { put("duration_millis", it) }
     outputArtifact?.let { put("output_artifact", it) }
+    rejectedOutput?.let { put("rejected_output", it) }
     blockedReason?.let { put("blocked_reason", it) }
     failureDisposition?.let { put("failure_disposition", it.wireValue) }
     if (fileManifestBefore.isNotEmpty()) put("file_manifest_before", fileManifestBefore)
@@ -276,6 +282,7 @@ data class FeatureTaskRuntimePhaseRecord(
           FeatureTaskRuntimePhaseExecutionOrigin::fromWireValue,
         ) ?: FeatureTaskRuntimePhaseExecutionOrigin.AGENT_EXECUTED,
         outputArtifact = raw.optionalStringField("output_artifact"),
+        rejectedOutput = raw.optionalStringField("rejected_output"),
         blockedReason = raw.optionalStringField("blocked_reason"),
         failureDisposition = raw.optionalStringField("failure_disposition")?.let { value ->
           FeatureTaskRuntimeFailureDisposition.fromWireValue(value)

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/goalrunner/GoalRunnerStatusProjectorTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/goalrunner/GoalRunnerStatusProjectorTest.kt
@@ -1,0 +1,98 @@
+package skillbill.goalrunner
+
+import skillbill.goalrunner.model.GoalRunnerStatusProjectionExtras
+import skillbill.goalrunner.model.GoalRunnerStatusProjector
+import skillbill.workflow.model.CurrentSubtaskIntent
+import skillbill.workflow.model.DecompositionManifest
+import skillbill.workflow.model.DecompositionSubtask
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GoalRunnerStatusProjectorTest {
+  @Test
+  fun `a relaunched subtask is not counted as blocked while its child workflow runs`() {
+    val projection = GoalRunnerStatusProjector.project(
+      manifest = manifest(currentSubtaskStatus = "blocked"),
+      extras = GoalRunnerStatusProjectionExtras(currentWorkflowStatus = "running"),
+    )
+
+    assertEquals(0, projection.blockedCount)
+    assertEquals(1, projection.pendingCount)
+  }
+
+  @Test
+  fun `a subtask with no live child keeps its durable blocked status`() {
+    val projection = GoalRunnerStatusProjector.project(
+      manifest = manifest(currentSubtaskStatus = "blocked"),
+      extras = GoalRunnerStatusProjectionExtras(currentWorkflowStatus = "blocked"),
+    )
+
+    assertEquals(1, projection.blockedCount)
+    assertEquals(0, projection.pendingCount)
+  }
+
+  // Only supervisor events are persisted, so a block recorded when a prior run stopped is still the newest
+  // stored event while a relaunched child runs. Rendering it would contradict the live workflow status.
+  @Test
+  fun `a block liveness signal is withheld while the child workflow runs`() {
+    val projection = GoalRunnerStatusProjector.project(
+      manifest = manifest(currentSubtaskStatus = "blocked"),
+      extras = GoalRunnerStatusProjectionExtras(
+        currentWorkflowStatus = "running",
+        latestLivenessSignal = "liveness=block phase=review role=goal_runner_supervisor",
+        latestObservabilityEvent = mapOf("liveness_class" to "block"),
+      ),
+    )
+
+    assertNull(projection.latestLivenessSignal)
+    assertNull(projection.latestObservabilityEvent)
+  }
+
+  @Test
+  fun `a non-block liveness signal is preserved while the child workflow runs`() {
+    val projection = GoalRunnerStatusProjector.project(
+      manifest = manifest(currentSubtaskStatus = "in_progress"),
+      extras = GoalRunnerStatusProjectionExtras(
+        currentWorkflowStatus = "running",
+        latestLivenessSignal = "liveness=durable_progress phase=implement",
+        latestObservabilityEvent = mapOf("liveness_class" to "durable_progress"),
+      ),
+    )
+
+    assertEquals("liveness=durable_progress phase=implement", projection.latestLivenessSignal)
+    assertEquals(mapOf("liveness_class" to "durable_progress"), projection.latestObservabilityEvent)
+  }
+
+  @Test
+  fun `a stored block signal is reported once the child workflow is no longer running`() {
+    val projection = GoalRunnerStatusProjector.project(
+      manifest = manifest(currentSubtaskStatus = "blocked"),
+      extras = GoalRunnerStatusProjectionExtras(
+        currentWorkflowStatus = "blocked",
+        latestLivenessSignal = "liveness=block phase=review role=goal_runner_supervisor",
+        latestObservabilityEvent = mapOf("liveness_class" to "block"),
+      ),
+    )
+
+    assertEquals("liveness=block phase=review role=goal_runner_supervisor", projection.latestLivenessSignal)
+  }
+
+  private fun manifest(currentSubtaskStatus: String): DecompositionManifest = DecompositionManifest(
+    issueKey = "SKILL-135",
+    featureName = "audit-first-review-gate",
+    parentSpecPath = ".feature-specs/SKILL-135/spec.md",
+    baseBranch = "main",
+    featureBranch = "feat/SKILL-135-audit-first-review-gate",
+    currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 1, action = "resume"),
+    subtasks = listOf(
+      DecompositionSubtask(
+        id = 1,
+        name = "Only subtask",
+        specPath = ".feature-specs/SKILL-135/spec_subtask_1.md",
+        status = currentSubtaskStatus,
+        workflowId = "wftr-20260720-192238-iwxj",
+      ),
+    ),
+  )
+}


### PR DESCRIPTION
Follow-up to #232. These three commits were authored on the SKILL-135 branch but were not included in that merge, so they are replayed here onto current `main`.

The cherry-picked tree is byte-for-byte identical to the original branch tip (tree `b0063e45`), and the cherry-pick applied with no conflicts.

## Changes

- **`fix(runtime): keep schema-rejected evidence out of the phase output artifact`** — schema-rejected evidence no longer leaks into the recorded phase output.
- **`chore(skill-bill): record SKILL-135 goal completion in the decomposition manifest`** — manifest bookkeeping only.
- **`fix(runtime): report live child state in goal status instead of a stale projection`** — `goal status` reports live child state rather than a stale projection.

Both runtime fixes ship with test coverage, including a new `GoalRunnerStatusProjectorTest`.

## Validation

Run locally against this exact tree:

- `(cd runtime-kotlin && ./gradlew check)` — pass
- `npx --yes agnix --strict .` — no issues found
- `scripts/validate_agent_configs` — pass
- `scripts/install_smoke_test.sh` — all scenarios passed
- `skill-bill validate` — pass

The macOS self-hosted runner leg was not reproducible locally and is covered by CI on this PR.