### PR TITLE
SKILL-165: ide-status-planning-progress

### DIFF
--- a/.feature-specs/SKILL-165-ide-status-planning-progress/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-165-ide-status-planning-progress/decomposition-manifest.yaml
@@ -9,18 +9,18 @@ base_branch: "main"
 feature_branch: "feat/SKILL-165-ide-status-planning-progress"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 1
+  subtask_id: 2
   action: "resume"
 subtasks:
 - id: 1
   name: "Emit goal planning status on the IDE status wire"
   spec_path: ".feature-specs/SKILL-165-ide-status-planning-progress/spec_subtask_1_runtime-wire-planning.md"
-  status: "pending"
+  status: "complete"
   branch: null
   commit_sha: null
   workflow_id: "wftr-20260807-121238-7e9m"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "commit_push"
   linear_issue_id: null
   finalizing_agent_id: null
   participating_agent_ids: []
@@ -31,7 +31,7 @@ subtasks:
   status: "pending"
   branch: null
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wftr-20260807-124620-bycf"
   blocked_reason: null
   last_resumable_step: null
   linear_issue_id: null

--- a/.feature-specs/SKILL-165-ide-status-planning-progress/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-165-ide-status-planning-progress/decomposition-manifest.yaml
@@ -3,13 +3,14 @@ contract_version: "0.5"
 issue_key: "SKILL-165"
 feature_name: "ide-status-planning-progress"
 parent_spec_path: ".feature-specs/SKILL-165-ide-status-planning-progress/spec.md"
+status: "in_progress"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-165-ide-status-planning-progress"
 stack_branches: []
 current_subtask_intent:
   subtask_id: 1
-  action: "start"
+  action: "resume"
 subtasks:
 - id: 1
   name: "Emit goal planning status on the IDE status wire"
@@ -17,10 +18,12 @@ subtasks:
   status: "pending"
   branch: null
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wftr-20260807-121238-7e9m"
   blocked_reason: null
   last_resumable_step: null
   linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
   dependencies: []
 - id: 2
   name: "Render planning progress in the IntelliJ status widget"
@@ -32,6 +35,8 @@ subtasks:
   blocked_reason: null
   last_resumable_step: null
   linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
   dependencies:
   - subtask_id: 1
     optional: false

--- a/intellij-plugin/agent/history.md
+++ b/intellij-plugin/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-08-07] SKILL-165 planning progress rendering (subtask 2)
+Areas: intellij-plugin/{domain,infrastructure/cli,presentation}
+- `IdeStatusJsonMapper` parses the optional planning block from `work status --format json`; absent or malformed planning degrades to no planning state rather than failing the whole status parse. reusable
+- Planning surfaces as an extra bar segment plus two tooltip lines (planning phase + `Progress: n/m`); when planning is absent the rendered output stays byte-identical to the pre-change baseline. reusable
+- Paused/pre-planning goals anchor elapsed at observation time in `StatusUiMapper` (paused states do not tick with the local UI clock); stale observations keep the STALE_NOTE alongside the planning segment. reusable
+- Planning state round-trips through `LastKnownDisplayCache`, so a stale cached render keeps planning context instead of dropping to a bare status.
+- Limitation: planning rendering is read-only display; no new CLI transport, no planning-driven refresh cadence, non-goal status families render unchanged.
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented
+
 ## [2026-08-07] SKILL-148 status-bar widget (subtask 3)
 Areas: intellij-plugin/{ui,presentation}, plugin.xml, docs
 - Registered `SkillBillStatusBarWidget` StatusBarWidgetFactory (id matches factory/widget) for normal project windows with resolvable project context. reusable

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/LastKnownDisplayCache.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/LastKnownDisplayCache.kt
@@ -60,6 +60,24 @@ fun SkillBillStatusOutcome.toCacheSnapshotOrNull(): LastKnownDisplayCache? =
                 observedAt = observedAt,
             )
 
+        is SkillBillStatusOutcome.Paused ->
+            LastKnownDisplayCache(
+                display = CachedDisplaySnapshot(
+                    summary = summary,
+                    repositoryIdentity = repositoryIdentity,
+                    issueKey = issueKey,
+                    currentStepId = currentStepId,
+                    currentStepLabel = currentStepLabel,
+                    progressCompleted = progressCompleted,
+                    progressTotal = progressTotal,
+                    startedAt = startedAt,
+                    currentSubtaskId = currentSubtaskId,
+                    subtaskStartedAt = subtaskStartedAt,
+                    updatedAt = updatedAt,
+                ),
+                observedAt = observedAt,
+            )
+
         is SkillBillStatusOutcome.Stale ->
             if (fromCache) {
                 null

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
@@ -38,6 +38,30 @@ sealed class SkillBillStatusOutcome {
         val subtaskStartedAt: Instant?,
         val updatedAt: Instant,
         override val diagnostic: StatusDiagnostic? = null,
+        val planning: GoalPlanningInfo? = null,
+    ) : SkillBillStatusOutcome()
+
+    /**
+     * A live lifecycle that is not running. Distinct from [Active] because spinner and
+     * ticking-clock decisions key off the type: a paused goal must show neither.
+     */
+    data class Paused(
+        override val observedAt: Instant,
+        val summary: String,
+        val repositoryIdentity: String,
+        val issueKey: String?,
+        val workflowId: String?,
+        val workflowFamily: String?,
+        val currentStepId: String,
+        val currentStepLabel: String,
+        val progressCompleted: Int?,
+        val progressTotal: Int?,
+        val startedAt: Instant?,
+        val currentSubtaskId: String?,
+        val subtaskStartedAt: Instant?,
+        val updatedAt: Instant,
+        override val diagnostic: StatusDiagnostic? = null,
+        val planning: GoalPlanningInfo? = null,
     ) : SkillBillStatusOutcome()
 
     data class Stale(
@@ -55,6 +79,7 @@ sealed class SkillBillStatusOutcome {
         val updatedAt: Instant?,
         val fromCache: Boolean = false,
         override val diagnostic: StatusDiagnostic? = null,
+        val planning: GoalPlanningInfo? = null,
     ) : SkillBillStatusOutcome()
 
     data class Blocked(
@@ -104,6 +129,19 @@ sealed class SkillBillStatusOutcome {
         override val diagnostic: StatusDiagnostic? = null,
     ) : SkillBillStatusOutcome()
 }
+
+/**
+ * Goal planning progress carried alongside a live goal snapshot. [state] holds the raw
+ * wire value; the plugin never restates the runtime's planning-state vocabulary.
+ */
+data class GoalPlanningInfo(
+    val state: String,
+    val sharedPreplanPrepared: Boolean,
+    val plannedSubtaskCount: Int,
+    val totalSubtaskCount: Int,
+    val currentPlanningSubtaskId: String? = null,
+    val reason: String? = null,
+)
 
 enum class UnavailableReason {
     MISSING_EXECUTABLE,

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
+import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.IDE_STATUS_CONTRACT_VERSION
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
 import dev.skillbill.intellij.domain.StatusDiagnostic
@@ -92,6 +93,7 @@ object IdeStatusJsonMapper {
         val subtaskId = subtask?.getAsString("id")
         val subtaskStartedAt = subtask?.getAsInstant("started_at")
         val updatedAt = root.getAsInstant("updated_at")
+        val planning = root.parsePlanning()
 
         // "No work here" is a healthy idle repository, not a broken status source.
         // Every other problem code is a genuine failure to obtain status.
@@ -140,6 +142,7 @@ object IdeStatusJsonMapper {
                 subtaskStartedAt = subtaskStartedAt,
                 updatedAt = updatedAt,
                 fromCache = false,
+                planning = planning,
             )
         }
 
@@ -147,6 +150,24 @@ object IdeStatusJsonMapper {
             "active", "paused" -> {
                 if (repositoryIdentity.isNullOrBlank() || stepId.isNullOrBlank() || stepLabel.isNullOrBlank() || updatedAt == null) {
                     malformed(observedAt, "incomplete_active_payload")
+                } else if (lifecycle == "paused") {
+                    SkillBillStatusOutcome.Paused(
+                        observedAt = observedAt,
+                        summary = summary,
+                        repositoryIdentity = repositoryIdentity,
+                        issueKey = issueKey,
+                        workflowId = workflowId,
+                        workflowFamily = workflowFamily,
+                        currentStepId = stepId,
+                        currentStepLabel = stepLabel,
+                        progressCompleted = progressCompleted,
+                        progressTotal = progressTotal,
+                        startedAt = startedAt,
+                        currentSubtaskId = subtaskId,
+                        subtaskStartedAt = subtaskStartedAt,
+                        updatedAt = updatedAt,
+                        planning = planning,
+                    )
                 } else {
                     SkillBillStatusOutcome.Active(
                         observedAt = observedAt,
@@ -163,6 +184,7 @@ object IdeStatusJsonMapper {
                         currentSubtaskId = subtaskId,
                         subtaskStartedAt = subtaskStartedAt,
                         updatedAt = updatedAt,
+                        planning = planning,
                     )
                 }
             }
@@ -236,6 +258,28 @@ object IdeStatusJsonMapper {
         return AbsolutePathGuard.redact(value).take(512)
     }
 
+    /**
+     * Planning is optional context, never a reason to lose a whole status reading:
+     * any missing, mistyped, or out-of-range field degrades the block to null and the
+     * surrounding outcome still maps normally.
+     */
+    private fun JsonObject.parsePlanning(): GoalPlanningInfo? {
+        val planning = getAsJsonObjectOrNull("planning") ?: return null
+        val state = planning.getAsString("state")?.takeUnless { it.isBlank() } ?: return null
+        val sharedPreplanPrepared = planning.getAsBoolean("shared_preplan_prepared") ?: return null
+        val planned = planning.getAsInt("planned_subtask_count")?.takeIf { it >= 0 } ?: return null
+        val total = planning.getAsInt("total_subtask_count")?.takeIf { it >= 0 } ?: return null
+        return GoalPlanningInfo(
+            state = state,
+            sharedPreplanPrepared = sharedPreplanPrepared,
+            plannedSubtaskCount = planned,
+            totalSubtaskCount = total,
+            currentPlanningSubtaskId = planning.getAsString("current_planning_subtask_id")
+                ?.takeUnless { it.isBlank() },
+            reason = planning.getAsString("reason")?.let { safeSummary(it, "") }?.takeUnless { it.isEmpty() },
+        )
+    }
+
     private fun JsonObject.getAsString(key: String): String? =
         get(key)?.takeUnless { it.isJsonNull }?.asStringOrNull()
 
@@ -243,6 +287,10 @@ object IdeStatusJsonMapper {
         get(key)?.takeUnless { it.isJsonNull }?.let {
             runCatching { it.asInt }.getOrNull()
         }
+
+    /** Strict: a JSON string "true" is a type error, not a boolean. */
+    private fun JsonObject.getAsBoolean(key: String): Boolean? =
+        get(key)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isBoolean }?.asBoolean
 
     private fun JsonObject.getAsInstant(key: String): Instant? {
         val raw = getAsString(key) ?: return null

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
@@ -24,16 +24,31 @@ object SkillBillStatusBarPresentation {
         val goalText = elapsedLabel(anchored.goalElapsed)
         val subtaskText = elapsedLabel(anchored.subtaskElapsed)
         val progress = validProgress(anchored.progressCompleted, anchored.progressTotal)
-        val progressText = progress?.let { "${it.first}/${it.second}" }
+        val progressText = progress?.let { (completed, total) ->
+            "${renderedPosition(anchored, completed, total)}/$total"
+        }
+        val planning = anchored.planning
+        val planningSegment = planning?.let { "Planning ${it.plannedSubtaskCount}/${it.totalSubtaskCount}" }
 
         val fullBar = when (anchored) {
             is SkillBillStatusUiState.Active ->
-                buildActiveBar(step ?: anchored.stepLabel, goalText, subtaskText, progressText)
+                buildActiveBar(step ?: anchored.stepLabel, planningSegment, goalText, subtaskText, progressText)
+
+            is SkillBillStatusUiState.Paused ->
+                buildString {
+                    append("Skill Bill · paused")
+                    step?.let { append(" · ").append(it) }
+                    planningSegment?.let { append(" · ").append(it) }
+                    append(" · ").append(goalText)
+                    append(" · ").append(subtaskText)
+                    progressText?.let { append(" · ").append(it) }
+                }
 
             is SkillBillStatusUiState.Stale ->
                 buildString {
                     append("Skill Bill · stale")
                     step?.let { append(" · ").append(it) }
+                    planningSegment?.let { append(" · ").append(it) }
                     append(" · ").append(goalText)
                     append(" · ").append(subtaskText)
                     progressText?.let { append(" · ").append(it) }
@@ -47,7 +62,18 @@ object SkillBillStatusBarPresentation {
         }
 
         val barText = truncateForBar(normalizeLabel(fullBar) ?: fullBar)
-        val tooltip = buildTooltip(anchored, lifecycle, step, goalText, subtaskText, progressText)
+        val preplanLine = planning?.let { "Pre-planning: " + if (it.sharedPreplanPrepared) "Done" else "In progress" }
+        val planningLine = planning?.let { "Planning: ${it.plannedSubtaskCount}/${it.totalSubtaskCount} subtasks" }
+        val tooltip = buildTooltip(
+            anchored,
+            lifecycle,
+            step,
+            goalText,
+            subtaskText,
+            progressText,
+            preplanLine,
+            planningLine,
+        )
         val accessibleName = "Skill Bill status: $lifecycle"
         val accessibleDescription = buildAccessibilityDescription(
             lifecycle = lifecycle,
@@ -57,6 +83,8 @@ object SkillBillStatusBarPresentation {
             progressText = progressText,
             detail = anchored.detail,
             elapsedNoun = elapsedNoun(anchored),
+            preplanLine = preplanLine,
+            planningLine = planningLine,
         )
 
         return MappedPresentation(
@@ -110,14 +138,28 @@ object SkillBillStatusBarPresentation {
     fun elapsedLabel(duration: Duration?): String =
         if (duration == null) UNAVAILABLE_ELAPSED else formatDuration(duration)
 
+    /**
+     * The rendered numerator is the *current* position, not the completed count: with a
+     * subtask in flight "1/4" reads as "1 of 4 done" and contradicts the running subtask
+     * clock beside it. Only in-flight lifecycles shift; the wire fields are untouched.
+     */
+    private fun renderedPosition(state: SkillBillStatusUiState, completed: Int, total: Int): Int {
+        val inFlight = state is SkillBillStatusUiState.Active ||
+            state is SkillBillStatusUiState.Stale ||
+            state is SkillBillStatusUiState.Paused
+        return if (inFlight && completed < total) completed + 1 else completed
+    }
+
     private fun buildActiveBar(
         stepLabel: String,
+        planningSegment: String?,
         goalText: String,
         subtaskText: String,
         progressText: String?,
     ): String =
         buildString {
             append("Skill Bill · ").append(stepLabel)
+            planningSegment?.let { append(" · ").append(it) }
             append(" · ").append(goalText)
             append(" · ").append(subtaskText)
             progressText?.let { append(" · ").append(it) }
@@ -130,12 +172,16 @@ object SkillBillStatusBarPresentation {
         goalText: String,
         subtaskText: String,
         progressText: String?,
+        preplanLine: String?,
+        planningLine: String?,
     ): String =
         buildString {
             append("Skill Bill — ").append(lifecycle)
             state.issueKey?.let { append("\nIssue: ").append(it) }
             state.workflowId?.let { append("\nWorkflow: ").append(it) }
             step?.let { append("\nStep: ").append(it) }
+            preplanLine?.let { append('\n').append(it) }
+            planningLine?.let { append('\n').append(it) }
             val elapsedNoun = elapsedNoun(state)
             append("\nGoal ").append(elapsedNoun).append(": ").append(goalText)
             append("\nSubtask ").append(elapsedNoun).append(": ").append(subtaskText)
@@ -164,10 +210,14 @@ object SkillBillStatusBarPresentation {
         progressText: String?,
         detail: String?,
         elapsedNoun: String,
+        preplanLine: String?,
+        planningLine: String?,
     ): String =
         buildString {
             append("Skill Bill. State: ").append(lifecycle).append('.')
             step?.let { append(" Step: ").append(it).append('.') }
+            preplanLine?.let { append(' ').append(it).append('.') }
+            planningLine?.let { append(' ').append(it).append('.') }
             append(" Goal ").append(elapsedNoun).append(": ").append(goalText).append('.')
             append(" Subtask ").append(elapsedNoun).append(": ").append(subtaskText).append('.')
             progressText?.let { append(" Progress: ").append(it).append('.') }
@@ -185,6 +235,7 @@ object SkillBillStatusBarPresentation {
             is SkillBillStatusUiState.Stale,
             is SkillBillStatusUiState.Blocked,
             is SkillBillStatusUiState.Failed,
+            is SkillBillStatusUiState.Paused,
             -> "ran"
 
             else -> "elapsed"
@@ -194,6 +245,7 @@ object SkillBillStatusBarPresentation {
         when (state) {
             is SkillBillStatusUiState.Idle -> "idle"
             is SkillBillStatusUiState.Active -> "active"
+            is SkillBillStatusUiState.Paused -> "paused"
             is SkillBillStatusUiState.Stale -> "stale"
             is SkillBillStatusUiState.Blocked -> "blocked"
             is SkillBillStatusUiState.Failed -> "failed"

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
@@ -32,27 +32,13 @@ object SkillBillStatusBarPresentation {
 
         val fullBar = when (anchored) {
             is SkillBillStatusUiState.Active ->
-                buildActiveBar(step ?: anchored.stepLabel, planningSegment, goalText, subtaskText, progressText)
+                buildRunBar("Skill Bill", step ?: anchored.stepLabel, planningSegment, goalText, subtaskText, progressText)
 
             is SkillBillStatusUiState.Paused ->
-                buildString {
-                    append("Skill Bill · paused")
-                    step?.let { append(" · ").append(it) }
-                    planningSegment?.let { append(" · ").append(it) }
-                    append(" · ").append(goalText)
-                    append(" · ").append(subtaskText)
-                    progressText?.let { append(" · ").append(it) }
-                }
+                buildRunBar("Skill Bill · paused", step, planningSegment, goalText, subtaskText, progressText)
 
             is SkillBillStatusUiState.Stale ->
-                buildString {
-                    append("Skill Bill · stale")
-                    step?.let { append(" · ").append(it) }
-                    planningSegment?.let { append(" · ").append(it) }
-                    append(" · ").append(goalText)
-                    append(" · ").append(subtaskText)
-                    progressText?.let { append(" · ").append(it) }
-                }
+                buildRunBar("Skill Bill · stale", step, planningSegment, goalText, subtaskText, progressText)
 
             is SkillBillStatusUiState.Blocked -> "Skill Bill · blocked"
             is SkillBillStatusUiState.Failed -> "Skill Bill · failed"
@@ -150,20 +136,38 @@ object SkillBillStatusBarPresentation {
         return if (inFlight && completed < total) completed + 1 else completed
     }
 
-    private fun buildActiveBar(
-        stepLabel: String,
+    /**
+     * The bar has a hard 48-char budget, and prefix + step + planning + two clocks +
+     * progress overflows it, so a plain concatenation loses whichever segment lands last.
+     * Segments are therefore dropped by ascending value until the line fits: the progress
+     * pair is redundant while planning is shown (planning only renders before execution
+     * starts), and the subtask clock is the least informative of the two clocks.
+     */
+    private fun buildRunBar(
+        prefix: String,
+        stepLabel: String?,
         planningSegment: String?,
         goalText: String,
         subtaskText: String,
         progressText: String?,
-    ): String =
-        buildString {
-            append("Skill Bill · ").append(stepLabel)
-            planningSegment?.let { append(" · ").append(it) }
-            append(" · ").append(goalText)
-            append(" · ").append(subtaskText)
-            progressText?.let { append(" · ").append(it) }
+    ): String {
+        val progressRank = if (planningSegment == null) 2 else 0
+        val optional = listOf(subtaskText to 1, progressText to progressRank)
+        var dropRank = -1
+        while (true) {
+            val bar = buildString {
+                append(prefix)
+                stepLabel?.let { append(" · ").append(it) }
+                planningSegment?.let { append(" · ").append(it) }
+                if (dropRank < 3) append(" · ").append(goalText)
+                for ((text, rank) in optional) {
+                    if (text != null && rank > dropRank) append(" · ").append(text)
+                }
+            }
+            if (bar.length <= BAR_TEXT_MAX_LENGTH || dropRank >= 3) return bar
+            dropRank++
         }
+    }
 
     private fun buildTooltip(
         state: SkillBillStatusUiState,

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusUiState.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusUiState.kt
@@ -1,5 +1,6 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.GoalPlanningInfo
 import java.time.Duration
 import java.time.Instant
 
@@ -26,6 +27,12 @@ sealed class SkillBillStatusUiState {
     open val subtaskStartedAt: Instant? get() = null
     open val lastUpdated: Instant? get() = null
     open val problemSummary: String? get() = null
+
+    /**
+     * Non-null only while planning progress is worth showing. Relevance is decided once,
+     * in [StatusUiMapper]; renderers must not re-derive it.
+     */
+    open val planning: GoalPlanningInfo? get() = null
 
     /** True when this state is not live. Always true for [Stale]; a modifier elsewhere. */
     open val stale: Boolean get() = this is Stale
@@ -56,6 +63,7 @@ sealed class SkillBillStatusUiState {
         override val startedAt: Instant?,
         override val subtaskStartedAt: Instant?,
         override val lastUpdated: Instant?,
+        override val planning: GoalPlanningInfo? = null,
     ) : SkillBillStatusUiState() {
         override val accessibilityText: String =
             buildString {
@@ -63,6 +71,24 @@ sealed class SkillBillStatusUiState {
                 goalElapsed?.let { append(", goal elapsed ").append(formatDuration(it)) }
                 subtaskElapsed?.let { append(", subtask elapsed ").append(formatDuration(it)) }
             }
+    }
+
+    data class Paused(
+        override val headline: String,
+        override val detail: String?,
+        override val goalElapsed: Duration?,
+        override val subtaskElapsed: Duration?,
+        override val progressCompleted: Int?,
+        override val progressTotal: Int?,
+        override val issueKey: String?,
+        override val workflowId: String?,
+        override val stepLabel: String,
+        override val startedAt: Instant?,
+        override val subtaskStartedAt: Instant?,
+        override val lastUpdated: Instant?,
+        override val planning: GoalPlanningInfo? = null,
+    ) : SkillBillStatusUiState() {
+        override val accessibilityText: String = "$headline (paused)"
     }
 
     data class Stale(
@@ -79,6 +105,7 @@ sealed class SkillBillStatusUiState {
         override val subtaskStartedAt: Instant? = null,
         override val lastUpdated: Instant? = null,
         override val problemSummary: String? = "Cached status is stale",
+        override val planning: GoalPlanningInfo? = null,
     ) : SkillBillStatusUiState() {
         override val accessibilityText: String = "$headline (stale)"
     }

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
@@ -1,5 +1,6 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
 import java.time.Duration
 import java.time.Instant
@@ -33,6 +34,32 @@ object StatusUiMapper {
                     startedAt = outcome.startedAt,
                     subtaskStartedAt = outcome.subtaskStartedAt,
                     lastUpdated = outcome.updatedAt,
+                    planning = relevantPlanning(
+                        outcome.planning,
+                        outcome.currentSubtaskId,
+                        outcome.progressCompleted,
+                    ),
+                )
+
+            is SkillBillStatusOutcome.Paused ->
+                SkillBillStatusUiState.Paused(
+                    headline = pausedHeadline(outcome),
+                    detail = outcome.summary,
+                    goalElapsed = elapsed(outcome.startedAt, settledAt(outcome.updatedAt, now)),
+                    subtaskElapsed = elapsed(outcome.subtaskStartedAt, settledAt(outcome.updatedAt, now)),
+                    progressCompleted = outcome.progressCompleted,
+                    progressTotal = outcome.progressTotal,
+                    issueKey = outcome.issueKey,
+                    workflowId = outcome.workflowId,
+                    stepLabel = outcome.currentStepLabel,
+                    startedAt = outcome.startedAt,
+                    subtaskStartedAt = outcome.subtaskStartedAt,
+                    lastUpdated = outcome.updatedAt,
+                    planning = relevantPlanning(
+                        outcome.planning,
+                        outcome.currentSubtaskId,
+                        outcome.progressCompleted,
+                    ),
                 )
 
             is SkillBillStatusOutcome.Stale ->
@@ -50,6 +77,11 @@ object StatusUiMapper {
                     subtaskStartedAt = outcome.subtaskStartedAt,
                     lastUpdated = outcome.updatedAt ?: outcome.observedAt,
                     problemSummary = if (outcome.fromCache) "Cached status is stale" else "Status is stale",
+                    planning = relevantPlanning(
+                        outcome.planning,
+                        outcome.currentSubtaskId,
+                        outcome.progressCompleted,
+                    ),
                 )
 
             is SkillBillStatusOutcome.Blocked ->
@@ -141,9 +173,30 @@ object StatusUiMapper {
             else -> state
         }
 
+    /**
+     * The one place planning relevance is decided, so bar, tooltip, and accessibility
+     * text cannot diverge. Planning stops being relevant once implementation starts:
+     * state `prepared`, or the snapshot already reports execution work. Snapshot-derived
+     * with no latch — `progress.completed` only moves forward.
+     */
+    private fun relevantPlanning(
+        planning: GoalPlanningInfo?,
+        currentSubtaskId: String?,
+        progressCompleted: Int?,
+    ): GoalPlanningInfo? {
+        if (planning == null || planning.state == "prepared") return null
+        if (!currentSubtaskId.isNullOrBlank() || (progressCompleted ?: 0) > 0) return null
+        return planning
+    }
+
     private fun activeHeadline(outcome: SkillBillStatusOutcome.Active): String {
         val key = outcome.issueKey?.let { "$it · " }.orEmpty()
         return "Skill Bill: $key${outcome.currentStepLabel}"
+    }
+
+    private fun pausedHeadline(outcome: SkillBillStatusOutcome.Paused): String {
+        val key = outcome.issueKey?.let { "$it · " }.orEmpty()
+        return "Skill Bill: ${key}paused"
     }
 
     private fun staleHeadline(outcome: SkillBillStatusOutcome.Stale): String {

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -106,6 +107,11 @@ class ProcessRunnerTest {
         assertEquals(2, result.exitCode)
     }
 }
+
+private const val VALID_PLANNING =
+    """"planning": {"state": "partially_planned", "shared_preplan_prepared": true,
+       "planned_subtask_count": 1, "total_subtask_count": 4,
+       "current_planning_subtask_id": "subtask-2"}"""
 
 class IdeStatusJsonMapperTest {
     private val now = java.time.Instant.parse("2026-08-06T10:00:00Z")
@@ -199,6 +205,69 @@ class IdeStatusJsonMapperTest {
     }
 
     @Test
+    fun `goal payload carrying planning maps into the outcome`() {
+        val outcome = IdeStatusJsonMapper.map(goalPayload(planning = VALID_PLANNING), now, 0)
+        assertTrue(outcome is SkillBillStatusOutcome.Active)
+        val planning = (outcome as SkillBillStatusOutcome.Active).planning
+        assertEquals("partially_planned", planning?.state)
+        assertEquals(true, planning?.sharedPreplanPrepared)
+        assertEquals(1, planning?.plannedSubtaskCount)
+        assertEquals(4, planning?.totalSubtaskCount)
+        assertEquals("subtask-2", planning?.currentPlanningSubtaskId)
+    }
+
+    @Test
+    fun `payload without planning maps exactly as today`() {
+        val outcome = IdeStatusJsonMapper.map(goalPayload(planning = null), now, 0)
+        assertTrue(outcome is SkillBillStatusOutcome.Active)
+        outcome as SkillBillStatusOutcome.Active
+        assertNull(outcome.planning)
+        assertEquals("SKILL-165", outcome.issueKey)
+        assertEquals("implement", outcome.currentStepId)
+        assertEquals(1, outcome.progressCompleted)
+        assertEquals(4, outcome.progressTotal)
+    }
+
+    @Test
+    fun `malformed planning degrades to null without failing the mapping`() {
+        val malformed = mapOf(
+            "non-object" to "\"planning\": \"nope\"",
+            "missing required key" to """"planning": {"state": "preplanned", "planned_subtask_count": 1, "total_subtask_count": 4}""",
+            "wrong type" to """"planning": {"state": "preplanned", "shared_preplan_prepared": "yes", "planned_subtask_count": 1, "total_subtask_count": 4}""",
+            "negative count" to """"planning": {"state": "preplanned", "shared_preplan_prepared": false, "planned_subtask_count": -1, "total_subtask_count": 4}""",
+        )
+        for ((case, block) in malformed) {
+            val outcome = IdeStatusJsonMapper.map(goalPayload(planning = block), now, 0)
+            assertTrue("$case must still map to Active", outcome is SkillBillStatusOutcome.Active)
+            assertNull("$case must degrade planning to null", (outcome as SkillBillStatusOutcome.Active).planning)
+        }
+    }
+
+    @Test
+    fun `fresh paused maps to Paused and stale paused still maps to Stale`() {
+        val fresh = IdeStatusJsonMapper.map(runtimeFixture(lifecycle = "paused"), now, 0)
+        assertTrue(fresh is SkillBillStatusOutcome.Paused)
+        assertEquals("implement", (fresh as SkillBillStatusOutcome.Paused).currentStepId)
+
+        val stale = IdeStatusJsonMapper.map(
+            runtimeFixture(lifecycle = "paused", freshness = "stale"),
+            now,
+            0,
+        )
+        assertTrue(stale is SkillBillStatusOutcome.Stale)
+    }
+
+    @Test
+    fun `active payload mapping is unchanged by the paused split`() {
+        val outcome = IdeStatusJsonMapper.map(fixture("active-runtime.json"), now, 0)
+        assertTrue(outcome is SkillBillStatusOutcome.Active)
+        outcome as SkillBillStatusOutcome.Active
+        assertEquals("SKILL-148", outcome.issueKey)
+        assertEquals("implement", outcome.currentStepId)
+        assertNull(outcome.planning)
+    }
+
+    @Test
     fun `expected contract version constant matches fixture`() {
         assertTrue(fixture("active-runtime.json").contains("\"contract_version\": \"$IDE_STATUS_CONTRACT_VERSION\""))
     }
@@ -220,6 +289,22 @@ class IdeStatusJsonMapperTest {
         check(contains(original)) { "Fixture no longer contains $original" }
         return replace(original, "\"$field\": \"$to\"")
     }
+
+    private fun goalPayload(planning: String?): String =
+        buildString {
+            append("{\"contract_version\":\"$IDE_STATUS_CONTRACT_VERSION\",")
+            append("\"repository_identity\":\"repo-root-realpath-v1:/repo\",")
+            append("\"lifecycle_state\":\"active\",\"freshness\":\"fresh\",")
+            append("\"issue_key\":\"SKILL-165\",\"workflow_id\":\"wfl-1\",")
+            append("\"workflow_family\":\"feature-goal\",")
+            append("\"current_step\":{\"id\":\"implement\",\"label\":\"Implement\"},")
+            append("\"progress\":{\"completed\":1,\"total\":4},")
+            append("\"started_at\":\"2026-08-06T08:00:00Z\",")
+            append("\"updated_at\":\"2026-08-06T09:59:00Z\",")
+            append("\"summary\":\"Goal SKILL-165 in progress.\"")
+            planning?.let { append(',').append(it) }
+            append('}')
+        }
 
     private fun fixture(name: String): String =
         javaClass.classLoader.getResourceAsStream("fixtures/$name")!!

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/prefs/PreferenceSanitizerAndCacheTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/prefs/PreferenceSanitizerAndCacheTest.kt
@@ -2,6 +2,7 @@ package dev.skillbill.intellij.infrastructure.prefs
 
 import dev.skillbill.intellij.domain.CachedDisplaySnapshot
 import dev.skillbill.intellij.domain.LastKnownDisplayCache
+import dev.skillbill.intellij.domain.toCacheSnapshotOrNull
 import dev.skillbill.intellij.domain.toStaleOutcome
 import dev.skillbill.intellij.fakes.FakePreferenceCache
 import java.time.Instant
@@ -27,6 +28,33 @@ class PreferenceSanitizerAndCacheTest {
         val outcome = cache.toStaleOutcome()
         assertTrue(outcome.fromCache)
         assertTrue(outcome is dev.skillbill.intellij.domain.SkillBillStatusOutcome.Stale)
+    }
+
+    @Test
+    fun `a paused outcome round-trips through the cache and re-emerges as stale`() {
+        val paused = dev.skillbill.intellij.domain.SkillBillStatusOutcome.Paused(
+            observedAt = Instant.parse("2026-08-06T09:00:00Z"),
+            summary = "paused by operator",
+            repositoryIdentity = "repo",
+            issueKey = "SKILL-165",
+            workflowId = "wfl-1",
+            workflowFamily = "feature-goal",
+            currentStepId = "implement",
+            currentStepLabel = "Implement",
+            progressCompleted = 1,
+            progressTotal = 4,
+            startedAt = Instant.parse("2026-08-06T08:00:00Z"),
+            currentSubtaskId = "2",
+            subtaskStartedAt = Instant.parse("2026-08-06T08:30:00Z"),
+            updatedAt = Instant.parse("2026-08-06T08:59:00Z"),
+        )
+        val cached = paused.toCacheSnapshotOrNull()
+        assertNotNull(cached)
+        val stale = cached!!.toStaleOutcome()
+        assertTrue(stale.fromCache)
+        assertEquals("SKILL-165", stale.issueKey)
+        assertEquals(1, stale.progressCompleted)
+        assertEquals(4, stale.progressTotal)
     }
 
     @Test

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
@@ -1,5 +1,7 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.GoalPlanningInfo
+import dev.skillbill.intellij.domain.SkillBillStatusOutcome
 import java.time.Duration
 import java.time.Instant
 import org.junit.Assert.assertEquals
@@ -18,7 +20,7 @@ class SkillBillStatusBarPresentationTest {
         assertTrue(mapped.barText.startsWith("Skill Bill · Implement"))
         assertTrue(mapped.barText.contains("2h 00m"))
         assertTrue(mapped.barText.contains("30m 00s"))
-        assertTrue(mapped.barText.contains("3/9"))
+        assertTrue(mapped.barText.contains("4/9"))
         assertTrue(mapped.showActivityAnimation)
         assertFalse(mapped.isStaleMarked)
     }
@@ -220,7 +222,7 @@ class SkillBillStatusBarPresentationTest {
         assertTrue(mapped.accessibleDescription.contains("Implement"))
         assertTrue(mapped.accessibleDescription.contains("Goal elapsed"))
         assertTrue(mapped.accessibleDescription.contains("Subtask elapsed"))
-        assertTrue(mapped.accessibleDescription.contains("3/9"))
+        assertTrue(mapped.accessibleDescription.contains("4/9"))
     }
 
     @Test
@@ -231,7 +233,7 @@ class SkillBillStatusBarPresentationTest {
         assertEquals("wfl-1", d.workflowId)
         assertEquals("active", d.lifecycleState)
         assertEquals("Implement", d.stepLabel)
-        assertEquals("3/9", d.progressText)
+        assertEquals("4/9", d.progressText)
         assertEquals("2h 00m", d.goalElapsedText)
         assertEquals("30m 00s", d.subtaskElapsedText)
         assertTrue(d.lastUpdateText!!.contains("2026-08-07"))
@@ -262,6 +264,204 @@ class SkillBillStatusBarPresentationTest {
         assertEquals(SkillBillStatusBarPresentation.UNAVAILABLE_ELAPSED, mapped.details.subtaskElapsedText)
     }
 
+    @Test
+    fun `planning renders a bar segment and both tooltip lines for either pre-planning state`() {
+        for (preplanPrepared in listOf(true, false)) {
+            val mapped = SkillBillStatusBarPresentation.map(
+                active(
+                    progressCompleted = 0,
+                    progressTotal = 4,
+                    planning = planning(sharedPreplanPrepared = preplanPrepared),
+                ),
+                now,
+            )
+            assertTrue(mapped.barText, mapped.barText.contains("Planning 1/4"))
+            assertTrue(
+                mapped.tooltipText,
+                mapped.tooltipText.contains(
+                    if (preplanPrepared) "Pre-planning: Done" else "Pre-planning: In progress",
+                ),
+            )
+            assertTrue(mapped.tooltipText, mapped.tooltipText.contains("Planning: 1/4 subtasks"))
+            assertTrue(mapped.accessibleDescription.contains("Planning: 1/4 subtasks"))
+            // Planning counts planned subtasks; execution progress marks the running one.
+            assertEquals("1/4", mapped.details.progressText)
+        }
+    }
+
+    @Test
+    fun `absent planning leaves bar and tooltip byte-for-byte unchanged`() {
+        val withoutPlanning = SkillBillStatusBarPresentation.map(active(), now)
+        assertEquals(
+            "Skill Bill · Implement · 2h 00m · 30m 00s · 4/9",
+            withoutPlanning.barText,
+        )
+        assertEquals(
+            "Skill Bill — active\nIssue: SKILL-148\nWorkflow: wfl-1\nStep: Implement" +
+                "\nGoal elapsed: 2h 00m\nSubtask elapsed: 30m 00s\nProgress: 4/9" +
+                "\nLast update: 2026-08-07 12:00:00Z\nworking",
+            withoutPlanning.tooltipText,
+        )
+    }
+
+    @Test
+    fun `a non-goal family snapshot renders no planning segment or pre-planning line`() {
+        // Non-goal families never carry planning on the wire, so the ui value is null.
+        val mapped = SkillBillStatusBarPresentation.map(active(planning = null), now)
+        assertFalse(mapped.barText.contains("Planning"))
+        assertFalse(mapped.tooltipText.contains("Pre-planning"))
+        assertFalse(mapped.accessibleDescription.contains("Pre-planning"))
+    }
+
+    @Test
+    fun `planning disappears once implementation starts`() {
+        // Relevance is decided in StatusUiMapper; by the time presentation sees a
+        // prepared or executing snapshot the ui planning value is already null.
+        val prepared = StatusUiMapper.map(
+            activeOutcome(planning = domainPlanning("prepared"), currentSubtaskId = null, completed = 0),
+            now,
+        )
+        val executing = StatusUiMapper.map(
+            activeOutcome(planning = domainPlanning("partially_planned"), currentSubtaskId = "2", completed = 0),
+            now,
+        )
+        val progressed = StatusUiMapper.map(
+            activeOutcome(planning = domainPlanning("partially_planned"), currentSubtaskId = null, completed = 1),
+            now,
+        )
+        for (state in listOf(prepared, executing, progressed)) {
+            val mapped = SkillBillStatusBarPresentation.map(state, now)
+            assertFalse(mapped.barText, mapped.barText.contains("Planning"))
+            assertFalse(mapped.tooltipText, mapped.tooltipText.contains("Pre-planning"))
+            assertFalse(mapped.tooltipText, mapped.tooltipText.contains("Planning:"))
+        }
+    }
+
+    @Test
+    fun `stale mid-planning keeps the stale treatment and the planning segment`() {
+        val mapped = SkillBillStatusBarPresentation.map(
+            SkillBillStatusUiState.Stale(
+                headline = "Skill Bill: Plan (stale)",
+                detail = "cached",
+                goalElapsed = Duration.ofMinutes(5),
+                subtaskElapsed = null,
+                progressCompleted = 0,
+                progressTotal = 4,
+                stepLabel = "Plan",
+                planning = planning(sharedPreplanPrepared = false),
+            ),
+            now,
+        )
+        assertTrue(mapped.isStaleMarked)
+        assertTrue(mapped.tooltipText.contains(SkillBillStatusBarPresentation.STALE_NOTE))
+        assertTrue(mapped.barText, mapped.barText.contains("Planning 1/4"))
+        assertTrue(mapped.tooltipText.contains("Planning: 1/4 subtasks"))
+    }
+
+    @Test
+    fun `execution progress renders the current position never one past the total`() {
+        val inFlight = SkillBillStatusBarPresentation.map(
+            active(progressCompleted = 1, progressTotal = 4),
+            now,
+        )
+        assertTrue(inFlight.barText, inFlight.barText.contains("2/4"))
+        assertEquals("2/4", inFlight.details.progressText)
+        assertTrue(inFlight.tooltipText.contains("\nProgress: 2/4"))
+
+        val zeroCompleted = SkillBillStatusBarPresentation.map(
+            active(progressCompleted = 0, progressTotal = 4),
+            now,
+        )
+        assertEquals("1/4", zeroCompleted.details.progressText)
+        assertTrue(zeroCompleted.tooltipText.contains("\nProgress: 1/4"))
+
+        val allComplete = SkillBillStatusBarPresentation.map(
+            active(progressCompleted = 4, progressTotal = 4),
+            now,
+        )
+        assertEquals("4/4", allComplete.details.progressText)
+        assertFalse(allComplete.barText.contains("5/4"))
+
+        val stale = SkillBillStatusBarPresentation.map(
+            SkillBillStatusUiState.Stale(
+                headline = "Skill Bill: Implement (stale)",
+                detail = "cached",
+                goalElapsed = Duration.ofMinutes(5),
+                subtaskElapsed = null,
+                progressCompleted = 1,
+                progressTotal = 4,
+                stepLabel = "Implement",
+            ),
+            now,
+        )
+        assertEquals("2/4", stale.details.progressText)
+    }
+
+    @Test
+    fun `paused names the state keeps the tooltip anchors and never animates`() {
+        val mapped = SkillBillStatusBarPresentation.map(
+            SkillBillStatusUiState.Paused(
+                headline = "Skill Bill: SKILL-165 · paused",
+                detail = "paused by operator",
+                goalElapsed = Duration.ofHours(2),
+                subtaskElapsed = Duration.ofMinutes(30),
+                progressCompleted = 1,
+                progressTotal = 4,
+                issueKey = "SKILL-165",
+                workflowId = "wfl-1",
+                stepLabel = "Implement",
+                startedAt = started,
+                subtaskStartedAt = subtaskStarted,
+                lastUpdated = now,
+            ),
+            now,
+        )
+        assertTrue(mapped.barText, mapped.barText.contains("paused"))
+        assertEquals("paused", mapped.details.lifecycleState)
+        assertTrue(mapped.tooltipText.contains("\nStep: Implement"))
+        assertTrue(mapped.tooltipText.contains("\nProgress: 2/4"))
+        assertTrue(mapped.tooltipText.contains("Goal ran: 2h 00m"))
+        assertEquals("ran", mapped.details.elapsedNoun)
+        assertFalse(mapped.showActivityAnimation)
+        assertFalse(mapped.isStaleMarked)
+    }
+
+    private fun planning(sharedPreplanPrepared: Boolean) = GoalPlanningInfo(
+        state = "partially_planned",
+        sharedPreplanPrepared = sharedPreplanPrepared,
+        plannedSubtaskCount = 1,
+        totalSubtaskCount = 4,
+    )
+
+    private fun domainPlanning(state: String) = GoalPlanningInfo(
+        state = state,
+        sharedPreplanPrepared = true,
+        plannedSubtaskCount = 1,
+        totalSubtaskCount = 4,
+    )
+
+    private fun activeOutcome(
+        planning: GoalPlanningInfo?,
+        currentSubtaskId: String?,
+        completed: Int,
+    ) = SkillBillStatusOutcome.Active(
+        observedAt = now,
+        summary = "working",
+        repositoryIdentity = "repo",
+        issueKey = "SKILL-165",
+        workflowId = "wfl-1",
+        workflowFamily = "feature-goal",
+        currentStepId = "implement",
+        currentStepLabel = "Implement",
+        progressCompleted = completed,
+        progressTotal = 4,
+        startedAt = started,
+        currentSubtaskId = currentSubtaskId,
+        subtaskStartedAt = subtaskStarted,
+        updatedAt = now,
+        planning = planning,
+    )
+
     private fun active(
         stepLabel: String = "Implement",
         headline: String = "Skill Bill: SKILL-148 · Implement",
@@ -271,6 +471,7 @@ class SkillBillStatusBarPresentationTest {
         progressTotal: Int? = 9,
         startedAt: Instant? = started,
         subtaskStartedAt: Instant? = subtaskStarted,
+        planning: GoalPlanningInfo? = null,
     ) = SkillBillStatusUiState.Active(
         headline = headline,
         detail = "working",
@@ -284,5 +485,6 @@ class SkillBillStatusBarPresentationTest {
         startedAt = startedAt,
         subtaskStartedAt = subtaskStartedAt,
         lastUpdated = now,
+        planning = planning,
     )
 }

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
@@ -275,7 +275,12 @@ class SkillBillStatusBarPresentationTest {
                 ),
                 now,
             )
-            assertTrue(mapped.barText, mapped.barText.contains("Planning 1/4"))
+            // The bar budget drops the redundant progress pair and the subtask clock so
+            // the planning segment and the goal clock both survive within 48 chars.
+            assertEquals("Skill Bill · Implement · Planning 1/4 · 2h 00m", mapped.barText)
+            assertTrue(
+                mapped.barText.length <= SkillBillStatusBarPresentation.BAR_TEXT_MAX_LENGTH,
+            )
             assertTrue(
                 mapped.tooltipText,
                 mapped.tooltipText.contains(
@@ -354,7 +359,7 @@ class SkillBillStatusBarPresentationTest {
         )
         assertTrue(mapped.isStaleMarked)
         assertTrue(mapped.tooltipText.contains(SkillBillStatusBarPresentation.STALE_NOTE))
-        assertTrue(mapped.barText, mapped.barText.contains("Planning 1/4"))
+        assertEquals("Skill Bill · stale · Plan · Planning 1/4", mapped.barText)
         assertTrue(mapped.tooltipText.contains("Planning: 1/4 subtasks"))
     }
 
@@ -416,7 +421,8 @@ class SkillBillStatusBarPresentationTest {
             ),
             now,
         )
-        assertTrue(mapped.barText, mapped.barText.contains("paused"))
+        assertEquals("Skill Bill · paused · Implement · 2h 00m · 2/4", mapped.barText)
+        assertTrue(mapped.barText.length <= SkillBillStatusBarPresentation.BAR_TEXT_MAX_LENGTH)
         assertEquals("paused", mapped.details.lifecycleState)
         assertTrue(mapped.tooltipText.contains("\nStep: Implement"))
         assertTrue(mapped.tooltipText.contains("\nProgress: 2/4"))

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/StatusUiMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/StatusUiMapperTest.kt
@@ -1,5 +1,6 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
 import dev.skillbill.intellij.domain.UnavailableReason
 import java.time.Duration
@@ -19,6 +20,7 @@ class StatusUiMapperTest {
         val outcomes = listOf(
             SkillBillStatusOutcome.Idle(now, "idle"),
             active(),
+            paused(updatedAt = now),
             SkillBillStatusOutcome.Stale(
                 observedAt = now,
                 summary = "stale",
@@ -73,6 +75,7 @@ class StatusUiMapperTest {
             listOf(
                 SkillBillStatusUiState.Idle::class,
                 SkillBillStatusUiState.Active::class,
+                SkillBillStatusUiState.Paused::class,
                 SkillBillStatusUiState.Stale::class,
                 SkillBillStatusUiState.Blocked::class,
                 SkillBillStatusUiState.Failed::class,
@@ -169,9 +172,116 @@ class StatusUiMapperTest {
         assertEquals(ui, StatusUiMapper.withElapsed(ui, muchLater.plusSeconds(3_600)))
     }
 
+    @Test
+    fun `paused maps to Paused with elapsed anchored to updatedAt not now`() {
+        val lastUpdate = Instant.parse("2026-08-06T10:30:00Z")
+        val muchLater = Instant.parse("2026-08-09T10:30:00Z")
+        val ui = StatusUiMapper.map(paused(updatedAt = lastUpdate), muchLater)
+        assertTrue(ui is SkillBillStatusUiState.Paused)
+        ui as SkillBillStatusUiState.Paused
+        // 10:00 start → 10:30 last update, not → observation three days later.
+        assertEquals(Duration.ofMinutes(30), ui.goalElapsed)
+        assertTrue(ui.headline.contains("paused"))
+        assertEquals(false, ui.stale)
+    }
+
+    @Test
+    fun `withElapsed does not tick a paused state but still re-anchors active`() {
+        val lastUpdate = Instant.parse("2026-08-06T10:30:00Z")
+        val paused = StatusUiMapper.map(paused(updatedAt = lastUpdate), lastUpdate)
+        assertEquals(paused, StatusUiMapper.withElapsed(paused, lastUpdate.plusSeconds(3_600)))
+
+        val active = StatusUiMapper.map(active(startedAt = started), started)
+        val ticked = StatusUiMapper.withElapsed(active, started.plusSeconds(45))
+            as SkillBillStatusUiState.Active
+        assertEquals(Duration.ofSeconds(45), ticked.goalElapsed)
+    }
+
+    @Test
+    fun `planning is carried only while it is still relevant`() {
+        val planning = GoalPlanningInfo(
+            state = "partially_planned",
+            sharedPreplanPrepared = false,
+            plannedSubtaskCount = 1,
+            totalSubtaskCount = 4,
+        )
+        val relevant = StatusUiMapper.map(
+            active(planning = planning, currentSubtaskId = null, progressCompleted = 0),
+            now,
+        ) as SkillBillStatusUiState.Active
+        assertEquals(planning, relevant.planning)
+
+        val prepared = StatusUiMapper.map(
+            active(planning = planning.copy(state = "prepared"), currentSubtaskId = null, progressCompleted = 0),
+            now,
+        ) as SkillBillStatusUiState.Active
+        assertNull(prepared.planning)
+
+        val executing = StatusUiMapper.map(
+            active(planning = planning, currentSubtaskId = "2", progressCompleted = 0),
+            now,
+        ) as SkillBillStatusUiState.Active
+        assertNull(executing.planning)
+
+        val progressed = StatusUiMapper.map(
+            active(planning = planning, currentSubtaskId = null, progressCompleted = 1),
+            now,
+        ) as SkillBillStatusUiState.Active
+        assertNull(progressed.planning)
+    }
+
+    @Test
+    fun `stale mid-planning retains the planning value`() {
+        val planning = GoalPlanningInfo(
+            state = "preplanned",
+            sharedPreplanPrepared = true,
+            plannedSubtaskCount = 0,
+            totalSubtaskCount = 4,
+        )
+        val ui = StatusUiMapper.map(
+            SkillBillStatusOutcome.Stale(
+                observedAt = now,
+                summary = "stale",
+                repositoryIdentity = "repo",
+                issueKey = "SKILL-165",
+                currentStepId = "plan",
+                currentStepLabel = "Plan",
+                progressCompleted = 0,
+                progressTotal = 4,
+                startedAt = started,
+                currentSubtaskId = null,
+                subtaskStartedAt = null,
+                updatedAt = now,
+                planning = planning,
+            ),
+            now,
+        ) as SkillBillStatusUiState.Stale
+        assertEquals(planning, ui.planning)
+    }
+
+    private fun paused(updatedAt: Instant) = SkillBillStatusOutcome.Paused(
+        observedAt = now,
+        summary = "paused",
+        repositoryIdentity = "repo-root-realpath-v1:/repo",
+        issueKey = "SKILL-165",
+        workflowId = "wfl-1",
+        workflowFamily = "feature-goal",
+        currentStepId = "implement",
+        currentStepLabel = "Implement",
+        progressCompleted = 1,
+        progressTotal = 4,
+        startedAt = started,
+        currentSubtaskId = "2",
+        subtaskStartedAt = subtaskStarted,
+        updatedAt = updatedAt,
+    )
+
     private fun active(
         startedAt: Instant? = started,
         subtaskStartedAt: Instant? = subtaskStarted,
+        planning: GoalPlanningInfo? = null,
+        currentSubtaskId: String? = "2",
+        progressCompleted: Int? = 3,
     ) = SkillBillStatusOutcome.Active(
         observedAt = now,
         summary = "active",
@@ -181,11 +291,12 @@ class StatusUiMapperTest {
         workflowFamily = "feature-task-runtime",
         currentStepId = "implement",
         currentStepLabel = "Implement",
-        progressCompleted = 3,
+        progressCompleted = progressCompleted,
         progressTotal = 9,
         startedAt = startedAt,
-        currentSubtaskId = "2",
+        currentSubtaskId = currentSubtaskId,
         subtaskStartedAt = subtaskStartedAt,
         updatedAt = now,
+        planning = planning,
     )
 }

--- a/orchestration/contracts/ide-status-schema.yaml
+++ b/orchestration/contracts/ide-status-schema.yaml
@@ -100,6 +100,40 @@ properties:
         description: >
           Durable current-subtask start instant. Omitted when the subtask scope
           does not exist or legacy state cannot provide it.
+  planning:
+    type: object
+    additionalProperties: false
+    description: >
+      Goal planning progress. Present only for feature-goal snapshots whose goal
+      status projection carries a planning block.
+    required:
+      - state
+      - shared_preplan_prepared
+      - planned_subtask_count
+      - total_subtask_count
+    properties:
+      state:
+        type: string
+        enum:
+          - not_started
+          - preplanned
+          - partially_planned
+          - blocked
+          - prepared
+      shared_preplan_prepared:
+        type: boolean
+      planned_subtask_count:
+        type: integer
+        minimum: 0
+      total_subtask_count:
+        type: integer
+        minimum: 0
+      current_planning_subtask_id:
+        type: string
+        minLength: 1
+      reason:
+        type: string
+        minLength: 1
   updated_at:
     type: string
     minLength: 1

--- a/runtime-kotlin/runtime-application/agent/history.md
+++ b/runtime-kotlin/runtime-application/agent/history.md
@@ -1,3 +1,13 @@
+## [2026-08-07] SKILL-165 subtask 1 — IDE status planning progress wiring
+Areas: runtime-application/{model,work}, orchestration/contracts, runtime-cli, runtime-infra-fs/contracts/workflow, .feature-specs/SKILL-165
+- IDE status gains an optional `planning` block (snake_case wire keys, omitted entirely when null) so goal decomposition progress is visible before any subtask exists; additive-only, so `contract_version` stays at `0.1`. reusable
+- `IdeStatusProjector` maps non-prepared planning to step `planning`/label `Planning` with a progress summary; prepared or absent planning keeps prior projection behavior, and non-goal families never carry planning.
+- Pattern: schema-first additive wire extension — canonical schema (`ide-status-schema.yaml`) with `additionalProperties:false` plus a contract-version parity test pins the shape, then models/projector/goldens follow. reusable
+- Pause precedence reconfirmed by test: a blocked candidate stays blocked under `paused`/`pause_requested`; only an active candidate projects `paused`.
+- Limitation: planning is projection-only (no consumer-side IDE rendering in this subtask); golden fixtures cover a single mid-planning goal shape.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-08-07] SKILL-164 subtask 3 — Audit and review projection delivery
 Areas: runtime-application/{evidence,featuretask}, runtime-domain/workflow/taskruntime, runtime-ports/taskruntime, runtime-infra-fs, orchestration/contracts, .feature-specs/SKILL-164
 - `FeatureTaskRuntimeSharedReviewEvidenceReference` is a closed-world projection (store_path, checkpoint_fingerprint, base_ref/head_ref, file/hunk index only) with an explicit field allowlist; no diff bytes cross the handoff boundary, so projection size stays independent of branch diff size. reusable

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
@@ -2,6 +2,7 @@ package skillbill.application.model
 
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.IDE_STATUS_CONTRACT_VERSION
+import skillbill.goalrunner.model.GoalPlanningStatusState
 import skillbill.ports.persistence.model.FeatureTaskRouteScope
 import java.nio.file.Path
 import java.time.Instant
@@ -70,6 +71,22 @@ data class IdeStatusCurrentSubtask(
   val startedAt: Instant? = null,
 )
 
+/** Goal planning progress mirrored from [skillbill.goalrunner.model.GoalPlanningStatusSnapshot]. */
+data class IdeStatusPlanning(
+  val state: GoalPlanningStatusState,
+  val sharedPreplanPrepared: Boolean,
+  val plannedSubtaskCount: Int,
+  val totalSubtaskCount: Int,
+  /** Wire-shaped subtask id; the goal projection carries it as an Int. */
+  val currentPlanningSubtaskId: String? = null,
+  val reason: String? = null,
+) {
+  init {
+    require(plannedSubtaskCount >= 0) { "plannedSubtaskCount must be non-negative." }
+    require(totalSubtaskCount >= 0) { "totalSubtaskCount must be non-negative." }
+  }
+}
+
 data class IdeStatusProblem(
   val code: IdeStatusProblemCode,
   val message: String,
@@ -120,6 +137,8 @@ data class IdeStatusSnapshot(
   val progress: IdeStatusProgress? = null,
   val startedAt: Instant? = null,
   val currentSubtask: IdeStatusCurrentSubtask? = null,
+  // Null default: only projectGoal populates planning, so every other family stays wire-identical.
+  val planning: IdeStatusPlanning? = null,
   val problem: IdeStatusProblem? = null,
   val contractVersion: String = IDE_STATUS_CONTRACT_VERSION,
 ) {
@@ -162,6 +181,20 @@ data class IdeStatusSnapshot(
         buildMap {
           put("id", subtask.id)
           subtask.startedAt?.let { put("started_at", it.toString()) }
+        },
+      )
+    }
+    planning?.let { planning ->
+      put(
+        "planning",
+        buildMap {
+          put("state", planning.state.wireValue)
+          put("shared_preplan_prepared", planning.sharedPreplanPrepared)
+          put("planned_subtask_count", planning.plannedSubtaskCount)
+          put("total_subtask_count", planning.totalSubtaskCount)
+          planning.currentPlanningSubtaskId?.takeIf(String::isNotBlank)
+            ?.let { put("current_planning_subtask_id", it) }
+          planning.reason?.takeIf(String::isNotBlank)?.let { put("reason", it) }
         },
       )
     }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
@@ -184,20 +184,7 @@ data class IdeStatusSnapshot(
         },
       )
     }
-    planning?.let { planning ->
-      put(
-        "planning",
-        buildMap {
-          put("state", planning.state.wireValue)
-          put("shared_preplan_prepared", planning.sharedPreplanPrepared)
-          put("planned_subtask_count", planning.plannedSubtaskCount)
-          put("total_subtask_count", planning.totalSubtaskCount)
-          planning.currentPlanningSubtaskId?.takeIf(String::isNotBlank)
-            ?.let { put("current_planning_subtask_id", it) }
-          planning.reason?.takeIf(String::isNotBlank)?.let { put("reason", it) }
-        },
-      )
-    }
+    planning?.let { put("planning", planningWireMap(it)) }
     put("updated_at", updatedAt.toString())
     put("freshness", freshness.wireValue)
     put("summary", summary)
@@ -211,6 +198,16 @@ data class IdeStatusSnapshot(
         },
       )
     }
+  }
+
+  private fun planningWireMap(planning: IdeStatusPlanning): Map<String, Any?> = buildMap {
+    put("state", planning.state.wireValue)
+    put("shared_preplan_prepared", planning.sharedPreplanPrepared)
+    put("planned_subtask_count", planning.plannedSubtaskCount)
+    put("total_subtask_count", planning.totalSubtaskCount)
+    planning.currentPlanningSubtaskId?.takeIf(String::isNotBlank)
+      ?.let { put("current_planning_subtask_id", it) }
+    planning.reason?.takeIf(String::isNotBlank)?.let { put("reason", it) }
   }
 }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
@@ -8,11 +8,14 @@ import skillbill.application.model.GoalRunnerStatusRequest
 import skillbill.application.model.IdeStatusCandidate
 import skillbill.application.model.IdeStatusCurrentSubtask
 import skillbill.application.model.IdeStatusLifecycleState
+import skillbill.application.model.IdeStatusPlanning
 import skillbill.application.model.IdeStatusProgress
 import skillbill.application.model.IdeStatusSnapshot
 import skillbill.application.model.IdeStatusStep
 import skillbill.application.model.IdeStatusWorkflowFamily
 import skillbill.application.workflow.WorkflowFamily
+import skillbill.goalrunner.model.GoalPlanningStatusSnapshot
+import skillbill.goalrunner.model.GoalPlanningStatusState
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.persistence.model.WorkItemKind
 import skillbill.workflow.WorkflowEngine
@@ -68,14 +71,19 @@ class IdeStatusProjector(
         repoRoot = context.repoRoot,
       ),
     )
+    val pauseRequestedOnControls = projection?.paused == true || projection?.pauseRequested == true
     val lifecycle = when {
-      projection?.paused == true || projection?.pauseRequested == true -> IdeStatusLifecycleState.PAUSED
+      // Pause controls only override an active candidate; a durable blocked/failed/terminal
+      // state is the stronger signal and must survive a stale pause flag.
+      pauseRequestedOnControls && candidate.lifecycleState == IdeStatusLifecycleState.ACTIVE ->
+        IdeStatusLifecycleState.PAUSED
       else -> candidate.lifecycleState
     }
-    val stepId = projection?.currentStep?.takeIf(String::isNotBlank)
-      ?: if (lifecycle == IdeStatusLifecycleState.TERMINAL) "done" else "goal"
-    val stepLabel = projection?.currentStep?.takeIf(String::isNotBlank)
-      ?: if (lifecycle == IdeStatusLifecycleState.TERMINAL) "Complete" else "Goal"
+    val planning = projection?.planning?.toIdeStatusPlanning()
+    // Ordered ahead of the currentStep preference: a mid-planning goal can already carry a
+    // stale currentStep string, and planning is the more accurate label while it runs.
+    val planningStep = planning?.takeIf { it.state != GoalPlanningStatusState.PREPARED && !lifecycle.isSettled() }
+    val step = goalStep(planningStep, projection?.currentStep, lifecycle)
     val total = (projection?.let { it.completeCount + it.pendingCount + it.blockedCount })
       ?.takeIf { it > 0 }
     val progress = total?.let {
@@ -98,13 +106,15 @@ class IdeStatusProjector(
       workflowId = candidate.workflowId,
       workflowFamily = IdeStatusWorkflowFamily.FEATURE_GOAL,
       lifecycleState = lifecycle,
-      currentStep = IdeStatusStep(id = stepId, label = stepLabel),
+      currentStep = step,
       progress = progress,
       startedAt = candidate.startedAt,
       currentSubtask = currentSubtask,
+      planning = planning,
       updatedAt = candidate.updatedAt,
       freshness = freshness,
-      summary = goalSummary(issueKey, lifecycle, stepLabel, projection?.blockedCount ?: 0),
+      summary = planningStep?.let { goalPlanningSummary(issueKey, it) }
+        ?: goalSummary(issueKey, lifecycle, step.label, projection?.blockedCount ?: 0),
     )
   }
 
@@ -215,6 +225,38 @@ class IdeStatusProjector(
     workflowId = candidate.workflowId,
   )
 }
+
+private fun goalStep(
+  planningStep: IdeStatusPlanning?,
+  projectedStep: String?,
+  lifecycle: IdeStatusLifecycleState,
+): IdeStatusStep {
+  if (planningStep != null) return IdeStatusStep(id = "planning", label = "Planning")
+  val projected = projectedStep?.takeIf(String::isNotBlank)
+  if (projected != null) return IdeStatusStep(id = projected, label = projected)
+  return if (lifecycle == IdeStatusLifecycleState.TERMINAL) {
+    IdeStatusStep(id = "done", label = "Complete")
+  } else {
+    IdeStatusStep(id = "goal", label = "Goal")
+  }
+}
+
+private fun GoalPlanningStatusSnapshot.toIdeStatusPlanning(): IdeStatusPlanning = IdeStatusPlanning(
+  state = state,
+  sharedPreplanPrepared = sharedPreplanPrepared,
+  plannedSubtaskCount = plannedSubtaskCount,
+  totalSubtaskCount = totalSubtaskCount,
+  currentPlanningSubtaskId = currentPlanningSubtaskId?.toString(),
+  reason = reason,
+)
+
+private fun IdeStatusLifecycleState.isSettled(): Boolean = this == IdeStatusLifecycleState.BLOCKED ||
+  this == IdeStatusLifecycleState.FAILED ||
+  this == IdeStatusLifecycleState.TERMINAL
+
+private fun goalPlanningSummary(issueKey: String, planning: IdeStatusPlanning): String =
+  "Goal $issueKey is planning subtasks " +
+    "(${planning.plannedSubtaskCount}/${planning.totalSubtaskCount} planned)."
 
 private fun goalSummary(
   issueKey: String,

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/model/IdeStatusModelsTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/model/IdeStatusModelsTest.kt
@@ -1,0 +1,89 @@
+package skillbill.application.model
+
+import skillbill.goalrunner.model.GoalPlanningStatusState
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * SKILL-165 Subtask 1: the emitted `planning` block must stay byte-identical to the
+ * snake_case property names in orchestration/contracts/ide-status-schema.yaml.
+ */
+class IdeStatusModelsTest {
+  @Test
+  fun `toStatusWireMap emits planning with snake_case keys matching the schema`() {
+    val wire = snapshot(
+      IdeStatusPlanning(
+        state = GoalPlanningStatusState.PARTIALLY_PLANNED,
+        sharedPreplanPrepared = true,
+        plannedSubtaskCount = 2,
+        totalSubtaskCount = 5,
+        currentPlanningSubtaskId = "3",
+        reason = "Planning subtask 3.",
+      ),
+    ).toStatusWireMap()
+
+    val planning = wire["planning"] as Map<*, *>
+    assertEquals(
+      listOf(
+        "state",
+        "shared_preplan_prepared",
+        "planned_subtask_count",
+        "total_subtask_count",
+        "current_planning_subtask_id",
+        "reason",
+      ),
+      planning.keys.map { it as String },
+    )
+    assertEquals("partially_planned", planning["state"])
+    assertEquals(true, planning["shared_preplan_prepared"])
+    assertEquals(2, planning["planned_subtask_count"])
+    assertEquals(5, planning["total_subtask_count"])
+    assertEquals("3", planning["current_planning_subtask_id"])
+    assertEquals("Planning subtask 3.", planning["reason"])
+  }
+
+  @Test
+  fun `toStatusWireMap omits optional planning sub-keys when they are null`() {
+    val wire = snapshot(
+      IdeStatusPlanning(
+        state = GoalPlanningStatusState.NOT_STARTED,
+        sharedPreplanPrepared = false,
+        plannedSubtaskCount = 0,
+        totalSubtaskCount = 0,
+      ),
+    ).toStatusWireMap()
+
+    val planning = wire["planning"] as Map<*, *>
+    assertEquals(
+      listOf("state", "shared_preplan_prepared", "planned_subtask_count", "total_subtask_count"),
+      planning.keys.map { it as String },
+    )
+    assertFalse(planning.containsKey("current_planning_subtask_id"))
+    assertFalse(planning.containsKey("reason"))
+  }
+
+  @Test
+  fun `toStatusWireMap omits the planning key entirely when planning is null`() {
+    val wire = snapshot(planning = null).toStatusWireMap()
+
+    // A present-but-null entry would fail schema validation differently; assert true absence.
+    assertFalse(wire.containsKey("planning"))
+    assertTrue(wire.containsKey("current_step"))
+  }
+
+  private fun snapshot(planning: IdeStatusPlanning?): IdeStatusSnapshot = IdeStatusSnapshot(
+    repositoryIdentity = "repo-root-realpath-v1:/repo",
+    issueKey = "SKILL-165",
+    workflowId = "goal-1",
+    workflowFamily = IdeStatusWorkflowFamily.FEATURE_GOAL,
+    lifecycleState = IdeStatusLifecycleState.ACTIVE,
+    currentStep = IdeStatusStep(id = "planning", label = "Planning"),
+    planning = planning,
+    updatedAt = Instant.parse("2026-08-06T10:00:00Z"),
+    freshness = IdeStatusFreshness.FRESH,
+    summary = "Goal SKILL-165 is planning subtasks (2/5 planned).",
+  )
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
@@ -488,7 +488,7 @@ class IdeStatusServiceTest {
   @Test
   fun `blocked goal candidate stays blocked under paused and pause_requested controls`() {
     listOf(
-      GoalRunnerControlState(paused = true),
+      GoalRunnerControlState(paused = true, pauseReason = "operator_request"),
       GoalRunnerControlState(pauseRequested = true),
     ).forEachIndexed { index, controlState ->
       val fixture = gitRepoFixture("ide-status-goal-blocked-pause-$index")
@@ -511,7 +511,7 @@ class IdeStatusServiceTest {
   @Test
   fun `active goal candidate still projects paused under pause controls`() {
     listOf(
-      GoalRunnerControlState(paused = true),
+      GoalRunnerControlState(paused = true, pauseReason = "operator_request"),
       GoalRunnerControlState(pauseRequested = true),
     ).forEachIndexed { index, controlState ->
       val fixture = gitRepoFixture("ide-status-goal-active-pause-$index")
@@ -536,15 +536,14 @@ class IdeStatusServiceTest {
     workflows = IdeStatusWorkflowStates(),
   )
 
-  private fun planningSnapshot(state: GoalPlanningStatusState): GoalPlanningStatusSnapshot =
-    GoalPlanningStatusSnapshot(
-      state = state,
-      sharedPreplanPrepared = true,
-      plannedSubtaskCount = 1,
-      totalSubtaskCount = 2,
-      currentPlanningSubtaskId = 2,
-      reason = null,
-    )
+  private fun planningSnapshot(state: GoalPlanningStatusState): GoalPlanningStatusSnapshot = GoalPlanningStatusSnapshot(
+    state = state,
+    sharedPreplanPrepared = true,
+    plannedSubtaskCount = 1,
+    totalSubtaskCount = 2,
+    currentPlanningSubtaskId = 2,
+    reason = null,
+  )
 
   private fun goalManifestState(fixture: Path, identity: String, childWorkflowId: String): GoalRunnerManifestState =
     GoalRunnerManifestState(

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
@@ -13,6 +13,8 @@ import skillbill.application.model.IdeStatusLifecycleState
 import skillbill.application.model.IdeStatusProblemCode
 import skillbill.application.model.IdeStatusRequest
 import skillbill.application.model.IdeStatusWorkflowFamily
+import skillbill.goalrunner.model.GoalPlanningStatusSnapshot
+import skillbill.goalrunner.model.GoalPlanningStatusState
 import skillbill.goalrunner.model.GoalRunnerControlState
 import skillbill.goalrunner.model.GoalRunnerExecutionLease
 import skillbill.goalrunner.model.GoalRunnerStoredOutcome
@@ -62,6 +64,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 /**
@@ -399,6 +402,150 @@ class IdeStatusServiceTest {
     )
   }
 
+  @Test
+  fun `goal mid-planning projects the planning step label and a planning-progress summary`() {
+    val fixture = gitRepoFixture("ide-status-goal-planning")
+    val identity = goalRepositoryIdentity(fixture)
+    val service = service(
+      goalOnlyDatabase(),
+      manifestStore = StubGoalManifestStore(
+        goalManifestState(fixture, identity, childWorkflowId = "w-child"),
+        planning = planningSnapshot(GoalPlanningStatusState.PARTIALLY_PLANNED),
+      ),
+    )
+
+    val result = service.status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    // The manifest carries lastResumableStep=implement, so this also proves the planning
+    // override is ordered ahead of the projection currentStep preference.
+    assertEquals("planning", result.snapshot.currentStep.id)
+    assertEquals("Planning", result.snapshot.currentStep.label)
+    assertEquals("Goal SKILL-148 is planning subtasks (1/2 planned).", result.snapshot.summary)
+    assertEquals(GoalPlanningStatusState.PARTIALLY_PLANNED, result.snapshot.planning?.state)
+    assertEquals("2", result.snapshot.planning?.currentPlanningSubtaskId)
+  }
+
+  @Test
+  fun `goal with prepared planning keeps todays step and summary`() {
+    val fixture = gitRepoFixture("ide-status-goal-planning-prepared")
+    val identity = goalRepositoryIdentity(fixture)
+    val service = service(
+      goalOnlyDatabase(),
+      manifestStore = StubGoalManifestStore(
+        goalManifestState(fixture, identity, childWorkflowId = "w-child"),
+        planning = planningSnapshot(GoalPlanningStatusState.PREPARED),
+      ),
+    )
+
+    val result = service.status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    assertEquals("implement", result.snapshot.currentStep.id)
+    assertEquals("implement", result.snapshot.currentStep.label)
+    assertEquals("Goal SKILL-148 is active on implement.", result.snapshot.summary)
+    assertEquals(GoalPlanningStatusState.PREPARED, result.snapshot.planning?.state)
+  }
+
+  @Test
+  fun `goal with a null planning projection keeps todays step and summary and emits no planning`() {
+    val fixture = gitRepoFixture("ide-status-goal-planning-absent")
+    val identity = goalRepositoryIdentity(fixture)
+    val service = service(
+      goalOnlyDatabase(),
+      manifestStore = StubGoalManifestStore(
+        goalManifestState(fixture, identity, childWorkflowId = "w-child"),
+        planning = null,
+      ),
+    )
+
+    val result = service.status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    assertEquals("implement", result.snapshot.currentStep.id)
+    assertEquals("implement", result.snapshot.currentStep.label)
+    assertEquals("Goal SKILL-148 is active on implement.", result.snapshot.summary)
+    assertNull(result.snapshot.planning)
+    assertFalse(result.snapshot.toStatusWireMap().containsKey("planning"))
+  }
+
+  @Test
+  fun `non-goal families never carry planning`() {
+    val fixture = gitRepoFixture("ide-status-planning-non-goal")
+    val identity = goalRepositoryIdentity(fixture)
+    val workflows = IdeStatusWorkflowStates()
+    workflows.saveFeatureImplementWorkflow(proseRecord("w-active", "2026-08-06T10:00:00Z"))
+    workflows.saveFeatureTaskExecutionIdentity(identityFor("w-active", identity))
+    val database = TrackingDatabase(
+      work = listOf(workItem("w-active", WorkItemKind.FEATURE_TASK_PROSE, "running", "2026-08-06T10:00:00Z")),
+      workflows = workflows,
+    )
+
+    val result = service(database).status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    assertEquals(IdeStatusWorkflowFamily.FEATURE_TASK_PROSE, result.snapshot.workflowFamily)
+    assertNull(result.snapshot.planning)
+    assertFalse(result.snapshot.toStatusWireMap().containsKey("planning"))
+  }
+
+  @Test
+  fun `blocked goal candidate stays blocked under paused and pause_requested controls`() {
+    listOf(
+      GoalRunnerControlState(paused = true),
+      GoalRunnerControlState(pauseRequested = true),
+    ).forEachIndexed { index, controlState ->
+      val fixture = gitRepoFixture("ide-status-goal-blocked-pause-$index")
+      val identity = goalRepositoryIdentity(fixture)
+      val service = service(
+        goalOnlyDatabase(goalState = "blocked"),
+        manifestStore = StubGoalManifestStore(
+          goalManifestState(fixture, identity, childWorkflowId = "w-child")
+            .copy(controlState = controlState.copy(repositoryIdentity = identity)),
+        ),
+      )
+
+      val result = service.status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+      assertEquals(IdeStatusLifecycleState.BLOCKED, result.snapshot.lifecycleState)
+      assertEquals("Goal SKILL-148 is blocked.", result.snapshot.summary)
+    }
+  }
+
+  @Test
+  fun `active goal candidate still projects paused under pause controls`() {
+    listOf(
+      GoalRunnerControlState(paused = true),
+      GoalRunnerControlState(pauseRequested = true),
+    ).forEachIndexed { index, controlState ->
+      val fixture = gitRepoFixture("ide-status-goal-active-pause-$index")
+      val identity = goalRepositoryIdentity(fixture)
+      val service = service(
+        goalOnlyDatabase(),
+        manifestStore = StubGoalManifestStore(
+          goalManifestState(fixture, identity, childWorkflowId = "w-child")
+            .copy(controlState = controlState.copy(repositoryIdentity = identity)),
+        ),
+      )
+
+      val result = service.status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+      assertEquals(IdeStatusLifecycleState.PAUSED, result.snapshot.lifecycleState)
+      assertEquals("Goal SKILL-148 is paused.", result.snapshot.summary)
+    }
+  }
+
+  private fun goalOnlyDatabase(goalState: String = "running"): TrackingDatabase = TrackingDatabase(
+    work = listOf(workItem("goal-1", WorkItemKind.FEATURE_GOAL, goalState, "2026-08-06T10:00:00Z")),
+    workflows = IdeStatusWorkflowStates(),
+  )
+
+  private fun planningSnapshot(state: GoalPlanningStatusState): GoalPlanningStatusSnapshot =
+    GoalPlanningStatusSnapshot(
+      state = state,
+      sharedPreplanPrepared = true,
+      plannedSubtaskCount = 1,
+      totalSubtaskCount = 2,
+      currentPlanningSubtaskId = 2,
+      reason = null,
+    )
+
   private fun goalManifestState(fixture: Path, identity: String, childWorkflowId: String): GoalRunnerManifestState =
     GoalRunnerManifestState(
       parentWorkflowId = "goal-1",
@@ -674,9 +821,18 @@ private class IdeStatusWorkflowStates : WorkflowStateRepository {
 
 private class StubGoalManifestStore(
   private val state: GoalRunnerManifestState,
+  private val planning: GoalPlanningStatusSnapshot? = null,
 ) : GoalRunnerManifestStore {
   override fun loadByIssueKey(issueKey: String, dbPathOverride: String?, repoRoot: Path?): GoalRunnerManifestState? =
     state.takeIf { it.manifest.issueKey.equals(issueKey, ignoreCase = true) }
+
+  override fun planningStatus(
+    parentWorkflowId: String,
+    orderedSubtaskIds: List<Int>,
+    blockedSubtaskId: Int?,
+    blockedReason: String?,
+    dbPathOverride: String?,
+  ): GoalPlanningStatusSnapshot? = planning
 
   override fun save(state: GoalRunnerManifestState, dbPathOverride: String?): GoalRunnerManifestState = state
 

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliWorkStatusTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliWorkStatusTest.kt
@@ -1,12 +1,21 @@
 package skillbill.cli
 
+import skillbill.application.model.IdeStatusFreshness
+import skillbill.application.model.IdeStatusLifecycleState
+import skillbill.application.model.IdeStatusPlanning
+import skillbill.application.model.IdeStatusProgress
+import skillbill.application.model.IdeStatusSnapshot
+import skillbill.application.model.IdeStatusStep
+import skillbill.application.model.IdeStatusWorkflowFamily
 import skillbill.cli.core.CliRuntime
 import skillbill.cli.model.CliRuntimeContext
 import skillbill.contracts.JsonSupport
 import skillbill.contracts.workflow.IdeStatusSchemaValidator
 import skillbill.db.core.DatabaseRuntime
+import skillbill.goalrunner.model.GoalPlanningStatusState
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -89,6 +98,37 @@ class CliWorkStatusTest {
 
     assertEquals(0, result.exitCode, result.stdout)
     assertTrue(before.contentEquals(Files.readAllBytes(dbPath)))
+  }
+
+  /**
+   * SKILL-165 Subtask 1: the CLI work-status fixture harness has no goal work item, so the
+   * end-to-end obligation is met at the emit-shape seam — the same `toStatusWireMap()` the CLI
+   * prints, validated by the same canonical schema validator the CLI runs.
+   */
+  @Test
+  fun `mid-planning goal emit shape validates against the canonical schema`() {
+    val snapshot = IdeStatusSnapshot(
+      repositoryIdentity = "repo-root-realpath-v1:/repo",
+      issueKey = "SKILL-165",
+      workflowId = "goal-1",
+      workflowFamily = IdeStatusWorkflowFamily.FEATURE_GOAL,
+      lifecycleState = IdeStatusLifecycleState.ACTIVE,
+      currentStep = IdeStatusStep(id = "planning", label = "Planning"),
+      progress = IdeStatusProgress(completed = 0, total = 5),
+      planning = IdeStatusPlanning(
+        state = GoalPlanningStatusState.PARTIALLY_PLANNED,
+        sharedPreplanPrepared = true,
+        plannedSubtaskCount = 2,
+        totalSubtaskCount = 5,
+        currentPlanningSubtaskId = "3",
+        reason = "Planning subtask 3.",
+      ),
+      updatedAt = Instant.parse("2026-08-06T10:00:00Z"),
+      freshness = IdeStatusFreshness.FRESH,
+      summary = "Goal SKILL-165 is planning subtasks (2/5 planned).",
+    )
+
+    IdeStatusSchemaValidator.validate(snapshot.toStatusWireMap(), "cli-goal-planning")
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusGoldenFixturesTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusGoldenFixturesTest.kt
@@ -93,6 +93,36 @@ class IdeStatusGoldenFixturesTest {
   }
 
   @Test
+  fun `feature-goal mid-planning golden validates`() {
+    IdeStatusSchemaValidator.validate(
+      linkedMapOf(
+        "contract_version" to IDE_STATUS_CONTRACT_VERSION,
+        "repository_identity" to "repo-root-realpath-v1:/repo",
+        "issue_key" to "SKILL-165",
+        "workflow_id" to "goal-2",
+        "workflow_family" to "feature-goal",
+        "lifecycle_state" to "active",
+        "current_step" to linkedMapOf("id" to "planning", "label" to "Planning"),
+        "progress" to linkedMapOf("completed" to 0, "total" to 5),
+        "started_at" to "2026-08-06T08:00:00Z",
+        // Both required and optional planning properties in one fixture.
+        "planning" to linkedMapOf(
+          "state" to "partially_planned",
+          "shared_preplan_prepared" to true,
+          "planned_subtask_count" to 2,
+          "total_subtask_count" to 5,
+          "current_planning_subtask_id" to "3",
+          "reason" to "Planning subtask 3.",
+        ),
+        "updated_at" to "2026-08-06T10:00:00Z",
+        "freshness" to "fresh",
+        "summary" to "Goal SKILL-165 is planning subtasks (2/5 planned).",
+      ),
+      "golden-goal-planning",
+    )
+  }
+
+  @Test
   fun `typed problem goldens validate`() {
     listOf(
       "missing_repository_identity",

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaContractVersionTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaContractVersionTest.kt
@@ -21,6 +21,17 @@ class IdeStatusSchemaContractVersionTest {
   }
 
   @Test
+  fun `additive planning property did not bump the contract version`() {
+    val schema = classpathSchema()
+    assertEquals("0.1", schema.path("properties").path("contract_version").path("const").asText())
+    assertEquals("0.1", IDE_STATUS_CONTRACT_VERSION)
+    assertTrue(
+      !schema.path("properties").path("planning").isMissingNode,
+      "planning must be present in the schema this parity test pins.",
+    )
+  }
+
+  @Test
   fun `schema id matches IdeStatusSchemaPaths EXPECTED_SCHEMA_ID`() {
     val schema = classpathSchema()
     assertEquals(IdeStatusSchemaPaths.EXPECTED_SCHEMA_ID, schema.path("\$id").asText())

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaValidatorTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaValidatorTest.kt
@@ -80,6 +80,133 @@ class IdeStatusSchemaValidatorTest {
     }
   }
 
+  @Test
+  fun `goal snapshot with a fully populated planning object passes`() {
+    IdeStatusSchemaValidator.validate(
+      goalSnapshotWithPlanning(
+        linkedMapOf(
+          "state" to "partially_planned",
+          "shared_preplan_prepared" to true,
+          "planned_subtask_count" to 2,
+          "total_subtask_count" to 5,
+          "current_planning_subtask_id" to "3",
+          "reason" to "Planning subtask 3.",
+        ),
+      ),
+      "test-planning-valid",
+    )
+  }
+
+  @Test
+  fun `goal snapshot with only required planning properties passes`() {
+    IdeStatusSchemaValidator.validate(
+      goalSnapshotWithPlanning(
+        linkedMapOf(
+          "state" to "not_started",
+          "shared_preplan_prepared" to false,
+          "planned_subtask_count" to 0,
+          "total_subtask_count" to 0,
+        ),
+      ),
+      "test-planning-minimal",
+    )
+  }
+
+  @Test
+  fun `unknown planning property fails loudly with typed error`() {
+    assertFailsWith<InvalidIdeStatusSchemaError> {
+      IdeStatusSchemaValidator.validate(
+        goalSnapshotWithPlanning(
+          linkedMapOf(
+            "state" to "preplanned",
+            "shared_preplan_prepared" to true,
+            "planned_subtask_count" to 1,
+            "total_subtask_count" to 4,
+            "planning_notes" to "nope",
+          ),
+        ),
+        "test-planning-unknown-property",
+      )
+    }
+  }
+
+  @Test
+  fun `negative planning counts fail loudly with typed error`() {
+    assertFailsWith<InvalidIdeStatusSchemaError> {
+      IdeStatusSchemaValidator.validate(
+        goalSnapshotWithPlanning(
+          linkedMapOf(
+            "state" to "preplanned",
+            "shared_preplan_prepared" to true,
+            "planned_subtask_count" to -1,
+            "total_subtask_count" to 4,
+          ),
+        ),
+        "test-planning-negative-planned",
+      )
+    }
+    assertFailsWith<InvalidIdeStatusSchemaError> {
+      IdeStatusSchemaValidator.validate(
+        goalSnapshotWithPlanning(
+          linkedMapOf(
+            "state" to "preplanned",
+            "shared_preplan_prepared" to true,
+            "planned_subtask_count" to 1,
+            "total_subtask_count" to -4,
+          ),
+        ),
+        "test-planning-negative-total",
+      )
+    }
+  }
+
+  @Test
+  fun `invalid planning state fails loudly with typed error`() {
+    assertFailsWith<InvalidIdeStatusSchemaError> {
+      IdeStatusSchemaValidator.validate(
+        goalSnapshotWithPlanning(
+          linkedMapOf(
+            "state" to "half_planned",
+            "shared_preplan_prepared" to true,
+            "planned_subtask_count" to 1,
+            "total_subtask_count" to 4,
+          ),
+        ),
+        "test-planning-bad-state",
+      )
+    }
+  }
+
+  @Test
+  fun `planning object missing a required property fails loudly with typed error`() {
+    assertFailsWith<InvalidIdeStatusSchemaError> {
+      IdeStatusSchemaValidator.validate(
+        goalSnapshotWithPlanning(
+          linkedMapOf(
+            "state" to "preplanned",
+            "planned_subtask_count" to 1,
+            "total_subtask_count" to 4,
+          ),
+        ),
+        "test-planning-missing-required",
+      )
+    }
+  }
+
+  private fun goalSnapshotWithPlanning(planning: Map<String, Any?>): LinkedHashMap<String, Any?> = linkedMapOf(
+    "contract_version" to IDE_STATUS_CONTRACT_VERSION,
+    "repository_identity" to "repo-root-realpath-v1:/repo",
+    "issue_key" to "SKILL-165",
+    "workflow_id" to "goal-1",
+    "workflow_family" to "feature-goal",
+    "lifecycle_state" to "active",
+    "current_step" to linkedMapOf("id" to "planning", "label" to "Planning"),
+    "planning" to planning,
+    "updated_at" to "2026-08-06T10:10:00Z",
+    "freshness" to "fresh",
+    "summary" to "Goal SKILL-165 is planning subtasks (2/5 planned).",
+  )
+
   private fun validIdleSnapshot(): LinkedHashMap<String, Any?> = linkedMapOf(
     "contract_version" to IDE_STATUS_CONTRACT_VERSION,
     "repository_identity" to "repo-root-realpath-v1:/repo",


### PR DESCRIPTION
Goal: ide-status-planning-progress

Subtasks:
- 1. Emit goal planning status on the IDE status wire (fdc8f2fb1224d916ceb86c7049d93943616d7681)
- 2. Render planning progress in the IntelliJ status widget (1e0f7d41325cf9d5dd5d8d24a6513f9ce17a3cf4)
