### PR TITLE
SKILL-170: cli-telemetry-outbox-drain

### DIFF
--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,14 @@
+## [2026-08-08] SKILL-170 CLI completion telemetry outbox drain (subtask 1)
+Areas: runtime-kotlin/runtime-cli/{telemetry,featuretask,goal}, .feature-specs/SKILL-170-cli-telemetry-outbox-drain
+- New `skillbill.cli.telemetry.drainTelemetryOnCompletion(telemetryService, dbOverride)` flushes the outbox at CLI completion boundaries by reusing `TelemetryService.autoSync` — no second sync path, settings resolution, or outbox query. reusable
+- Called from exactly two completion boundaries: `FeatureTaskRuntimeCliCommands` and `GoalCliCommands`. Non-runtime verbs (status, config, review) deliberately do not drain.
+- Failure isolation is the contract: the drain runs on a daemon thread joined with a 5s bound and swallows every `Exception`, so an unreachable/blackholed proxy can never change exit code, stdout, or reported outcome, and never delays process exit. Nothing is written to stdout or stderr.
+- Level gating is inherited free from `autoSync`'s early return — resolved level `off` invokes no requester and marks nothing synced; no new gate was added.
+- Test support: `RecordingTelemetryRequester` plus `CliCompletionTelemetryDrainSupport` seed a non-empty outbox and assert it drained; call-site-removal mutation check confirms both drain tests fail without the call sites. reusable
+- Limits: no retry, backoff, or scheduling for a failed sync; `autoSync` reconciler cadence and the emitted event set are unchanged.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-08-08] SKILL-168 goal stop verb and durable pause timestamp (subtask 3)
 Areas: runtime-kotlin/{runtime-domain,runtime-ports,runtime-application,runtime-infra-sqlite,runtime-cli}, .feature-specs/SKILL-168-ide-status-goal-controls
 - `GoalRunnerControlState` gained a nullable pause timestamp with a construction invariant mirroring `pauseReason`: `paused = true` without a timestamp is rejected. Legacy rows without the column decode through the store, so the invariant is enforced at construction, not at read. reusable

--- a/runtime-kotlin/agent/history.md
+++ b/runtime-kotlin/agent/history.md
@@ -1,3 +1,15 @@
+## [2026-08-08] SKILL-170 telemetry outbox visibility and drain-gap cause record (subtask 2)
+Areas: runtime-kotlin/{runtime-ports,runtime-infra-sqlite,runtime-application,runtime-cli}, .feature-specs/SKILL-170-cli-telemetry-outbox-drain
+- `TelemetryOutboxRepository.lastSyncedAt()` (SQLite: `SELECT MAX(synced_at)`) plus `TelemetryStatusResult.lastSyncedAt` make `telemetry status` answer "has this install ever delivered?"; the CLI emits `last_synced_at` and an always-present `last_sync_state` of `never_synced`/`synced` because the text formatter drops null values and a nullable timestamp alone cannot carry the distinction. reusable
+- `telemetry status` became level-independent: it reads pending count, latest error, and last sync for every resolved level including `off`, gated only on the database existing. `install_id` and `batch_size` stay gated on `enabled`, so an off install still shows its queue depth without leaking its identity.
+- Status is now strictly a read — it no longer materializes the database as a side effect. Test fixtures that relied on that side effect create the database through `DatabaseRuntime.ensureDatabase` instead.
+- Confirmed root cause of the drain gap: `TelemetryService.autoSync` was wired only into `McpRuntime`; `runtime-cli/src/main` contained no `telemetryService` reference at all, so CLI-only installs queued events forever and never delivered them. Subtask 1 added the CLI completion-boundary drain.
+- Evidence that surfaced it: 10,690 projection-measurement rows spanning 148 distinct `workflow_id`s but exactly one distinct `install_id` over 21 days, plus a user-observed workflow (`wftr-20260807-123754-11fb`) with zero rows while its chronological neighbours were present. Ruled out: a blank `proxy_url` (it resolves to the hosted relay, not a no-op) and a default-off level (the default is `anonymous`).
+- Unresolved: the drain gap does not account for installs deliberately set to `off`, or for installs that never completed a runtime boundary at all. This cannot be settled until subtask 1 ships and new `install_id`s either do or do not appear in the relay — the investigation stays open.
+- Known limitation: `last_synced_at` derives from `MAX(synced_at)`, so the outbox `clear()` that `setLevel` performs erases it and a level change resets an install to `never_synced`.
+Feature flag: N/A
+Acceptance criteria: 5/5 implemented
+
 ## [2026-08-08] SKILL-170 CLI completion telemetry outbox drain (subtask 1)
 Areas: runtime-kotlin/runtime-cli/{telemetry,featuretask,goal}, .feature-specs/SKILL-170-cli-telemetry-outbox-drain
 - New `skillbill.cli.telemetry.drainTelemetryOnCompletion(telemetryService, dbOverride)` flushes the outbox at CLI completion boundaries by reusing `TelemetryService.autoSync` — no second sync path, settings resolution, or outbox query. reusable

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/TelemetryResults.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/TelemetryResults.kt
@@ -14,6 +14,7 @@ data class TelemetryStatusResult(
   val installId: String? = null,
   val batchSize: Int? = null,
   val latestError: String? = null,
+  val lastSyncedAt: String? = null,
 )
 
 data class TelemetrySyncStatusResult(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/telemetry/TelemetryService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/telemetry/TelemetryService.kt
@@ -29,7 +29,7 @@ class TelemetryService(
   fun status(dbOverride: String?): TelemetryStatusResult {
     val dbPath = database.resolveDbPath(dbOverride)
     val settings = loadTelemetrySettings(settingsProvider)
-    if (!settings.enabled) {
+    if (!database.databaseExists(dbOverride)) {
       return TelemetrySyncRuntime.telemetryStatusPayload(dbPath, settings)
     }
     return database.read(dbOverride) { unitOfWork ->
@@ -38,6 +38,7 @@ class TelemetryService(
         settings = settings,
         pendingEvents = unitOfWork.telemetryOutbox.pendingCount(),
         latestError = unitOfWork.telemetryOutbox.latestError(),
+        lastSyncedAt = unitOfWork.telemetryOutbox.lastSyncedAt(),
       )
     }
   }
@@ -134,6 +135,9 @@ private fun sessionTelemetryOutboxRepository(
 
   override fun latestError(): String? =
     database.read(dbOverride) { unitOfWork -> unitOfWork.telemetryOutbox.latestError() }
+
+  override fun lastSyncedAt(): String? =
+    database.read(dbOverride) { unitOfWork -> unitOfWork.telemetryOutbox.lastSyncedAt() }
 
   override fun markSynced(id: Long, syncedAt: String) {
     database.transaction(dbOverride) { unitOfWork -> unitOfWork.telemetryOutbox.markSynced(id, syncedAt) }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/telemetry/sync/TelemetrySyncRuntime.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/telemetry/sync/TelemetrySyncRuntime.kt
@@ -43,16 +43,12 @@ object TelemetrySyncRuntime {
     settings: TelemetrySettings,
     pendingEvents: Int = 0,
     latestError: String? = null,
-  ): TelemetryStatusResult {
-    val result = baseStatusResult(dbPath, settings)
-    if (!settings.enabled) {
-      return result
-    }
-    return result.copy(
-      pendingEvents = pendingEvents,
-      latestError = latestError,
-    )
-  }
+    lastSyncedAt: String? = null,
+  ): TelemetryStatusResult = baseStatusResult(dbPath, settings).copy(
+    pendingEvents = pendingEvents,
+    latestError = latestError,
+    lastSyncedAt = lastSyncedAt,
+  )
 
   fun autoSyncTelemetry(
     settings: TelemetrySettings,

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/RuntimeExceptionTelemetryTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/RuntimeExceptionTelemetryTest.kt
@@ -115,6 +115,7 @@ class RuntimeExceptionTelemetryTest {
       override fun listPending(limit: Int?): List<TelemetryOutboxRecord> = emptyList()
       override fun pendingCount(): Int = 0
       override fun latestError(): String? = null
+      override fun lastSyncedAt(): String? = null
       override fun markSynced(id: Long, syncedAt: String) = Unit
       override fun markSynced(eventIds: List<Long>) = Unit
       override fun markFailed(id: Long, lastError: String) = Unit

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeCliCommands.kt
@@ -42,6 +42,7 @@ import skillbill.application.model.WorkflowFamilyKind
 import skillbill.application.model.WorkflowOpenResult
 import skillbill.application.model.WorkflowUpdateResult
 import skillbill.application.review.RequestedReviewMode
+import skillbill.application.telemetry.TelemetryService
 import skillbill.application.workflow.WorkflowService
 import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
@@ -49,6 +50,7 @@ import skillbill.cli.core.formatOption
 import skillbill.cli.core.refuseRuntimeRefusedAgents
 import skillbill.cli.core.refuseUnavailableAgentLaunchers
 import skillbill.cli.core.refuseUnsupportedModelDirectives
+import skillbill.cli.telemetry.drainTelemetryOnCompletion
 import skillbill.cli.workflow.toCliMap
 import skillbill.config.model.CompactionSettings
 import skillbill.config.model.PhaseModelDirective
@@ -82,6 +84,7 @@ data class FeatureTaskRuntimeRunDependencies(
   val configResolutionService: ConfigResolutionService,
   val agentAddonSelectionPort: AgentAddonSelectionPort,
   val executableLookup: ExecutableLookup,
+  val telemetryService: TelemetryService,
   val state: CliRunState,
 )
 
@@ -250,6 +253,7 @@ abstract class FeatureTaskRuntimePhaseAgentCommand(
     }
     val payload = report.toRuntimeRunCliMap()
     state.completeText(runtimeRunText(payload), payload, exitCode = payload.runtimeRunExitCode())
+    drainTelemetryOnCompletion(deps.telemetryService, state.dbOverride)
   }
 
   private fun prepareRuntimeRun(deps: FeatureTaskRuntimeRunDependencies): PreparedRuntimeRun {

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
@@ -34,11 +34,13 @@ import skillbill.application.model.GoalRunnerStopStatus
 import skillbill.application.model.GoalRunnerStopVerbResult
 import skillbill.application.review.RequestedReviewMode
 import skillbill.application.system.RuntimeProvenanceService
+import skillbill.application.telemetry.TelemetryService
 import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
 import skillbill.cli.core.refuseRuntimeRefusedAgents
 import skillbill.cli.core.refuseUnavailableAgentLaunchers
 import skillbill.cli.featuretask.parseAgentAddonSelection
+import skillbill.cli.telemetry.drainTelemetryOnCompletion
 import skillbill.contracts.system.RuntimeProvenanceContract
 import skillbill.error.DatabaseAccessError
 import skillbill.goalrunner.model.ExecutionLiveness
@@ -83,6 +85,7 @@ class GoalRunCommand(
   private val agentAddonSelectionPort: AgentAddonSelectionPort,
   private val executableLookup: ExecutableLookup,
   goalRunSubcommands: GoalRunSubcommands,
+  private val telemetryService: TelemetryService,
   private val state: CliRunState,
 ) : DocumentedCliCommand("goal", "Run a decomposed goal in the foreground.") {
   private val issueKey by argument(help = "Parent issue key for the decomposed goal.").optional()
@@ -215,6 +218,9 @@ class GoalRunCommand(
     )
     val payload = report.toGoalRunCliMap()
     state.completeText(goalRunText(payload), payload, exitCode = payload.goalExitCode())
+    // Parent completion only: child CLI feature-task processes drain themselves, so a per-child
+    // parent drain would only add concurrent SQLite writers on the same database.
+    drainTelemetryOnCompletion(telemetryService, state.dbOverride)
   }
 
   private fun runRequest(

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommands.kt
@@ -79,6 +79,7 @@ class GoalRunSubcommands(
 )
 
 @Inject
+@Suppress("LongParameterList")
 class GoalRunCommand(
   private val goalRunner: GoalRunner,
   private val runtimeProvenanceService: RuntimeProvenanceService,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/CliCompletionTelemetryDrain.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/CliCompletionTelemetryDrain.kt
@@ -1,0 +1,32 @@
+package skillbill.cli.telemetry
+
+import skillbill.application.telemetry.TelemetryService
+
+/**
+ * Wall-clock bound for the completion drain. An untimed HTTP request against a blackholed proxy
+ * must never hold up process exit, so the drain runs on a daemon thread and is abandoned here.
+ */
+private const val DRAIN_TIMEOUT_MILLIS = 5_000L
+
+/**
+ * Flushes the telemetry outbox at a CLI completion boundary by reusing [TelemetryService.autoSync].
+ * Level gating comes free from autoSync's early return; every [Exception] is swallowed so a drain
+ * can never change the run's reported outcome or exit code, and nothing reaches stdout or stderr.
+ */
+internal fun drainTelemetryOnCompletion(telemetryService: TelemetryService, dbOverride: String?) {
+  val worker = Thread {
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    try {
+      telemetryService.autoSync(dbOverride)
+    } catch (error: Exception) {
+      // Intentionally silent: telemetry never speaks on a completed run's output channels.
+    }
+  }
+  worker.isDaemon = true
+  worker.start()
+  try {
+    worker.join(DRAIN_TIMEOUT_MILLIS)
+  } catch (interrupted: InterruptedException) {
+    Thread.currentThread().interrupt()
+  }
+}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/TelemetryCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/TelemetryCliResultMappers.kt
@@ -17,6 +17,9 @@ internal fun TelemetryStatusResult.toCliMap(): Map<String, Any?> = linkedMapOf<S
   "proxy_url" to proxyUrl,
   "custom_proxy_url" to customProxyUrl,
   "pending_events" to pendingEvents,
+  "last_synced_at" to lastSyncedAt,
+  // emitText drops null values, so the never-synced/synced distinction needs its own non-null key.
+  "last_sync_state" to if (lastSyncedAt == null) "never_synced" else "synced",
 ).apply {
   installId?.let { put("install_id", it) }
   batchSize?.let { put("batch_size", it) }

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCompletionTelemetryDrainSupport.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCompletionTelemetryDrainSupport.kt
@@ -1,0 +1,83 @@
+package skillbill.cli
+
+import skillbill.cli.core.CliRuntime
+import skillbill.cli.model.CliRuntimeContext
+import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.telemetry.model.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.sql.DriverManager
+
+/**
+ * Records every request instead of touching the network, so a completion drain in a CLI test can
+ * never reach a real relay. [failure] makes the sync path throw the escaping exception type the
+ * failure-isolation contract exists to contain.
+ */
+internal class RecordingTelemetryRequester(
+  private val failure: (() -> Nothing)? = null,
+) : HttpRequester {
+  val requests: MutableList<String> = mutableListOf()
+
+  override fun execute(
+    method: String,
+    url: String,
+    bodyJson: String?,
+    headers: Map<String, String>,
+  ): HttpResponse {
+    requests += url
+    failure?.invoke()
+    return HttpResponse(statusCode = 200, body = "{}")
+  }
+}
+
+/**
+ * Writes the durable config the telemetry settings provider resolves from [userHome], so a CLI
+ * test can drive an install whose resolved level is enabled (or explicitly `off`) without ever
+ * reading the developer's real config.
+ */
+internal fun writeTelemetryConfig(userHome: Path, level: String, proxyUrl: String) {
+  val configPath = userHome.resolve(".config/skill-bill/config.json")
+  Files.createDirectories(configPath.parent)
+  Files.writeString(
+    configPath,
+    """
+      {
+        "install_id": "cli-drain-fixture-install",
+        "telemetry": { "level": "$level", "proxy_url": "$proxyUrl" }
+      }
+    """.trimIndent(),
+  )
+}
+
+/** Unroutable by construction: a fixture that reached it would be making a real network call. */
+internal const val TELEMETRY_FIXTURE_PROXY_URL = "http://127.0.0.1:9/telemetry"
+
+/**
+ * Creates the fixture database through a real CLI invocation rather than hand-authored schema, so
+ * seeded outbox rows always match the schema the runtime itself creates.
+ */
+internal fun materializeTelemetryDatabase(userHome: Path, dbPath: Path, level: String, context: CliRuntimeContext) {
+  writeTelemetryConfig(userHome, level = level, proxyUrl = TELEMETRY_FIXTURE_PROXY_URL)
+  val status = CliRuntime.run(listOf("--db", dbPath.toString(), "telemetry", "status"), context)
+  check(status.exitCode == 0) { "telemetry status did not materialize the fixture database: ${status.stdout}" }
+}
+
+internal fun seedTelemetryOutbox(dbPath: Path, eventName: String) {
+  DriverManager.getConnection("jdbc:sqlite:$dbPath").use { connection ->
+    connection.prepareStatement("INSERT INTO telemetry_outbox (event_name, payload_json) VALUES (?, ?)").use {
+      it.setString(1, eventName)
+      it.setString(2, """{"fixture":true}""")
+      it.executeUpdate()
+    }
+  }
+}
+
+internal fun pendingTelemetryOutboxCount(dbPath: Path): Int =
+  DriverManager.getConnection("jdbc:sqlite:$dbPath").use { connection ->
+    connection.prepareStatement("SELECT COUNT(*) FROM telemetry_outbox WHERE synced_at IS NULL").use { statement ->
+      statement.executeQuery().use { rows ->
+        rows.next()
+        rows.getInt(1)
+      }
+    }
+  }

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCompletionTelemetryDrainSupport.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCompletionTelemetryDrainSupport.kt
@@ -2,6 +2,7 @@ package skillbill.cli
 
 import skillbill.cli.core.CliRuntime
 import skillbill.cli.model.CliRuntimeContext
+import skillbill.db.core.DatabaseRuntime
 import java.nio.file.Files
 import java.nio.file.Path
 import java.sql.DriverManager
@@ -29,13 +30,14 @@ internal fun writeTelemetryConfig(userHome: Path, level: String, proxyUrl: Strin
 internal const val TELEMETRY_FIXTURE_PROXY_URL = "http://127.0.0.1:9/telemetry"
 
 /**
- * Creates the fixture database through a real CLI invocation rather than hand-authored schema, so
- * seeded outbox rows always match the schema the runtime itself creates.
+ * Creates the fixture database through the runtime's own schema bootstrap rather than hand-authored
+ * DDL, so seeded outbox rows always match the schema the runtime itself creates.
  */
 internal fun materializeTelemetryDatabase(userHome: Path, dbPath: Path, level: String, context: CliRuntimeContext) {
   writeTelemetryConfig(userHome, level = level, proxyUrl = TELEMETRY_FIXTURE_PROXY_URL)
+  DatabaseRuntime.ensureDatabase(dbPath).close()
   val status = CliRuntime.run(listOf("--db", dbPath.toString(), "telemetry", "status"), context)
-  check(status.exitCode == 0) { "telemetry status did not materialize the fixture database: ${status.stdout}" }
+  check(status.exitCode == 0) { "telemetry status did not read the fixture database: ${status.stdout}" }
 }
 
 internal fun seedTelemetryOutbox(dbPath: Path, eventName: String) {

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCompletionTelemetryDrainSupport.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliCompletionTelemetryDrainSupport.kt
@@ -2,33 +2,9 @@ package skillbill.cli
 
 import skillbill.cli.core.CliRuntime
 import skillbill.cli.model.CliRuntimeContext
-import skillbill.ports.telemetry.HttpRequester
-import skillbill.ports.telemetry.model.HttpResponse
 import java.nio.file.Files
 import java.nio.file.Path
 import java.sql.DriverManager
-
-/**
- * Records every request instead of touching the network, so a completion drain in a CLI test can
- * never reach a real relay. [failure] makes the sync path throw the escaping exception type the
- * failure-isolation contract exists to contain.
- */
-internal class RecordingTelemetryRequester(
-  private val failure: (() -> Nothing)? = null,
-) : HttpRequester {
-  val requests: MutableList<String> = mutableListOf()
-
-  override fun execute(
-    method: String,
-    url: String,
-    bodyJson: String?,
-    headers: Map<String, String>,
-  ): HttpResponse {
-    requests += url
-    failure?.invoke()
-    return HttpResponse(statusCode = 200, body = "{}")
-  }
-}
 
 /**
  * Writes the durable config the telemetry settings provider resolves from [userHome], so a CLI
@@ -72,9 +48,13 @@ internal fun seedTelemetryOutbox(dbPath: Path, eventName: String) {
   }
 }
 
-internal fun pendingTelemetryOutboxCount(dbPath: Path): Int =
+internal fun pendingTelemetryOutboxCount(dbPath: Path): Int = telemetryOutboxCount(dbPath, "synced_at IS NULL")
+
+internal fun syncedTelemetryOutboxCount(dbPath: Path): Int = telemetryOutboxCount(dbPath, "synced_at IS NOT NULL")
+
+private fun telemetryOutboxCount(dbPath: Path, predicate: String): Int =
   DriverManager.getConnection("jdbc:sqlite:$dbPath").use { connection ->
-    connection.prepareStatement("SELECT COUNT(*) FROM telemetry_outbox WHERE synced_at IS NULL").use { statement ->
+    connection.prepareStatement("SELECT COUNT(*) FROM telemetry_outbox WHERE $predicate").use { statement ->
       statement.executeQuery().use { rows ->
         rows.next()
         rows.getInt(1)

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -13,6 +13,8 @@ import skillbill.ports.agentrun.ExecutableLookup
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
 import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
 import skillbill.ports.agentrun.model.AgentRunLaunchRequest
+import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.telemetry.UnconfiguredHttpRequester
 import skillbill.ports.workflow.GoalSubtaskReviewGitOperations
 import skillbill.ports.workflow.GoalSubtaskReviewGitOperationsProvider
 import skillbill.ports.workflow.RepositoryFingerprintGitOperations
@@ -1831,7 +1833,92 @@ class CliFeatureTaskRuntimeSpecLookupTest {
     assertContains(resumed.stdout, "was persisted in prose mode")
     assertEquals(emptyList(), resumeLauncher.requests)
   }
+
+  @Test
+  fun `feature-task runtime completion drains a non-empty telemetry outbox`() {
+    val fixture = runtimeFixture()
+    val requester = RecordingTelemetryRequester()
+    fixture.materializeDatabaseWithTelemetry(level = "anonymous", requester = requester)
+    seedTelemetryOutbox(fixture.dbPath, "skillbill_fixture_event")
+    assertEquals(1, pendingTelemetryOutboxCount(fixture.dbPath))
+
+    val run = CliRuntime.run(
+      fixture.runCommand(extra = listOf("--agent", "codex")),
+      fixture.context(RecordingPhaseLauncher(), requester = requester),
+    )
+
+    assertEquals(0, run.exitCode, run.stdout)
+    assertEquals(0, pendingTelemetryOutboxCount(fixture.dbPath))
+    assertEquals(1, requester.requests.size, requester.requests.toString())
+    assertContains(requester.requests.single(), TELEMETRY_FIXTURE_PROXY_URL)
+  }
+
+  @Test
+  fun `feature-task runtime completion with telemetry off transmits nothing and retains the outbox`() {
+    val fixture = runtimeFixture()
+    val requester = RecordingTelemetryRequester()
+    // The database only materializes through an enabled read, so enable first and then resolve
+    // the install back to 'off' for the run under assertion.
+    fixture.materializeDatabaseWithTelemetry(level = "anonymous", requester = requester)
+    seedTelemetryOutbox(fixture.dbPath, "skillbill_fixture_event")
+    writeTelemetryConfig(fixture.tempDir, level = "off", proxyUrl = TELEMETRY_FIXTURE_PROXY_URL)
+
+    val run = CliRuntime.run(
+      fixture.runCommand(extra = listOf("--agent", "codex")),
+      fixture.context(RecordingPhaseLauncher(), requester = requester),
+    )
+
+    assertEquals(0, run.exitCode, run.stdout)
+    assertEquals(emptyList(), requester.requests)
+    assertEquals(1, pendingTelemetryOutboxCount(fixture.dbPath))
+  }
+
+  @Test
+  @Suppress("TooGenericExceptionThrown")
+  fun `a throwing telemetry drain leaves the feature-task runtime outcome byte-for-byte unchanged`() {
+    val passing = runtimeDrainOutcome(RecordingTelemetryRequester())
+    val throwing = runtimeDrainOutcome(
+      // RuntimeException is caught by neither autoSyncTelemetry nor CliRuntime, so it is the type
+      // that would reach the operator's result if the drain were not isolated.
+      RecordingTelemetryRequester(failure = { throw RuntimeException("telemetry proxy exploded") }),
+    )
+
+    assertEquals(0, passing.exitCode)
+    assertEquals(passing.exitCode, throwing.exitCode)
+    assertEquals(passing.stdout, throwing.stdout)
+    assertEquals(passing.payload, throwing.payload)
+    assertEquals("", passing.stderr)
+    assertEquals("", throwing.stderr)
+  }
+
+  private fun runtimeDrainOutcome(requester: RecordingTelemetryRequester): DrainOutcome {
+    val fixture = runtimeFixture()
+    val stderr = StringBuilder()
+    fixture.materializeDatabaseWithTelemetry(level = "anonymous", requester = requester)
+    seedTelemetryOutbox(fixture.dbPath, "skillbill_fixture_event")
+
+    val run = CliRuntime.run(
+      fixture.runCommand(extra = listOf("--agent", "codex")),
+      fixture.context(RecordingPhaseLauncher(), requester = requester, liveStderr = { stderr.append(it) }),
+    )
+
+    // workflow_id is minted per run, so it is the one field two runs may legitimately differ on.
+    val workflowId = run.payload?.get("workflow_id")?.toString().orEmpty()
+    return DrainOutcome(
+      exitCode = run.exitCode,
+      stdout = run.stdout.replace(workflowId, "<workflow-id>"),
+      payload = run.payload.orEmpty().filterKeys { it != "workflow_id" },
+      stderr = stderr.toString(),
+    )
+  }
 }
+
+private data class DrainOutcome(
+  val exitCode: Int,
+  val stdout: String,
+  val payload: Map<String, Any?>,
+  val stderr: String,
+)
 
 private data class FeatureTaskRuntimeCliFixture(
   val tempDir: Path,
@@ -1847,16 +1934,21 @@ private data class FeatureTaskRuntimeCliFixture(
     // existing completion/blocked expectations stand; branch-setup tests override this to start on
     // the default branch. The real git adapter is bypassed because the tempDir is not a git repo.
     workflowGitOperations: WorkflowGitOperations = FakeRuntimeGitOperations(),
+    requester: HttpRequester = UnconfiguredHttpRequester,
   ): CliRuntimeContext = CliRuntimeContext(
     userHome = tempDir,
     agentRunLauncher = launcher,
     environment = environment,
+    requester = requester,
     liveStdout = liveStdout,
     liveStderr = liveStderr,
     workflowGitOperations = workflowGitOperations,
     // CLI unit tests assert orchestration, not host PATH; production still uses PathExecutableLookup.
     executableLookup = ExecutableLookup { true },
   )
+
+  fun materializeDatabaseWithTelemetry(level: String, requester: HttpRequester) =
+    materializeTelemetryDatabase(tempDir, dbPath, level, context(RecordingPhaseLauncher(), requester = requester))
 
   fun runCommand(extra: List<String> = emptyList()): List<String> = buildList {
     add("--db")

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -1849,8 +1849,10 @@ class CliFeatureTaskRuntimeSpecLookupTest {
 
     assertEquals(0, run.exitCode, run.stdout)
     assertEquals(0, pendingTelemetryOutboxCount(fixture.dbPath))
-    assertEquals(1, requester.requests.size, requester.requests.toString())
-    assertContains(requester.requests.single(), TELEMETRY_FIXTURE_PROXY_URL)
+    // The run records its own events too, so the batch count is incidental; every request must
+    // still be the fixture proxy, which is what proves nothing reached a real relay.
+    assertTrue(requester.requests.isNotEmpty())
+    assertTrue(requester.requests.all { it.contains(TELEMETRY_FIXTURE_PROXY_URL) }, requester.requests.toString())
   }
 
   @Test
@@ -1870,7 +1872,8 @@ class CliFeatureTaskRuntimeSpecLookupTest {
 
     assertEquals(0, run.exitCode, run.stdout)
     assertEquals(emptyList(), requester.requests)
-    assertEquals(1, pendingTelemetryOutboxCount(fixture.dbPath))
+    assertEquals(0, syncedTelemetryOutboxCount(fixture.dbPath))
+    assertTrue(pendingTelemetryOutboxCount(fixture.dbPath) >= 1)
   }
 
   @Test
@@ -1925,6 +1928,7 @@ private data class FeatureTaskRuntimeCliFixture(
   val dbPath: Path,
   val specPath: Path,
 ) {
+  @Suppress("LongParameterList")
   fun context(
     launcher: AgentRunLauncher,
     environment: Map<String, String> = emptyMap(),

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -22,6 +22,8 @@ import skillbill.ports.agentrun.model.AgentRunOutputStream
 import skillbill.ports.goalrunner.GoalPullRequestPort
 import skillbill.ports.goalrunner.model.GoalPullRequestRequest
 import skillbill.ports.goalrunner.model.GoalPullRequestResult
+import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.telemetry.UnconfiguredHttpRequester
 import skillbill.ports.workflow.GoalSubtaskReviewGitOperations
 import skillbill.ports.workflow.GoalSubtaskReviewGitOperationsProvider
 import skillbill.ports.workflow.RepositoryFingerprintGitOperations
@@ -67,6 +69,26 @@ class CliGoalRuntimeTest {
     assertContains(result.stdout, "reset")
     assertContains(result.stdout, "--debug-child-output")
     assertContains(result.stdout, "raw child streams hidden")
+  }
+
+  @Test
+  fun `goal completion drains a non-empty telemetry outbox`() {
+    val fixture = goalFixture(subtaskCount = 1)
+    val requester = RecordingTelemetryRequester()
+    fixture.materializeDatabaseWithTelemetry(level = "anonymous", requester = requester)
+    seedTelemetryOutbox(fixture.dbPath, "skillbill_fixture_event")
+    assertEquals(1, pendingTelemetryOutboxCount(fixture.dbPath))
+
+    val result = CliRuntime.run(
+      fixture.goalCommand(),
+      fixture.context(launcher = GoalFixtureAgentRunLauncher(fixture), requester = requester),
+    )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    assertContains(result.stdout, "goal SKILL-901: finished")
+    assertEquals(0, pendingTelemetryOutboxCount(fixture.dbPath))
+    assertEquals(1, requester.requests.size, requester.requests.toString())
+    assertContains(requester.requests.single(), TELEMETRY_FIXTURE_PROXY_URL)
   }
 
   @Test
@@ -1862,8 +1884,10 @@ internal data class GoalCliFixture(
     liveStdout: (String) -> Unit = {},
     liveStderr: (String) -> Unit = {},
     workflowGitOperations: WorkflowGitOperations = GoalTestWorkflowGitOperations,
+    requester: HttpRequester = UnconfiguredHttpRequester,
   ): CliRuntimeContext = CliRuntimeContext(
     userHome = tempDir,
+    requester = requester,
     workflowGitOperations = workflowGitOperations,
     agentRunLauncher = launcher,
     goalPullRequestPort = pullRequests,
@@ -1871,6 +1895,13 @@ internal data class GoalCliFixture(
     liveStderr = liveStderr,
     // CLI unit tests assert orchestration, not host PATH; production still uses PathExecutableLookup.
     executableLookup = ExecutableLookup { true },
+  )
+
+  fun materializeDatabaseWithTelemetry(level: String, requester: HttpRequester) = materializeTelemetryDatabase(
+    tempDir,
+    dbPath,
+    level,
+    context(launcher = NoopGoalTestAgentRunLauncher, requester = requester),
   )
 
   fun goalCommand(dbPath: Path = this@GoalCliFixture.dbPath, extra: List<String> = emptyList()): List<String> =

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -87,8 +87,8 @@ class CliGoalRuntimeTest {
     assertEquals(0, result.exitCode, result.stdout)
     assertContains(result.stdout, "goal SKILL-901: finished")
     assertEquals(0, pendingTelemetryOutboxCount(fixture.dbPath))
-    assertEquals(1, requester.requests.size, requester.requests.toString())
-    assertContains(requester.requests.single(), TELEMETRY_FIXTURE_PROXY_URL)
+    assertTrue(requester.requests.isNotEmpty())
+    assertTrue(requester.requests.all { it.contains(TELEMETRY_FIXTURE_PROXY_URL) }, requester.requests.toString())
   }
 
   @Test
@@ -1887,6 +1887,7 @@ internal data class GoalCliFixture(
     requester: HttpRequester = UnconfiguredHttpRequester,
   ): CliRuntimeContext = CliRuntimeContext(
     userHome = tempDir,
+    environment = emptyMap(),
     requester = requester,
     workflowGitOperations = workflowGitOperations,
     agentRunLauncher = launcher,

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliRuntimeTest.kt
@@ -10,6 +10,7 @@ import skillbill.cli.model.CliRuntimeContext
 import skillbill.contracts.JsonSupport
 import skillbill.db.core.DatabaseRuntime
 import skillbill.db.telemetry.LifecycleTelemetryStore
+import skillbill.db.telemetry.TelemetryOutboxStore
 import skillbill.ports.telemetry.HttpRequester
 import skillbill.ports.telemetry.model.HttpResponse
 import skillbill.ports.workflow.repositoryFingerprint
@@ -23,7 +24,10 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 @Suppress("LargeClass")
 class CliRuntimeTest {
@@ -289,6 +293,63 @@ class CliRuntimeTest {
     val (statsPayload, capturedRequests) = remoteStatsScenario(configPath)
     assertEquals(expectedRemoteStatsPayload(), statsPayload)
     assertEquals(expectedCliRemoteStatsRequests(), capturedRequests)
+  }
+
+  // SKILL-170 AC-001/AC-002/AC-004: queue depth and sync state are visible at every resolved level.
+  @Test
+  fun `telemetry status reports queue depth and sync state across outbox states`() {
+    val empty = telemetryStatusState(level = "anonymous", pendingEvents = 0, priorSync = false)
+    assertEquals(0, empty["pending_events"])
+    assertEquals("never_synced", empty["last_sync_state"])
+    assertNull(empty["last_synced_at"])
+
+    val neverSynced = telemetryStatusState(level = "anonymous", pendingEvents = 2, priorSync = false)
+    assertEquals(2, neverSynced["pending_events"])
+    assertEquals("never_synced", neverSynced["last_sync_state"])
+    assertNull(neverSynced["last_synced_at"])
+
+    val syncedWithPending = telemetryStatusState(level = "anonymous", pendingEvents = 2, priorSync = true)
+    assertEquals(2, syncedWithPending["pending_events"])
+    assertEquals("synced", syncedWithPending["last_sync_state"])
+    assertNotNull(syncedWithPending["last_synced_at"])
+
+    val disabled = telemetryStatusState(level = "off", pendingEvents = 3, priorSync = true)
+    assertEquals(false, disabled["telemetry_enabled"])
+    assertEquals(3, disabled["pending_events"], "An off install must still show what is queued and undelivered.")
+    assertEquals("synced", disabled["last_sync_state"])
+    assertNull(disabled["install_id"], "An off install must not leak the install id.")
+  }
+
+  // The text formatter drops null values, so the distinction has to survive without last_synced_at.
+  @Test
+  fun `telemetry status renders the sync state distinction in text format`() {
+    val neverSynced = telemetryStatusText(level = "anonymous", pendingEvents = 1, priorSync = false)
+    assertContains(neverSynced, "pending_events: 1")
+    assertContains(neverSynced, "last_sync_state: never_synced")
+
+    val synced = telemetryStatusText(level = "anonymous", pendingEvents = 1, priorSync = true)
+    assertContains(synced, "last_sync_state: synced")
+    assertContains(synced, "last_synced_at: ")
+  }
+
+  // AC-003: proven negatively — the requester fails the test if status reaches for the network at all.
+  @Test
+  fun `telemetry status makes no network call and tolerates a missing database`() {
+    val tempDir = Files.createTempDirectory("skillbill-cli-telemetry-status-read")
+    val dbPath = tempDir.resolve("metrics.db")
+    writeTelemetryConfig(tempDir, level = "anonymous", proxyUrl = TELEMETRY_FIXTURE_PROXY_URL)
+
+    val result =
+      CliRuntime.run(
+        listOf("--db", dbPath.toString(), "telemetry", "status", "--format", "json"),
+        telemetryStatusContext(tempDir),
+      )
+
+    assertEquals(0, result.exitCode, result.stdout)
+    val payload = decodeJsonObject(result.stdout)
+    assertEquals(0, payload["pending_events"])
+    assertEquals("never_synced", payload["last_sync_state"])
+    assertFalse(Files.exists(dbPath), "telemetry status is a read: it must not create the database.")
   }
 
   @Test
@@ -1158,6 +1219,37 @@ private fun seedGoalStatsDb(dbPath: Path) {
       level = "full",
     )
   }
+}
+
+/** Fails the run rather than reaching the network, so any status-path HTTP call fails the suite. */
+private fun telemetryStatusContext(userHome: Path): CliRuntimeContext = CliRuntimeContext(
+  environment = emptyMap(),
+  userHome = userHome,
+  requester = HttpRequester { _, _, _, _ -> fail("telemetry status must perform no network call") },
+)
+
+private fun telemetryStatusState(level: String, pendingEvents: Int, priorSync: Boolean): Map<String, Any?> =
+  decodeJsonObject(telemetryStatusStdout(level, pendingEvents, priorSync, json = true))
+
+private fun telemetryStatusText(level: String, pendingEvents: Int, priorSync: Boolean): String =
+  telemetryStatusStdout(level, pendingEvents, priorSync, json = false)
+
+private fun telemetryStatusStdout(level: String, pendingEvents: Int, priorSync: Boolean, json: Boolean): String {
+  val tempDir = Files.createTempDirectory("skillbill-cli-telemetry-status")
+  val dbPath = tempDir.resolve("metrics.db")
+  writeTelemetryConfig(tempDir, level = level, proxyUrl = TELEMETRY_FIXTURE_PROXY_URL)
+  DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+    val store = TelemetryOutboxStore(connection)
+    if (priorSync) {
+      store.markSynced(listOf(store.enqueue("skillbill_goal_finished", """{"seed":"delivered"}""")))
+    }
+    repeat(pendingEvents) { index -> store.enqueue("skillbill_review_finished", """{"seed":$index}""") }
+  }
+  val arguments =
+    listOf("--db", dbPath.toString(), "telemetry", "status") + if (json) listOf("--format", "json") else emptyList()
+  val result = CliRuntime.run(arguments, telemetryStatusContext(tempDir))
+  assertEquals(0, result.exitCode, result.stdout)
+  return result.stdout
 }
 
 private fun writeTelemetryConfig(tempDir: Path, level: String): Path {

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/RecordingTelemetryRequester.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/RecordingTelemetryRequester.kt
@@ -1,0 +1,21 @@
+package skillbill.cli
+
+import skillbill.ports.telemetry.HttpRequester
+import skillbill.ports.telemetry.model.HttpResponse
+
+/**
+ * Records every request instead of touching the network, so a completion drain in a CLI test can
+ * never reach a real relay. [failure] makes the sync path throw the escaping exception type the
+ * failure-isolation contract exists to contain.
+ */
+internal class RecordingTelemetryRequester(
+  private val failure: (() -> Nothing)? = null,
+) : HttpRequester {
+  val requests: MutableList<String> = mutableListOf()
+
+  override fun execute(method: String, url: String, bodyJson: String?, headers: Map<String, String>): HttpResponse {
+    requests += url
+    failure?.invoke()
+    return HttpResponse(statusCode = 200, body = "{}")
+  }
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -2392,6 +2392,8 @@ private object NoopTelemetryOutboxRepository : TelemetryOutboxRepository {
 
   override fun latestError(): String? = null
 
+  override fun lastSyncedAt(): String? = null
+
   override fun markSynced(id: Long, syncedAt: String) = Unit
 
   override fun markSynced(eventIds: List<Long>) = Unit
@@ -2430,6 +2432,8 @@ private class InMemoryTelemetryOutboxRepository(
   override fun pendingCount(): Int = rows.count { it.syncedAt == null }
 
   override fun latestError(): String? = rows.lastOrNull { it.syncedAt == null && it.lastError.isNotBlank() }?.lastError
+
+  override fun lastSyncedAt(): String? = rows.mapNotNull { it.syncedAt }.maxOrNull()
 
   override fun markSynced(id: Long, syncedAt: String) {
     markSynced(listOf(id))

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/TelemetryLevelMutationServiceTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/TelemetryLevelMutationServiceTest.kt
@@ -324,6 +324,8 @@ private class MutationTelemetryOutboxRepository(
 
   override fun latestError(): String? = null
 
+  override fun lastSyncedAt(): String? = rows.mapNotNull(TelemetryOutboxRecord::syncedAt).maxOrNull()
+
   override fun markSynced(id: Long, syncedAt: String) = Unit
 
   override fun markSynced(eventIds: List<Long>) = Unit

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/TelemetryOutboxStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/telemetry/TelemetryOutboxStore.kt
@@ -96,6 +96,21 @@ class TelemetryOutboxStore(
     }
   }
 
+  override fun lastSyncedAt(): String? = connection.prepareStatement(
+    """
+      SELECT MAX(synced_at)
+      FROM telemetry_outbox
+      WHERE synced_at IS NOT NULL
+    """.trimIndent(),
+  ).use { statement ->
+    statement.executeQuery().use { resultSet ->
+      if (!resultSet.next()) {
+        return null
+      }
+      resultSet.getString(1)
+    }
+  }
+
   override fun markSynced(id: Long, syncedAt: String) {
     connection.prepareStatement(
       """

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/TelemetryOutboxStoreTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/TelemetryOutboxStoreTest.kt
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import java.sql.Connection
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class TelemetryOutboxStoreTest {
@@ -132,6 +133,22 @@ class TelemetryOutboxStoreTest {
         scalarString(connection, "SELECT skill_bill_version FROM telemetry_outbox WHERE id = $id"),
       )
       assertEquals("9.9.9-injected", store.listPending().single { it.id == id }.skillBillVersion)
+    }
+  }
+
+  // SKILL-170 AC-002: the status surface needs a never-synced/synced distinction that survives a non-empty outbox.
+  @Test
+  fun `lastSyncedAt is null until a row is marked synced`() {
+    withOutbox { _, store ->
+      val id = store.enqueue(eventName = "skillbill_goal_finished", payloadJson = "{}")
+      store.enqueue(eventName = "skillbill_review_finished", payloadJson = "{}")
+
+      assertEquals(null, store.lastSyncedAt(), "An outbox that never delivered has no successful sync timestamp.")
+
+      store.markSynced(listOf(id))
+
+      assertNotNull(store.lastSyncedAt(), "A delivered row must expose a successful sync timestamp.")
+      assertEquals(1, store.pendingCount(), "The still-pending row must remain queued alongside the sync timestamp.")
     }
   }
 

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/TelemetryOutboxRepository.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/TelemetryOutboxRepository.kt
@@ -11,6 +11,8 @@ interface TelemetryOutboxRepository {
 
   fun latestError(): String?
 
+  fun lastSyncedAt(): String?
+
   fun markSynced(id: Long, syncedAt: String)
 
   fun markSynced(eventIds: List<Long>)


### PR DESCRIPTION
Goal: cli-telemetry-outbox-drain

Subtasks:
- 1. CLI runtime drains its own telemetry outbox (5418ef6bbd171c1ff088ab5cacbbebd3e1c548eb)
- 2. Local outbox visibility and recorded cause (d9005aa49a2be99edabc43d2fe0331f02914ba88)
