### PR TITLE
fix(goal): retry empty provider planning turns instead of blocking

### DIFF
--- a/.feature-specs/SKILL-172-goal-planning-burst-and-context/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-172-goal-planning-burst-and-context/decomposition-manifest.yaml
@@ -1,0 +1,35 @@
+---
+contract_version: "0.5"
+issue_key: "SKILL-172"
+feature_name: "goal-planning-burst-and-context"
+parent_spec_path: ".feature-specs/SKILL-172-goal-planning-burst-and-context/spec.md"
+execution_model: "same_branch_commit_per_subtask"
+base_branch: "main"
+feature_branch: "feat/SKILL-172-goal-planning-burst-and-context"
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: "none"
+subtasks:
+- id: 1
+  name: "Planning-context discovery stops buying review routing tables"
+  spec_path: ".feature-specs/SKILL-172-goal-planning-burst-and-context/spec_subtask_1_planning-context-discovery.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: null
+  blocked_reason: null
+  last_resumable_step: null
+  linear_issue_id: null
+  dependencies: []
+- id: 2
+  name: "Planning burst control: launch pacing and empty-turn backoff"
+  spec_path: ".feature-specs/SKILL-172-goal-planning-burst-and-context/spec_subtask_2_planning-burst-control.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: null
+  blocked_reason: null
+  last_resumable_step: null
+  linear_issue_id: null
+  dependencies: []

--- a/.feature-specs/SKILL-172-goal-planning-burst-and-context/spec.md
+++ b/.feature-specs/SKILL-172-goal-planning-burst-and-context/spec.md
@@ -1,0 +1,144 @@
+# SKILL-172: Goal planning burst control and planning-context waste
+
+Status: Prepared
+
+## Intended Outcome
+
+Goal planning stops generating the token burst that trips provider rate ceilings, and stops
+spending its bounded context budget on content no planning agent can use. Concretely: a
+14-subtask goal plans to completion in one run instead of blocking every two or three
+subtasks and requiring a resume, and the shared context packet carries the curated boundary
+memory it was designed to carry.
+
+## Background
+
+A goal with 14 subtasks blocked repeatedly during planning against `--agent cursor`. The
+proximate symptom was Cursor exiting 0 with an empty harvest, but the investigation found two
+skill-bill-side causes underneath it.
+
+### Cause 1 — planning context is spent on review routing tables
+
+`FileSystemGoalPlanningContextDiscovery.discover` populates three packet fields:
+
+| Packet field | Reads |
+|---|---|
+| `platform_packs` | `platform-packs/*/platform.yaml` — every pack present |
+| `boundary_memory` | `platform-packs/*/agent/history.md` + `agent/decisions.md` |
+| `validation_guidance` | the repo's root `AGENTS.md` |
+
+Discovery is bounded by `GoalPlanningContext.MAX_DISCOVERY_TOTAL_BYTES = 32KB` total,
+`MAX_DISCOVERY_EXCERPT_BYTES = 4KB` per file, and it fills that budget in argument order —
+platform packs first (`FileSystemGoalPlanningContextDiscovery.kt:17`), then boundary memory,
+then AGENTS.md.
+
+This repo has nine platform packs and every `platform.yaml` exceeds the 4KB excerpt cap. Eight
+files at 4096 bytes exhausts the 32,768-byte budget exactly, at which point `canRead()` returns
+false. So for every planning launch in a repo with eight or more packs:
+
+- `platform_packs` — eight packs, 32KB, the full budget
+- `boundary_memory` — **empty**
+- `validation_guidance` — **empty**
+
+The content being bought with that budget is not planning input. Every top-level key in
+`platform.yaml` is review or quality-check routing: `routing_signals`,
+`declared_code_review_areas`, `declared_files`, `area_metadata`, `lane_conditions`,
+`declared_quality_check_file`, `pointers`. There is no build, convention, or architecture
+guidance in it. Because of the 4KB excerpt cap the planner only ever receives the routing
+header and a list of review-specialist content paths.
+
+Meanwhile `boundary_memory` — the curated `history.md`/`decisions.md` handoff that makes
+fresh-context-per-subtask planning work — is starved to nothing, and `AGENTS.md`, which is
+genuinely repo conventions, never arrives either.
+
+`GoalPlanningContext.platformPacks` has exactly one consumer: `GoalPlanningSweep.kt:684`,
+which copies it into the packet. Nothing reads it downstream. The other `platformPacks`
+symbols across install, scaffold and review are unrelated types operating on
+`platformPacksRoot` paths.
+
+### Cause 2 — the sweep is an unpaced burst source
+
+`GoalPlanningContextPromptFormatter.append` serialises the whole shared packet into every
+subtask plan prompt; only the tail varies per subtask (spec path and dependency metadata).
+`producePlan` (`GoalPlanningSweep.kt:241`) calls `producePhase` once per subtask with no delay
+between launches, so a 14-subtask goal fires 15 sequential launches of a large, near-identical
+payload back to back.
+
+Observed effect across 48 Cursor transcripts from one day: 11 empty turns, all clustered at
+the end of runs of consecutive successful turns, each recovering after an idle gap. Planning
+progress across resumes went 2 → 4 → 6 → 9 → 12 → 15, i.e. each resume cleared two or three
+subtasks before hitting the ceiling again. A ~500-character control prompt carrying no packet
+also returned empty inside a degraded window, so the trigger is cumulative account load, not
+prompt content.
+
+SKILL-172 does not attempt to fix the provider. It removes skill-bill's contribution to the
+burst and stops the retry path from spending its whole budget inside the degraded window.
+
+### Already landed
+
+Commit `50bbdf38` on `fix/cursor-empty-planning-harvest` added `EmptyProviderTurn`
+classification, bounded retry, durable rejection evidence under rule `empty-planning-harvest`,
+and Cursor decoder corrections (camelCase usage keys, longest-assistant fallback,
+`--stream-partial-output` split from liveness). That retry fires immediately with no delay,
+which is what subtask 2 corrects.
+
+## Acceptance Criteria
+
+1. Goal planning discovery no longer reads `platform-packs/*/platform.yaml`; the
+   `platform_packs` packet field serialises as an empty object.
+2. In a repository with nine platform packs, a freshly built packet carries non-empty
+   `boundary_memory` and non-empty `validation_guidance` — the regression that made both empty
+   is covered by a test that fails against the current implementation.
+3. The packet key set is unchanged, `GoalPlanningSharedContextPacket.VERSION` stays `"0.1"`,
+   and a packet checkpointed before this change still passes `validate()` on resume.
+4. Consecutive per-subtask plan launches are separated by a configurable pace interval, applied
+   between launches only — never before the first launch and never after the last.
+5. `EmptyProviderTurn` retries back off between attempts rather than relaunching immediately;
+   the backoff grows per attempt.
+6. Both the pace interval and the backoff schedule are injected through a seam a test can drive
+   without real elapsed time, following the injected-`java.time.Clock` precedent already used in
+   `GoalRunner` and `GoalRunnerExecutionCoordinator`. No bare `Thread.sleep` in application code.
+7. Pacing and backoff are provider-neutral: no agent identity is read at either site.
+8. Waiting is interruptible and honours the existing pause and authorization boundaries — a
+   paced or backing-off sweep still stops promptly at a durable pause boundary rather than
+   sleeping through it.
+9. `./gradlew build -x sourcesJar` and `detekt` pass. (`:runtime-infra-fs:sourcesJar` fails on
+   clean `main` for an unrelated task-dependency defect and is out of scope.)
+
+## Non-Goals
+
+- No removal of the `platform_packs` key or rename of `validation_guidance` to
+  `repo_conventions`. Both change the packet key set, which `validate()` matches exactly and
+  which is covered by `integrity_sha256`, so both require a `VERSION` bump and a recovery
+  migration. Deliberately deferred to separate work.
+- No change to fresh-context-per-subtask. Re-sending the shared packet per subtask is the
+  design; this work reduces what the packet contains and how fast launches are issued, not the
+  isolation model.
+- No provider-side work: no Cursor bug report, no agent failover after N empty turns, no model
+  override defaults for planning.
+- No change to `MAX_FIX_LOOP_ITERATIONS` or to the retry cap itself.
+- No change to the install, scaffold, or review subsystems that legitimately consume platform
+  packs.
+
+## Constraints
+
+- `GoalPlanningSharedContextPacket.validate` asserts `packet.keys == PACKET_FIELDS` exactly and
+  verifies `integrity_sha256` over the packet. Values may change freely; keys may not, without
+  a version bump.
+- Packets are checkpointed into the preplan payload and read back on resume. Any change must
+  leave already-checkpointed packets recoverable.
+- Pacing adds wall-clock time to a phase already bounded by `--planning-budget-minutes` and
+  `--max-wall-clock-minutes`. The default pace must not push a normal goal past those bounds;
+  state the arithmetic for a 15-subtask goal in the subtask spec.
+- `allWarningsAsErrors = true` is in force.
+
+## Dependencies
+
+Builds on commit `50bbdf38` (`EmptyProviderTurn` classification and retry). Subtask 2 modifies
+the retry path that commit introduced. Subtask 1 is independent of both.
+
+## Next Path
+
+After merge, re-run a wide decomposed goal against Cursor and compare planning completion in a
+single run against the 2 → 4 → 6 → 9 → 12 → 15 resume pattern. If empties persist at the same
+depth, the remaining burst is upstream of pacing and the deferred packet-key work plus provider
+failover become the next candidates.

--- a/.feature-specs/SKILL-172-goal-planning-burst-and-context/spec_subtask_1_planning-context-discovery.md
+++ b/.feature-specs/SKILL-172-goal-planning-burst-and-context/spec_subtask_1_planning-context-discovery.md
@@ -1,0 +1,79 @@
+# SKILL-172 Subtask 1 - Planning-context discovery stops buying review routing tables
+
+Parent spec: [.feature-specs/SKILL-172-goal-planning-burst-and-context/spec.md](spec.md)
+Issue key: SKILL-172
+
+## Scope
+
+Stop goal-planning context discovery from reading `platform-packs/*/platform.yaml`, so the
+32KB discovery budget is spent on the boundary memory and repo conventions a planning agent
+can actually use.
+
+Today `FileSystemGoalPlanningContextDiscovery.discover` reads platform packs first
+(`FileSystemGoalPlanningContextDiscovery.kt:17`). In a repo with eight or more packs whose
+`platform.yaml` exceeds the 4KB per-file excerpt cap, those reads consume the entire
+`MAX_DISCOVERY_TOTAL_BYTES = 32KB` budget, `canRead()` goes false, and `boundary_memory` and
+`validation_guidance` both come back empty. The content bought is review and quality-check
+routing metadata — `routing_signals`, `declared_code_review_areas`, `declared_files`,
+`area_metadata`, `lane_conditions`, `declared_quality_check_file`, `pointers` — with no
+planning value, and truncated at 4KB so only the routing header ever arrives.
+
+Keep the `platform_packs` packet field present and serialising as `{}`. Removing the key
+changes `PACKET_FIELDS`, which `validate()` matches exactly and `integrity_sha256` covers, and
+would break resume for in-flight goals. Key removal is deferred to versioned work.
+
+Primary files:
+
+- `runtime-infra-fs/src/main/kotlin/skillbill/goalplanning/FileSystemGoalPlanningContextDiscovery.kt`
+- `runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/model/GoalPlanningContext.kt`
+- `runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningSweep.kt` (line 684, packet assembly)
+
+Verified before scoping: `GoalPlanningContext.platformPacks` has exactly one consumer, the
+packet assembly at `GoalPlanningSweep.kt:684`. Every other `platformPacks` symbol in the tree
+belongs to install, scaffold, or review and operates on `platformPacksRoot` paths or
+`InstallPlatformPackSnapshot`, none of which this subtask touches.
+
+## Acceptance Criteria
+
+1. `FileSystemGoalPlanningContextDiscovery` no longer reads `platform-packs/*/platform.yaml`,
+   and the assembled packet's `platform_packs` field is an empty object.
+2. A test over a fixture repo containing nine platform packs, each `platform.yaml` larger than
+   `MAX_DISCOVERY_EXCERPT_BYTES`, plus per-pack `agent/history.md` and `agent/decisions.md` and
+   a root `AGENTS.md`, asserts that `boundary_memory` and `validation_guidance` are both
+   non-empty. This test must fail against the current implementation before the fix.
+3. The discovery budget still bounds total bytes, per-file excerpt size, and file count; this
+   subtask reallocates the budget, it does not raise or remove it.
+4. `GoalPlanningSharedContextPacket.PACKET_FIELDS` and `VERSION` are unchanged, and a packet
+   serialised before this change still passes `validate()` — covered by a test that validates a
+   packet fixture carrying populated `platform_packs`.
+5. Boundary memory is read before repo conventions, and the ordering is stated in a comment so
+   a future reader knows the sequence is load-bearing rather than incidental.
+6. If discovery still cannot fit everything, what survives is deterministic and documented —
+   silent truncation by argument order is not acceptable as the final behaviour.
+7. `./gradlew build -x sourcesJar` and `detekt` pass.
+
+## Non-Goals
+
+- No removal of the `platform_packs` packet key and no rename of `validation_guidance`; both
+  require a `VERSION` bump and recovery migration and are deferred.
+- No change to `MAX_DISCOVERY_*` values.
+- No change to install, scaffold, or review platform-pack handling.
+- No change to what the planning briefing does with the packet once assembled.
+
+## Dependency Notes
+
+Standalone. Independent of subtask 2 and of commit `50bbdf38`. Can land first or second.
+
+## Validation Strategy
+
+1. New discovery test over a nine-pack fixture asserting non-empty `boundary_memory` and
+   `validation_guidance`; confirm it fails before the change and passes after.
+2. Packet-compatibility test: a packet fixture with populated `platform_packs` still passes
+   `GoalPlanningSharedContextPacket.validate` and its `integrity_sha256` check.
+3. `(cd runtime-kotlin && ./gradlew :runtime-infra-fs:test :runtime-application:test detekt)`.
+4. `(cd runtime-kotlin && ./gradlew build -x sourcesJar)`.
+
+## Next Path
+
+Subtask 2 (planning burst control), or the deferred versioned packet change that removes the
+now-empty `platform_packs` key and renames `validation_guidance` to `repo_conventions`.

--- a/.feature-specs/SKILL-172-goal-planning-burst-and-context/spec_subtask_2_planning-burst-control.md
+++ b/.feature-specs/SKILL-172-goal-planning-burst-and-context/spec_subtask_2_planning-burst-control.md
@@ -1,0 +1,92 @@
+# SKILL-172 Subtask 2 - Planning burst control: launch pacing and empty-turn backoff
+
+Parent spec: [.feature-specs/SKILL-172-goal-planning-burst-and-context/spec.md](spec.md)
+Issue key: SKILL-172
+
+## Scope
+
+Stop the planning sweep from issuing its launches as fast as the provider will accept them,
+in the two places where it currently does.
+
+**Pacing.** `producePlan` (`GoalPlanningSweep.kt:241`) calls `producePhase` once per subtask
+with no gap, so a 14-subtask goal fires 15 sequential launches of a large, near-identical
+payload back to back. Introduce a configurable interval applied *between* consecutive plan
+launches.
+
+**Backoff.** Commit `50bbdf38` made an `EmptyProviderTurn` retryable under the fix-loop cap,
+but the retry relaunches immediately. Against a rate ceiling that spends all three attempts
+inside roughly ninety seconds and blocks the goal anyway — the observed 4:18 / 4:19 / 4:19
+triple. Make the retry back off, growing per attempt.
+
+Both are provider-neutral: neither site may read agent identity.
+
+Primary files:
+
+- `runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningSweep.kt`
+- `runtime-application/src/main/kotlin/skillbill/application/model/GoalPlanningSweepModels.kt`
+- `runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt` (seam binding)
+- `runtime-application/src/test/kotlin/skillbill/application/GoalPlanningSweepTest.kt`
+
+## Acceptance Criteria
+
+1. Consecutive per-subtask plan launches are separated by a configurable pace interval. The
+   interval is applied between launches only — not before the first and not after the last —
+   asserted by a test that records launch ordinals and observed waits.
+2. `EmptyProviderTurn` retries wait before relaunching, and the wait grows per attempt. A test
+   drives all three attempts and asserts the observed schedule, including that attempt 1 is not
+   preceded by a wait.
+3. Waiting goes through an injected seam that a test can drive without real elapsed time,
+   following the injected `java.time.Clock` precedent in `GoalRunner` and
+   `GoalRunnerExecutionCoordinator`. The whole suite must not become measurably slower.
+4. No bare `Thread.sleep` in application code.
+5. Neither the pacing site nor the backoff site reads agent identity, model, or any
+   provider-specific field.
+6. Waiting is interruptible and does not sleep through a durable pause boundary: a sweep paced
+   or backing off still observes `planningPauseOutcome` and the spawn-authorization boundary
+   promptly. Covered by a test that pauses mid-sweep.
+7. A thread interrupt during a wait terminates the sweep the same way an interrupt during a
+   launch does — it does not surface as an unexpected planning failure or a swallowed exception.
+8. Defaults are stated with their arithmetic: the subtask records the chosen pace and backoff
+   values and the added wall-clock for a 15-subtask goal, and confirms that total stays inside
+   the default `--planning-budget-minutes` and `--max-wall-clock-minutes` bounds.
+9. Existing `GoalPlanningSweepTest` cases continue to pass unchanged in intent — in particular
+   the empty-turn retry, exhaustion, and evidence tests added in `50bbdf38`.
+10. `./gradlew build -x sourcesJar` and `detekt` pass.
+
+## Non-Goals
+
+- No change to `MAX_FIX_LOOP_ITERATIONS` or the number of retry attempts.
+- No agent failover after N empty turns, and no provider-specific special casing.
+- No pacing of non-planning launches (implement, audit, review, validate). This subtask is
+  scoped to the planning sweep, which is the burst source under investigation.
+- No adaptive or feedback-driven rate control. A fixed pace and a fixed backoff schedule are
+  sufficient; anything adaptive needs evidence this does not already resolve it.
+- No change to how an empty turn is classified or recorded — that landed in `50bbdf38`.
+
+## Dependency Notes
+
+Depends on commit `50bbdf38`, which introduced `GoalPlanningPhaseProduction.EmptyProviderTurn`
+and the retry branch this subtask adds backoff to. Independent of subtask 1; either may land
+first, though landing subtask 1 first reduces payload per launch and makes any measurement of
+this subtask's effect cleaner.
+
+## Validation Strategy
+
+1. Pacing test: multi-subtask sweep with a fake wait seam, asserting waits occur between
+   launches only and match the configured interval.
+2. Backoff test: all-empty sweep, asserting the per-attempt wait schedule and that attempt 1 is
+   unpreceded.
+3. Pause test: pause the sweep while a wait is pending; assert it stops at the pause boundary
+   rather than completing the wait and launching.
+4. Interrupt test: interrupt during a wait; assert the same terminal shape as an interrupt
+   during launch.
+5. Re-run the `50bbdf38` empty-turn tests unchanged.
+6. `(cd runtime-kotlin && ./gradlew :runtime-application:test detekt)` and
+   `(cd runtime-kotlin && ./gradlew build -x sourcesJar)`.
+7. Manual, after merge: run a wide decomposed goal against Cursor and compare single-run
+   planning completion against the 2 → 4 → 6 → 9 → 12 → 15 resume pattern.
+
+## Next Path
+
+Measure a real wide goal. If empties persist at the same depth after pacing and backoff, the
+remaining burst is upstream of this change and provider failover becomes the next candidate.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningSweep.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningSweep.kt
@@ -5,11 +5,15 @@ import skillbill.application.decomposition.DECOMPOSITION_MANIFEST_FILENAME
 import skillbill.application.featuretask.FeatureTaskRuntimeFixLoopPolicy
 import skillbill.application.featuretask.FeatureTaskRuntimePhaseBriefingAssembler
 import skillbill.application.featuretask.FeatureTaskRuntimePhasePromptComposer
+import skillbill.application.featuretask.FeatureTaskRuntimePhaseRecorder
+import skillbill.application.featuretask.RejectedOutputDiagnosticRequest
 import skillbill.application.featuretask.boundedSchemaGateDetail
 import skillbill.application.featuretask.producerProjectionGateReason
 import skillbill.application.featuretask.sha256HexUtf8
 import skillbill.application.model.GoalPlanningAttemptRecord
+import skillbill.application.model.GoalPlanningEmptyTurnEvidence
 import skillbill.application.model.GoalPlanningPhaseProduction
+import skillbill.application.model.GoalPlanningRejectionRecord
 import skillbill.application.model.GoalPlanningSweepOutcome
 import skillbill.application.model.GoalRunnerRunRequest
 import skillbill.application.workflow.GoalPlanningPreparationCheckpoint
@@ -98,6 +102,7 @@ class DefaultGoalPlanningSweep(
   private val planningProjectionValidator: FeatureTaskRuntimePlanningProjectionValidator,
   private val planningAttemptRecorder: GoalPlanningAttemptRecorder = GoalPlanningAttemptRecorder.NONE,
   private val manifestStore: GoalRunnerManifestStore,
+  private val planningRejectionRecorder: GoalPlanningRejectionRecorder = GoalPlanningRejectionRecorder.NONE,
 ) : GoalPlanningSweep {
   @Suppress("ReturnCount")
   override fun prepare(state: GoalRunnerManifestState, request: GoalRunnerRunRequest): GoalPlanningSweepOutcome {
@@ -325,6 +330,7 @@ class DefaultGoalPlanningSweep(
     finalizePayload: (String) -> String = { it },
   ): GoalPlanningPhaseProduction {
     var priorSchemaFailure: String? = null
+    var lastRejection: String? = null
     repeat(FeatureTaskRuntimeFixLoopPolicy.MAX_FIX_LOOP_ITERATIONS) { attemptIndex ->
       val attempt = attemptIndex + 1
       val production = produceAttemptOrStop(
@@ -345,39 +351,64 @@ class DefaultGoalPlanningSweep(
         is GoalPlanningPhaseProduction.SchemaRejected -> {
           recordPlanningAttempt(shared, phaseId, subtask, attempt, GoalProgressOutcome.FAILED)
           priorSchemaFailure = production.reason
+          lastRejection = production.reason
+          return@repeat
+        }
+
+        is GoalPlanningPhaseProduction.EmptyProviderTurn -> {
+          recordPlanningAttempt(shared, phaseId, subtask, attempt, GoalProgressOutcome.FAILED)
+          recordEmptyProviderTurn(shared, phaseId, subtask, attempt, production)
+          // Deliberately leaves priorSchemaFailure untouched: there is no rejected output to
+          // remediate, and injecting one would describe output the agent never produced.
+          lastRejection = production.reason
           return@repeat
         }
 
         is GoalPlanningPhaseProduction.Captured -> Unit
       }
-      val captured = production
-      val payload = finalizePayload(captured.payload)
-      val accepted = if (payload == captured.payload) {
-        skillbill.workflow.taskruntime.model.AcceptedFeatureTaskRuntimePhaseOutput(
-          normalizedOutput = captured.normalizedOutput,
-          repairEvidence = captured.repairEvidence,
-        )
-      } else {
-        outputValidator.validatePhaseOutput(payload, phaseId).requireAcceptedOutput(phaseId)
-      }
-      val canonicalPayload = accepted.normalizedOutput.canonicalJson
-      val gateReason = projectionGateReason(canonicalPayload, phaseId)
-      if (gateReason == null) {
+      val gated = gateCapturedPayload(production, phaseId, finalizePayload)
+      if (gated is GoalPlanningPhaseProduction.Captured) {
         recordPlanningAttempt(shared, phaseId, subtask, attempt, GoalProgressOutcome.SUCCEEDED)
-        return GoalPlanningPhaseProduction.Captured(
-          canonicalPayload,
-          accepted.normalizedOutput,
-          // Enrichment revalidates the final payload, but it must not discard evidence captured
-          // while structurally repairing the child output before enrichment.
-          accepted.repairEvidence ?: captured.repairEvidence,
-        )
+        return gated
       }
+      val gateReason = (gated as GoalPlanningPhaseProduction.SchemaRejected).reason
       recordPlanningAttempt(shared, phaseId, subtask, attempt, GoalProgressOutcome.FAILED)
       priorSchemaFailure = gateReason
+      lastRejection = gateReason
     }
     return GoalPlanningPhaseProduction.Stopped(
-      stopped(shared, subtask?.id ?: 0, fixLoopExhaustedReason(phaseId, priorSchemaFailure.orEmpty()), phaseId),
+      stopped(shared, subtask?.id ?: 0, fixLoopExhaustedReason(phaseId, lastRejection.orEmpty()), phaseId),
     )
+  }
+
+  /**
+   * Runs the exact bytes that would be checkpointed through the producer projection gate. Returns
+   * the captured production when the gate accepts, or the bounded gate detail as a rejection.
+   */
+  private fun gateCapturedPayload(
+    captured: GoalPlanningPhaseProduction.Captured,
+    phaseId: String,
+    finalizePayload: (String) -> String,
+  ): GoalPlanningPhaseProduction {
+    val payload = finalizePayload(captured.payload)
+    val accepted = if (payload == captured.payload) {
+      skillbill.workflow.taskruntime.model.AcceptedFeatureTaskRuntimePhaseOutput(
+        normalizedOutput = captured.normalizedOutput,
+        repairEvidence = captured.repairEvidence,
+      )
+    } else {
+      outputValidator.validatePhaseOutput(payload, phaseId).requireAcceptedOutput(phaseId)
+    }
+    val canonicalPayload = accepted.normalizedOutput.canonicalJson
+    val gateReason = projectionGateReason(canonicalPayload, phaseId)
+      ?: return GoalPlanningPhaseProduction.Captured(
+        canonicalPayload,
+        accepted.normalizedOutput,
+        // Enrichment revalidates the final payload, but it must not discard evidence captured
+        // while structurally repairing the child output before enrichment.
+        accepted.repairEvidence ?: captured.repairEvidence,
+      )
+    return GoalPlanningPhaseProduction.SchemaRejected(gateReason)
   }
 
   @Suppress("TooGenericExceptionCaught")
@@ -406,6 +437,29 @@ class DefaultGoalPlanningSweep(
         subtask?.id ?: 0,
         unexpectedPlanningFailureReason(phaseId, error),
         phaseId,
+      ),
+    )
+  }
+
+  private fun recordEmptyProviderTurn(
+    shared: GoalPlanningSharedContext,
+    phaseId: String,
+    subtask: DecompositionSubtask?,
+    attempt: Int,
+    production: GoalPlanningPhaseProduction.EmptyProviderTurn,
+  ) {
+    planningRejectionRecorder.record(
+      GoalPlanningRejectionRecord(
+        parentWorkflowId = shared.parentWorkflowId,
+        issueKey = shared.issueKey,
+        dbPathOverride = shared.dbPathOverride,
+        phaseId = phaseId,
+        subtaskId = subtask?.id ?: 0,
+        attempt = attempt,
+        rule = EMPTY_PLANNING_HARVEST_RULE,
+        reason = production.reason,
+        agentId = production.evidence.agentId,
+        rawEvidence = production.evidence.rawOutputPreview.orEmpty(),
       ),
     )
   }
@@ -440,9 +494,12 @@ class DefaultGoalPlanningSweep(
   }
 
   private fun fixLoopExhaustedReason(phaseId: String, lastFailure: String): String =
-    "Goal planning '$phaseId' produced schema-invalid output on every attempt " +
+    "Goal planning '$phaseId' produced no acceptable output on every attempt " +
       "(cap=${FeatureTaskRuntimeFixLoopPolicy.MAX_FIX_LOOP_ITERATIONS}); nothing was checkpointed. " +
-      "Last schema failure: $lastFailure"
+      "Last failure: $lastFailure"
+
+  private fun emptyTurnReason(phaseId: String, evidence: GoalPlanningEmptyTurnEvidence): String =
+    "Goal planning '$phaseId' agent turn exited cleanly and returned no output. ${evidence.summary()}"
 
   @Suppress("ReturnCount")
   private fun produceAttempt(
@@ -472,6 +529,7 @@ class DefaultGoalPlanningSweep(
           stopped(shared, currentSubtaskId, projectionRejectedReason(phaseId, error), phaseId),
         )
       }
+    val startedAtNanos = System.nanoTime()
     val outcome = runCatching { launchPlanningAttempt(shared, request, subtask, phaseId, prompt) }
       .getOrElse { error ->
         if (error is GoalRunnerLaunchAuthorizationDeniedException) {
@@ -480,10 +538,9 @@ class DefaultGoalPlanningSweep(
         }
         throw error
       }
+    val durationMs = (System.nanoTime() - startedAtNanos) / NANOS_PER_MILLI
     val stdout = stdoutFor(outcome)
-      ?: return GoalPlanningPhaseProduction.Stopped(
-        stopped(shared, currentSubtaskId, exhaustedReason(outcome, request.planningBudget), phaseId),
-      )
+      ?: return emptyOrStopped(outcome, shared, request, currentSubtaskId, phaseId, durationMs)
     return validatePlanningAttemptOutput(stdout, shared, currentSubtaskId, phaseId)
   }
 
@@ -692,6 +749,42 @@ class DefaultGoalPlanningSweep(
   private fun preparationStateReadReason(error: Throwable): String =
     "Goal planning preparation state could not be read: ${error.message.orEmpty()}"
 
+  /**
+   * A planning launch that exits zero, reports no failure mode and still harvests nothing is a
+   * provider flake, not a bad prompt. It is retried under the same fix-loop cap instead of blocking
+   * the goal on its first occurrence, and its launch facts are retained so the recurrence is
+   * countable rather than anecdotal.
+   */
+  private fun emptyOrStopped(
+    outcome: AgentRunLaunchOutcome,
+    shared: GoalPlanningSharedContext,
+    request: GoalRunnerRunRequest,
+    currentSubtaskId: Int,
+    phaseId: String,
+    durationMs: Long,
+  ): GoalPlanningPhaseProduction {
+    val evidence = emptyTurnEvidence(outcome, durationMs)
+      ?: return GoalPlanningPhaseProduction.Stopped(
+        stopped(shared, currentSubtaskId, exhaustedReason(outcome, request.planningBudget), phaseId),
+      )
+    return GoalPlanningPhaseProduction.EmptyProviderTurn(emptyTurnReason(phaseId, evidence), evidence)
+  }
+
+  private fun emptyTurnEvidence(outcome: AgentRunLaunchOutcome, durationMs: Long): GoalPlanningEmptyTurnEvidence? {
+    if (outcome !is AgentRunLaunchFacts) return null
+    val cleanExit = !outcome.spawnFailed && !outcome.timedOut && !outcome.interrupted && outcome.exitStatus == 0
+    if (!cleanExit) return null
+    return GoalPlanningEmptyTurnEvidence(
+      agentId = outcome.agent.id,
+      durationMs = durationMs,
+      exitStatus = outcome.exitStatus,
+      inputTokens = outcome.inputTokens,
+      outputTokens = outcome.outputTokens,
+      assistantEventCount = outcome.assistantEventCount,
+      rawOutputPreview = outcome.rawOutputPreview,
+    )
+  }
+
   private fun stdoutFor(outcome: AgentRunLaunchOutcome): String? = when (outcome) {
     is AgentRunLaunchFacts -> outcome.stdout.takeIf { stdout ->
       !outcome.spawnFailed &&
@@ -800,6 +893,46 @@ class DefaultGoalPlanningSweep(
     const val PHASE_PREPLAN: String = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN
     const val PHASE_PLAN: String = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN
     const val SHARED_CONTEXT_FIELD = "_goal_planning_shared_context"
+    const val EMPTY_PLANNING_HARVEST_RULE = "empty-planning-harvest"
+    const val NANOS_PER_MILLI = 1_000_000L
+  }
+}
+
+/**
+ * Durable evidence seam for a planning attempt the run rejected without any output to gate. Kept
+ * separate from [GoalPlanningAttemptRecorder], which counts attempts but retains no launch facts.
+ */
+fun interface GoalPlanningRejectionRecorder {
+  fun record(record: GoalPlanningRejectionRecord)
+
+  companion object {
+    val NONE: GoalPlanningRejectionRecorder = GoalPlanningRejectionRecorder {}
+  }
+}
+
+@Inject
+class DurableGoalPlanningRejectionRecorder(
+  private val recorder: FeatureTaskRuntimePhaseRecorder,
+) : GoalPlanningRejectionRecorder {
+  override fun record(record: GoalPlanningRejectionRecord) {
+    // Evidence must never decide the run's outcome: a diagnostics failure leaves the planning
+    // rejection exactly as classified rather than converting it into a crash.
+    runCatching {
+      recorder.recordRejectedOutput(
+        RejectedOutputDiagnosticRequest(
+          workflowId = record.parentWorkflowId,
+          phaseId = record.phaseId,
+          attempt = record.attempt.coerceAtLeast(1),
+          rule = record.rule,
+          path = "/",
+          reason = record.reason,
+          agentId = record.agentId,
+          model = "unspecified",
+          rawResponse = record.rawEvidence.encodeToByteArray(),
+        ),
+        record.dbPathOverride,
+      )
+    }
   }
 }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalPlanningSweepModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/GoalPlanningSweepModels.kt
@@ -44,5 +44,60 @@ internal sealed interface GoalPlanningPhaseProduction {
     val reason: String,
   ) : GoalPlanningPhaseProduction
 
+  /**
+   * The launch itself succeeded and the provider returned nothing usable. Distinct from
+   * [SchemaRejected] because there is no rejected output to remediate: relaunching the identical
+   * prompt is the whole fix, and the prior-failure remediation text would describe output that was
+   * never produced.
+   */
+  data class EmptyProviderTurn(
+    val reason: String,
+    val evidence: GoalPlanningEmptyTurnEvidence,
+  ) : GoalPlanningPhaseProduction
+
   data class Stopped(val outcome: GoalPlanningSweepOutcome.Stopped) : GoalPlanningPhaseProduction
 }
+
+/**
+ * Launch-shaped facts about a zero-exit planning turn that yielded nothing. These are the facts that
+ * separate a provider that answered nothing from a harvest that lost the answer, and they are the
+ * only evidence the run retains once the undecodable transport is dropped.
+ */
+data class GoalPlanningEmptyTurnEvidence(
+  val agentId: String,
+  val durationMs: Long,
+  val exitStatus: Int?,
+  val inputTokens: Long?,
+  val outputTokens: Long?,
+  val assistantEventCount: Int?,
+  val rawOutputPreview: String?,
+) {
+  /** Payload-free one-line summary safe to surface to an operator and to store as a reason. */
+  fun summary(): String = buildString {
+    append("EmptyProviderTurn: agent=")
+    append(agentId)
+    append(" durationMs=")
+    append(durationMs)
+    append(" exitStatus=")
+    append(exitStatus ?: "none")
+    append(" assistantEvents=")
+    append(assistantEventCount ?: "unknown")
+    append(" inputTokens=")
+    append(inputTokens ?: "unknown")
+    append(" outputTokens=")
+    append(outputTokens ?: "unknown")
+  }
+}
+
+data class GoalPlanningRejectionRecord(
+  val parentWorkflowId: String,
+  val issueKey: String,
+  val dbPathOverride: String?,
+  val phaseId: String,
+  val subtaskId: Int,
+  val attempt: Int,
+  val rule: String,
+  val reason: String,
+  val agentId: String,
+  val rawEvidence: String,
+)

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalPlanningSweepTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalPlanningSweepTest.kt
@@ -4,8 +4,10 @@ import skillbill.application.featuretask.FeatureTaskRuntimeFixLoopPolicy
 import skillbill.application.featuretask.sha256HexUtf8
 import skillbill.application.goalrunner.DefaultGoalPlanningSweep
 import skillbill.application.goalrunner.GoalPlanningAttemptRecorder
+import skillbill.application.goalrunner.GoalPlanningRejectionRecorder
 import skillbill.application.goalrunner.GoalRunner
 import skillbill.application.model.GoalPlanningAttemptRecord
+import skillbill.application.model.GoalPlanningRejectionRecord
 import skillbill.application.model.GoalPlanningSweepOutcome
 import skillbill.application.model.GoalRunnerRunRequest
 import skillbill.application.workflow.GoalPlanningPreparationCheckpoint
@@ -369,7 +371,9 @@ class GoalPlanningSweepTest {
     val fixtures = sharedSweepFixtures()
     val discovery = CountingContextDiscovery()
     val runOneLauncher = SweepPlanningLauncher { phase, subtaskId, _ ->
-      if (subtaskId == 2 && phase == "plan") launchFacts(stdout = "") else validPhaseOutcome(phase)
+      // A hard launch failure, not an empty harvest: this case is about resume continuing at the
+      // next subtask, and an empty harvest now spends the bounded retry budget before it stops.
+      if (subtaskId == 2 && phase == "plan") spawnBlockedOutcome() else validPhaseOutcome(phase)
     }
     val runOne = DefaultGoalPlanningSweep(
       fixtures.checkpoint,
@@ -594,7 +598,98 @@ class GoalPlanningSweepTest {
     assertEquals("preplan", stopped.lastResumableStep)
     assertEquals(0, harness.preparedCount())
     assertEquals(FeatureTaskRuntimeFixLoopPolicy.MAX_FIX_LOOP_ITERATIONS, harness.launcher.phases.size)
-    assertTrue(stopped.blockedReason.contains("schema-invalid output"), stopped.blockedReason)
+    assertTrue(stopped.blockedReason.contains("no acceptable output"), stopped.blockedReason)
+    assertTrue(stopped.blockedReason.contains("Last failure:"), stopped.blockedReason)
+  }
+
+  @Test
+  fun `empty provider turn on a clean exit is retried under the fix-loop cap instead of blocking at once`() {
+    var launches = 0
+    val harness = sweepHarness { phase, _, _ ->
+      launches += 1
+      if (launches == 1) emptyProviderTurnOutcome() else validPhaseOutcome(phase)
+    }
+
+    val outcome = harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
+
+    assertIs<GoalPlanningSweepOutcome.PreparedAll>(outcome)
+    assertEquals(listOf("preplan", "preplan", "plan"), harness.launcher.phases)
+    assertEquals(1, harness.preparedCount())
+  }
+
+  @Test
+  fun `empty provider turn retry does not tell the agent its prior output was schema-rejected`() {
+    var launches = 0
+    val harness = sweepHarness { phase, _, _ ->
+      launches += 1
+      if (launches == 1) emptyProviderTurnOutcome() else validPhaseOutcome(phase)
+    }
+
+    harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
+
+    val retryPrompt = harness.launcher.requests[1].skillRunRequest.promptOverride.orEmpty()
+    assertFalse(
+      retryPrompt.contains("Previous attempt was REJECTED by the schema gate"),
+      "there is no rejected output to remediate when the provider returned nothing",
+    )
+  }
+
+  @Test
+  fun `exhausted empty provider turns block with launch facts rather than a schema verdict`() {
+    val harness = sweepHarness { _, _, _ -> emptyProviderTurnOutcome() }
+
+    val outcome = harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
+
+    val stopped = assertIs<GoalPlanningSweepOutcome.Stopped>(outcome)
+    assertEquals(FeatureTaskRuntimeFixLoopPolicy.MAX_FIX_LOOP_ITERATIONS, harness.launcher.phases.size)
+    assertEquals(0, harness.preparedCount())
+    assertContains(stopped.blockedReason, "EmptyProviderTurn")
+    assertContains(stopped.blockedReason, "assistantEvents=0")
+    assertContains(stopped.blockedReason, "outputTokens=0")
+    assertFalse(
+      stopped.blockedReason.contains("schema-invalid"),
+      "an operator must not be told the schema rejected output that was never produced",
+    )
+  }
+
+  @Test
+  fun `empty provider turns are retained as durable rejection evidence`() {
+    val recorded = mutableListOf<GoalPlanningRejectionRecord>()
+    val harness = sweepHarness(planningRejectionRecorder = { recorded += it }) { _, _, _ ->
+      emptyProviderTurnOutcome()
+    }
+
+    harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
+
+    assertEquals(FeatureTaskRuntimeFixLoopPolicy.MAX_FIX_LOOP_ITERATIONS, recorded.size)
+    assertEquals(listOf(1, 2, 3), recorded.map { it.attempt })
+    val first = recorded.first()
+    assertEquals("empty-planning-harvest", first.rule)
+    assertEquals("preplan", first.phaseId)
+    assertEquals("claude", first.agentId)
+    assertContains(first.reason, "EmptyProviderTurn")
+    assertEquals("{\"type\":\"result\",\"result\":\"\"}", first.rawEvidence)
+  }
+
+  @Test
+  fun `a non-zero exit still blocks immediately rather than burning the retry budget`() {
+    val harness = sweepHarness { _, _, _ ->
+      AgentRunLaunchFacts(
+        agent = InstallAgent.CLAUDE,
+        exitStatus = 2,
+        stdout = "",
+        stderr = "boom",
+        timedOut = false,
+        interrupted = false,
+        spawnFailed = false,
+      )
+    }
+
+    val outcome = harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
+
+    val stopped = assertIs<GoalPlanningSweepOutcome.Stopped>(outcome)
+    assertEquals(1, harness.launcher.phases.size)
+    assertContains(stopped.blockedReason, "exited with status 2")
   }
 
   @Test
@@ -1106,6 +1201,21 @@ private fun GoalPlanningPreparationRecord.preplanRoot(): Map<String, Any?> =
 
 private fun validPhaseOutcome(phase: String): AgentRunLaunchOutcome = launchFacts(stdout = phasePayload(phase))
 
+/** A provider turn that charged input, emitted no assistant event, and still exited zero. */
+private fun emptyProviderTurnOutcome(): AgentRunLaunchOutcome = AgentRunLaunchFacts(
+  agent = InstallAgent.CLAUDE,
+  exitStatus = 0,
+  stdout = "",
+  stderr = "",
+  timedOut = false,
+  interrupted = false,
+  spawnFailed = false,
+  inputTokens = 33110,
+  outputTokens = 0,
+  assistantEventCount = 0,
+  rawOutputPreview = "{\"type\":\"result\",\"result\":\"\"}",
+)
+
 private fun spawnBlockedOutcome(): AgentRunLaunchOutcome = AgentRunLaunchFacts(
   agent = InstallAgent.CLAUDE,
   exitStatus = null,
@@ -1573,6 +1683,7 @@ private fun sweepHarness(
     NoopFeatureTaskRuntimePlanningProjectionValidator,
   planningAttemptRecorder: GoalPlanningAttemptRecorder = GoalPlanningAttemptRecorder.NONE,
   manifestStore: GoalRunnerManifestStore = NoopGoalPlanningManifestStore,
+  planningRejectionRecorder: GoalPlanningRejectionRecorder = GoalPlanningRejectionRecorder.NONE,
   behavior: (phase: String, subtaskId: Int, request: GoalRunnerSubtaskLaunchRequest) -> AgentRunLaunchOutcome,
 ): SweepHarness {
   val fixtures = sharedSweepFixtures(
@@ -1591,6 +1702,7 @@ private fun sweepHarness(
     planningProjectionValidator,
     planningAttemptRecorder,
     manifestStore = manifestStore,
+    planningRejectionRecorder = planningRejectionRecorder,
   )
   return SweepHarness(fixtures, launcher, sweep)
 }

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -14,8 +14,10 @@ import skillbill.application.featuretask.FeatureTaskRuntimeWorkerCoordinator
 import skillbill.application.goalrunner.DefaultGoalPlanningSweep
 import skillbill.application.goalrunner.DefaultGoalRunnerExecutionCoordinator
 import skillbill.application.goalrunner.DurableGoalPlanningAttemptRecorder
+import skillbill.application.goalrunner.DurableGoalPlanningRejectionRecorder
 import skillbill.application.goalrunner.GoalLifecycleTelemetryEmitter
 import skillbill.application.goalrunner.GoalPlanningAttemptRecorder
+import skillbill.application.goalrunner.GoalPlanningRejectionRecorder
 import skillbill.application.goalrunner.GoalPlanningSweep
 import skillbill.application.goalrunner.GoalRunner
 import skillbill.application.goalrunner.GoalRunnerExecutionCoordinator
@@ -387,6 +389,12 @@ abstract class RuntimeComponent(
   @JvmSynthetic
   internal fun goalPlanningAttemptRecorder(recorder: DurableGoalPlanningAttemptRecorder): GoalPlanningAttemptRecorder =
     recorder
+
+  @Provides
+  @JvmSynthetic
+  internal fun goalPlanningRejectionRecorder(
+    recorder: DurableGoalPlanningRejectionRecorder,
+  ): GoalPlanningRejectionRecorder = recorder
 
   @Provides
   @JvmSynthetic

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
@@ -35,14 +35,13 @@ class ProcessAgentRunAdapter(
       is LauncherResolution.Missing -> return unavailableLauncherFacts(request, built, resolution.message)
     }
     val result = processRunner.run(processRequest(command, request))
-    val decoded = runCatching {
-      (command.outputDecoder ?: commandBuilder.outputDecoder).decode(result.stdout)
-    }.getOrElse { error ->
-      if (error is skillbill.infrastructure.fs.CursorReviewStreamMalformedError) {
-        DecodedAgentRunOutput(result.stdout)
-      } else {
-        throw error
-      }
+    val decoder = command.outputDecoder ?: commandBuilder.outputDecoder
+    val decoded = runCatching { decoder.decode(result.stdout) }.getOrElse { error ->
+      if (!decoder.undecodable(error)) throw error
+      // A stream we could not decode is not phase output. Handing the raw transport back made the
+      // phase schema gate see several conflicting envelopes instead of one undecodable turn, so the
+      // operator was told the agent wrote bad output when it had written none we could read.
+      DecodedAgentRunOutput(text = "", rawOutputPreview = result.stdout.take(RAW_OUTPUT_PREVIEW_MAX_CHARS))
     }
     val normalizedStdout = normalizeStdout(agent, decoded.text)
     val decodedBodyBytes = if (normalizedStdout == result.stdout) {
@@ -80,6 +79,8 @@ class ProcessAgentRunAdapter(
       // This decoder runs after process completion. Completion facts are never an enforceable
       // provider seam, irrespective of what a future command builder can expose in flight.
       providerUsageEnforceable = false,
+      assistantEventCount = decoded.assistantEventCount,
+      rawOutputPreview = decoded.rawOutputPreview,
     )
   }
 
@@ -171,17 +172,43 @@ data class DecodedAgentRunOutput(
   val outputTokens: Long? = null,
   val reasoningTokens: Long? = null,
   val totalTokens: Long? = null,
+  /** Assistant turns observed on transports that expose them; null when the transport has no such event. */
+  val assistantEventCount: Int? = null,
+  /** Bounded raw-transport excerpt, set only when decoding produced no usable text. */
+  val rawOutputPreview: String? = null,
 )
 
-fun interface AgentRunOutputDecoder {
+interface AgentRunOutputDecoder {
   fun decode(stdout: String): DecodedAgentRunOutput
 
+  /**
+   * Decoder-declared classification of a decode failure. A decoder that owns a transport it cannot
+   * always parse says so here; the launcher then degrades that launch to an empty harvest with a
+   * bounded preview instead of promoting undecodable bytes to phase output. Decoders that treat
+   * every failure as fatal inherit the default and keep propagating.
+   */
+  fun undecodable(error: Throwable): Boolean = false
+
   companion object {
-    val PLAIN = AgentRunOutputDecoder { DecodedAgentRunOutput(it) }
-    val CLAUDE_JSON = AgentRunOutputDecoder { stdout -> decodeClaudeJson(stdout) }
-    val CLAUDE_STREAM_JSON = AgentRunOutputDecoder { stdout -> decodeClaudeStreamJson(stdout) }
-    val CODEX_JSONL = AgentRunOutputDecoder { stdout -> decodeCodexJsonl(stdout) }
-    val CURSOR_STREAM_JSON = AgentRunOutputDecoder { stdout -> decodeCursorStreamJson(stdout) }
+    val PLAIN = decoder { DecodedAgentRunOutput(it) }
+    val CLAUDE_JSON = decoder { stdout -> decodeClaudeJson(stdout) }
+    val CLAUDE_STREAM_JSON = decoder { stdout -> decodeClaudeStreamJson(stdout) }
+    val CODEX_JSONL = decoder { stdout -> decodeCodexJsonl(stdout) }
+    val CURSOR_STREAM_JSON: AgentRunOutputDecoder = object : AgentRunOutputDecoder {
+      override fun decode(stdout: String): DecodedAgentRunOutput = decodeCursorStreamJson(stdout)
+
+      /**
+       * A truncated or interleaved Cursor stream is a transport defect, not a provider verdict: the
+       * remaining envelopes carry no answer we can read, so the launch is an empty harvest.
+       */
+      override fun undecodable(error: Throwable): Boolean =
+        error is skillbill.infrastructure.fs.CursorReviewStreamMalformedError
+    }
+
+    private fun decoder(body: (String) -> DecodedAgentRunOutput): AgentRunOutputDecoder =
+      object : AgentRunOutputDecoder {
+        override fun decode(stdout: String): DecodedAgentRunOutput = body(stdout)
+      }
   }
 }
 
@@ -250,6 +277,8 @@ private fun decodeCursorStreamJson(stdout: String): DecodedAgentRunOutput {
   }
 
   var terminalText: String? = null
+  var longestAssistantText: String? = null
+  var assistantEventCount = 0
   var usage: com.fasterxml.jackson.databind.JsonNode? = null
   var decodedEnvelope = false
   var errorEvent = false
@@ -283,6 +312,12 @@ private fun decodeCursorStreamJson(stdout: String): DecodedAgentRunOutput {
         errorMessage = event.path("message").takeIf { it.isTextual }?.asText()
         // Error is stored and thrown later after parsing completes
       }
+      "assistant" -> {
+        assistantEventCount += 1
+        cursorAssistantText(event)?.let { text ->
+          if (text.length > (longestAssistantText?.length ?: 0)) longestAssistantText = text
+        }
+      }
       "result" -> {
         terminalText = event.path("result").takeIf { it.isTextual }?.asText()
         event.path("usage").takeUnless { it.isMissingNode || it.isNull }?.let { usage = it }
@@ -308,19 +343,40 @@ private fun decodeCursorStreamJson(stdout: String): DecodedAgentRunOutput {
     }
   }
 
-  return when {
-    decodedEnvelope && terminalText == null -> DecodedAgentRunOutput("")
-    !decodedEnvelope -> DecodedAgentRunOutput(stdout)
-    else -> DecodedAgentRunOutput(
-      text = terminalText ?: "",
-      inputTokens = usage?.longOrNull("input_tokens"),
-      cachedInputTokens = usage?.longOrNull("cached_input_tokens"),
-      outputTokens = usage?.longOrNull("output_tokens"),
-      reasoningTokens = usage?.longOrNull("reasoning_tokens"),
-      totalTokens = usage?.longOrNull("total_tokens"),
-    )
-  }
+  // A terminal `result` of "" is a real Cursor outcome: the CLI can exit 0 having charged input
+  // tokens and produced no answer at all. Fall back to the longest assistant turn so a blank
+  // terminal event does not discard text the provider actually emitted, and never promote raw
+  // transport bytes to phase output — the phase schema gate reads several JSON envelopes as
+  // conflicting candidates rather than as an empty turn.
+  val harvested = terminalText?.takeIf(String::isNotBlank) ?: longestAssistantText.orEmpty()
+  return DecodedAgentRunOutput(
+    text = harvested,
+    inputTokens = usage.cursorTokens("inputTokens", "input_tokens"),
+    cachedInputTokens = usage.cursorTokens("cachedInputTokens", "cached_input_tokens"),
+    outputTokens = usage.cursorTokens("outputTokens", "output_tokens"),
+    reasoningTokens = usage.cursorTokens("reasoningTokens", "reasoning_tokens"),
+    totalTokens = usage.cursorTokens("totalTokens", "total_tokens"),
+    assistantEventCount = assistantEventCount.takeIf { decodedEnvelope },
+    rawOutputPreview = stdout.take(RAW_OUTPUT_PREVIEW_MAX_CHARS).takeIf { harvested.isBlank() },
+  )
 }
+
+/** Cursor emits camelCase usage keys; older captures and fixtures use snake_case. Accept both. */
+private fun com.fasterxml.jackson.databind.JsonNode?.cursorTokens(vararg fields: String): Long? =
+  this?.let { node -> fields.firstNotNullOfOrNull { field -> node.longOrNull(field) } }
+
+private fun cursorAssistantText(event: com.fasterxml.jackson.databind.JsonNode): String? {
+  val content = event.path("message").path("content")
+  if (content.isArray) {
+    val joined = content.mapNotNull { part -> part.path("text").takeIf { it.isTextual }?.asText() }
+      .joinToString("")
+    return joined.takeIf(String::isNotBlank)
+  }
+  return event.path("message").path("text").takeIf { it.isTextual }?.asText()?.takeIf(String::isNotBlank)
+    ?: event.path("text").takeIf { it.isTextual }?.asText()?.takeIf(String::isNotBlank)
+}
+
+private const val RAW_OUTPUT_PREVIEW_MAX_CHARS = 2_000
 
 private fun com.fasterxml.jackson.databind.JsonNode.longOrNull(field: String): Long? =
   path(field).takeIf { it.isIntegralNumber && it.canConvertToLong() }?.longValue()

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunCommandBuilders.kt
@@ -263,11 +263,15 @@ class CursorAgentRunCommandBuilder : AgentRunCommandBuilder {
 
   override fun build(request: SkillRunRequest): AgentRunCommand {
     requireProcessLaunch(request, reviewIsolation)
-    val streaming = request.streamProviderOutput || request.streamOutputForLiveness
+    // --stream-partial-output turns one answer into a run of incremental assistant deltas. That is
+    // what a caller asking for provider output wants, and precisely what a caller asking only for a
+    // liveness signal does not: the deltas are indistinguishable from finished turns at harvest
+    // time. Liveness falls back to process heartbeat instead, as Codex already does.
+    val streamPartialOutput = request.streamProviderOutput
     val isReviewLaunch = request.reviewEvidenceBroker != null
 
     return goalContinuationCommand(request, agent) ?: AgentRunCommand(
-      command = buildCursorCommand(request, isReviewLaunch, streaming),
+      command = buildCursorCommand(request, isReviewLaunch, streamPartialOutput),
       workingDirectory = request.repoRoot,
       timeout = request.timeout,
       stdinText = launchPrompt(request),
@@ -275,52 +279,54 @@ class CursorAgentRunCommandBuilder : AgentRunCommandBuilder {
       inheritEnvironment = !isReviewLaunch,
       conversationIsolation = request.conversationIsolation,
       idlePolicy = when {
-        request.streamOutputForLiveness -> AgentRunIdlePolicy.OUTPUT_EXTENDED
-        request.readOnlyPhase -> AgentRunIdlePolicy.HEARTBEAT_EXTENDED
-        else -> AgentRunIdlePolicy.DB_PROGRESS_ONLY
+        streamPartialOutput && request.streamOutputForLiveness -> AgentRunIdlePolicy.OUTPUT_EXTENDED
+        else -> unstreamedLivenessPolicy(request)
       },
       environmentPassthroughKeys = if (isReviewLaunch) CURSOR_PROVIDER_PASSTHROUGH_KEYS else emptySet(),
     )
   }
 
-  private fun buildCursorCommand(request: SkillRunRequest, isReviewLaunch: Boolean, streaming: Boolean): List<String> =
-    buildList {
-      add("agent")
-      add("--print")
+  private fun buildCursorCommand(
+    request: SkillRunRequest,
+    isReviewLaunch: Boolean,
+    streamPartialOutput: Boolean,
+  ): List<String> = buildList {
+    add("agent")
+    add("--print")
 
-      if (isReviewLaunch) {
-        request.nativeReviewWorkerName?.let { worker ->
-          add("/$worker")
-        }
-        add("--workspace")
-        add(request.repoRoot.toString())
-      } else {
-        add("--force")
-        add("--trust")
-        add("--approve-mcps")
-        add("--workspace")
-        add(request.repoRoot.toString())
+    if (isReviewLaunch) {
+      request.nativeReviewWorkerName?.let { worker ->
+        add("/$worker")
       }
+      add("--workspace")
+      add(request.repoRoot.toString())
+    } else {
+      add("--force")
+      add("--trust")
+      add("--approve-mcps")
+      add("--workspace")
+      add(request.repoRoot.toString())
+    }
 
-      add("--output-format")
-      add("stream-json")
-      if (streaming) add("--stream-partial-output")
+    add("--output-format")
+    add("stream-json")
+    if (streamPartialOutput) add("--stream-partial-output")
 
-      request.modelOverride?.let { model ->
-        val modelArg = request.effortOverride?.let { effort ->
-          mergeModelEffort(model, effort)
-        } ?: model
-        add("--model")
-        add(modelArg)
-      }
-      request.effortOverride?.let { effort ->
-        if (request.modelOverride == null) {
-          require(false) {
-            "Cursor effort directive requires a model directive; add a model directive or remove the effort assignment."
-          }
+    request.modelOverride?.let { model ->
+      val modelArg = request.effortOverride?.let { effort ->
+        mergeModelEffort(model, effort)
+      } ?: model
+      add("--model")
+      add(modelArg)
+    }
+    request.effortOverride?.let { effort ->
+      if (request.modelOverride == null) {
+        require(false) {
+          "Cursor effort directive requires a model directive; add a model directive or remove the effort assignment."
         }
       }
     }
+  }
 
   private fun mergeModelEffort(model: String, effort: String): String {
     val effortPrefix = "[effort="

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunCommandBuildersTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunCommandBuildersTest.kt
@@ -26,6 +26,8 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
@@ -465,12 +467,28 @@ class AgentRunCommandBuildersTest {
   }
 
   @Test
-  fun `cursor streaming launch adds --stream-partial-output and OUTPUT_EXTENDED idle policy`() {
+  fun `cursor provider-output launch adds --stream-partial-output and OUTPUT_EXTENDED idle policy`() {
     val builder = CursorAgentRunCommandBuilder()
-    val command = builder.build(request().copy(streamOutputForLiveness = true))
+    val command = builder.build(
+      request().copy(streamProviderOutput = true, streamOutputForLiveness = true),
+    )
 
     assertTrue(command.command.contains("--stream-partial-output"))
     assertEquals(AgentRunIdlePolicy.OUTPUT_EXTENDED, command.idlePolicy)
+  }
+
+  @Test
+  fun `cursor liveness-only launch withholds --stream-partial-output and falls back to heartbeat`() {
+    val builder = CursorAgentRunCommandBuilder()
+    val command = builder.build(request().copy(streamOutputForLiveness = true))
+
+    assertFalse(
+      command.command.contains("--stream-partial-output"),
+      "partial deltas must not be requested for liveness alone; they are indistinguishable from " +
+        "finished turns at harvest time",
+    )
+    assertTrue(command.command.contains("stream-json"), "the terminal-event transport is still required")
+    assertEquals(AgentRunIdlePolicy.HEARTBEAT_EXTENDED, command.idlePolicy)
   }
 
   @Test
@@ -562,6 +580,59 @@ class AgentRunCommandBuildersTest {
     assertEquals("final", decoded.text)
     assertEquals("final", decoded.text)
     assertEquals(15, decoded.totalTokens)
+  }
+
+  @Test
+  fun `cursor decoder reads camelCase usage keys the CLI actually emits`() {
+    val usage = """{"inputTokens":28164,"cachedInputTokens":11,"outputTokens":0,"totalTokens":28175}"""
+    val jsonl = """{"type":"result","result":"PLAN-OK","usage":$usage}"""
+
+    val decoded = AgentRunOutputDecoder.CURSOR_STREAM_JSON.decode(jsonl)
+
+    assertEquals(28164, decoded.inputTokens)
+    assertEquals(11, decoded.cachedInputTokens)
+    assertEquals(0, decoded.outputTokens)
+    assertEquals(28175, decoded.totalTokens)
+  }
+
+  @Test
+  fun `cursor decoder reports an empty successful turn with zero assistant events`() {
+    val jsonl = """{"type":"system","subtype":"init"}
+{"type":"user","message":{"content":[{"type":"text","text":"briefing"}]}}
+{"type":"result","subtype":"success","is_error":false,"result":"","usage":{"inputTokens":33110,"outputTokens":0}}"""
+
+    val decoded = AgentRunOutputDecoder.CURSOR_STREAM_JSON.decode(jsonl)
+
+    assertEquals("", decoded.text)
+    assertEquals(0, decoded.assistantEventCount)
+    assertEquals(33110, decoded.inputTokens)
+    assertEquals(0, decoded.outputTokens)
+    assertNotNull(decoded.rawOutputPreview, "an empty harvest must retain bounded transport evidence")
+  }
+
+  @Test
+  fun `cursor decoder falls back to the longest assistant turn when the terminal result is blank`() {
+    val jsonl = """{"type":"assistant","message":{"content":[{"type":"text","text":"short"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"{\"status\":\"completed\"}"}]}}
+{"type":"result","result":"","usage":{"inputTokens":10,"outputTokens":4}}"""
+
+    val decoded = AgentRunOutputDecoder.CURSOR_STREAM_JSON.decode(jsonl)
+
+    assertEquals("""{"status":"completed"}""", decoded.text)
+    assertEquals(2, decoded.assistantEventCount)
+    assertNull(decoded.rawOutputPreview, "a harvested turn is not empty-turn evidence")
+  }
+
+  @Test
+  fun `cursor decoder declares an undecodable stream so the launcher degrades to an empty harvest`() {
+    val decoder = AgentRunOutputDecoder.CURSOR_STREAM_JSON
+
+    assertTrue(decoder.undecodable(CursorReviewStreamMalformedError("truncated", RuntimeException())))
+    assertFalse(decoder.undecodable(CursorReviewStreamError("provider said no")))
+    assertFalse(
+      AgentRunOutputDecoder.PLAIN.undecodable(CursorReviewStreamMalformedError("truncated", RuntimeException())),
+      "the default policy keeps propagating; only a decoder that owns the transport may degrade",
+    )
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/launcher/AgentRunLauncherTest.kt
@@ -1115,7 +1115,7 @@ class HeadlessAgentRunAdapterTest {
 
     val captured = runner.requests.single()
     assertEquals(100.milliseconds, captured.timeout)
-    assertTrue(captured.command.contains("--stream-partial-output"))
+    assertTrue(captured.command.contains("stream-json"))
   }
 
   @Test

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
@@ -244,6 +244,18 @@ data class AgentRunLaunchFacts(
   val totalTokens: Long? = null,
   val tokenOwnership: AgentRunTokenOwnership = AgentRunTokenOwnership.DIRECT,
   val providerUsageEnforceable: Boolean = false,
+  /**
+   * Count of provider assistant turns the decoder observed, when the transport exposes them. A zero
+   * count on a zero-exit launch distinguishes "the provider answered nothing" from "the provider
+   * answered and the harvest lost it"; null means the transport carries no such signal.
+   */
+  val assistantEventCount: Int? = null,
+  /**
+   * Bounded, non-authoritative excerpt of the raw provider transport, retained only when decoding
+   * yielded no usable text. It exists for durable failure evidence and must never be treated as
+   * phase output.
+   */
+  val rawOutputPreview: String? = null,
   /** True when raw output exceeded the retention cap, so [stdout] is missing trailing content. */
   val stdoutTruncated: Boolean = false,
   val stdoutByteSize: Long = stdoutBytes.size.toLong(),
@@ -261,6 +273,7 @@ data class AgentRunLaunchFacts(
     ) {
       "Provider token values cannot be negative."
     }
+    assistantEventCount?.let { count -> require(count >= 0) { "assistantEventCount cannot be negative." } }
   }
 }
 


### PR DESCRIPTION
# Summary

A goal planning launch that exited zero, reported no failure mode and harvested nothing blocked the goal on its first occurrence, and told the operator its output was **schema-invalid** — when in fact the agent had produced no output at all. On a 14-subtask goal this meant planning stopped every two or three subtasks and needed a manual resume.

This makes the empty turn a recognised, retryable, evidenced condition rather than a terminal mystery, and fixes three Cursor decode defects found underneath it.

**Provider-neutral (all agents):**

- A clean-exit empty harvest is classified as `EmptyProviderTurn` and retried under the existing `MAX_FIX_LOOP_ITERATIONS` cap instead of stopping immediately. Non-zero exits, timeouts, interrupts and spawn failures still block at once — they don't burn the retry budget.
- The retry deliberately does **not** set `priorSchemaFailure`. There is no rejected output to remediate, and injecting the remediation preamble would describe output the agent never produced.
- The block reason now carries launch facts — `EmptyProviderTurn: agent=… durationMs=… assistantEvents=0 inputTokens=… outputTokens=0` — instead of blaming the schema gate. Each occurrence is persisted through the existing rejected-output diagnostics under rule `empty-planning-harvest`, so the failure class is countable rather than anecdotal.
- Decoders now declare whether a decode failure is undecodable transport (`AgentRunOutputDecoder.undecodable`). The launcher degrades those to an empty harvest with a bounded preview rather than handing raw stream envelopes to the phase schema gate, which read them as *multiple conflicting schema candidates*. This also removes an agent-specific error type that shared launcher code was naming directly.

**Cursor-local, inside its own decoder and command builder:**

- Usage keys are read as camelCase **and** snake_case. Cursor emits `inputTokens`/`outputTokens`; the decoder only read snake_case, so **every Cursor token fact has been decoding to `null`** — not zero. Any classifier keyed on `outputTokens == 0` would have silently never fired, and Cursor cost telemetry has been blank throughout.
- A blank terminal `result` falls back to the longest assistant turn instead of discarding text the provider did emit.
- `--stream-partial-output` is gated on `streamProviderOutput` only, never on liveness alone; liveness falls back to heartbeat, as Codex already does. Partial deltas are indistinguishable from finished turns at harvest time. Claude is untouched — its stream-json events are complete turns, not deltas.

**Also included:** spec artifacts for `SKILL-172`, covering the follow-up this PR does *not* fix — dropping platform-pack discovery from planning context (eight `platform.yaml` review-routing files exhaust the 32KB discovery budget exactly, starving `boundary_memory` and `AGENTS.md` to empty), plus pacing between subtask plan launches and backoff between empty-turn retries.

## Feature Flags

N/A

# How Has This Been Tested?

`:runtime-ports:test`, `:runtime-infra-fs:test`, `:runtime-application:test`, `:runtime-core:test`, `detekt` and `spotless` all pass, as does `./gradlew build -x sourcesJar`.

New coverage: five `GoalPlanningSweepTest` cases (empty turn retried under the cap; retry carries no schema-rejection preamble; exhaustion reports launch facts not a schema verdict; evidence persisted for all three attempts; non-zero exit still blocks on attempt 1) and four `AgentRunCommandBuildersTest` cases (camelCase usage keys; zero-assistant empty success with retained preview; longest-assistant fallback; decoder-declared undecodable policy).

Two existing tests changed intentionally:

- `AgentRunLauncherTest` — the cursor timeout test asserted `--stream-partial-output` on a liveness-only launch, which is exactly the coupling being removed. Now asserts `stream-json`.
- `GoalPlanningSweepTest` — the resume test used empty stdout as a crash simulant and expected 3 launches; an empty harvest now spends the retry budget, so it uses `spawnBlockedOutcome()` and keeps testing resume rather than retry counts.

To reproduce the original failure and confirm the new behaviour:

1. Check out this branch and run `(cd runtime-kotlin && ./gradlew :runtime-application:test --tests '*GoalPlanningSweepTest*')`.
2. Confirm `empty provider turn on a clean exit is retried under the fix-loop cap instead of blocking at once` passes; on `main` the equivalent path returns `Stopped` on attempt 1.
3. Run `(cd runtime-kotlin && ./gradlew :runtime-infra-fs:test --tests '*AgentRunCommandBuildersTest*')` and confirm `cursor decoder reads camelCase usage keys the CLI actually emits` passes; on `main` those fields decode to `null`.
4. Full gate: `(cd runtime-kotlin && ./gradlew build -x sourcesJar && ./gradlew detekt)`.

> **Note on `-x sourcesJar`:** `:runtime-infra-fs:sourcesJar` fails with a Gradle implicit-dependency validation error (it consumes `build/generated/skillbill-contracts` without declaring a dependency on `copyWorkflowStateSchema`). Verified by stash that this fails identically on clean `main` — pre-existing and out of scope for this PR.
