### PR TITLE
fix(goal): scoped replan clears its hydrated child, and goal elapsed measures execution time

### DIFF
--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/Constants.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/Constants.kt
@@ -28,6 +28,10 @@ const val PAUSE_REQUESTED_WIRE_KEY: String = "pause_requested"
 /** Wire key carrying the instant a recorded pause took effect. Optional. */
 const val PAUSED_AT_WIRE_KEY: String = "paused_at"
 
+const val ACTIVE_DURATION_MS_WIRE_KEY: String = "active_duration_ms"
+
+const val ACTIVE_DURATION_AS_OF_WIRE_KEY: String = "active_duration_as_of"
+
 /** `workflow_family` value identifying a decomposed feature goal. */
 const val FEATURE_GOAL_WORKFLOW_FAMILY: String = "feature-goal"
 

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
@@ -65,6 +65,13 @@ sealed class SkillBillStatusOutcome {
         val pauseRequested: Boolean? = null,
         /** Instant a recorded pause took effect; absent for an inferred pause. */
         val pausedAt: Instant? = null,
+        /**
+         * Execution time the runtime accumulated for this goal, excluding blocked, paused, and
+         * unattended gaps. Null when the snapshot carried none, which is not zero work.
+         */
+        val activeDurationMs: Long? = null,
+        /** Instant [activeDurationMs] is current as of; present only while a lease is live. */
+        val activeDurationAsOf: Instant? = null,
     ) : SkillBillStatusOutcome()
 
     /**
@@ -92,6 +99,10 @@ sealed class SkillBillStatusOutcome {
         val pauseRequested: Boolean? = null,
         /** Instant a recorded pause took effect; absent for an inferred pause. */
         val pausedAt: Instant? = null,
+        /** See [Active.activeDurationMs]. A paused goal accumulates none while it waits. */
+        val activeDurationMs: Long? = null,
+        /** See [Active.activeDurationAsOf]; absent once the runner released its lease. */
+        val activeDurationAsOf: Instant? = null,
     ) : SkillBillStatusOutcome()
 
     data class Stale(

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
@@ -4,6 +4,8 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
+import dev.skillbill.intellij.domain.ACTIVE_DURATION_AS_OF_WIRE_KEY
+import dev.skillbill.intellij.domain.ACTIVE_DURATION_MS_WIRE_KEY
 import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.IDE_STATUS_CONTRACT_VERSION
 import dev.skillbill.intellij.domain.NO_MATCHING_WORK_REASON_CODE
@@ -100,6 +102,8 @@ object IdeStatusJsonMapper {
         // Both optional and goal-family-only: a missing key stays null, never false.
         val pauseRequested = root.getAsBoolean(PAUSE_REQUESTED_WIRE_KEY)
         val pausedAt = root.getAsInstant(PAUSED_AT_WIRE_KEY)
+        val activeDurationMs = root.getAsNonNegativeLong(ACTIVE_DURATION_MS_WIRE_KEY)
+        val activeDurationAsOf = root.getAsInstant(ACTIVE_DURATION_AS_OF_WIRE_KEY)
 
         // "No work here" is a healthy idle repository, not a broken status source.
         // Every other problem code is a genuine failure to obtain status.
@@ -176,6 +180,8 @@ object IdeStatusJsonMapper {
                         planning = planning,
                         pauseRequested = pauseRequested,
                         pausedAt = pausedAt,
+                        activeDurationMs = activeDurationMs,
+                        activeDurationAsOf = activeDurationAsOf,
                     )
                 } else {
                     SkillBillStatusOutcome.Active(
@@ -196,6 +202,8 @@ object IdeStatusJsonMapper {
                         planning = planning,
                         pauseRequested = pauseRequested,
                         pausedAt = pausedAt,
+                        activeDurationMs = activeDurationMs,
+                        activeDurationAsOf = activeDurationAsOf,
                     )
                 }
             }
@@ -314,6 +322,12 @@ object IdeStatusJsonMapper {
     /** Strict: a JSON string "true" is a type error, not a boolean. */
     private fun JsonObject.getAsBoolean(key: String): Boolean? =
         get(key)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isBoolean }?.asBoolean
+
+    /** Strict and non-negative: a malformed or negative duration is dropped, never shown as work. */
+    private fun JsonObject.getAsNonNegativeLong(key: String): Long? =
+        get(key)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isNumber }
+            ?.let { runCatching { it.asLong }.getOrNull() }
+            ?.takeIf { it >= 0 }
 
     private fun JsonObject.getAsInstant(key: String): Instant? {
         val raw = getAsString(key) ?: return null

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusUiState.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusUiState.kt
@@ -94,6 +94,9 @@ sealed class SkillBillStatusUiState {
         override val planning: GoalPlanningInfo? = null,
         override val workflowFamily: String? = null,
         override val pauseRequested: Boolean? = null,
+        /** Retained so the 1s ticker re-anchors the active clock without a new poll. */
+        val activeDurationMs: Long? = null,
+        val activeDurationAsOf: Instant? = null,
     ) : SkillBillStatusUiState() {
         override val accessibilityText: String =
             buildString {

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
@@ -37,7 +37,12 @@ object StatusUiMapper {
                 SkillBillStatusUiState.Active(
                     headline = activeHeadline(outcome),
                     detail = outcome.summary,
-                    goalElapsed = elapsed(outcome.startedAt, now),
+                    goalElapsed = activeElapsed(
+                        outcome.activeDurationMs,
+                        outcome.activeDurationAsOf,
+                        outcome.startedAt,
+                        now,
+                    ),
                     subtaskElapsed = elapsed(outcome.subtaskStartedAt, now),
                     progressCompleted = outcome.progressCompleted,
                     progressTotal = outcome.progressTotal,
@@ -54,13 +59,20 @@ object StatusUiMapper {
                     ),
                     workflowFamily = outcome.workflowFamily,
                     pauseRequested = outcome.pauseRequested,
+                    activeDurationMs = outcome.activeDurationMs,
+                    activeDurationAsOf = outcome.activeDurationAsOf,
                 )
 
             is SkillBillStatusOutcome.Paused ->
                 SkillBillStatusUiState.Paused(
                     headline = pausedHeadline(outcome),
                     detail = outcome.summary,
-                    goalElapsed = elapsed(outcome.startedAt, settledAt(outcome.updatedAt, now)),
+                    goalElapsed = activeElapsed(
+                        outcome.activeDurationMs,
+                        outcome.activeDurationAsOf,
+                        outcome.startedAt,
+                        settledAt(outcome.updatedAt, now),
+                    ),
                     subtaskElapsed = elapsed(outcome.subtaskStartedAt, settledAt(outcome.updatedAt, now)),
                     progressCompleted = outcome.progressCompleted,
                     progressTotal = outcome.progressTotal,
@@ -175,6 +187,27 @@ object StatusUiMapper {
     }
 
     /**
+     * The goal clock. Prefers the runtime's accumulated execution time, which excludes the stretches
+     * a goal spends blocked, paused, or simply unattended between runs — `now - startedAt` counts all
+     * of those as work and reports an overnight gap as hours of progress.
+     *
+     * [asOf] is present only while a lease is live; the tail since then is added so the clock ticks
+     * between polls, and the next heartbeat folds that same tail into [accumulatedMs] without
+     * double counting. Falls back to wall clock when the snapshot carries no accumulated value,
+     * which keeps older runtimes and non-goal families rendering exactly as before.
+     */
+    fun activeElapsed(
+        accumulatedMs: Long?,
+        asOf: Instant?,
+        startedAt: Instant?,
+        now: Instant,
+    ): Duration? {
+        if (accumulatedMs == null) return elapsed(startedAt, now)
+        val tailMillis = asOf?.let { (now.toEpochMilli() - it.toEpochMilli()).coerceAtLeast(0L) } ?: 0L
+        return Duration.ofMillis(accumulatedMs + tailMillis)
+    }
+
+    /**
      * Re-anchors elapsed clocks from retained start timestamps without a new poll.
      *
      * Only live work ticks. Settled states (stale/blocked/failed) already carry a
@@ -184,7 +217,12 @@ object StatusUiMapper {
     fun withElapsed(state: SkillBillStatusUiState, now: Instant): SkillBillStatusUiState =
         when (state) {
             is SkillBillStatusUiState.Active -> state.copy(
-                goalElapsed = elapsed(state.startedAt, now),
+                goalElapsed = activeElapsed(
+                    state.activeDurationMs,
+                    state.activeDurationAsOf,
+                    state.startedAt,
+                    now,
+                ),
                 subtaskElapsed = elapsed(state.subtaskStartedAt, now),
             )
             else -> state

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
@@ -338,6 +338,41 @@ class IdeStatusJsonMapperTest {
         assertNull(without.pausedAt)
     }
 
+    @Test
+    fun `active duration parses when present and stays absent when omitted`() {
+        val withDuration = goalPayload(null).dropLast(1) +
+            ",\"active_duration_ms\":1380000,\"active_duration_as_of\":\"2026-08-06T09:59:00Z\"}"
+        val parsed = IdeStatusJsonMapper.map(withDuration, now, 0) as SkillBillStatusOutcome.Active
+        assertEquals(1_380_000L, parsed.activeDurationMs)
+        assertEquals(java.time.Instant.parse("2026-08-06T09:59:00Z"), parsed.activeDurationAsOf)
+
+        // Absent must stay null rather than becoming zero: null falls back to the wall clock,
+        // whereas zero would render "0s" as a measurement.
+        val without = IdeStatusJsonMapper.map(goalPayload(null), now, 0) as SkillBillStatusOutcome.Active
+        assertNull(without.activeDurationMs)
+        assertNull(without.activeDurationAsOf)
+    }
+
+    @Test
+    fun `a malformed active duration is dropped rather than rendered as work`() {
+        val cases = listOf(
+            "\"active_duration_ms\":-1",
+            "\"active_duration_ms\":\"1380000\"",
+            "\"active_duration_ms\":null",
+        )
+        cases.forEach { field ->
+            val payload = goalPayload(null).dropLast(1) + ",$field}"
+            val parsed = IdeStatusJsonMapper.map(payload, now, 0) as SkillBillStatusOutcome.Active
+            assertNull("Expected $field to be dropped", parsed.activeDurationMs)
+        }
+
+        val unparseableAnchor = goalPayload(null).dropLast(1) +
+            ",\"active_duration_ms\":1000,\"active_duration_as_of\":\"not-an-instant\"}"
+        val parsed = IdeStatusJsonMapper.map(unparseableAnchor, now, 0) as SkillBillStatusOutcome.Active
+        assertEquals(1_000L, parsed.activeDurationMs)
+        assertNull("An unparseable anchor must not license a live tail", parsed.activeDurationAsOf)
+    }
+
     private fun String.replaceField(field: String, from: String, to: String): String {
         val original = "\"$field\": \"$from\""
         check(contains(original)) { "Fixture no longer contains $original" }

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/StatusUiMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/StatusUiMapperTest.kt
@@ -161,6 +161,93 @@ class StatusUiMapperTest {
         assertNull(ui.subtaskElapsed)
     }
 
+    /**
+     * The reported bug: a goal opened 12h ago that ran for minutes read "12h 10m" under a live
+     * spinner, because the clock was wall time since start and the overnight blocked stretch was
+     * counted as work.
+     */
+    @Test
+    fun `the goal clock counts execution time and excludes the gap a goal spent blocked`() {
+        val openedAt = Instant.parse("2026-08-07T18:22:00Z")
+        val observedAt = Instant.parse("2026-08-08T06:31:00Z")
+        val ui = StatusUiMapper.map(
+            active(startedAt = openedAt, subtaskStartedAt = observedAt).copy(
+                activeDurationMs = Duration.ofMinutes(23).toMillis(),
+                activeDurationAsOf = observedAt,
+            ),
+            observedAt,
+        ) as SkillBillStatusUiState.Active
+
+        assertEquals(Duration.ofMinutes(23), ui.goalElapsed)
+        // The wall clock this replaces still spans the whole overnight gap.
+        assertEquals(Duration.ofHours(12).plusMinutes(9), StatusUiMapper.elapsed(openedAt, observedAt))
+    }
+
+    @Test
+    fun `the live tail ticks between polls and the next heartbeat does not double count it`() {
+        val asOf = Instant.parse("2026-08-08T06:31:00Z")
+        val tenSecondsLater = asOf.plusSeconds(10)
+        val accumulated = Duration.ofMinutes(5)
+        val ui = StatusUiMapper.map(
+            active(startedAt = asOf, subtaskStartedAt = asOf).copy(
+                activeDurationMs = accumulated.toMillis(),
+                activeDurationAsOf = asOf,
+            ),
+            tenSecondsLater,
+        ) as SkillBillStatusUiState.Active
+        assertEquals(accumulated.plusSeconds(10), ui.goalElapsed)
+
+        // The heartbeat folds that same tail in and re-anchors; the total must not jump.
+        val afterHeartbeat = StatusUiMapper.map(
+            active(startedAt = asOf, subtaskStartedAt = asOf).copy(
+                activeDurationMs = accumulated.plusSeconds(10).toMillis(),
+                activeDurationAsOf = tenSecondsLater,
+            ),
+            tenSecondsLater,
+        ) as SkillBillStatusUiState.Active
+        assertEquals(accumulated.plusSeconds(10), afterHeartbeat.goalElapsed)
+    }
+
+    @Test
+    fun `a released lease freezes the goal clock at the accumulated total`() {
+        val asOf = Instant.parse("2026-08-08T06:31:00Z")
+        val ui = StatusUiMapper.map(
+            active(startedAt = asOf, subtaskStartedAt = asOf).copy(
+                activeDurationMs = Duration.ofMinutes(7).toMillis(),
+                activeDurationAsOf = null,
+            ),
+            asOf.plusSeconds(3600),
+        ) as SkillBillStatusUiState.Active
+        assertEquals(Duration.ofMinutes(7), ui.goalElapsed)
+    }
+
+    @Test
+    fun `a snapshot without an accumulated total keeps the previous wall-clock behaviour`() {
+        val start = Instant.parse("2026-08-06T10:00:00Z")
+        val ui = StatusUiMapper.map(
+            active(startedAt = start, subtaskStartedAt = start),
+            start.plusSeconds(45),
+        ) as SkillBillStatusUiState.Active
+        assertEquals(Duration.ofSeconds(45), ui.goalElapsed)
+    }
+
+    @Test
+    fun `withElapsed ticks the active clock from the accumulated total not from startedAt`() {
+        val openedAt = Instant.parse("2026-08-07T18:22:00Z")
+        val asOf = Instant.parse("2026-08-08T06:31:00Z")
+        val active = StatusUiMapper.map(
+            active(startedAt = openedAt, subtaskStartedAt = asOf).copy(
+                activeDurationMs = Duration.ofMinutes(23).toMillis(),
+                activeDurationAsOf = asOf,
+            ),
+            asOf,
+        ) as SkillBillStatusUiState.Active
+
+        val ticked = StatusUiMapper.withElapsed(active, asOf.plusSeconds(5)) as SkillBillStatusUiState.Active
+
+        assertEquals(Duration.ofMinutes(23).plusSeconds(5), ticked.goalElapsed)
+    }
+
     @Test
     fun `withElapsed re-anchors from startedAt and leaves absent subtask absent`() {
         val start = Instant.parse("2026-08-06T10:00:00Z")

--- a/orchestration/contracts/ide-status-schema.yaml
+++ b/orchestration/contracts/ide-status-schema.yaml
@@ -145,6 +145,21 @@ properties:
     description: >
       Instant the pause took effect, from the durable control record. Omitted when
       the paused projection is inferred from lease expiry rather than recorded.
+  active_duration_ms:
+    type: integer
+    minimum: 0
+    description: >
+      Time the goal spent actually executing, accumulated from lease heartbeats. This is
+      not the wall clock since started_at: intervals where the goal sat blocked, paused,
+      or unattended between runs are excluded. Omitted for snapshots with no durable
+      control record. Consumers add now - active_duration_as_of while that field is present.
+  active_duration_as_of:
+    type: string
+    minLength: 1
+    description: >
+      Instant active_duration_ms is current as of. Present only while a lease is live, so
+      a reader can tick the live tail without double counting -- the next heartbeat folds
+      that same tail into active_duration_ms. Absent means the accumulated value is final.
   updated_at:
     type: string
     minLength: 1

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunner.kt
@@ -756,7 +756,8 @@ class GoalRunner(
           "Goal-subtask planning import conflicts with the stored shared preplan or subtask plan. " +
             "This occurs when a shared preplan was regenerated after the child was hydrated, " +
             "making the previously-imported planning bytes stale. " +
-            "Recovery requires hard reset: 'skill-bill goal reset ${state.manifest.issueKey} --hard --yes'. " +
+            "Recover this subtask's child without discarding sibling planning or completed commits: " +
+            "'${scopedChildRecoveryCommand(state.manifest.issueKey, error.subtaskId)}'. " +
             "Planning failure: ${error.message.orEmpty()}",
           "preplan",
         )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
@@ -132,6 +132,8 @@ class GoalRunnerStatusService(
             pauseReason = loadedState.controlState.pauseReason,
             pausedAt = loadedState.controlState.pausedAt,
             stopAfterSubtaskId = loadedState.controlState.stopAfterSubtaskId,
+            activeDurationMs = loadedState.controlState.activeDurationMs,
+            activeDurationAsOf = loadedState.controlState.activeDurationAsOf,
           ),
         )
       }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
@@ -512,6 +512,7 @@ class GoalRunnerStatusService(
     discardedPlan = written.deletedPlanCount > 0,
     discardedSharedPreplan = written.discardedSharedPreplan,
     cascadedPlanSubtaskIds = written.cascadedPlanSubtaskIds,
+    clearedChildSubtaskIds = written.clearedChildSubtaskIds,
     before = GoalRunnerReplanSnapshot(
       status = before.manifest.status,
       currentSubtaskId = before.manifest.currentSubtaskIntent.subtaskId.takeIf { it > 0 },

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerWorkflowStores.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerWorkflowStores.kt
@@ -413,9 +413,13 @@ class WorkflowGoalRunnerManifestStore(
       }
       val plannedAfter = preparations.listPreparedPlanSubtaskIds(state.parentWorkflowId)
       val sharedAfter = preparations.hasPreparedSharedPreplan(state.parentWorkflowId)
+      // A child hydrated from the discarded plan still holds those planning bytes as its own import.
+      // Leaving it behind makes the next launch fail the hydration provenance check, which used to
+      // strand a scoped replan on advice to hard reset.
+      val clearedChildIds = deleteStaleReplanChildren(unitOfWork, state, listOf(subtaskId) + cascadedIds)
       val projection = saveWorkflowProjectionInTransaction(
         unitOfWork,
-        state,
+        state.copy(manifest = state.manifest.afterReplanChildDeletion(clearedChildIds)),
         mergeConcurrentProgress = false,
       )
       GoalRunnerScopedReplanWriteResult(
@@ -427,6 +431,7 @@ class WorkflowGoalRunnerManifestStore(
         sharedPreplanPreparedBefore = sharedBefore,
         discardedSharedPreplan = sharedBefore && !sharedAfter,
         cascadedPlanSubtaskIds = cascadedIds,
+        clearedChildSubtaskIds = clearedChildIds,
       ) to projection.projectionArtifactsJson
     }
     DecompositionManifestWriter.writeProjectionFromWorkflowState(
@@ -1320,6 +1325,45 @@ private fun DecompositionManifest.afterIncompatibleChildDeletion(subtaskId: Int)
     }
   },
 ).withParentStatus()
+
+// Terminal subtasks keep their child workflow: a scoped replan preserves every completed subtask's
+// commit_sha and workflow_id, and a finished child is never re-hydrated from the discarded plan.
+private fun deleteStaleReplanChildren(
+  unitOfWork: UnitOfWork,
+  state: GoalRunnerManifestState,
+  subtaskIds: List<Int>,
+): List<Int> = subtaskIds.distinct().sorted().filter { id ->
+  val subtask = state.manifest.subtasks.singleOrNull { it.id == id }
+  val childWorkflowId = subtask?.workflowId?.takeIf(String::isNotBlank)
+  if (subtask == null || childWorkflowId == null || subtask.status in setOf("complete", "skipped")) {
+    false
+  } else {
+    // Only terminal children are deletable here, so a live or resumable child is left untouched.
+    unitOfWork.workflowStates.deleteGoalChildWorkflow(state.parentWorkflowId, id, childWorkflowId) == 1
+  }
+}
+
+// Unlike afterIncompatibleChildDeletion this preserves the caller's currentSubtaskIntent, which the
+// replan path has already retargeted at the replanned subtask.
+private fun DecompositionManifest.afterReplanChildDeletion(subtaskIds: List<Int>): DecompositionManifest {
+  if (subtaskIds.isEmpty()) return this
+  return copy(
+    subtasks = subtasks.map { subtask ->
+      if (subtask.id !in subtaskIds) {
+        subtask
+      } else {
+        subtask.copy(
+          status = "pending",
+          branch = null,
+          commitSha = null,
+          workflowId = null,
+          blockedReason = null,
+          lastResumableStep = null,
+        )
+      }
+    },
+  ).withParentStatus()
+}
 
 private data class ProjectedManifestCandidate(
   val path: Path,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalRunnerRequests.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalRunnerRequests.kt
@@ -309,6 +309,7 @@ data class GoalRunnerReplanResult(
   val discardedPlan: Boolean,
   val discardedSharedPreplan: Boolean = false,
   val cascadedPlanSubtaskIds: List<Int> = emptyList(),
+  val clearedChildSubtaskIds: List<Int> = emptyList(),
   val before: GoalRunnerReplanSnapshot,
   val after: GoalRunnerReplanSnapshot,
 )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
@@ -143,6 +143,9 @@ data class IdeStatusSnapshot(
   // wire-identical. pause_requested is never emitted as false for the same reason.
   val pauseRequested: Boolean? = null,
   val pausedAt: Instant? = null,
+  // Execution time rather than wall clock since startedAt; see the contract's active_duration_ms.
+  val activeDurationMs: Long? = null,
+  val activeDurationAsOf: Instant? = null,
   val problem: IdeStatusProblem? = null,
   val contractVersion: String = IDE_STATUS_CONTRACT_VERSION,
 ) {
@@ -191,6 +194,7 @@ data class IdeStatusSnapshot(
     planning?.let { put("planning", planningWireMap(it)) }
     pauseRequested?.takeIf { it }?.let { put("pause_requested", true) }
     pausedAt?.let { put("paused_at", it.toString()) }
+    putActiveDuration()
     put("updated_at", updatedAt.toString())
     put("freshness", freshness.wireValue)
     put("summary", summary)
@@ -204,6 +208,12 @@ data class IdeStatusSnapshot(
         },
       )
     }
+  }
+
+  /** Both keys are optional and goal-family-only, so a snapshot without them stays wire-identical. */
+  private fun MutableMap<String, Any?>.putActiveDuration() {
+    activeDurationMs?.let { put("active_duration_ms", it) }
+    activeDurationAsOf?.let { put("active_duration_as_of", it.toString()) }
   }
 
   private fun planningWireMap(planning: IdeStatusPlanning): Map<String, Any?> = buildMap {

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
@@ -115,6 +115,8 @@ class IdeStatusProjector(
       // Durable record only: a lease-expiry-inferred pause has no recorded instant, and
       // back-filling from heartbeat_at/updated_at would sell an inference as a record.
       pausedAt = parseInstantOrNull(projection?.pausedAt),
+      activeDurationMs = projection?.recordedActiveDurationMs(),
+      activeDurationAsOf = projection?.liveActiveDurationAnchor(),
       updatedAt = candidate.updatedAt,
       freshness = freshness,
       // "is planning subtasks" describes work in flight, so a paused goal keeps the Planning
@@ -143,6 +145,24 @@ class IdeStatusProjector(
    * Only [ExecutionLiveness.IDLE] qualifies; UNKNOWN is a lease-read failure and must not
    * be read as absence.
    */
+  /**
+   * Zero accumulated time with no live anchor is not an observation that the goal did no work — it
+   * is a goal the runtime never watched execute, including every goal that predates the accumulator.
+   * Emitting the zero would have a consumer render "0s" as fact; omitting it lets the consumer fall
+   * back to its own clock.
+   */
+  private fun GoalRunnerStatusProjection.recordedActiveDurationMs(): Long? =
+    activeDurationMs.takeIf { it > 0 || liveActiveDurationAnchor() != null }
+
+  /**
+   * The anchor is a licence to add `now - anchor`, so it is published only while the lease is
+   * genuinely live. A killed runner never reaches `releaseExecutionLease`, leaving a stale anchor
+   * behind; honouring it would grow an unbounded tail and restore the inflated clock this exists to
+   * remove. UNKNOWN is a lease-read failure and is not evidence of a live lease.
+   */
+  private fun GoalRunnerStatusProjection.liveActiveDurationAnchor(): Instant? =
+    parseInstantOrNull(activeDurationAsOf).takeIf { executionLiveness == ExecutionLiveness.LIVE }
+
   private fun goalLifecycle(
     candidate: IdeStatusCandidate,
     projection: GoalRunnerStatusProjection?,

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
@@ -1072,6 +1072,85 @@ class WorkflowServiceTest {
     )
   }
 
+  /**
+   * A scoped replan discards the subtask's stored plan, but a child hydrated from that plan keeps the
+   * old planning bytes as its own import. Leaving the child behind made the next launch fail the
+   * hydration provenance check and strand the goal on advice to hard reset, discarding every
+   * completed subtask's commit mapping to recover one amended subtask.
+   */
+  @Test
+  fun `scoped replan deletes the replanned subtask's hydrated child and preserves completed siblings`() {
+    val workflows = RecordingGoalChildDeletionWorkflowStates()
+    val before = decompositionRuntime(status = "in_progress").copy(
+      currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 2, action = "start"),
+      subtasks = listOf(
+        decompositionRuntime(status = "complete").subtasks.single().copy(
+          id = 1,
+          status = "complete",
+          commitSha = "sha-done",
+          workflowId = "wfl-child-1",
+          lastResumableStep = "commit_push",
+        ),
+        decompositionRuntime(status = "blocked").subtasks.single().copy(
+          id = 2,
+          status = "blocked",
+          workflowId = "wfl-child-2",
+          blockedReason = "planning import conflicts",
+          lastResumableStep = "audit",
+        ),
+      ),
+    )
+    val result = scopedReplanStore(workflows, before).saveScopedReplan(
+      state = scopedReplanState(before, "skillbill-scoped-replan-child"),
+      subtaskId = 2,
+      dbPathOverride = null,
+      options = skillbill.ports.goalrunner.model.GoalRunnerScopedReplanOptions(),
+    )
+
+    assertEquals(listOf(2), result.clearedChildSubtaskIds)
+    assertEquals(listOf(Triple("wfl-parent", 2, "wfl-child-2")), workflows.scopedDeletions)
+    val replanned = result.state.manifest.subtasks.single { it.id == 2 }
+    assertEquals("pending", replanned.status)
+    assertNull(replanned.workflowId, "A stale hydrated child must not survive the replan.")
+    assertNull(replanned.blockedReason)
+    assertNull(replanned.lastResumableStep)
+    val completed = result.state.manifest.subtasks.single { it.id == 1 }
+    assertEquals("complete", completed.status)
+    assertEquals("sha-done", completed.commitSha, "Scoped replan must preserve completed commit mappings.")
+    assertEquals("wfl-child-1", completed.workflowId)
+    assertEquals(
+      CurrentSubtaskIntent(subtaskId = 2, action = "start"),
+      result.state.manifest.currentSubtaskIntent,
+      "Child deletion must not retarget the intent the replan already set.",
+    )
+  }
+
+  @Test
+  fun `scoped replan keeps a live child that scoped deletion refuses to remove`() {
+    val workflows = RecordingGoalChildDeletionWorkflowStates(deletable = false)
+    val before = decompositionRuntime(status = "in_progress").copy(
+      currentSubtaskIntent = CurrentSubtaskIntent(subtaskId = 1, action = "resume"),
+      subtasks = listOf(
+        decompositionRuntime(status = "in_progress").subtasks.single().copy(
+          id = 1,
+          status = "in_progress",
+          workflowId = "wfl-child-1",
+          lastResumableStep = "implement",
+        ),
+      ),
+    )
+    val result = scopedReplanStore(workflows, before).saveScopedReplan(
+      state = scopedReplanState(before, "skillbill-scoped-replan-live-child"),
+      subtaskId = 1,
+      dbPathOverride = null,
+      options = skillbill.ports.goalrunner.model.GoalRunnerScopedReplanOptions(),
+    )
+
+    assertEquals(emptyList(), result.clearedChildSubtaskIds)
+    assertEquals("wfl-child-1", result.state.manifest.subtasks.single().workflowId)
+    assertEquals("implement", result.state.manifest.subtasks.single().lastResumableStep)
+  }
+
   @Test
   fun `goal completion boundary persists terminal child state into the parent workflow`() {
     val workflows = InMemoryWorkflowStates()
@@ -2807,6 +2886,38 @@ private fun rejectingDecompositionManifestValidator(rejectedSources: Set<String>
     }
   }
 
+private fun scopedReplanStore(
+  workflows: RecordingGoalChildDeletionWorkflowStates,
+  manifest: DecompositionManifest,
+): WorkflowGoalRunnerManifestStore {
+  workflows.saveFeatureImplementWorkflow(
+    workflowRecord(
+      workflowId = "wfl-parent",
+      artifactsPatch = mapOf(
+        "plan" to mapOf("mode" to "decompose"),
+        DECOMPOSITION_RUNTIME_ARTIFACT_KEY to
+          encodeDecompositionManifestMap(manifest, testDecompositionManifestValidator),
+      ),
+    ),
+  )
+  return WorkflowGoalRunnerManifestStore(
+    database = FakeDatabaseSessionFactory(workflows),
+    workflowSnapshotValidator = testWorkflowSnapshotValidator,
+    decompositionManifestValidator = testDecompositionManifestValidator,
+    decompositionManifestFileStore = TestDecompositionManifestFileStore,
+    phaseOutputValidator = AlwaysValidValidator,
+    planningProjectionValidator = realPlanningProjectionValidator,
+  )
+}
+
+// A temp repoRoot keeps the projection writer off the process cwd, which other tests assert stays clean.
+private fun scopedReplanState(manifest: DecompositionManifest, tempPrefix: String) = GoalRunnerManifestState(
+  "wfl-parent",
+  "/fake/metrics.db",
+  manifest,
+  repoRoot = Files.createTempDirectory(tempPrefix),
+)
+
 private fun decompositionRuntime(status: String): DecompositionManifest = DecompositionManifest(
   issueKey = "SKILL-52.1",
   featureName = "install-policy-extraction",
@@ -3550,6 +3661,22 @@ private class RecordingGoalRunnerControlRepository : GoalRunnerControlRepository
   ): GoalRunnerOutOfBandAcceptance {
     acceptances.getOrPut(parentWorkflowId, ::mutableMapOf)[acceptance.subtaskId] = acceptance
     return acceptance
+  }
+}
+
+/**
+ * Mirrors `WorkflowStateStore.deleteGoalChildWorkflow`, which deletes only terminal goal children;
+ * [deletable] stands in for a live or resumable child the SQL predicate refuses to remove.
+ */
+internal class RecordingGoalChildDeletionWorkflowStates(
+  private val deletable: Boolean = true,
+  delegate: InMemoryWorkflowStates = InMemoryWorkflowStates(),
+) : WorkflowStateRepository by delegate {
+  val scopedDeletions = mutableListOf<Triple<String, Int, String>>()
+
+  override fun deleteGoalChildWorkflow(parentWorkflowId: String, subtaskId: Int, workflowId: String): Int {
+    scopedDeletions += Triple(parentWorkflowId, subtaskId, workflowId)
+    return if (deletable) 1 else 0
   }
 }
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
@@ -752,6 +752,45 @@ class IdeStatusServiceTest {
     assertFalse(wire.containsKey("paused_at"))
   }
 
+  /**
+   * Zero is not an observation that the goal did no work. Emitting it would have the widget render
+   * "Goal elapsed: 0s" as fact for every goal predating the accumulator, instead of letting the
+   * consumer fall back to its own clock.
+   */
+  @Test
+  fun `a goal with no recorded execution omits the active duration rather than publishing zero`() {
+    val wire = goalWireMapUnderControls(
+      "ide-status-goal-active-duration-unrecorded",
+      GoalRunnerControlState(),
+    ) { result ->
+      assertEquals(IdeStatusLifecycleState.ACTIVE, result.snapshot.lifecycleState)
+    }
+
+    assertFalse(wire.containsKey("active_duration_ms"))
+    assertFalse(wire.containsKey("active_duration_as_of"))
+  }
+
+  /**
+   * A killed runner never reaches releaseExecutionLease, so its anchor survives in the durable
+   * record. Publishing it would license the consumer to add an unbounded `now - anchor` tail and
+   * rebuild the inflated clock the accumulator exists to remove.
+   */
+  @Test
+  fun `a stale anchor from a dead runner is withheld while the accumulated total still ships`() {
+    val wire = goalWireMapUnderControls(
+      "ide-status-goal-active-duration-stale-anchor",
+      GoalRunnerControlState(
+        activeDurationMs = 90_000,
+        activeDurationAsOf = "2026-08-06T09:00:00Z",
+      ),
+    ) { result ->
+      assertEquals(IdeStatusLifecycleState.ACTIVE, result.snapshot.lifecycleState)
+    }
+
+    assertEquals(90_000L, wire["active_duration_ms"])
+    assertFalse(wire.containsKey("active_duration_as_of"))
+  }
+
   @Test
   fun `non-goal families never carry pause signals`() {
     val fixture = gitRepoFixture("ide-status-pause-non-goal")

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
@@ -1219,6 +1219,7 @@ private fun GoalRunnerReplanResult?.toGoalReplanCliMap(issueKey: String): Map<St
     "discarded_plan" to it.discardedPlan,
     "discarded_shared_preplan" to it.discardedSharedPreplan,
     "cascaded_plan_subtask_ids" to it.cascadedPlanSubtaskIds,
+    "cleared_child_subtask_ids" to it.clearedChildSubtaskIds,
     "before" to replanSnapshotMap(it.before),
     "after" to replanSnapshotMap(it.after),
   )

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -805,6 +805,13 @@ class CliGoalSharedPreplanReplanTest {
     val cascaded = replan.payload?.get("cascaded_plan_subtask_ids") as? List<*>
     assertTrue(!cascaded.isNullOrEmpty(), "cascade must name at least one sibling plan")
     assertFalse(3 in cascaded.mapNotNull { (it as? Number)?.toInt() ?: (it as? String)?.toIntOrNull() })
+    // The replan deletes children hydrated from a discarded plan, but never a completed subtask's:
+    // that would drop the commit_sha and workflow_id mapping this cascade is required to preserve.
+    val clearedChildren = (replan.payload.get("cleared_child_subtask_ids") as? List<*>)
+      ?.mapNotNull { (it as? Number)?.toInt() ?: (it as? String)?.toIntOrNull() }
+      .orEmpty()
+    assertFalse(1 in clearedChildren, "a completed subtask's child must survive the cascade")
+    assertFalse(2 in clearedChildren, "a completed subtask's child must survive the cascade")
     val statusAfter = goalStatus(fixture, launcher)
     assertContains(statusAfter.stdout, "shared_preplan=false")
     assertContains(statusAfter.stdout, "complete: 2")

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerModels.kt
@@ -253,6 +253,13 @@ const val GOAL_PAUSE_REASON_OPERATOR_STOP: String = "operator_stop"
 /** The runner process was terminated from outside; its shutdown hook recorded the interruption. */
 const val GOAL_PAUSE_REASON_RUNNER_INTERRUPTED: String = "runner_interrupted"
 
+/**
+ * Longest heartbeat gap that still counts as execution. A live runner heartbeats every
+ * `GoalRunnerExecutionCoordinator.HEARTBEAT_SECONDS`; a larger gap means the runner was gone and the
+ * interval was downtime, so it must not be folded into the active total.
+ */
+const val GOAL_ACTIVE_HEARTBEAT_GAP_LIMIT_MS: Long = 20_000
+
 /** Durable parent-owned pause, stop-after, and execution state, separate from the checked-in manifest. */
 data class GoalRunnerControlState(
   val stopAfterSubtaskId: Int? = null,
@@ -264,9 +271,17 @@ data class GoalRunnerControlState(
   val stopAfterConsumed: Boolean = false,
   val repositoryIdentity: String? = null,
   val executionLease: GoalRunnerExecutionLease? = null,
+  // Time this goal spent actually executing, which is not the wall clock since it was opened: a goal
+  // sits blocked, paused, or simply unattended between runs, and those gaps are not work.
+  val activeDurationMs: Long = 0,
+  // The instant activeDurationMs is current as of, set while a lease is live. A reader adds
+  // now - activeDurationAsOf to get the live total; the next heartbeat folds that same tail in.
+  val activeDurationAsOf: String? = null,
 ) {
   init {
     stopAfterSubtaskId?.let { require(it > 0) { "stopAfterSubtaskId must be positive when provided." } }
+    require(activeDurationMs >= 0) { "activeDurationMs must not be negative." }
+    activeDurationAsOf?.let { require(it.isNotBlank()) { "activeDurationAsOf must not be blank when provided." } }
     require(!pauseConsumed || pauseRequested) {
       "pauseConsumed cannot be true when pauseRequested is false."
     }
@@ -374,6 +389,8 @@ data class GoalRunnerStatusProjection(
   val pauseReason: String? = null,
   val pausedAt: String? = null,
   val stopAfterSubtaskId: Int? = null,
+  val activeDurationMs: Long = 0,
+  val activeDurationAsOf: String? = null,
 )
 
 /**
@@ -415,6 +432,8 @@ data class GoalRunnerStatusProjectionExtras(
   val pauseReason: String? = null,
   val pausedAt: String? = null,
   val stopAfterSubtaskId: Int? = null,
+  val activeDurationMs: Long = 0,
+  val activeDurationAsOf: String? = null,
 )
 
 object GoalRunnerStatusProjector {
@@ -466,6 +485,8 @@ object GoalRunnerStatusProjector {
       pauseReason = extras.pauseReason,
       pausedAt = extras.pausedAt,
       stopAfterSubtaskId = extras.stopAfterSubtaskId,
+      activeDurationMs = extras.activeDurationMs,
+      activeDurationAsOf = extras.activeDurationAsOf,
     )
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/agentaddon/AgentAddonSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/agentaddon/AgentAddonSchemaValidator.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.contracts.agentaddon.AGENT_ADDON_CONTRACT_VERSION
 import skillbill.contracts.agentaddon.AgentAddonSchemaPaths
 import skillbill.error.InvalidAgentAddonSchemaError
@@ -55,7 +56,7 @@ class AgentAddonSchemaValidator(
           "schema contract version '$version' does not match '$AGENT_ADDON_CONTRACT_VERSION'",
         )
       }
-      JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(node)
+      JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(node, LOCALE_STABLE_SCHEMA_CONFIG)
     }
 }
 

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/SchemaValidatorLocale.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/SchemaValidatorLocale.kt
@@ -1,0 +1,20 @@
+package skillbill.contracts
+
+import com.networknt.schema.PathType
+import com.networknt.schema.SchemaValidatorsConfig
+import java.util.Locale
+
+/**
+ * networknt renders every violation message through `MessageFormat` under the JVM default locale, so the
+ * same rejection reads differently per host: an `en_DE` machine regroups 4096 as "4.096", and a `de_DE`
+ * one translates the sentence outright. These messages are governed text — they are echoed verbatim into
+ * the retry prompt a producing agent must act on — so a regrouped digit reads as a different constraint
+ * and a translated one as no constraint at all. Pin the rendering to English so it is host-independent.
+ *
+ * `pathType` is restated because supplying any config at all switches the factory off its LEGACY default
+ * and onto JSON_POINTER. LEGACY and JSON_PATH agree on ordinary paths but not on keys holding a `/`:
+ * LEGACY emits `$.pointers.code-review/bill-x[0].name`, JSON_PATH bracket-quotes the key. Callers parse
+ * these locations back into field paths, so LEGACY is the one that keeps reported locations unchanged.
+ */
+internal val LOCALE_STABLE_SCHEMA_CONFIG: SchemaValidatorsConfig =
+  SchemaValidatorsConfig.builder().locale(Locale.ENGLISH).pathType(PathType.LEGACY).build()

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/install/InstallPlanSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/install/InstallPlanSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidInstallPlanSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -163,7 +164,7 @@ private fun loadSchema(): JsonSchema {
     InstallPlanSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    return factory.getSchema(jsonText)
+    return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     // F-403 (carried over from 2a): a misbuilt deploy artifact (missing
     // classpath resource, corrupt YAML, or a shadowed copy) would

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/review/ReviewContextSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/review/ReviewContextSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidReviewContextSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -173,7 +174,7 @@ private fun loadReviewContextSchema(): ReviewContextSchemas {
     ReviewContextSchemaValidator.assertIdentity(yamlNode)
     val mapper = ObjectMapper()
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    val envelopeSchema = factory.getSchema(mapper.writeValueAsString(yamlNode))
+    val envelopeSchema = factory.getSchema(mapper.writeValueAsString(yamlNode), LOCALE_STABLE_SCHEMA_CONFIG)
     val defs = yamlNode.path("\$defs")
     val branches = yamlNode.path("oneOf").asSequence()
       .map { branch -> branch.path("\$ref").asText("").substringAfterLast('/') }
@@ -183,7 +184,7 @@ private fun loadReviewContextSchema(): ReviewContextSchemas {
         wrapper.put("\$schema", yamlNode.path("\$schema").asText())
         wrapper.put("\$ref", "#/\$defs/" + name)
         wrapper.set<com.fasterxml.jackson.databind.node.ObjectNode>("\$defs", defs.deepCopy())
-        factory.getSchema(mapper.writeValueAsString(wrapper))
+        factory.getSchema(mapper.writeValueAsString(wrapper), LOCALE_STABLE_SCHEMA_CONFIG)
       }
     return ReviewContextSchemas(envelopeSchema, branches)
   } catch (error: Throwable) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/DecompositionManifestSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/DecompositionManifestSchemaValidator.kt
@@ -12,6 +12,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidDecompositionManifestSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -183,7 +184,7 @@ private fun loadDecompositionManifestSchema(): JsonSchema {
     DecompositionManifestSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    return factory.getSchema(jsonText)
+    return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     decompositionManifestLog.log(
       Level.SEVERE,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeAuditGenerationSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeAuditGenerationSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidFeatureTaskRuntimeAuditGenerationSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -35,7 +36,7 @@ object FeatureTaskRuntimeAuditGenerationSchemaValidator {
   }
 
   private fun compile(document: JsonNode): JsonSchema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    .getSchema(ObjectMapper().writeValueAsString(document))
+    .getSchema(ObjectMapper().writeValueAsString(document), LOCALE_STABLE_SCHEMA_CONFIG)
 
   private fun formatReason(errors: Set<ValidationMessage>): String =
     errors.sortedBy { it.instanceLocation?.toString().orEmpty() }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeCheckpointIdentitySchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeCheckpointIdentitySchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidFeatureTaskRuntimeCheckpointIdentitySchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -35,7 +36,7 @@ object FeatureTaskRuntimeCheckpointIdentitySchemaValidator {
   }
 
   private fun compile(document: JsonNode): JsonSchema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    .getSchema(ObjectMapper().writeValueAsString(document))
+    .getSchema(ObjectMapper().writeValueAsString(document), LOCALE_STABLE_SCHEMA_CONFIG)
 
   private fun formatReason(errors: Set<ValidationMessage>): String =
     errors.sortedBy { it.instanceLocation?.toString().orEmpty() }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeHandoffEnvelopeSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeHandoffEnvelopeSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.FeatureTaskRuntimeHandoffProjectionFailureKind
 import skillbill.error.InvalidFeatureTaskRuntimeHandoffProjectionError
 import java.nio.file.Files
@@ -74,7 +75,7 @@ private fun loadHandoffEnvelopeSchema(): JsonSchema = try {
   val yamlNode = YAMLMapper().readTree(readHandoffEnvelopeSchemaText())
   FeatureTaskRuntimeHandoffEnvelopeSchemaValidator.assertIdentity(yamlNode)
   JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    .getSchema(ObjectMapper().writeValueAsString(yamlNode))
+    .getSchema(ObjectMapper().writeValueAsString(yamlNode), LOCALE_STABLE_SCHEMA_CONFIG)
 } catch (error: InvalidFeatureTaskRuntimeHandoffProjectionError) {
   throw error
 } catch (error: Exception) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeHandoffFoundationSchemaValidators.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeHandoffFoundationSchemaValidators.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidFeatureTaskRuntimePersistenceSchemaError
 import skillbill.error.InvalidFeatureTaskRuntimePhaseHandoffSchemaError
 import skillbill.error.InvalidFeatureTaskRuntimeProjectionMeasurementSchemaError
@@ -62,7 +63,7 @@ private fun validateAgainst(
     val document = YAMLMapper().readTree(readContract(classpathResource, repoPath))
     require(document.path("\$id").asText() == expectedId) { "schema identity mismatch" }
     val schema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-      .getSchema(ObjectMapper().writeValueAsString(document))
+      .getSchema(ObjectMapper().writeValueAsString(document), LOCALE_STABLE_SCHEMA_CONFIG)
     schema.validate(ObjectMapper().valueToTree(payload))
   }
   if (failures.isNotEmpty()) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeImplementationAttemptSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeImplementationAttemptSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidFeatureTaskRuntimeImplementationAttemptSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -35,7 +36,7 @@ object FeatureTaskRuntimeImplementationAttemptSchemaValidator {
   }
 
   private fun compile(document: JsonNode): JsonSchema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    .getSchema(ObjectMapper().writeValueAsString(document))
+    .getSchema(ObjectMapper().writeValueAsString(document), LOCALE_STABLE_SCHEMA_CONFIG)
 
   private fun formatReason(errors: Set<ValidationMessage>): String =
     errors.sortedBy { it.instanceLocation?.toString().orEmpty() }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidator.kt
@@ -13,6 +13,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.FeatureTaskRuntimePhaseOutputFailureKind
 import skillbill.error.InvalidFeatureTaskRuntimeAuditRepairPlanSchemaError
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
@@ -476,7 +477,7 @@ internal fun loadAuditRepairPlanSchemaText(text: String, sourceLabel: String): J
       "'$FEATURE_TASK_RUNTIME_AUDIT_REPAIR_CONTRACT_VERSION'."
   }
   JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    .getSchema(ObjectMapper().writeValueAsString(node))
+    .getSchema(ObjectMapper().writeValueAsString(node), LOCALE_STABLE_SCHEMA_CONFIG)
 } catch (error: InvalidFeatureTaskRuntimeAuditRepairPlanSchemaError) {
   throw error
 } catch (error: Exception) {
@@ -510,7 +511,7 @@ private fun loadFeatureTaskRuntimePhaseOutputSchema(): JsonSchema {
     FeatureTaskRuntimePhaseOutputSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    return factory.getSchema(jsonText)
+    return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     featureTaskRuntimePhaseOutputLog.log(
       Level.SEVERE,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionSchemaValidator.kt
@@ -10,6 +10,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidFeatureTaskRuntimePlanningProjectionSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -52,7 +53,7 @@ object FeatureTaskRuntimePlanningProjectionSchemaValidator {
     }
 
   private fun compile(document: JsonNode): JsonSchema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    .getSchema(ObjectMapper().writeValueAsString(document))
+    .getSchema(ObjectMapper().writeValueAsString(document), LOCALE_STABLE_SCHEMA_CONFIG)
 
   private val PROJECTION_VARIANT_DEFS: Set<String> = setOf(
     "preplanning_digest",

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeQuarantineSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeQuarantineSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidFeatureTaskRuntimeQuarantineSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -36,7 +37,7 @@ object FeatureTaskRuntimeQuarantineSchemaValidator {
   }
 
   private fun compile(document: JsonNode): JsonSchema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    .getSchema(ObjectMapper().writeValueAsString(document))
+    .getSchema(ObjectMapper().writeValueAsString(document), LOCALE_STABLE_SCHEMA_CONFIG)
 
   private fun formatReason(errors: Set<ValidationMessage>): String =
     errors.sortedBy { it.instanceLocation?.toString().orEmpty() }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/GoalObservabilityEventSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/GoalObservabilityEventSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidGoalObservabilityEventSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -104,7 +105,8 @@ private fun loadGoalObservabilityEventSchema(): JsonSchema {
     val yamlNode = YAMLMapper().readTree(yamlText)
     GoalObservabilityEventSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
-    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(jsonText)
+    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+      .getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     goalObservabilityLog.log(
       Level.SEVERE,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/GoalPlanningPreparationSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/GoalPlanningPreparationSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidGoalPlanningPreparationSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -143,7 +144,7 @@ private fun loadGoalPlanningPreparationSchema(): JsonSchema {
     GoalPlanningPreparationSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    return factory.getSchema(jsonText)
+    return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     goalPlanningPreparationLog.log(
       Level.SEVERE,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/GoalProgressEventSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/GoalProgressEventSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidGoalProgressEventSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -104,7 +105,8 @@ private fun loadGoalProgressEventSchema(): JsonSchema {
     val yamlNode = YAMLMapper().readTree(yamlText)
     GoalProgressEventSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
-    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(jsonText)
+    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+      .getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     goalProgressLog.log(
       Level.SEVERE,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/IdeStatusSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/IdeStatusSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidIdeStatusSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -104,7 +105,8 @@ private fun loadIdeStatusSchema(): JsonSchema {
     val yamlNode = YAMLMapper().readTree(yamlText)
     IdeStatusSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
-    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(jsonText)
+    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+      .getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     ideStatusLog.log(
       Level.SEVERE,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/WorkflowStateSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/WorkflowStateSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidWorkflowStateSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -190,7 +191,7 @@ private fun loadSchema(): JsonSchema {
     assertWorkflowStateSchemaIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    return factory.getSchema(jsonText)
+    return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (error: Throwable) {
     // F-403: a misbuilt deploy artifact (missing classpath resource,
     // corrupt YAML, or a shadowed copy) would otherwise silently

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.contracts.workflow.PRODUCER_OUTPUT_EVIDENCE_CONTRACT_VERSION
 import skillbill.contracts.workflow.ProducerOutputEvidenceSchemaPaths
 import skillbill.error.InvalidProducerOutputEvidenceSchemaError
@@ -45,6 +46,7 @@ object ProducerOutputEvidenceSchemaValidator {
         "Canonical producer output evidence schema resource is missing.",
       )
     val document: JsonNode = resource.use { stream -> YAMLMapper().readTree(stream) }
-    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(document)
+    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+      .getSchema(document, LOCALE_STABLE_SCHEMA_CONFIG)
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.contracts.workflow.REJECTED_OUTPUT_DIAGNOSTIC_CONTRACT_VERSION
 import skillbill.contracts.workflow.RejectedOutputDiagnosticSchemaPaths
 import skillbill.error.InvalidRejectedOutputDiagnosticSchemaError
@@ -48,6 +49,7 @@ object RejectedOutputDiagnosticSchemaValidator {
         "Canonical rejected-output diagnostic schema resource is missing.",
       )
     val document: JsonNode = resource.use { stream -> YAMLMapper().readTree(stream) }
-    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(document)
+    return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+      .getSchema(document, LOCALE_STABLE_SCHEMA_CONFIG)
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/NativeAgentLinkInventory.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/NativeAgentLinkInventory.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.contracts.nativeagent.NATIVE_AGENT_LINK_INVENTORY_CONTRACT_VERSION
 import skillbill.contracts.nativeagent.NativeAgentLinkInventorySchemaPaths
 import skillbill.error.InvalidNativeAgentLinkInventorySchemaError
@@ -32,7 +33,8 @@ internal object NativeAgentLinkInventory {
   private val mapper = ObjectMapper().enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
   private val schema by lazy {
     val resource = requireNotNull(javaClass.getResourceAsStream(NativeAgentLinkInventorySchemaPaths.CLASSPATH_RESOURCE))
-    JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(YAMLMapper().readTree(resource))
+    JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+      .getSchema(YAMLMapper().readTree(resource), LOCALE_STABLE_SCHEMA_CONFIG)
   }
 
   fun reconcile(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/nativeagent/composition/NativeAgentCompositionSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/nativeagent/composition/NativeAgentCompositionSchemaValidator.kt
@@ -9,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.InvalidNativeAgentCompositionSchemaError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -149,7 +150,7 @@ object NativeAgentCompositionSchemaValidator {
       assertIdentity(yamlNode)
       val jsonText = jsonMapper.writeValueAsString(yamlNode)
       val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-      return factory.getSchema(jsonText)
+      return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
     } catch (error: Throwable) {
       // F-403 (carried over from 2a/2b): a misbuilt deploy artifact
       // (missing classpath resource, corrupt YAML, or a shadowed copy)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/platformpack/PlatformPackSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/scaffold/platformpack/PlatformPackSchemaValidator.kt
@@ -7,6 +7,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.LOCALE_STABLE_SCHEMA_CONFIG
 import skillbill.error.ContractVersionMismatchError
 import skillbill.error.InvalidManifestSchemaError
 import skillbill.scaffold.runtime.SHELL_CONTRACT_VERSION
@@ -264,7 +265,7 @@ private fun loadSchema(): JsonSchema {
   assertSchemaIdentity(yamlNode)
   val jsonText = ObjectMapper().writeValueAsString(yamlNode)
   val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-  return factory.getSchema(jsonText)
+  return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
 }
 
 /**

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/SchemaValidatorLocaleStabilityTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/SchemaValidatorLocaleStabilityTest.kt
@@ -1,0 +1,73 @@
+package skillbill.contracts.workflow
+
+import skillbill.error.InvalidFeatureTaskRuntimePlanningProjectionSchemaError
+import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+
+/**
+ * networknt renders violation messages through `MessageFormat` under the JVM default locale, and the
+ * runtime echoes those messages verbatim into the retry prompt a producing agent must act on. A host in
+ * a non-US region therefore used to change what the agent was told: `en_DE` regrouped the 4096-character
+ * cap as "4.096" — which reads as a four-character budget — and `de_DE` translated the sentence outright,
+ * leaving no machine-actionable constraint at all. This was not hypothetical: it broke CI on a macOS
+ * runner whose region is DE while its language is English.
+ *
+ * Locking the rendering here rather than in the failing consumer keeps the guarantee where the cause is,
+ * and the location assertion pins the path dialect that supplying a validator config would otherwise
+ * silently switch (LEGACY -> JSON_POINTER), which callers parse back into dotted field paths.
+ */
+class SchemaValidatorLocaleStabilityTest {
+  @Test
+  fun `a length violation renders in English with US grouping under any host locale`() {
+    withDefaultLocale(Locale.GERMANY) {
+      val error = assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
+        FeatureTaskRuntimePlanningProjectionSchemaValidator.validate(
+          payload = overLongEvidenceReceipt(),
+          sourceLabel = "implement#produced_outputs",
+        )
+      }
+      assertContains(error.message.orEmpty(), "must be at most 4,096 characters long")
+    }
+  }
+
+  @Test
+  fun `violation locations stay in the dotted dialect callers parse under any host locale`() {
+    withDefaultLocale(Locale.GERMANY) {
+      val error = assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
+        FeatureTaskRuntimePlanningProjectionSchemaValidator.validate(
+          payload = overLongEvidenceReceipt(),
+          sourceLabel = "implement#produced_outputs",
+        )
+      }
+      assertContains(error.message.orEmpty(), "\$.reconciliation_evidence.evidence")
+    }
+  }
+
+  private fun overLongEvidenceReceipt(): Map<String, Any?> = linkedMapOf(
+    "projection_kind" to "implementation_receipt",
+    "contract_version" to FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION,
+    "completed_task_ids" to listOf("task-01"),
+    "changed_paths" to listOf("runtime-domain/model/X.kt"),
+    "tests_executed" to listOf(linkedMapOf("name" to "XTest.kt", "outcome" to "passed")),
+    "reconciliation_evidence" to linkedMapOf(
+      "reconciled" to true,
+      "evidence" to "Verified X.kt matches the plan commitment; no edit was required. ".repeat(80),
+    ),
+    "repository_checkpoint" to linkedMapOf("fingerprint" to "abc123"),
+    "reconciled_state" to linkedMapOf("reconciled" to true),
+    "deferred_repair_item_ids" to emptyList<String>(),
+    "repair_item_results" to emptyList<Map<String, Any?>>(),
+  )
+
+  private fun withDefaultLocale(locale: Locale, block: () -> Unit) {
+    val previous = Locale.getDefault()
+    Locale.setDefault(locale)
+    try {
+      block()
+    } finally {
+      Locale.setDefault(previous)
+    }
+  }
+}

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/workflow/GoalRunnerControlStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/workflow/GoalRunnerControlStore.kt
@@ -37,12 +37,16 @@ internal class GoalRunnerControlStore(
   }
 
   override fun clearControlState(parentWorkflowId: String) {
-    val executionLease = controlState(parentWorkflowId).executionLease
-    if (executionLease != null) {
-      persistControlState(
-        parentWorkflowId,
-        GoalRunnerControlState(executionLease = executionLease),
-      )
+    val existing = controlState(parentWorkflowId)
+    // The lease and the accumulated execution total are runtime bookkeeping, not operator intent.
+    // Clearing a pause must not restart the goal's execution clock at zero.
+    val retained = GoalRunnerControlState(
+      executionLease = existing.executionLease,
+      activeDurationMs = existing.activeDurationMs,
+      activeDurationAsOf = existing.activeDurationAsOf,
+    )
+    if (retained != GoalRunnerControlState()) {
+      persistControlState(parentWorkflowId, retained)
       return
     }
     connection.prepareStatement(
@@ -177,6 +181,8 @@ private fun GoalRunnerControlState.toArtifactMap(): Map<String, Any?> = mapOf(
   "stop_after_consumed" to stopAfterConsumed,
   "repository_identity" to repositoryIdentity,
   "execution_lease" to executionLease?.toArtifactMap(),
+  "active_duration_ms" to activeDurationMs,
+  "active_duration_as_of" to activeDurationAsOf,
 )
 
 /**
@@ -198,6 +204,8 @@ private fun decodeControlState(raw: String): GoalRunnerControlState {
     "stop_after_consumed",
     "repository_identity",
     "execution_lease",
+    "active_duration_ms",
+    "active_duration_as_of",
   )
   state.keys.forEach { key ->
     require(key in allowedKeys) { "Goal runner control state has unsupported field '$key'." }
@@ -212,8 +220,23 @@ private fun decodeControlState(raw: String): GoalRunnerControlState {
     stopAfterConsumed = state.booleanOrDefault("stop_after_consumed", false),
     repositoryIdentity = state.nullableString("repository_identity"),
     executionLease = state["execution_lease"]?.let(::decodeExecutionLease),
+    activeDurationMs = state.nonNegativeLongOrDefault("active_duration_ms"),
+    activeDurationAsOf = state.nullableString("active_duration_as_of"),
   )
 }
+
+// A record written before the active clock existed simply has no accumulated time yet, which reads
+// as "never observed executing" and starts accumulating on the next heartbeat. Numeric coercion
+// matches the sibling decoders: a surprising-but-integral primitive must not fail the whole control
+// row, because that would take status, pause, resume, and the lease down with it.
+private fun Map<String, Any?>.nonNegativeLongOrDefault(key: String): Long = when (val value = this[key]) {
+  null -> 0L
+  is java.math.BigInteger -> runCatching { value.longValueExact() }.getOrNull()
+  is java.math.BigDecimal -> runCatching { value.toBigIntegerExact().longValueExact() }.getOrNull()
+  is Number -> value.toLong()
+  else -> null
+}?.takeIf { it >= 0 }
+  ?: error("Goal runner control state field '$key' must be a non-negative integer.")
 
 /**
  * Pause timestamp for a durable record written before `paused_at` existed. Downstream consumers read

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/GoalRunnerControlStoreTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/GoalRunnerControlStoreTest.kt
@@ -201,4 +201,139 @@ class GoalRunnerControlStoreTest {
       assertEquals(null, store.executionLease("parent-lease"))
     }
   }
+
+  /** Clearing a pause is operator intent; it must not reset the goal's accumulated execution clock. */
+  @Test
+  fun `clearing control state preserves the accumulated execution clock`() {
+    val dbPath = Files.createTempDirectory("skillbill-goal-clear-active-clock").resolve("metrics.db")
+    val lease = GoalRunnerExecutionLease(
+      generation = 1,
+      ownerToken = "owner-token-123456",
+      hostIdentity = "host",
+      bootIdentity = "boot",
+      pid = 42,
+      processBirthToken = "birth",
+      heartbeatAt = "2026-08-02T10:00:00Z",
+      expiresAt = "2026-08-02T10:00:30Z",
+    )
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val store = GoalRunnerControlStore(connection)
+      assertTrue(store.acquireExecutionLease("parent-clear", lease))
+      assertTrue(store.heartbeatExecutionLease("parent-clear", lease.copy(heartbeatAt = "2026-08-02T10:00:10Z")))
+      val paused = store.controlState("parent-clear")
+      store.persistControlState(
+        "parent-clear",
+        paused.copy(
+          pauseRequested = true,
+          paused = true,
+          pauseReason = "operator_request",
+          pausedAt = "2026-08-02T10:00:10Z",
+        ),
+      )
+
+      store.clearControlState("parent-clear")
+
+      val cleared = store.controlState("parent-clear")
+      assertEquals(false, cleared.paused)
+      assertEquals(10_000, cleared.activeDurationMs)
+      assertEquals("2026-08-02T10:00:10Z", cleared.activeDurationAsOf)
+    }
+  }
+
+  /**
+   * The goal clock must measure execution, not the wall clock since the goal was opened. A goal that
+   * sits blocked overnight and is relaunched the next morning has not been working for twelve hours.
+   */
+  @Test
+  fun `the active execution clock caps an over-long heartbeat gap instead of counting the downtime`() {
+    val dbPath = Files.createTempDirectory("skillbill-goal-active-clock").resolve("metrics.db")
+    val lease = GoalRunnerExecutionLease(
+      generation = 1,
+      ownerToken = "owner-token-123456",
+      hostIdentity = "host",
+      bootIdentity = "boot",
+      pid = 42,
+      processBirthToken = "birth",
+      heartbeatAt = "2026-08-07T18:22:00Z",
+      expiresAt = "2026-08-07T18:22:30Z",
+    )
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val store = GoalRunnerControlStore(connection)
+      assertTrue(store.acquireExecutionLease("parent-clock", lease))
+      assertEquals(0, store.controlState("parent-clock").activeDurationMs)
+
+      // Two ten-second heartbeats: twenty seconds of real execution.
+      assertTrue(store.heartbeatExecutionLease("parent-clock", lease.copy(heartbeatAt = "2026-08-07T18:22:10Z")))
+      assertTrue(store.heartbeatExecutionLease("parent-clock", lease.copy(heartbeatAt = "2026-08-07T18:22:20Z")))
+      assertEquals(20_000, store.controlState("parent-clock").activeDurationMs)
+
+      // The runner dies here and the goal sits blocked overnight. A heartbeat landing twelve hours
+      // later cannot mean twelve hours of work: the gap is capped at one interval, so the overnight
+      // downtime stays out of the total while the runner still gets credit for being alive.
+      assertTrue(store.heartbeatExecutionLease("parent-clock", lease.copy(heartbeatAt = "2026-08-08T06:31:00Z")))
+      assertEquals(40_000, store.controlState("parent-clock").activeDurationMs)
+
+      // Work resumes from that anchor and keeps accumulating normally.
+      assertTrue(store.heartbeatExecutionLease("parent-clock", lease.copy(heartbeatAt = "2026-08-08T06:31:10Z")))
+      assertEquals(50_000, store.controlState("parent-clock").activeDurationMs)
+    }
+  }
+
+  /** A late tick from a GC pause or a contended write still covers real execution. */
+  @Test
+  fun `a heartbeat slightly past the limit is credited one interval rather than discarded`() {
+    val dbPath = Files.createTempDirectory("skillbill-goal-late-heartbeat").resolve("metrics.db")
+    val lease = GoalRunnerExecutionLease(
+      generation = 1,
+      ownerToken = "owner-token-123456",
+      hostIdentity = "host",
+      bootIdentity = "boot",
+      pid = 42,
+      processBirthToken = "birth",
+      heartbeatAt = "2026-08-07T18:22:00Z",
+      expiresAt = "2026-08-07T18:22:30Z",
+    )
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val store = GoalRunnerControlStore(connection)
+      assertTrue(store.acquireExecutionLease("parent-late", lease))
+      assertTrue(store.heartbeatExecutionLease("parent-late", lease.copy(heartbeatAt = "2026-08-07T18:22:20.001Z")))
+      assertEquals(20_000, store.controlState("parent-late").activeDurationMs)
+    }
+  }
+
+  @Test
+  fun `reacquiring a lease after downtime resumes the clock without counting the downtime`() {
+    val dbPath = Files.createTempDirectory("skillbill-goal-active-clock-reacquire").resolve("metrics.db")
+    val lease = GoalRunnerExecutionLease(
+      generation = 1,
+      ownerToken = "owner-token-123456",
+      hostIdentity = "host",
+      bootIdentity = "boot",
+      pid = 42,
+      processBirthToken = "birth",
+      heartbeatAt = "2026-08-07T18:22:00Z",
+      expiresAt = "2026-08-07T18:22:30Z",
+    )
+
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      val store = GoalRunnerControlStore(connection)
+      assertTrue(store.acquireExecutionLease("parent-reacquire", lease))
+      assertTrue(store.heartbeatExecutionLease("parent-reacquire", lease.copy(heartbeatAt = "2026-08-07T18:22:10Z")))
+      assertTrue(store.releaseExecutionLease("parent-reacquire", lease.ownerToken, lease.generation))
+
+      val nextDay = lease.copy(
+        generation = 2,
+        heartbeatAt = "2026-08-08T06:31:00Z",
+        expiresAt = "2026-08-08T06:31:30Z",
+      )
+      assertTrue(store.acquireExecutionLease("parent-reacquire", nextDay))
+      assertEquals(10_000, store.controlState("parent-reacquire").activeDurationMs)
+
+      assertTrue(store.heartbeatExecutionLease("parent-reacquire", nextDay.copy(heartbeatAt = "2026-08-08T06:31:05Z")))
+      assertEquals(15_000, store.controlState("parent-reacquire").activeDurationMs)
+    }
+  }
 }

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/telemetry/TelemetryEventSchemaValidator.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/telemetry/TelemetryEventSchemaValidator.kt
@@ -7,13 +7,23 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.PathType
+import com.networknt.schema.SchemaValidatorsConfig
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
 import skillbill.error.InvalidTelemetryEventSchemaError
+import java.util.Locale
 import java.util.logging.Level
 import java.util.logging.Logger
 
 private val log: Logger = Logger.getLogger("skillbill.mcp.TelemetryEventSchemaValidator")
+
+// Mirrors runtime-infra-fs's locale pin (this module does not depend on it): networknt renders violation
+// messages through MessageFormat under the JVM default locale, so a rejection reason would otherwise
+// regroup numbers or translate outright depending on the host. `pathType` restates the factory's LEGACY
+// default, which supplying any config would otherwise switch to JSON_POINTER.
+private val LOCALE_STABLE_SCHEMA_CONFIG: SchemaValidatorsConfig =
+  SchemaValidatorsConfig.builder().locale(Locale.ENGLISH).pathType(PathType.LEGACY).build()
 
 /**
  * SKILL-48 Subtask 2d: validates a telemetry-event-shaped
@@ -202,7 +212,7 @@ private fun loadSchema(): JsonSchema {
     TelemetryEventSchemaValidator.assertIdentity(yamlNode)
     val jsonText = ObjectMapper().writeValueAsString(yamlNode)
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
-    return factory.getSchema(jsonText)
+    return factory.getSchema(jsonText, LOCALE_STABLE_SCHEMA_CONFIG)
   } catch (typed: InvalidTelemetryEventSchemaError) {
     // F-403 (carried over from 2a/2b): a misbuilt deploy artifact
     // (missing classpath resource, corrupt YAML, or a shadowed copy)

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/model/GoalRunnerPortModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/model/GoalRunnerPortModels.kt
@@ -33,6 +33,9 @@ data class GoalRunnerScopedReplanWriteResult(
   val sharedPreplanPreparedBefore: Boolean = sharedPreplanPrepared,
   val discardedSharedPreplan: Boolean = false,
   val cascadedPlanSubtaskIds: List<Int> = emptyList(),
+  // Subtasks whose already-hydrated child workflow was deleted because the discarded plan left its
+  // imported planning bytes stale. Without this the next launch fails the hydration provenance check.
+  val clearedChildSubtaskIds: List<Int> = emptyList(),
 )
 
 /**

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/GoalRunnerControlRepository.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/GoalRunnerControlRepository.kt
@@ -1,5 +1,6 @@
 package skillbill.ports.persistence
 
+import skillbill.goalrunner.model.GOAL_ACTIVE_HEARTBEAT_GAP_LIMIT_MS
 import skillbill.goalrunner.model.GoalRunnerControlState
 import skillbill.goalrunner.model.GoalRunnerExecutionLease
 import skillbill.ports.goalrunner.model.GoalRunnerOutOfBandAcceptance
@@ -40,7 +41,12 @@ interface GoalRunnerControlRepository {
   ): Boolean {
     val state = controlState(parentWorkflowId)
     if (state.executionLease?.ownerToken != expectedOwnerToken) return false
-    persistControlState(parentWorkflowId, state.copy(executionLease = lease))
+    // A new run starts the active clock at this instant. The gap since the previous run ended was
+    // downtime and is never folded in, however long the goal sat blocked or unattended.
+    persistControlState(
+      parentWorkflowId,
+      state.copy(executionLease = lease, activeDurationAsOf = lease.heartbeatAt),
+    )
     return true
   }
 
@@ -48,7 +54,7 @@ interface GoalRunnerControlRepository {
     val state = controlState(parentWorkflowId)
     val current = state.executionLease ?: return false
     if (current.ownerToken != lease.ownerToken || current.generation != lease.generation) return false
-    persistControlState(parentWorkflowId, state.copy(executionLease = lease))
+    persistControlState(parentWorkflowId, state.advancedBy(lease.heartbeatAt).copy(executionLease = lease))
     return true
   }
 
@@ -56,9 +62,34 @@ interface GoalRunnerControlRepository {
     val state = controlState(parentWorkflowId)
     val current = state.executionLease ?: return false
     if (current.ownerToken != ownerToken || current.generation != generation) return false
-    persistControlState(parentWorkflowId, state.copy(executionLease = null))
+    // The tail since the last heartbeat is dropped rather than trusted: release carries no clock, and
+    // an unbounded tail is exactly what this accumulator exists to keep out. It is under one interval.
+    persistControlState(
+      parentWorkflowId,
+      state.copy(executionLease = null, activeDurationAsOf = null),
+    )
     return true
   }
+}
+
+/**
+ * Folds the interval since [GoalRunnerControlState.activeDurationAsOf] into the active total.
+ *
+ * The interval is capped at [GOAL_ACTIVE_HEARTBEAT_GAP_LIMIT_MS] rather than discarded when it runs
+ * long. A gap that wide means the runner was not alive for all of it -- a killed run whose lease was
+ * later reacquired -- so the excess is downtime and must not be counted; but a merely late tick from
+ * a GC pause or a contended write still covers real execution, and dropping it outright would make
+ * the accumulator undercount exactly when the machine is busiest. Capping keeps downtime out while
+ * crediting at most one interval of work. An unparseable or backwards timestamp advances nothing and
+ * only re-anchors the marker.
+ */
+private fun GoalRunnerControlState.advancedBy(heartbeatAt: String): GoalRunnerControlState {
+  val previous = activeDurationAsOf ?: return copy(activeDurationAsOf = heartbeatAt)
+  val elapsedMs = runCatching {
+    java.time.Duration.between(java.time.Instant.parse(previous), java.time.Instant.parse(heartbeatAt)).toMillis()
+  }.getOrNull() ?: return copy(activeDurationAsOf = heartbeatAt)
+  val counted = elapsedMs.coerceIn(0, GOAL_ACTIVE_HEARTBEAT_GAP_LIMIT_MS)
+  return copy(activeDurationMs = activeDurationMs + counted, activeDurationAsOf = heartbeatAt)
 }
 
 object EmptyGoalRunnerControlRepository : GoalRunnerControlRepository


### PR DESCRIPTION
Two independent goal-runtime fixes found while running SKILL-168, each with its own commit.

## 1. Scoped replan left a stale hydrated child (`1ada66b4`)

`skill-bill goal replan --subtask N` discarded that subtask's stored plan but left the child workflow that had already been hydrated from it. The child keeps those planning bytes as its own import, so the next launch failed the hydration provenance check and blocked — with an error recommending `goal reset --hard`, which discards every completed subtask's `commit_sha` and `workflow_id` to recover one amended subtask. Scoped replan exists precisely to avoid that, so the documented recovery path led into the destructive one.

`saveScopedReplan` now deletes the hydrated child for each replanned subtask inside the same transaction as the plan discard. Terminal subtasks are skipped so completed commit mappings survive, and the underlying SQL only removes terminal children, so a live or resumable child is untouched. Cleared ids surface through the port and service results and the CLI's `cleared_child_subtask_ids`.

`IncompatibleGoalPlanningPreparationRecoveryError` now points at `scopedChildRecoveryCommand` — the command the runtime already emits for incompatible terminal children elsewhere — instead of recommending a hard reset.

## 2. Goal elapsed counted time the goal was not working (`bb22936b`)

The IntelliJ status widget read `Goal elapsed: 12h 10m` for a goal that had run for minutes, under a live spinner next to a 23-minute subtask clock. The plugin computed `now - started_at`; the goal had sat blocked overnight. Freezing on settled states only hid the gap until the goal went active again and the clock jumped back to full wall time.

The runtime now accumulates `activeDurationMs` on the durable control record as lease heartbeats land. An interval is capped at `GOAL_ACTIVE_HEARTBEAT_GAP_LIMIT_MS` (twice the heartbeat) so overnight downtime stays out while a late tick from a GC pause or contended write still counts. `clearControlState` preserves the total for the same reason it preserves the lease — both are runtime bookkeeping, not operator intent, so clearing a pause must not restart the clock at zero.

The ide-status contract gains two additive optional fields, `active_duration_ms` and `active_duration_as_of`. The total is omitted unless meaningful, so a goal the runtime never watched execute is not reported as zero work; the anchor ships only while the lease is live, so a killed runner's stale anchor cannot license an unbounded tail. The plugin renders `accumulated + (now - anchor)` while live and falls back to the previous wall-clock path when the fields are absent, leaving older runtimes and non-goal families wire-identical.

No `contract_version` bump: both fields are additive and optional, and older consumers ignore them.

## Review

`/bill-code-review` (inline, Kotlin pack) raised six findings on the second commit; all six are fixed in it. The two that mattered were self-inflicted regressions in the first cut: publishing `active_duration_ms: 0` for goals with no recorded execution, which rendered `0s` as fact for exactly the pre-upgrade goals that motivated the change; and publishing the anchor without a liveness check, which let a killed runner rebuild the inflated clock.

## Testing

`test` and `detekt` pass in `runtime-kotlin`, and `test` passes in `intellij-plugin`, both forced with `--rerun-tasks --no-build-cache` (the Gradle build cache was serving stale test results).

Added coverage: the reported 12h scenario as a regression test; tick-without-double-counting across a heartbeat; frozen clock after lease release; unchanged fallback when the fields are absent; store-level capping, reacquisition after downtime, and clear-pause preservation; wire encode assertions for omission and stale-anchor withholding; plugin decode fixtures for absent, negative, string-typed, null, and unparseable input; and a real-SQLite CLI assertion that a cascade never clears a completed subtask's child.

## Known gap

No end-to-end real-DB case proves the plan discard and child delete commit or roll back as one unit — the CLI fixture never reaches a replan with a blocked child, so that path rests on a fake plus the SQL status guard.

## QA

1. Reinstall the runtime; the installed build at `~/.skill-bill` predates this.
2. Start a goal, let it run, then stop it and leave it idle for a stretch. Relaunch and confirm the widget's goal clock reflects execution time rather than time since the goal was opened.
3. Amend a subtask spec whose child is already hydrated, run `skill-bill goal replan <key> --subtask <id>`, and confirm the goal relaunches without an incompatible-planning block and that completed subtasks keep their commits.