### PR TITLE
SKILL-169: correct over-length fields instead of burning the fix loop

### DIFF
--- a/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/decomposition-manifest.yaml
@@ -1,0 +1,38 @@
+---
+contract_version: "0.5"
+issue_key: "SKILL-170"
+feature_name: "cli-telemetry-outbox-drain"
+parent_spec_path: ".feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec.md"
+execution_model: "same_branch_commit_per_subtask"
+base_branch: "main"
+feature_branch: "feat/SKILL-170-cli-telemetry-outbox-drain"
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: "none"
+subtasks:
+- id: 1
+  name: "CLI runtime drains its own telemetry outbox"
+  spec_path: ".feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec_subtask_1_cli-runtime-outbox-drain.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: null
+  blocked_reason: null
+  last_resumable_step: null
+  linear_issue_id: null
+  dependencies: []
+- id: 2
+  name: "Local outbox visibility and recorded cause"
+  spec_path: ".feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec_subtask_2_outbox-visibility-and-cause-record.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: null
+  blocked_reason: null
+  last_resumable_step: null
+  linear_issue_id: null
+  dependencies:
+  - subtask_id: 1
+    optional: true
+    skipped: false

--- a/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec.md
+++ b/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec.md
@@ -1,0 +1,109 @@
+# SKILL-170 — CLI telemetry outbox never drains
+
+## Intended Outcome
+
+Telemetry queued by a CLI-driven runtime run must actually reach the proxy, and an install
+that is queuing-but-not-sending must be diagnosable locally without querying PostHog.
+
+Today neither holds. Every telemetry row in the project's PostHog traces to a single
+`install_id`, so the telemetry loop — described in the project's own positioning as the
+compounding moat — is running at N=1 against its author's dev machine. No user install is
+transmitting.
+
+## Evidence
+
+**Fleet-wide non-transmission (confirmed, 2026-08-08).** Over the trailing 21 days the
+`skillbill_feature_task_runtime_projection_measurement` event carries 10,690 rows across 148
+distinct `workflow_id` values and exactly **one** distinct `install_id`:
+
+```sql
+SELECT countDistinct(properties.install_id), countDistinct(properties.workflow_id)
+FROM events
+WHERE event = 'skillbill_feature_task_runtime_projection_measurement'
+  AND timestamp > now() - INTERVAL 21 DAY
+→ installs: 1    workflows: 148
+```
+
+Repository paths inside the payloads identify that install as the maintainer's machine. A
+user-reported blocker on workflow `wftr-20260807-123754-11fb` returned zero rows for every
+event type, while workflows immediately before (`12:12:38`) and after (`12:46:20`) that
+timestamp are present — the absent workflow belongs to a non-transmitting install, not to a
+gap in the event stream.
+
+**The drain is only wired into the MCP server (confirmed).** `TelemetryService.autoSync`
+(`runtime-application/.../telemetry/TelemetryService.kt:64`) has exactly three callers, all in
+`runtime-mcp/.../core/McpRuntime.kt` (lines 93, 126, 220). A grep for `telemetryService` across
+`runtime-cli/src/main/kotlin` returns nothing. The CLI ships a manual
+`skill-bill telemetry sync` command (`TelemetryCliCommands.kt:57`), but nothing invokes a drain
+automatically on a CLI path.
+
+The consequence: a user who runs `skill-bill goal` / the feature-task runtime without also
+running the MCP server enqueues telemetry into a local SQLite outbox that is never flushed.
+Events are written and retained; they simply never leave the machine.
+
+**Ruled out.** A blank `proxy_url` in `defaultLocalTelemetryConfig`
+(`TelemetryConfigRules.kt:12`) is *not* the cause — `runtime-kotlin/agent/history.md:2256`
+records that blank correctly resolves to the hosted relay. The default level is `anonymous`,
+not `off` (`TelemetryConfigRules.kt:11`), so the default config is opted in.
+
+**Not yet confirmed.** Whether the missing CLI drain is the *sole* cause. Users may also be
+setting `level: off`, or never completing an install that enables telemetry. Nothing today
+distinguishes "queued and stuck" from "never queued" from outside the machine, which is why
+this was invisible until a PostHog cardinality check surfaced it.
+
+## Scope
+
+Two independent halves:
+
+- **Drain.** A CLI runtime run flushes its own outbox, on the same guarded path the MCP
+  server already uses, so queued events leave the machine without the operator running a
+  manual command.
+- **Observability.** `skill-bill telemetry status` reports pending outbox depth and last
+  successful sync, so a stuck outbox is a local, one-command diagnosis rather than an
+  inference from missing rows in a remote analytics project.
+
+## Acceptance Criteria
+
+1. A CLI-driven feature-task-runtime or goal run flushes pending telemetry through the same
+   guarded drain path the MCP server uses, without the operator invoking
+   `skill-bill telemetry sync` manually.
+2. The drain never fails, delays, or alters a runtime run: a sync error, an unreachable
+   proxy, or an absent database leaves the run's outcome and exit code unchanged.
+3. The drain respects the resolved telemetry level: an install at `level: off` transmits
+   nothing, and the level-independent measurement events keep their existing behaviour.
+4. `skill-bill telemetry status` reports the pending outbox event count and the last
+   successful sync timestamp, so a queued-but-unsent install is diagnosable locally.
+5. A regression test proves a CLI runtime completion drains a non-empty outbox, and would
+   fail against the current code where no CLI path calls a drain.
+6. The confirmed root cause and whatever the investigation finds about remaining causes are
+   recorded in the runtime boundary history, including any cause the drain gap does *not*
+   explain.
+
+## Constraints
+
+- Telemetry must never fail the run. Every existing emission seam swallows its own errors
+  (`FeatureTaskRuntimePhaseRecorder.recordSharedEvidenceMeasurement` is the local pattern);
+  the drain must hold the same property at a coarser granularity.
+- Do not widen what is transmitted. This feature changes *when* the outbox flushes and what
+  the operator can see locally — not the event set, the payload fields, or the privacy level
+  semantics.
+- Reuse `TelemetryService.autoSync` and `TelemetrySyncRuntime.autoSyncTelemetry` rather than
+  authoring a second sync path. Note that `autoSync` reaches the reconciler with the default
+  cadence while manual sync passes `cadenceSeconds = 0` (`TelemetryService.kt:51,67`); keep
+  that distinction rather than collapsing it.
+- No new network calls on a read-only or status-only command path.
+
+## Non-Goals
+
+- Changing the default telemetry level, the consent flow, or install-time opt-in copy.
+- Adding retry, backoff, or a background daemon for failed syncs.
+- Backfilling telemetry already queued on user machines.
+- Fixing the PostHog-side schema or dashboards.
+- The `bill-feature-verify` proxy `workflow` argument defect found alongside this
+  (every enum value resolves to `feature-task-prose`) — separate issue, separate key.
+
+## Validation Strategy
+
+`cd runtime-kotlin && ./gradlew check` is the gate. Note that `check` may already be red on
+`main` for reasons unrelated to this work; establish the baseline before attributing a
+failure to this change.

--- a/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec_subtask_1_cli-runtime-outbox-drain.md
+++ b/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec_subtask_1_cli-runtime-outbox-drain.md
@@ -1,0 +1,66 @@
+# SKILL-170 — Subtask 1: CLI runtime drains its own telemetry outbox
+
+## Scope
+
+Wire the existing guarded drain into the CLI runtime paths, so a run that completes without
+an MCP server present still flushes what it queued.
+
+`TelemetryService.autoSync` (`runtime-application/.../telemetry/TelemetryService.kt:64`) is
+already the correct entry point: it resolves settings, returns early when telemetry is
+disabled or the database is absent, reconciles stale sessions, and delegates to
+`TelemetrySyncRuntime.autoSyncTelemetry`. Its only callers today are
+`runtime-mcp/.../core/McpRuntime.kt:93,126,220`.
+
+The work is to give the CLI an equivalent call site at runtime-completion boundaries, and to
+guarantee it cannot affect the run.
+
+In scope:
+
+- Identify the CLI completion boundaries that should drain (the feature-task-runtime run and
+  the goal run at minimum) and call the existing `autoSync` there.
+- Guarantee failure isolation: wrap so that a throwing or slow sync cannot change the run's
+  outcome, exit code, or stdout contract.
+- A regression test that fails against current code.
+
+Out of scope: any change to what is emitted, to sync internals, or to the reconciler cadence.
+
+## Acceptance Criteria
+
+1. A CLI-driven feature-task-runtime run and a CLI-driven goal run each invoke the existing
+   guarded drain at completion, without the operator running `skill-bill telemetry sync`.
+2. The drain reuses `TelemetryService.autoSync`; no second sync path, settings resolution, or
+   outbox query is introduced.
+3. A drain that throws, or whose proxy is unreachable, leaves the run's reported outcome and
+   process exit code byte-for-byte unchanged, and emits nothing to stdout.
+4. An install whose resolved telemetry level is `off` transmits nothing on the new path.
+5. A regression test drives a CLI runtime completion with a non-empty outbox and asserts the
+   outbox drained; the same test fails when the new call site is removed.
+6. A test asserts the failure-isolation property directly by making the sync path throw and
+   asserting the run outcome is unaffected.
+
+## Non-Goals
+
+- Retry, backoff, or scheduling for a failed sync.
+- Draining on non-runtime CLI commands (status, config, review) — completion boundaries only.
+- Changing `autoSync`'s reconciler cadence, or collapsing it into the manual-sync
+  `cadenceSeconds = 0` path.
+- Altering the emitted event set or payloads.
+
+## Dependency Notes
+
+None. This subtask is independent of subtask 2 and can land alone; it is the half that
+actually restores transmission.
+
+## Validation Strategy
+
+`cd runtime-kotlin && ./gradlew check`.
+
+Beyond the gate, verify the mechanism rather than only the unit test: run a CLI runtime
+against a scratch state dir with telemetry enabled and a deliberately unreachable proxy
+URL, confirm the run completes normally, then confirm the outbox still holds its rows.
+Repeat against a reachable target and confirm the rows leave.
+
+## Next Path
+
+Subtask 2 (`telemetry status` outbox visibility), or land alone if transmission is the only
+thing needed now.

--- a/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec_subtask_2_outbox-visibility-and-cause-record.md
+++ b/.feature-specs/SKILL-170-cli-telemetry-outbox-drain/spec_subtask_2_outbox-visibility-and-cause-record.md
@@ -1,0 +1,59 @@
+# SKILL-170 — Subtask 2: local outbox visibility and recorded cause
+
+## Scope
+
+Make "queued but never sent" diagnosable on the machine it happens on, and record what the
+investigation concluded.
+
+The reason this went unnoticed for the life of the project is that non-transmission has no
+local symptom: events are written successfully, the run reports nothing wrong, and the only
+evidence is an absence of rows in a remote analytics project that few people query. A
+one-command local read closes that gap.
+
+In scope:
+
+- `skill-bill telemetry status` reports pending outbox event count and last successful sync
+  timestamp alongside the fields it already prints.
+- Record in the runtime boundary history what was confirmed (the MCP-only drain wiring) and
+  what the drain gap does **not** explain, if anything remains after subtask 1 lands.
+
+`TelemetrySyncRuntime` already computes `pendingEvents` and `latestError` when building a
+sync result (`TelemetrySyncRuntime.kt:50-54`); prefer surfacing those existing values over
+introducing a parallel query.
+
+## Acceptance Criteria
+
+1. `skill-bill telemetry status` reports the pending outbox event count.
+2. `skill-bill telemetry status` reports the last successful sync timestamp, and distinguishes
+   "never synced" from "synced but the outbox is non-empty".
+3. `telemetry status` performs no network call — it remains a local read.
+4. The status surface reports these fields for every resolved telemetry level, including
+   `off`, so an operator can see that events are queued and deliberately not being sent.
+5. The runtime boundary history records the confirmed root cause, the PostHog cardinality
+   evidence that surfaced it, and any residual cause the drain gap does not account for.
+
+## Non-Goals
+
+- A new dashboard, daemon, or periodic reporter.
+- Alerting or nagging the operator about a non-empty outbox.
+- Changing the status command's existing field names or output contract beyond additions.
+- Backfilling or re-sending telemetry already stranded on user machines.
+
+## Dependency Notes
+
+Optional dependency on subtask 1. It reads more usefully after the drain exists (a non-empty
+outbox then means something is genuinely wrong rather than being the normal steady state),
+but it does not require subtask 1 to land first and can be executed independently.
+
+## Validation Strategy
+
+`cd runtime-kotlin && ./gradlew check`.
+
+Additionally exercise the command against three states — empty outbox, non-empty outbox with
+a prior successful sync, and non-empty outbox never synced — and confirm each renders
+distinguishably.
+
+## Next Path
+
+Feature complete. If residual non-transmission remains after subtask 1, the history record
+written here is the input to whatever issue follows.

--- a/runtime-kotlin/ARCHITECTURE.md
+++ b/runtime-kotlin/ARCHITECTURE.md
@@ -431,6 +431,7 @@ runtime-ports
     - `skillbill.workflow.taskruntime.model.PhaseHandoffProjectionDeclaration.fromArtifactMap`
     - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionMeasurement.toTelemetryMap`
     - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeSharedEvidenceMeasurement.toTelemetryMap`
+    - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionMeasurement.toTelemetryMap`
     - `skillbill.workflow.FeatureTaskRuntimeQuarantineValidator.validateQuarantineRecord`
     - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry.toArtifactMap`
     - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry.fromArtifactMap`
@@ -1214,6 +1215,7 @@ Categories:
 - `skillbill.workflow.taskruntime.model.PhaseHandoffProjectionDeclaration.fromArtifactMap`
 - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionMeasurement.toTelemetryMap`
 - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeSharedEvidenceMeasurement.toTelemetryMap`
+- `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionMeasurement.toTelemetryMap`
 - `skillbill.workflow.FeatureTaskRuntimeQuarantineValidator.validateQuarantineRecord`
 - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry.toArtifactMap`
 - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry.fromArtifactMap`

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptComposer.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptComposer.kt
@@ -16,7 +16,6 @@ import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeFeatureSize
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffProjectionBudget
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeOperatorBlockRetry
 import skillbill.workflow.taskruntime.model.GoalSubtaskCommitFocusedAccounting
-import skillbill.workflow.taskruntime.model.MAX_AUDIT_REPAIR_REF_LENGTH
 
 /**
  * Pure composer of the full prompt a feature-task-runtime phase agent receives. The persisted
@@ -172,54 +171,8 @@ object FeatureTaskRuntimePhasePromptComposer {
     }
     return base + remediationCorrection +
       unparseableRootCorrection(briefing, priorSchemaFailure) +
-      boundedReferenceCorrection(priorSchemaFailure) +
-      unreconciledReceiptCorrection(priorSchemaFailure)
-  }
-
-  // The receipt's `reconciled` is `const: true`, so a producer that reports 'completed' while asserting
-  // `reconciled: false` is not describing a repairable field error — it is describing work it did not
-  // finish, and no edit to that field makes the claim true. This names the envelope that carries
-  // unfinished work instead; what happens after that envelope is not this directive's business.
-  private fun unreconciledReceiptCorrection(priorSchemaFailure: String): String {
-    val namesReconciled = priorSchemaFailure.contains("reconciliation_evidence.reconciled") ||
-      priorSchemaFailure.contains("reconciliation_evidence/reconciled")
-    if (!namesReconciled || !priorSchemaFailure.contains("must be the constant value")) {
-      return ""
-    }
-    return """
-
-      A 'completed' implementation_receipt asserts a reconciled working tree: reconciliation_evidence.reconciled
-      must be true, and 'completed' is the only status that may carry this receipt. Do not report 'completed'
-      with reconciled false, and do not flip the flag to true unless the tree really is at target. If the work
-      is genuinely incomplete, leave this phase through a 'blocked' or 'failed' envelope instead.
-    """.trimIndent()
-  }
-
-  private fun boundedReferenceCorrection(priorSchemaFailure: String): String {
-    val field = when {
-      priorSchemaFailure.contains("artifact_ref") -> "artifact_ref"
-      priorSchemaFailure.contains("check_ref") -> "check_ref"
-      else -> return ""
-    }
-    val reportsLengthViolation = priorSchemaFailure.contains("must be at most") ||
-      priorSchemaFailure.contains("allows at most") ||
-      priorSchemaFailure.contains("maxLength")
-    if (!reportsLengthViolation) {
-      return ""
-    }
-    val replacement = if (field == "artifact_ref") {
-      "one repository-relative path, optionally followed by one :symbol, such as " +
-        "runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt"
-    } else {
-      "one acceptance-criterion, finding, test, or check identifier, such as AC-005 or McpStdioServerTest"
-    }
-    return """
-
-      The rejected $field is a bounded pointer, not an evidence container. Replace it with $replacement.
-      It MUST be at most $MAX_AUDIT_REPAIR_REF_LENGTH characters. Do not concatenate multiple paths,
-      symbols, findings, commands, or explanations into this field. Put necessary detail in the issue,
-      fix, or other schema-authorized descriptive fields.
-    """.trimIndent()
+      FeatureTaskRuntimeSchemaFailureCorrections.lengthViolation(priorSchemaFailure) +
+      FeatureTaskRuntimeSchemaFailureCorrections.unreconciledReceipt(priorSchemaFailure)
   }
 
   // The `<root> must be an object` / malformed-output failures mean the runtime could not extract ANY

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptDirectives.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptDirectives.kt
@@ -257,7 +257,10 @@ internal val phaseDirectives: Map<String, String> = mapOf(
     "\"$FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION\": completed_task_ids, " +
     "normalized changed_paths, " +
     "tests_added, tests_updated, deviations, unresolved_items, " +
-    "reconciliation_evidence, and the repository_checkpoint the audit will verify against). When the " +
+    "reconciliation_evidence, and the repository_checkpoint the audit will verify against). Every " +
+    "receipt field is a bounded summary, not a transcript: a segment that applied no edits reports that " +
+    "it applied none, names what already satisfied the work, and stops — the audit re-reads the tree " +
+    "itself, so proving convergence path by path here only risks overflowing the field. When the " +
     "briefing carries audit_gaps, reuse its immutable initial preplan and plan outputs and change " +
     "only what the latest listed gaps require; do not regenerate planning, expand scope, or disturb " +
     "settled implementation. Under the audit-gap loop, report repair_item_results for every carried " +

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -68,6 +68,7 @@ import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionFailureC
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionKind
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionMeasurement
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionMeasurement
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRepairItemResult
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeResolvedBranch
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeSharedEvidenceMeasurement
@@ -89,6 +90,8 @@ import skillbill.workflow.taskruntime.model.featureTaskRuntimeImplementationAtte
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeOwnedPathDigest
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineEntriesFromWire
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineRecordToWire
+import skillbill.workflow.taskruntime.model.featureTaskRuntimeRejectionCapOf
+import skillbill.workflow.taskruntime.model.featureTaskRuntimeRejectionViolationClassOf
 import java.time.Duration
 import java.time.Instant
 
@@ -144,6 +147,35 @@ class FeatureTaskRuntimePhaseRecorder(
       ),
     )
     service.record(request)
+    recordRejectionMeasurement(unitOfWork, request)
+  }
+
+  /**
+   * Counts the rejection itself. The projection measurement seam records only projections that PASSED,
+   * so an attempt rejected by the schema gate — and therefore a fix loop about to exhaust — leaves no
+   * trace outside the operator's block reason and the private diagnostic row. This is the one event that
+   * makes the failure class countable.
+   *
+   * Payload-free by construction: the pointer and the classification are derived from the validator's
+   * own constraint text, never from the rejected response. Telemetry must never fail the run, so a
+   * malformed reason degrades to an unclassified row rather than throwing.
+   */
+  private fun recordRejectionMeasurement(unitOfWork: UnitOfWork, request: RejectedOutputDiagnosticRequest) {
+    try {
+      unitOfWork.lifecycleTelemetry.featureTaskRuntimeRejection(
+        FeatureTaskRuntimeRejectionMeasurement(
+          workflowId = request.workflowId,
+          phaseId = request.phaseId,
+          iteration = request.attempt.coerceAtLeast(1),
+          rule = request.rule,
+          pointerPath = request.path.ifBlank { "/" },
+          violationClass = featureTaskRuntimeRejectionViolationClassOf(request.reason),
+          declaredCap = featureTaskRuntimeRejectionCapOf(request.reason),
+        ),
+      )
+    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+      // Telemetry must never fail the run or change the rejection outcome.
+    }
   }
 
   fun retainProducerOutput(evidence: ProducerOutputEvidence, dbOverride: String? = null) =

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSchemaFailureCorrections.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSchemaFailureCorrections.kt
@@ -1,0 +1,123 @@
+package skillbill.application.featuretask
+
+import skillbill.workflow.taskruntime.model.MAX_AUDIT_REPAIR_REF_LENGTH
+
+/**
+ * The retry corrections derivable from the validator's reason alone.
+ *
+ * These are separated from [FeatureTaskRuntimePhasePromptComposer] because they need nothing from the
+ * briefing: each is a pure function of the rejection text, which is also what makes them directly
+ * testable. The corrections that DO need briefing context — the fill-in skeleton, the audit-remediation
+ * item list — stay with the composer that owns that context.
+ */
+internal object FeatureTaskRuntimeSchemaFailureCorrections {
+  // The receipt's `reconciled` is `const: true`, so a producer that reports 'completed' while asserting
+  // `reconciled: false` is not describing a repairable field error — it is describing work it did not
+  // finish, and no edit to that field makes the claim true. This names the envelope that carries
+  // unfinished work instead; what happens after that envelope is not this directive's business.
+  fun unreconciledReceipt(priorSchemaFailure: String): String {
+    val namesReconciled = priorSchemaFailure.contains("reconciliation_evidence.reconciled") ||
+      priorSchemaFailure.contains("reconciliation_evidence/reconciled")
+    if (!namesReconciled || !priorSchemaFailure.contains("must be the constant value")) {
+      return ""
+    }
+    return """
+
+      A 'completed' implementation_receipt asserts a reconciled working tree: reconciliation_evidence.reconciled
+      must be true, and 'completed' is the only status that may carry this receipt. Do not report 'completed'
+      with reconciled false, and do not flip the flag to true unless the tree really is at target. If the work
+      is genuinely incomplete, leave this phase through a 'blocked' or 'failed' envelope instead.
+    """.trimIndent()
+  }
+
+  // Every bounded wire field can overflow, not just the two pointer fields. Echoing the validator reason
+  // alone is enough for a *missing* field — the reason names it and the agent adds it — but not for an
+  // over-length one: the agent already knows which field, and what it does not infer is that it must stop
+  // explaining and start compressing. Left uncorrected it re-argues the same case at the same length until
+  // the bounded fix loop exhausts, which is exactly how an over-long `reconciliation_evidence.evidence`
+  // burned three identical implement attempts while an over-long `artifact_ref` recovered on its next one.
+  // So the length branch is decided by the violation, and the field only selects which advice follows.
+  fun lengthViolation(priorSchemaFailure: String): String {
+    val cap = statedCap(priorSchemaFailure) ?: return ""
+    // The two pointer fields are matched by name rather than by position: their advice is about what the
+    // field is for, so it holds wherever in the message they are named, including the audit-repair
+    // rejections that report them through a bare dotted path with no pointer prefix at all.
+    return when {
+      priorSchemaFailure.contains("artifact_ref") -> boundedPointerAdvice("artifact_ref", cap)
+      priorSchemaFailure.contains("check_ref") -> boundedPointerAdvice("check_ref", cap)
+      else -> compressionAdvice(offendingFieldName(priorSchemaFailure), cap)
+    }
+  }
+
+  // The validator renders caps with digit grouping past a thousand ("4,096"), so the separator is part of
+  // the number, not a delimiter after it. Reading the cap from the message rather than from a constant is
+  // what lets one branch serve fields bounded at 128, 256, 1024, and 4096 alike. A `maxLength` mention with
+  // no readable number still counts as a length violation; the advice then simply omits the figure.
+  private fun statedCap(priorSchemaFailure: String): Int? {
+    val stated = LENGTH_VIOLATION_PATTERN.find(priorSchemaFailure)?.groupValues?.get(1)
+    if (stated != null) {
+      return stated.replace(",", "").toIntOrNull() ?: UNSTATED_CAP
+    }
+    return if (priorSchemaFailure.contains("maxLength")) UNSTATED_CAP else null
+  }
+
+  // Mirrors the two pointer shapes `rejectionPath` already parses on the run-loop side — `$.a.b[0].c` and
+  // `at '/a/b'` — plus the bare dotted path the domain-side constructors report (`deviations[0].note:`),
+  // which carries no prefix to anchor on and so is found by the violation clause that follows it. The last
+  // named segment is the offending field; array indices are positions within it, not the field itself.
+  private fun offendingFieldName(priorSchemaFailure: String): String? {
+    val pointer = DOLLAR_POINTER_PATTERN.find(priorSchemaFailure)?.value?.removePrefix("$")
+      ?: SLASH_POINTER_PATTERN.find(priorSchemaFailure)?.groupValues?.get(1)
+      ?: BARE_PATH_PATTERN.find(priorSchemaFailure)?.groupValues?.get(1)
+      ?: return null
+    return pointer.split('.', '/')
+      .map { it.substringBefore('[') }
+      .lastOrNull { it.isNotBlank() }
+  }
+
+  private fun boundedPointerAdvice(field: String, cap: Int): String {
+    val replacement = if (field == "artifact_ref") {
+      "one repository-relative path, optionally followed by one :symbol, such as " +
+        "runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpStdioServerTest.kt"
+    } else {
+      "one acceptance-criterion, finding, test, or check identifier, such as AC-005 or McpStdioServerTest"
+    }
+    val statedCap = if (cap == UNSTATED_CAP) MAX_AUDIT_REPAIR_REF_LENGTH else cap
+    return """
+
+      The rejected $field is a bounded pointer, not an evidence container. Replace it with $replacement.
+      It MUST be at most $statedCap characters. Do not concatenate multiple paths,
+      symbols, findings, commands, or explanations into this field. Put necessary detail in the issue,
+      fix, or other schema-authorized descriptive fields.
+    """.trimIndent()
+  }
+
+  // Names the one correction the agent will not reach on its own: the retry must be SHORTER, not restated.
+  // A field this size is a summary of work, and the strongest signal that it overflowed is a segment that
+  // applied no edits and spent the response proving convergence instead.
+  private fun compressionAdvice(field: String?, cap: Int): String {
+    val subject = field?.let { "The rejected $it" } ?: "The rejected field"
+    val limit = if (cap == UNSTATED_CAP) "its declared limit" else "$cap characters"
+    return """
+
+      $subject exceeded $limit. It is a bounded SUMMARY, not a verification transcript.
+      Your previous attempt was rejected for length alone — its content was not disputed, so restating the
+      same case at the same length will be rejected again. Shorten what you already claimed: keep the
+      conclusion and one concrete anchor (a checkpoint fingerprint, a count of changed paths, a single
+      representative path), and drop per-file walkthroughs, reasoning narration, and quoted output. If a
+      segment applied no edits, say that it applied none and why it was already satisfied — the absence of
+      work is shorter to report than to prove. Move any remaining detail into the schema-authorized
+      descriptive fields for this projection, not into this one.
+    """.trimIndent()
+  }
+
+  // A length violation whose figure the validator did not state; the advice omits the number rather than
+  // inventing one, so no correction ever names a cap the schema does not actually enforce.
+  private const val UNSTATED_CAP: Int = -1
+  private val LENGTH_VIOLATION_PATTERN =
+    Regex("""(?:must be|allows) at most ([0-9][0-9,]*) characters""", RegexOption.IGNORE_CASE)
+  private val DOLLAR_POINTER_PATTERN = Regex("""\$(?:\.[A-Za-z0-9_-]+|\[[0-9]+])+""")
+  private val SLASH_POINTER_PATTERN = Regex("""at '(/[^\s']*)'""")
+  private val BARE_PATH_PATTERN =
+    Regex("""([A-Za-z_][A-Za-z0-9_\[\].-]*)\s*:\s*(?:must be|allows) at most""", RegexOption.IGNORE_CASE)
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhasePromptComposerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhasePromptComposerTest.kt
@@ -780,6 +780,80 @@ class FeatureTaskRuntimePhasePromptComposerTest {
   }
 
   @Test
+  fun `an oversized reconciliation evidence field is told to compress rather than restate`() {
+    // The blocker this branch fixes: three implement attempts rejected identically because the agent
+    // re-argued its no-op convergence case at the same length each time. The validator renders the cap
+    // with digit grouping, so the real message carries "4,096" and the advice must still name 4096.
+    val retry = FeatureTaskRuntimePhasePromptComposer.compose(
+      ISSUE_KEY,
+      briefingFor("implement"),
+      priorSchemaFailure =
+      "Projection validation failed: implement#produced_outputs: " +
+        "\$.reconciliation_evidence.evidence: must be at most 4,096 characters long",
+    )
+
+    assertContains(retry, "The rejected evidence exceeded 4096 characters")
+    assertContains(retry, "bounded SUMMARY, not a verification transcript")
+    assertContains(retry, "rejected for length alone")
+    assertContains(retry, "applied no edits")
+    assertTrue(
+      !retry.contains("bounded pointer, not an evidence container"),
+      "the pointer-replacement advice belongs to artifact_ref/check_ref only",
+    )
+  }
+
+  @Test
+  fun `any other over-length field receives the compression guidance naming that field`() {
+    val retry = FeatureTaskRuntimePhasePromptComposer.compose(
+      ISSUE_KEY,
+      briefingFor("implement"),
+      priorSchemaFailure = "\$.deviations[0].note: must be at most 4,096 characters long",
+    )
+
+    assertContains(retry, "The rejected note exceeded 4096 characters")
+    assertContains(retry, "bounded SUMMARY, not a verification transcript")
+  }
+
+  @Test
+  fun `a non-length field violation adds no compression guidance`() {
+    // Guards the byte-for-byte-unchanged retry for violations the echoed reason already resolves.
+    val retry = FeatureTaskRuntimePhasePromptComposer.compose(
+      ISSUE_KEY,
+      briefingFor("implement"),
+      priorSchemaFailure =
+      "\$.reconciliation_evidence.evidence: property 'evidence' is not defined in the schema",
+    )
+
+    assertTrue(!retry.contains("bounded SUMMARY"), "a missing/undefined property is not a length violation")
+    assertTrue(!retry.contains("bounded pointer"), "no pointer advice either")
+  }
+
+  @Test
+  fun `a length violation whose cap was truncated away adds no guidance and does not crash`() {
+    // boundedSchemaGateDetail caps validator text at 500 chars, so a long reason can lose its tail.
+    val retry = FeatureTaskRuntimePhasePromptComposer.compose(
+      ISSUE_KEY,
+      briefingFor("implement"),
+      priorSchemaFailure = "Projection validation failed: \$.reconciliation_evidence.ev… [truncated]",
+    )
+
+    assertContains(retry, "Previous attempt was REJECTED by the schema gate", false, "still corrects")
+    assertTrue(!retry.contains("bounded SUMMARY"), "no length advice without a stated violation")
+  }
+
+  @Test
+  fun `a maxLength violation with no readable figure still compresses without naming a cap`() {
+    val retry = FeatureTaskRuntimePhasePromptComposer.compose(
+      ISSUE_KEY,
+      briefingFor("implement"),
+      priorSchemaFailure = "\$.unresolved_items[0]: maxLength constraint violated",
+    )
+
+    assertContains(retry, "exceeded its declared limit")
+    assertTrue(!retry.contains("exceeded -1 characters"), "the sentinel cap never reaches the prompt")
+  }
+
+  @Test
   fun `audit remediation output contract names every carried item and required evidence field`() {
     val briefing = briefingFor("implement").copy(
       auditRepairItemIds = listOf("ac-004-gap-2-item-1", "ac-005-gap-1-item-1"),

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/RealValidatorReceiptFixLoopConvergenceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/RealValidatorReceiptFixLoopConvergenceTest.kt
@@ -61,11 +61,33 @@ class RealValidatorReceiptFixLoopConvergenceTest {
     )
   }
 
+  /**
+   * SKILL-169: the fourth field-observed class, and the one that actually reached a user. An over-length
+   * `evidence` differs from the three above in that the producer's content is not wrong — only its size —
+   * so the echoed reason alone left the agent re-arguing the same case at the same length until the cap
+   * exhausted. Convergence here proves the retry carries the compression directive, not just the constraint.
+   */
+  @Test
+  fun `an over-length reconciliation evidence converges instead of exhausting the cap`() {
+    assertConvergesFromConstraintText(
+      malformedReceipt = RECEIPT_EVIDENCE_TOO_LONG,
+      expectedConstraintFragments = arrayOf("must be at most 4,096 characters long"),
+      expectedRetryGuidance = arrayOf(
+        "bounded SUMMARY, not a verification transcript",
+        "rejected for length alone",
+      ),
+    )
+  }
+
   // The producer emits the malformed receipt once, then — as an agent reading an actionable rejection
   // would — emits a valid one. Convergence is the assertion: the run completes, implement launched exactly
   // twice, and that is strictly under the cap. A regression that drops the constraint text does not fail
   // here by leaking; it fails at the retry-prompt assertion, which is the signal this test exists for.
-  private fun assertConvergesFromConstraintText(malformedReceipt: String, expectedConstraintFragments: Array<String>) {
+  private fun assertConvergesFromConstraintText(
+    malformedReceipt: String,
+    expectedConstraintFragments: Array<String>,
+    expectedRetryGuidance: Array<String> = emptyArray(),
+  ) {
     var implementAttempts = 0
     val harness = runnerHarness(
       launcher = RuntimeRecordingLauncher { request ->
@@ -95,6 +117,9 @@ class RealValidatorReceiptFixLoopConvergenceTest {
       .map { requireNotNull(it.skillRunRequest.promptOverride) }
       .filter { phaseIdFromPrompt(it) == "implement" }[1]
     assertRetryPromptNamesConstraint(retryPrompt, "producer-projection", *expectedConstraintFragments)
+    expectedRetryGuidance.forEach { guidance ->
+      assertTrue(retryPrompt.contains(guidance), "the retry prompt withheld the correction '$guidance'.")
+    }
   }
 }
 
@@ -119,3 +144,13 @@ private val RECEIPT_MISSING_EVIDENCE: String = receiptEnvelope("""{"reconciled":
 // Class 3: a string where the closed object belongs. Canonicalization never coerces a type, so the schema
 // rejects and the producer must emit the object.
 private val RECEIPT_EVIDENCE_AS_STRING: String = receiptEnvelope(""""tree is at target state"""")
+
+// Class 4: every governed key present and well-typed, but `evidence` past its 4096-char cap — the shape a
+// no-op reconciliation segment produces when it proves convergence path by path instead of reporting it.
+// Built from a repeated clause so the fixture reads as the verification prose it stands in for.
+private val RECEIPT_EVIDENCE_TOO_LONG: String = receiptEnvelope(
+  "{\"reconciled\":true,\"evidence\":\"" +
+    "Verified src/Foo.kt matches the plan commitment at checkpoint 8ffee05e; no edit was required. "
+      .repeat(50) +
+    "\"}",
+)

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeSchemaPaths.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeSchemaPaths.kt
@@ -103,6 +103,8 @@ object FeatureTaskRuntimePersistenceSchemaPaths {
 
 const val FEATURE_TASK_RUNTIME_PROJECTION_MEASUREMENT_CONTRACT_VERSION: String = "0.1"
 
+const val FEATURE_TASK_RUNTIME_REJECTION_MEASUREMENT_CONTRACT_VERSION: String = "0.1"
+
 object FeatureTaskRuntimeProjectionMeasurementSchemaPaths {
   const val REPO_RELATIVE_PATH: String =
     "orchestration/contracts/feature-task-runtime-projection-measurement-schema.yaml"

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
@@ -2000,6 +2000,9 @@ class RuntimeArchitectureTest {
       "skillbill.workflow.taskruntime.model.PhaseHandoffProjectionDeclaration.fromArtifactMap",
       "skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionMeasurement.toTelemetryMap",
       "skillbill.workflow.taskruntime.model.FeatureTaskRuntimeSharedEvidenceMeasurement.toTelemetryMap",
+      // SKILL-169: payload-free schema-gate rejection accounting; counts rejected attempts, which the
+      // projection measurement above cannot, since it only records projections that passed.
+      "skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionMeasurement.toTelemetryMap",
       // SKILL-140: durable append-only quarantine evidence store (private, prompt-invisible) and its
       // domain-owned schema validator port (infra-fs adapter bound in DI).
       "skillbill.workflow.FeatureTaskRuntimeQuarantineValidator.validateQuarantineRecord",

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffFoundationModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffFoundationModels.kt
@@ -2,6 +2,7 @@ package skillbill.workflow.taskruntime.model
 
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PROJECTION_MEASUREMENT_CONTRACT_VERSION
+import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_REJECTION_MEASUREMENT_CONTRACT_VERSION
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_SHARED_EVIDENCE_PROJECTION_CONTRACT_VERSION
 
 const val FEATURE_TASK_RUNTIME_INCOMPATIBLE_RECORD_GUIDANCE: String =
@@ -126,6 +127,104 @@ enum class FeatureTaskRuntimeSharedEvidenceOutcome(val wireValue: String) {
   REUSE("reuse"),
   CHECKPOINT_CHANGE_REDERIVATION("checkpoint_change_rederivation"),
 }
+
+/**
+ * Privacy-safe accounting for an attempt the schema gate REJECTED. The projection measurement above
+ * records only projections that passed, so without this type an exhausted fix loop is invisible to
+ * everyone except the operator reading the block — which is how a recurring over-length receipt field
+ * reached users before anyone could see it happening.
+ *
+ * The same payload-free boundary the retry path enforces applies here: the pointer and the
+ * classification are emitted, never the offending value. [observedLength] is a length, not content.
+ */
+data class FeatureTaskRuntimeRejectionMeasurement(
+  val workflowId: String,
+  val phaseId: String,
+  val iteration: Int,
+  val rule: String,
+  val pointerPath: String,
+  val violationClass: FeatureTaskRuntimeRejectionViolationClass,
+  val declaredCap: Int? = null,
+  val observedLength: Int? = null,
+  val exhaustedFixLoop: Boolean = false,
+) {
+  init {
+    require(workflowId.isNotBlank()) { "FeatureTaskRuntimeRejectionMeasurement.workflowId must be non-blank." }
+    require(phaseId.isNotBlank()) { "FeatureTaskRuntimeRejectionMeasurement.phaseId must be non-blank." }
+    require(iteration >= 1) { "FeatureTaskRuntimeRejectionMeasurement.iteration must be >= 1." }
+    require(rule.isNotBlank()) { "FeatureTaskRuntimeRejectionMeasurement.rule must be non-blank." }
+    require(pointerPath.isNotBlank()) {
+      "FeatureTaskRuntimeRejectionMeasurement.pointerPath must be non-blank."
+    }
+    require(declaredCap == null || declaredCap >= 0) {
+      "FeatureTaskRuntimeRejectionMeasurement.declaredCap must be non-negative."
+    }
+    require(observedLength == null || observedLength >= 0) {
+      "FeatureTaskRuntimeRejectionMeasurement.observedLength must be non-negative."
+    }
+  }
+
+  @OpenBoundaryMap("Content-free feature-task-runtime rejection measurement telemetry seam")
+  fun toTelemetryMap(): Map<String, Any?> = linkedMapOf(
+    "contract_version" to FEATURE_TASK_RUNTIME_REJECTION_MEASUREMENT_CONTRACT_VERSION,
+    "workflow_id" to workflowId,
+    "phase_id" to phaseId,
+    "iteration" to iteration,
+    "rule" to rule,
+    "pointer_path" to pointerPath,
+    "violation_class" to violationClass.wireValue,
+    "exhausted_fix_loop" to exhaustedFixLoop,
+  ).apply {
+    declaredCap?.let { put("declared_cap", it) }
+    observedLength?.let { put("observed_length", it) }
+  }
+}
+
+/**
+ * Why the gate rejected, at the coarsest granularity that still separates repairable field errors from
+ * an unparseable response. [LENGTH] is the one this vocabulary exists to make countable.
+ */
+enum class FeatureTaskRuntimeRejectionViolationClass(val wireValue: String) {
+  LENGTH("length"),
+  MISSING("missing"),
+  TYPE("type"),
+  CONST("const"),
+  MALFORMED("malformed"),
+  OTHER("other"),
+}
+
+// The validator groups digits past a thousand ("4,096"), so the separator belongs to the number.
+private val REJECTION_LENGTH_PATTERN =
+  Regex("""(?:must be|allows) at most ([0-9][0-9,]*) characters""", RegexOption.IGNORE_CASE)
+
+/**
+ * The declared cap a validator reason names, or null when it names none. Reading the figure from the
+ * message rather than from a constant is what lets one classifier serve every bounded field regardless
+ * of its cap.
+ */
+fun featureTaskRuntimeRejectionCapOf(validationReason: String): Int? =
+  REJECTION_LENGTH_PATTERN.find(validationReason)?.groupValues?.get(1)?.replace(",", "")?.toIntOrNull()
+
+/**
+ * Classifies a validator reason into the countable vocabulary. Ordered most-specific first: a length
+ * violation is recognised by its stated cap (or a bare `maxLength` mention) before the broader type and
+ * shape phrasings, which would otherwise absorb it — "must be at most N characters" also matches "must
+ * be a".
+ */
+fun featureTaskRuntimeRejectionViolationClassOf(validationReason: String): FeatureTaskRuntimeRejectionViolationClass =
+  when {
+    featureTaskRuntimeRejectionCapOf(validationReason) != null || validationReason.contains("maxLength") ->
+      FeatureTaskRuntimeRejectionViolationClass.LENGTH
+    validationReason.contains("is malformed") || validationReason.contains("must be an object") ->
+      FeatureTaskRuntimeRejectionViolationClass.MALFORMED
+    validationReason.contains("must be the constant value") ->
+      FeatureTaskRuntimeRejectionViolationClass.CONST
+    validationReason.contains("is missing") || validationReason.contains("is not defined in the schema") ->
+      FeatureTaskRuntimeRejectionViolationClass.MISSING
+    validationReason.contains("expected") || validationReason.contains("must be a") ->
+      FeatureTaskRuntimeRejectionViolationClass.TYPE
+    else -> FeatureTaskRuntimeRejectionViolationClass.OTHER
+  }
 
 enum class FeatureTaskRuntimeProjectionFailureClassification(val wireValue: String) {
   INVALID_CONTRACT("invalid_contract"),

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeRejectionMeasurementTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeRejectionMeasurementTest.kt
@@ -1,0 +1,134 @@
+package skillbill.workflow.taskruntime
+
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionMeasurement
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionViolationClass
+import skillbill.workflow.taskruntime.model.featureTaskRuntimeRejectionCapOf
+import skillbill.workflow.taskruntime.model.featureTaskRuntimeRejectionViolationClassOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FeatureTaskRuntimeRejectionMeasurementTest {
+  @Test
+  fun `the blocker's own rejection reason classifies as a length violation carrying its cap`() {
+    val reason = "Projection validation failed: implement#produced_outputs: " +
+      "\$.reconciliation_evidence.evidence: must be at most 4,096 characters long"
+
+    assertEquals(FeatureTaskRuntimeRejectionViolationClass.LENGTH, featureTaskRuntimeRejectionViolationClassOf(reason))
+    assertEquals(4096, featureTaskRuntimeRejectionCapOf(reason))
+  }
+
+  @Test
+  fun `a length violation is not absorbed by the broader type phrasing it also matches`() {
+    // "must be at most N characters" also contains "must be a"; ordering is what keeps it LENGTH.
+    val reason = "artifact_ref: must be at most 256 characters long"
+
+    assertEquals(FeatureTaskRuntimeRejectionViolationClass.LENGTH, featureTaskRuntimeRejectionViolationClassOf(reason))
+    assertEquals(256, featureTaskRuntimeRejectionCapOf(reason))
+  }
+
+  @Test
+  fun `each remaining validator phrasing lands in its own class`() {
+    val cases = mapOf(
+      "\$.produced_outputs: maxLength constraint violated" to FeatureTaskRuntimeRejectionViolationClass.LENGTH,
+      "Phase output is malformed: unexpected end-of-input" to FeatureTaskRuntimeRejectionViolationClass.MALFORMED,
+      "<root> must be an object." to FeatureTaskRuntimeRejectionViolationClass.MALFORMED,
+      "contract_version: must be the constant value '0.1'" to FeatureTaskRuntimeRejectionViolationClass.CONST,
+      "produced_outputs.projection_kind is missing" to FeatureTaskRuntimeRejectionViolationClass.MISSING,
+      "property 'criterion' is not defined in the schema" to FeatureTaskRuntimeRejectionViolationClass.MISSING,
+      "\$.deviations[0]: string found, object expected" to FeatureTaskRuntimeRejectionViolationClass.TYPE,
+      "gap_id must be unique, duplicated [ac-002-gap-1]" to FeatureTaskRuntimeRejectionViolationClass.OTHER,
+    )
+
+    cases.forEach { (reason, expected) ->
+      assertEquals(expected, featureTaskRuntimeRejectionViolationClassOf(reason), "misclassified: $reason")
+    }
+  }
+
+  @Test
+  fun `a reason stating no cap yields no cap rather than a fabricated one`() {
+    assertNull(featureTaskRuntimeRejectionCapOf("\$.produced_outputs: maxLength constraint violated"))
+    assertNull(featureTaskRuntimeRejectionCapOf("produced_outputs.projection_kind is missing"))
+  }
+
+  @Test
+  fun `the emitted map carries the pointer and classification but never the offending value`() {
+    val offendingValue = "the agent's verbose reconciliation narrative that overflowed the field"
+    val map = FeatureTaskRuntimeRejectionMeasurement(
+      workflowId = "wftr-20260807-123754-11fb",
+      phaseId = "implement",
+      iteration = 3,
+      rule = "producer-projection",
+      pointerPath = "/reconciliation_evidence/evidence",
+      violationClass = FeatureTaskRuntimeRejectionViolationClass.LENGTH,
+      declaredCap = 4096,
+      observedLength = 16608,
+      exhaustedFixLoop = true,
+    ).toTelemetryMap()
+
+    assertEquals("wftr-20260807-123754-11fb", map["workflow_id"])
+    assertEquals("/reconciliation_evidence/evidence", map["pointer_path"])
+    assertEquals("length", map["violation_class"])
+    assertEquals(4096, map["declared_cap"])
+    assertEquals(16608, map["observed_length"])
+    assertEquals(true, map["exhausted_fix_loop"])
+    assertFalse(
+      map.values.any { it is String && it.contains(offendingValue) },
+      "the rejection event must never carry the rejected payload",
+    )
+  }
+
+  @Test
+  fun `optional measures are omitted rather than emitted as nulls`() {
+    val map = FeatureTaskRuntimeRejectionMeasurement(
+      workflowId = "wf-1",
+      phaseId = "audit",
+      iteration = 1,
+      rule = "phase-output-schema",
+      pointerPath = "/",
+      violationClass = FeatureTaskRuntimeRejectionViolationClass.MALFORMED,
+    ).toTelemetryMap()
+
+    assertFalse(map.containsKey("declared_cap"), "an unstated cap is absent, not null")
+    assertFalse(map.containsKey("observed_length"), "an unmeasured length is absent, not null")
+    assertTrue(map.containsKey("violation_class"), "the classification is always present")
+  }
+
+  @Test
+  fun `identity and counter fields loud-fail rather than emitting an unattributable row`() {
+    assertFailsWith<IllegalArgumentException> {
+      FeatureTaskRuntimeRejectionMeasurement(
+        workflowId = " ",
+        phaseId = "implement",
+        iteration = 1,
+        rule = "producer-projection",
+        pointerPath = "/",
+        violationClass = FeatureTaskRuntimeRejectionViolationClass.LENGTH,
+      )
+    }
+    assertFailsWith<IllegalArgumentException> {
+      FeatureTaskRuntimeRejectionMeasurement(
+        workflowId = "wf-1",
+        phaseId = "implement",
+        iteration = 0,
+        rule = "producer-projection",
+        pointerPath = "/",
+        violationClass = FeatureTaskRuntimeRejectionViolationClass.LENGTH,
+      )
+    }
+    assertFailsWith<IllegalArgumentException> {
+      FeatureTaskRuntimeRejectionMeasurement(
+        workflowId = "wf-1",
+        phaseId = "implement",
+        iteration = 1,
+        rule = "producer-projection",
+        pointerPath = "/",
+        violationClass = FeatureTaskRuntimeRejectionViolationClass.LENGTH,
+        observedLength = -1,
+      )
+    }
+  }
+}

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/LifecycleTelemetryStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/LifecycleTelemetryStore.kt
@@ -15,6 +15,7 @@ import skillbill.telemetry.model.PrDescriptionGeneratedRecord
 import skillbill.telemetry.model.QualityCheckFinishedRecord
 import skillbill.telemetry.model.QualityCheckStartedRecord
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionMeasurement
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionMeasurement
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeSharedEvidenceMeasurement
 import java.sql.Connection
 
@@ -31,6 +32,10 @@ class LifecycleTelemetryStore(
 
   override fun featureTaskRuntimeSharedEvidence(record: FeatureTaskRuntimeSharedEvidenceMeasurement) {
     enqueueTelemetry(connection, "skillbill_feature_task_runtime_shared_evidence", record.toTelemetryMap())
+  }
+
+  override fun featureTaskRuntimeRejection(record: FeatureTaskRuntimeRejectionMeasurement) {
+    enqueueTelemetry(connection, "skillbill_feature_task_runtime_rejection", record.toTelemetryMap())
   }
 
   override fun featureImplementStarted(record: FeatureImplementStartedRecord, level: String) {

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/LifecycleTelemetryRepository.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/LifecycleTelemetryRepository.kt
@@ -14,6 +14,7 @@ import skillbill.telemetry.model.PrDescriptionGeneratedRecord
 import skillbill.telemetry.model.QualityCheckFinishedRecord
 import skillbill.telemetry.model.QualityCheckStartedRecord
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionMeasurement
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeRejectionMeasurement
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeSharedEvidenceMeasurement
 
 // SKILL-66 Subtask 2: the lifecycle telemetry contract spans the
@@ -24,6 +25,8 @@ interface LifecycleTelemetryRepository {
   fun featureTaskRuntimeProjectionMeasurement(record: FeatureTaskRuntimeProjectionMeasurement) = Unit
 
   fun featureTaskRuntimeSharedEvidence(record: FeatureTaskRuntimeSharedEvidenceMeasurement) = Unit
+
+  fun featureTaskRuntimeRejection(record: FeatureTaskRuntimeRejectionMeasurement) = Unit
 
   fun featureImplementStarted(record: FeatureImplementStartedRecord, level: String)
 


### PR DESCRIPTION
# Summary

An over-length bounded field re-argued itself at the same length on every retry until the fix loop exhausted. The only length-aware retry correction matched `artifact_ref`/`check_ref` **by name**, so an over-long `reconciliation_evidence.evidence` fell through to the generic "do not repeat the same mistake" text and blocked a user's goal after three identical rejections — while an over-long `artifact_ref` in the same run recovered on its next attempt.

Echoing the validator reason is enough for a *missing* field: the reason names it and the agent adds it. It is not enough for an *over-length* one — the agent already knows the field, and what it does not infer is that it must stop explaining and start compressing.

Not a one-off: PostHog `blocked_reason` shows 21 bounded-fix-loop exhaustions since 2026-06-25, including `producer-projection at '/reconciliation_evidence'` on 2026-07-29 — same field, same phase, nine days before the user hit it.

Key changes:

- **Generalized the correction** to any field reporting a length violation. The cap is read from the message (the validator groups digits — `4,096`) and the field from the pointer, so one branch serves fields capped at 128/256/1024/4096. Pointer-replacement advice stays a specialization for the two ref fields.
- **Extracted** the reason-derived corrections into `FeatureTaskRuntimeSchemaFailureCorrections.kt`. They need nothing from the briefing, which is what makes them a cohesive unit and directly testable. (Also what kept the composer under detekt's `LargeClass` without a suppression.)
- **Preventive directive** on `PHASE_IMPLEMENT`: receipt fields are bounded summaries, and a segment applying zero edits reports that briefly. The incentive to overflow is highest when there is least to report — the payload behind this blocker was a no-op reconciliation proving convergence path by path.
- **Rejection telemetry** (`skillbill_feature_task_runtime_rejection`), payload-free. The existing projection measurement records only projections that *passed*, so an exhausting fix loop was invisible outside the operator's block reason. Emitted from `FeatureTaskRuntimePhaseRecorder.recordRejectedOutput` — the single funnel every rejection class already routes through.
- **SKILL-170 spec** for a separate finding surfaced by the same investigation: PostHog holds exactly **one** `install_id` across 148 workflows in 21 days. No user install is transmitting telemetry. `TelemetryService.autoSync` has three callers, all in `McpRuntime`; `runtime-cli` references it nowhere.

Two notes for the reviewer:

- Two pointer dialects were not enough. The real `artifact_ref` message uses a **bare dotted path** (`gaps[0].failure_evidence.artifact_ref:`) with no `$.` or `at '/…'` prefix; the existing test caught this. A third pattern was added.
- One unrelated hunk: `IdeStatusService.kt` had a pre-existing spotless violation already failing `check` on `main` (verified by reverting and re-running `spotlessKotlinCheck` on otherwise-clean code). Reformatted so this branch's gate can pass.

## Feature Flags

N/A

# How Has This Been Tested?

`cd runtime-kotlin && ./gradlew clean check` — green.

- **6 composer cases**: the real over-length `evidence` message (comma grouping included), `artifact_ref` regression, a third field, a non-length violation adding no guidance, a truncated reason, and a `maxLength` mention with no readable figure.
- **7 domain cases**: classification per validator phrasing, cap parsing, payload-free emission, absent-vs-null optional fields, constructor loud-fails.
- **1 end-to-end convergence regression** — the one that matters. `RealValidatorReceiptFixLoopConvergenceTest` drives an over-length `evidence` through the **real** validator and asserts the run converges in 2 implement launches instead of exhausting `cap=3`, and that the retry prompt carries the compression directive. This also confirmed the validator genuinely emits the comma-grouped `4,096`, so the parsing is verified against real output rather than an assumption.

To reproduce the regression:

1. `cd runtime-kotlin`
2. `./gradlew :runtime-application:test --tests '*RealValidatorReceiptFixLoopConvergenceTest*'`
3. All 4 tests pass; `an over-length reconciliation evidence converges instead of exhausting the cap` is the new one.
4. Delete the `lengthViolation(...)` call from `retryCorrectionDirective` and re-run — that test fails on the missing guidance, confirming it is not vacuous.
