### PR TITLE
chore(SKILL-154): reconcile decomposition manifest to terminal state

### DIFF
--- a/.feature-specs/SKILL-154-goal-context-efficiency-and-monitoring/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-154-goal-context-efficiency-and-monitoring/decomposition-manifest.yaml
@@ -3,14 +3,14 @@ contract_version: "0.5"
 issue_key: "SKILL-154"
 feature_name: "goal-context-efficiency-and-monitoring"
 parent_spec_path: ".feature-specs/SKILL-154-goal-context-efficiency-and-monitoring/spec.md"
-status: "in_progress"
+status: "complete"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-154-goal-context-efficiency-and-monitoring"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 2
-  action: "resume"
+  subtask_id: 0
+  action: "complete"
 subtasks:
 - id: 1
   name: "context-efficient-skill-and-goal-orchestration"
@@ -28,7 +28,7 @@ subtasks:
 - id: 2
   name: "deterministic-goal-pause-and-completion-control"
   spec_path: ".feature-specs/SKILL-154-goal-context-efficiency-and-monitoring/spec_subtask_2_goal-pause-and-completion-control.md"
-  status: "pending"
+  status: "complete"
   branch: null
   commit_sha: null
   workflow_id: "wftr-20260801-155341-kb53"
@@ -44,10 +44,10 @@ subtasks:
 - id: 3
   name: "monitor-only-skill-and-integration-conformance"
   spec_path: ".feature-specs/SKILL-154-goal-context-efficiency-and-monitoring/spec_subtask_3_bill-monitor-skill.md"
-  status: "pending"
+  status: "complete"
   branch: null
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wftr-20260801-180517-wdsn"
   blocked_reason: null
   last_resumable_step: null
   linear_issue_id: null


### PR DESCRIPTION
SKILL-154 finished with all three subtasks complete in the goal DB, but the checked-in decomposition manifest merged via #248 still said `in_progress` with subtasks 2 and 3 `pending`.

Reconcile the YAML to the terminal shape the runtime's `reconcileGoalManifest` would produce:

- parent `status: complete`
- `current_subtask_intent: {subtask_id: 0, action: complete}`
- subtasks 2 and 3 `complete`; subtask 3 gains its `workflow_id` (`wftr-20260801-180517-wdsn`) from the durable outcome store

Verified against `skill-bill goal status SKILL-154` (3/3 complete) and `goal_subtask_events`.