### PR TITLE
SKILL-183: phase-model-visibility

### DIFF
--- a/.feature-specs/SKILL-183-phase-model-visibility/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-183-phase-model-visibility/decomposition-manifest.yaml
@@ -3,14 +3,14 @@ contract_version: "0.5"
 issue_key: "SKILL-183"
 feature_name: "phase-model-visibility"
 parent_spec_path: ".feature-specs/SKILL-183-phase-model-visibility/spec.md"
-status: "in_progress"
+status: "complete"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-183-phase-model-visibility"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 2
-  action: "resume"
+  subtask_id: 0
+  action: "complete"
 subtasks:
 - id: 1
   name: "Record the launched model on the durable phase record and emit it on the\
@@ -30,12 +30,12 @@ subtasks:
   name: "Surface the current phase's recorded model in the IntelliJ plugin status\
     \ popup"
   spec_path: ".feature-specs/SKILL-183-phase-model-visibility/spec_subtask_2_plugin-current-phase-model.md"
-  status: "pending"
+  status: "complete"
   branch: null
   commit_sha: null
   workflow_id: "wftr-20260811-120452-c1xx"
   blocked_reason: null
-  last_resumable_step: null
+  last_resumable_step: "commit_push"
   linear_issue_id: null
   finalizing_agent_id: null
   participating_agent_ids: []

--- a/.feature-specs/SKILL-183-phase-model-visibility/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-183-phase-model-visibility/decomposition-manifest.yaml
@@ -1,0 +1,45 @@
+---
+contract_version: "0.5"
+issue_key: "SKILL-183"
+feature_name: "phase-model-visibility"
+parent_spec_path: ".feature-specs/SKILL-183-phase-model-visibility/spec.md"
+status: "in_progress"
+execution_model: "same_branch_commit_per_subtask"
+base_branch: "main"
+feature_branch: "feat/SKILL-183-phase-model-visibility"
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 2
+  action: "resume"
+subtasks:
+- id: 1
+  name: "Record the launched model on the durable phase record and emit it on the\
+    \ IDE status contract"
+  spec_path: ".feature-specs/SKILL-183-phase-model-visibility/spec_subtask_1_record-launched-phase-model.md"
+  status: "complete"
+  branch: null
+  commit_sha: null
+  workflow_id: "wftr-20260811-103834-kw89"
+  blocked_reason: null
+  last_resumable_step: "commit_push"
+  linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
+  dependencies: []
+- id: 2
+  name: "Surface the current phase's recorded model in the IntelliJ plugin status\
+    \ popup"
+  spec_path: ".feature-specs/SKILL-183-phase-model-visibility/spec_subtask_2_plugin-current-phase-model.md"
+  status: "pending"
+  branch: null
+  commit_sha: null
+  workflow_id: "wftr-20260811-120452-c1xx"
+  blocked_reason: null
+  last_resumable_step: null
+  linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
+  dependencies:
+  - subtask_id: 1
+    optional: false
+    skipped: false

--- a/.feature-specs/SKILL-183-phase-model-visibility/spec.md
+++ b/.feature-specs/SKILL-183-phase-model-visibility/spec.md
@@ -1,0 +1,92 @@
+# SKILL-183 — Surface the model the current runtime phase actually launched with
+
+## Context
+
+Machine-global `execution_matrix` in `~/.config/skill-bill/config.json` routes each
+feature-task runtime phase to a model and optional effort. `FeatureTaskRuntimeModelResolver`
+resolves a `PhaseModelDirective` per phase, `FeatureTaskRuntimeRunLoop` merges it for Cursor,
+and the agent-run command builders render it as `--model` / `--effort`. After that the value is
+gone: it is a launch argument, never durable state.
+
+The consequence is that an operator cannot answer "what is the review phase actually running
+on right now?" from anything but the config file plus a mental replay of the tier rules. The
+config is a projection of intent; it can also be edited mid-goal. Two model-routing
+mistakes are invisible today: a phase silently resolving to no directive at all (inherits the
+parent model), and a phase resolving to a model the operator did not intend after a config or
+tier change.
+
+The IntelliJ plugin already surfaces live runtime state — repository, issue key, current step,
+progress, subtask, active duration, planning, pause — through a status-bar widget backed by
+`skill-bill` CLI JSON validated against `orchestration/contracts/ide-status-schema.yaml`. The
+current phase's model belongs in exactly that surface, read from durable runtime state so it
+reports what ran rather than what config would produce now.
+
+## Intended Outcome
+
+An operator watching a feature-task or goal run from the IntelliJ status widget can open the
+status popup and see one `Model:` line naming the model (and effort, when set) that the
+currently executing phase actually launched with, sourced from durable workflow state.
+
+## Acceptance Criteria
+
+1. A feature-task runtime phase that launches with a resolved model directive writes the model
+   and, when present, the effort it actually launched with into durable per-phase workflow state.
+2. A phase that launches with no model directive records no model, and existing workflow rows
+   written before this change keep loading, resuming, and projecting status without error.
+3. The IDE status payload carries the current phase's recorded model as an optional field, stays
+   schema-valid against `orchestration/contracts/ide-status-schema.yaml`, and golden fixtures
+   cover both the present and absent cases.
+4. A plugin build compiled before this change still maps a payload containing the new field
+   normally instead of reporting an incompatible contract.
+5. `IdeStatusJsonMapper` parses the field and degrades it to null on a missing, mistyped, or
+   blank value without losing the surrounding status outcome.
+6. The status details popup renders exactly one additional `Model:` line when the current phase
+   has a recorded model, and omits the line entirely when it does not.
+
+## Constraints
+
+- The durable per-phase authority is `FeatureTaskRuntimePhaseRecord` in
+  `runtime-kotlin/runtime-domain/.../taskruntime/model/FeatureTaskRuntimePersistenceModels.kt`,
+  persisted as a JSON artifact map under `FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY` by
+  `FeatureTaskRuntimePhaseRecorder`. New fields are additive and optional on that record; absent
+  keys must decode to null rather than failing the read.
+- The IDE status contract change is additive-optional. Do not bump
+  `IDE_STATUS_CONTRACT_VERSION` in a way that makes an existing plugin build report
+  `Incompatible`: the plugin compares `contract_version` for strict equality.
+- The schema sets `additionalProperties: false`, so the new key must be declared in
+  `orchestration/contracts/ide-status-schema.yaml` for the producer's own validation to pass.
+- Model routing itself is unchanged. This feature records and displays what was used; it does
+  not alter resolution, precedence, tier defaults, or CLI rendering.
+- The working tree carries an unrelated in-progress change to
+  `runtime-domain/.../config/model/ExecutionMatrixModels.kt` and its test (per-phase agent
+  override keys). Work over it; do not revert, stash, or extend it.
+- Test bar is delete-by-default. Add tests only where they pin a nameable regression.
+
+## Non-Goals
+
+- No full phase-to-model table in the popup, and no projection for phases that have not run.
+- No status-bar widget text or tooltip change.
+- No `execution_matrix` schema work; per-phase agent override keys landed separately.
+- No new telemetry event for the launched model.
+- No display of the resolved agent alongside the model.
+
+## Subtasks
+
+1. Record the launched model on the durable phase record and emit it on the IDE status contract.
+2. Surface the current phase's recorded model in the IntelliJ plugin status popup.
+
+## Validation Strategy
+
+- Runtime: round-trip a phase record with and without a model through
+  `toArtifactMap()` and the from-wire decode; assert a pre-change artifact map (no model keys)
+  decodes to null fields. Assert the emitted status wire map validates against the schema in
+  both shapes via the existing `IdeStatusSchemaValidator` path.
+- Contract: extend the golden fixtures with a model-present case and keep an absent case.
+- Plugin: assert `IdeStatusJsonMapper` degrades a mistyped/blank model to null while the
+  surrounding outcome still maps, and assert the popup line appears exactly once when present
+  and not at all when absent.
+- Run `(cd runtime-kotlin && ./gradlew check)` and the `intellij-plugin` test task.
+
+## Next Path
+
+Subtask 1 lands the durable record and the contract field; subtask 2 consumes it in the plugin.

--- a/.feature-specs/SKILL-183-phase-model-visibility/spec_subtask_1_record-launched-phase-model.md
+++ b/.feature-specs/SKILL-183-phase-model-visibility/spec_subtask_1_record-launched-phase-model.md
@@ -1,0 +1,114 @@
+# SKILL-183 · Subtask 1 — Record the launched model on the durable phase record and emit it on the IDE status contract
+
+## Scope
+
+Today the resolved model directive is a launch argument and nothing more.
+`FeatureTaskRuntimeModelResolver.resolve` returns a `PhaseModelDirective`,
+`FeatureTaskRuntimeRunLoop` pre-merges model and effort for Cursor before handing them to the
+launcher as `modelOverride` / `effortOverride`, and `AgentRunCommandBuilders` renders them onto
+the child CLI. No durable state records what the phase actually launched with.
+
+Give the launched directive a durable home and put it on the IDE status wire.
+
+**Durable record.** `FeatureTaskRuntimePhaseRecord`
+(`runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt`)
+is the per-phase authority: it already carries `resolvedAgentId`, `status`, `attemptCount`,
+`startedAt`, `loopId`, `edgeIteration`, and `outputArtifact`, and is persisted as a JSON artifact
+map under `FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY` by `FeatureTaskRuntimePhaseRecorder`.
+Add two optional fields — the launched model and the launched effort — defaulting to null, with
+the same non-blank-when-present validation style the record's `init` block already uses for its
+other optional strings. Extend `toArtifactMap()` and the matching from-wire decode so both keys
+round-trip, and so an artifact map written before this change (neither key present) decodes to
+null fields instead of failing.
+
+Record the value the child was actually launched with, after Cursor's model/effort merge, not the
+pre-merge directive. For Cursor the merged string is what identifies the model; for the other
+model-directive-capable agents model and effort stay separate. A phase that launches with no
+directive records neither field.
+
+Thread the value from the launch site to the write: `FeatureTaskRuntimePhaseStateRequest` carries
+the launched model and effort, and `recordPhaseState` / `recordCompletedPhase` persist them onto
+the record through the existing `phaseRecordFor` path. Do not add a second write; the value must
+land in the same transaction that advances the phase, so a crash cannot leave a phase whose
+recorded model disagrees with the attempt that ran.
+
+**Status wire.** `IdeStatusSnapshot.toStatusWireMap()`
+(`runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt`) gains an
+optional `current_model` object mirroring the config's own vocabulary:
+
+```json
+"current_model": { "model": "gpt-5.6-luna-xhigh", "effort": "high" }
+```
+
+`effort` is optional inside it; the whole object is omitted when the current phase has no
+recorded model. A nested object matches the existing `current_step` / `progress` /
+`current_subtask` shape and leaves room for effort without a second top-level key. Declare it in
+`orchestration/contracts/ide-status-schema.yaml` — the schema is `additionalProperties: false`,
+so an undeclared key fails the producer's own validation.
+
+`IdeStatusProjector` populates it for the feature-task-runtime and goal families by reading the
+phase record for the step it already selected as `current_step`. When the projector cannot
+resolve a phase record for that step, omit the field rather than guessing; this is optional
+context and must never cost a status reading.
+
+**Contract version.** Do not bump `IDE_STATUS_CONTRACT_VERSION`. The plugin compares
+`contract_version` for strict equality and reports `Incompatible` on any mismatch, so a bump
+would break every plugin build in the field to add an optional field they can ignore. Confirm
+`IdeStatusSchemaContractVersionTest` agrees that an additive-optional field needs no bump; if it
+asserts otherwise, surface that as a blocking finding rather than bumping the version.
+
+Do not change model resolution, precedence, tier defaults, or CLI rendering. Do not add a
+telemetry event.
+
+## Acceptance Criteria
+
+1. `FeatureTaskRuntimePhaseRecord` carries an optional launched model and an optional launched
+   effort, both defaulting to null and both rejected when present-but-blank.
+2. A phase record with a model and effort round-trips through `toArtifactMap()` and the from-wire
+   decode with both values intact.
+3. An artifact map containing neither key — the shape every pre-change workflow row holds —
+   decodes to a record with null model and null effort, and the surrounding workflow row loads,
+   resumes, and projects status without error.
+4. A phase launched with a resolved directive persists the model the child was actually launched
+   with, including Cursor's merged `model[effort=…]` form, in the same transaction that advances
+   the phase.
+5. A phase launched with no directive persists neither field.
+6. `IdeStatusSnapshot.toStatusWireMap()` emits `current_model` with a required `model` and an
+   optional `effort` when the current phase has a recorded model, and omits the key entirely
+   otherwise.
+7. Both emitted shapes validate against `orchestration/contracts/ide-status-schema.yaml`, and the
+   golden fixtures cover a model-present case and a model-absent case.
+8. `IDE_STATUS_CONTRACT_VERSION` is unchanged.
+9. `(cd runtime-kotlin && ./gradlew check)` passes.
+
+## Non-Goals
+
+- Any plugin-side parsing or rendering; that is subtask 2.
+- A per-phase model table or a projection for phases that have not run.
+- Changing how models are resolved, merged, or rendered onto child CLIs.
+- Recording the resolved agent id alongside the model; the record already carries it.
+- A telemetry event for the launched model.
+
+## Dependencies
+
+None. This subtask lands first because the contract field it adds is what subtask 2 consumes.
+
+## Validation Strategy
+
+- Unit-test the phase-record round trip for three shapes: model + effort, model only, and an
+  artifact map with neither key present (the pre-change shape). The third is the regression that
+  matters — it is what proves existing rows still load.
+- Assert the wire map through the existing `IdeStatusSchemaValidator` path for both the
+  model-present and model-absent snapshots, so an undeclared or mistyped key fails the producer's
+  own `additionalProperties: false` gate rather than reaching a client.
+- Extend `IdeStatusGoldenFixturesTest` with the model-present fixture, keeping an absent case.
+- Check `IdeStatusSchemaContractVersionTest` before writing the schema change: it decides whether
+  an additive-optional field is allowed at the current version.
+- For the Cursor path, assert the persisted model equals the merged string the builder renders,
+  not the pre-merge directive, so the recorded value matches the `--model` argument the child
+  actually received.
+- Run the affected module tests, then `(cd runtime-kotlin && ./gradlew check)`.
+
+## Next Path
+
+Subtask 2 parses `current_model` in the plugin and renders the current phase's `Model:` line.

--- a/.feature-specs/SKILL-183-phase-model-visibility/spec_subtask_2_plugin-current-phase-model.md
+++ b/.feature-specs/SKILL-183-phase-model-visibility/spec_subtask_2_plugin-current-phase-model.md
@@ -1,0 +1,89 @@
+# SKILL-183 · Subtask 2 — Surface the current phase's recorded model in the IntelliJ plugin status popup
+
+## Scope
+
+Subtask 1 puts an optional `current_model` object on the IDE status wire. This subtask carries it
+through the plugin's existing read path to one line in the details popup.
+
+The plugin path is: `CliSkillBillStatusRepository` shells out to the CLI →
+`IdeStatusJsonMapper.map` turns stdout into a `SkillBillStatusOutcome` →
+`StatusUiMapper` builds `SkillBillStatusUiState` → `StatusDetailsPopupContent` renders it.
+
+**Mapper.** `IdeStatusJsonMapper` already has the degradation rule this field must follow:
+`parsePlanning()` states that optional context is "never a reason to lose a whole status
+reading", and any missing, mistyped, or out-of-range field degrades the block to null while the
+surrounding outcome still maps. Parse `current_model` the same way — a non-object value, a
+missing or blank `model`, or a non-string `model` yields null, not a malformed-output outcome. A
+present-but-blank `effort` degrades to null effort while keeping the model. Reuse
+`getAsJsonObjectOrNull` and `getAsString`; the file's private helpers already cover every access
+this needs.
+
+Run the parsed value through `safeSummary`-equivalent redaction only if a model id could ever
+carry a path — it cannot, so plain trimming plus a bounded `take` is sufficient. Do not widen
+`AbsolutePathGuard` usage for it.
+
+**Domain.** The outcomes that can carry a current step are `Active`, `Paused`, `Stale`,
+`Blocked`, and `Failed` (`SkillBillStatusOutcome.kt`). The model is current-phase context, so it
+belongs on the same outcomes that already carry `currentStepId` / `currentStepLabel`. Add it as
+an optional field with a null default so no existing construction site or test fixture breaks.
+`Idle` and `Done` have no current phase and must not carry it.
+
+**Presentation and UI.** `StatusUiMapper` passes the value into `SkillBillStatusUiState`;
+`StatusDetailsPopupContent` renders exactly one additional row labelled `Model:` positioned with
+the other current-phase context, and renders nothing at all — no label, no placeholder, no
+em dash — when the value is null. When an effort is present, render it inline with the model in
+a single row rather than adding a second row.
+
+Leave the status-bar widget text, icon, and tooltip untouched. Leave
+`GoalControlsPresentation`, refresh cadence, and the preference cache untouched.
+
+`PluginArchitectureTest` enforces the plugin's layering; the new field must not introduce a
+dependency that violates it.
+
+## Acceptance Criteria
+
+1. `IdeStatusJsonMapper` maps a payload whose `current_model` carries a non-blank `model` into an
+   outcome carrying that model, and carries the `effort` when present.
+2. A payload whose `current_model` is absent, not an object, or carries a missing, blank, or
+   non-string `model` maps to a null model while the surrounding status outcome still maps
+   normally — never to `Unavailable` or `Incompatible`.
+3. A `current_model` with a valid `model` and a blank or mistyped `effort` maps to that model with
+   a null effort.
+4. The model is carried on the outcomes that already carry a current step (`Active`, `Paused`,
+   `Stale`, `Blocked`, `Failed`) and is absent from `Idle` and `Done`.
+5. `StatusDetailsPopupContent` renders exactly one `Model:` row when a model is present, and no
+   row, label, or placeholder when it is null.
+6. When an effort is present it appears in that same single row alongside the model.
+7. The status-bar widget text, icon, and tooltip are byte-identical to their pre-change output for
+   the same status.
+8. `PluginArchitectureTest` passes unchanged, and the `intellij-plugin` test task passes.
+
+## Non-Goals
+
+- A per-phase model table, or any model for a phase other than the current one.
+- Any status-bar widget or tooltip change.
+- New refresh, caching, or preference behaviour for the model value.
+- Any runtime-side change; subtask 1 owns the producer and the contract.
+- Localization or theming work beyond matching the popup's existing row style.
+
+## Dependencies
+
+Depends on subtask 1: the `current_model` field, its schema declaration, and its golden fixtures
+must exist before this subtask can parse or test against them.
+
+## Validation Strategy
+
+- Extend `ProcessRunnerAndMapperTest`, which already builds raw JSON payload strings and asserts
+  mapper outcomes, with the degradation cases: absent key, non-object value, blank `model`,
+  non-string `model`, blank `effort`. Each must keep the surrounding outcome intact — that is the
+  nameable regression, since a strict parse here would turn an optional field into a lost status
+  reading.
+- Extend the popup fixture test with a present case and an absent case, asserting the `Model:`
+  row appears exactly once and is wholly absent respectively.
+- Assert widget text for an unchanged status to prove no collateral drift into the bar.
+- Run the `intellij-plugin` test task.
+
+## Next Path
+
+Feature complete: the runtime records what each phase launched with and the plugin shows it for
+the phase currently running.

--- a/intellij-plugin/agent/history.md
+++ b/intellij-plugin/agent/history.md
@@ -1,3 +1,15 @@
+## [2026-08-11] SKILL-183 current-phase model in status popup (subtask 2)
+
+Areas: intellij-plugin/{domain,infrastructure/cli,presentation,ui}
+- The IDE status wire now carries an optional `current_model` object (`model` + optional `effort`), parsed into a `CurrentPhaseModel` and threaded domain → presentation → popup as one `Model:` row that is wholly absent when null. Producer side is the runtime (subtask 1).
+- `IdeStatusJsonMapper.parseCurrentModel` follows the file's established optional-context degradation rule from `parsePlanning`: non-object, missing/blank/mistyped field degrades to null and the surrounding outcome still maps — never `Unavailable`/`Incompatible`. Copy this rule for any future optional wire block. reusable
+- New private helper `getAsStringPrimitive` is strict: a JSON number or boolean is a type error, not coerced text — unlike the older lenient `getAsString`. Prefer it for new string wire fields. reusable
+- Model carried only on outcomes that already carry a current step (`Active`, `Paused`, `Stale`, `Blocked`, `Failed`); `Idle`/`Done` have no current phase and must not carry it. Added with null defaults so no existing construction site or fixture broke.
+- Sanitization is trim + bounded `take` (120 model / 40 effort) only; a model id can never carry a path, so `AbsolutePathGuard` was deliberately not widened.
+- Limitation: status-bar text, icon, and tooltip are intentionally byte-identical — the model is popup-only. No per-phase model table, no new caching or refresh behaviour.
+Feature flag: N/A
+Acceptance criteria: 8/8 implemented
+
 ## [2026-08-08] SKILL-168 plugin goal Stop/Pause controls (subtask 5)
 
 Areas: intellij-plugin/{application,composition,domain,infrastructure/cli,presentation,ui}, intellij-plugin/src/main/resources/META-INF

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/Constants.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/Constants.kt
@@ -25,6 +25,12 @@ const val UNCORROBORATED_IDLE_TOLERANCE: Int = 1
  */
 const val PAUSE_REQUESTED_WIRE_KEY: String = "pause_requested"
 
+/**
+ * Wire key carrying the model (and optional effort) the current phase launched with.
+ * Optional context: absence degrades to no model, never to a lost status reading.
+ */
+const val CURRENT_MODEL_WIRE_KEY: String = "current_model"
+
 /** Wire key carrying the instant a recorded pause took effect. Optional. */
 const val PAUSED_AT_WIRE_KEY: String = "paused_at"
 

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/Constants.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/Constants.kt
@@ -26,10 +26,24 @@ const val UNCORROBORATED_IDLE_TOLERANCE: Int = 1
 const val PAUSE_REQUESTED_WIRE_KEY: String = "pause_requested"
 
 /**
- * Wire key carrying the model (and optional effort) the current phase launched with.
+ * Wire key carrying the model (and optional effort and phase id) the current phase launched with.
  * Optional context: absence degrades to no model, never to a lost status reading.
  */
 const val CURRENT_MODEL_WIRE_KEY: String = "current_model"
+
+/**
+ * Mirrors the `current_model` length bounds in `orchestration/contracts/ide-status-schema.yaml`.
+ * A value past these is rejected rather than clipped, so the popup never shows a model identifier
+ * that never existed.
+ */
+const val MODEL_MAX_LENGTH: Int = 120
+
+const val EFFORT_MAX_LENGTH: Int = 40
+
+const val PHASE_ID_MAX_LENGTH: Int = 64
+
+/** Display bound for the composed model row; the popup has no width cap of its own. */
+const val MODEL_TEXT_MAX_LENGTH: Int = 60
 
 /** Wire key carrying the instant a recorded pause took effect. Optional. */
 const val PAUSED_AT_WIRE_KEY: String = "paused_at"

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
@@ -76,6 +76,8 @@ sealed class SkillBillStatusOutcome {
         val activeDurationMs: Long? = null,
         /** Instant [activeDurationMs] is current as of; present only while a lease is live. */
         val activeDurationAsOf: Instant? = null,
+        /** Model the current phase launched with; null when the snapshot carried none. */
+        val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusOutcome()
 
     /**
@@ -107,6 +109,8 @@ sealed class SkillBillStatusOutcome {
         val activeDurationMs: Long? = null,
         /** See [Active.activeDurationAsOf]; absent once the runner released its lease. */
         val activeDurationAsOf: Instant? = null,
+        /** See [Active.currentModel]. */
+        val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusOutcome()
 
     data class Stale(
@@ -129,6 +133,8 @@ sealed class SkillBillStatusOutcome {
         val activeDurationMs: Long? = null,
         /** See [Active.activeDurationAsOf]; absent once the runner released its lease. */
         val activeDurationAsOf: Instant? = null,
+        /** See [Active.currentModel]. */
+        val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusOutcome()
 
     data class Blocked(
@@ -149,6 +155,8 @@ sealed class SkillBillStatusOutcome {
         val activeDurationMs: Long? = null,
         /** See [Active.activeDurationAsOf]; absent once the runner released its lease. */
         val activeDurationAsOf: Instant? = null,
+        /** See [Active.currentModel]. */
+        val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusOutcome()
 
     data class Failed(
@@ -169,6 +177,8 @@ sealed class SkillBillStatusOutcome {
         val activeDurationMs: Long? = null,
         /** See [Active.activeDurationAsOf]; absent once the runner released its lease. */
         val activeDurationAsOf: Instant? = null,
+        /** See [Active.currentModel]. */
+        val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusOutcome()
 
     data class Unavailable(
@@ -225,6 +235,15 @@ data class GoalPlanningInfo(
     val totalSubtaskCount: Int,
     val currentPlanningSubtaskId: String? = null,
     val reason: String? = null,
+)
+
+/**
+ * The model the current phase launched with, plus its reasoning effort when the runtime
+ * recorded one. Optional context on a live snapshot; a missing block is simply no model.
+ */
+data class CurrentPhaseModel(
+    val model: String,
+    val effort: String? = null,
 )
 
 enum class UnavailableReason {

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/domain/SkillBillStatusOutcome.kt
@@ -244,6 +244,12 @@ data class GoalPlanningInfo(
 data class CurrentPhaseModel(
     val model: String,
     val effort: String? = null,
+    /**
+     * The runtime phase the model belongs to. A goal's step is a goal-level label — often
+     * `Planning` — so for the goal family this is the only thing that says which phase is meant.
+     * Absent when the producer could not resolve it.
+     */
+    val phaseId: String? = null,
 )
 
 enum class UnavailableReason {

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
@@ -335,15 +335,19 @@ object IdeStatusJsonMapper {
      */
     private fun JsonObject.parseCurrentModel(): CurrentPhaseModel? {
         val currentModel = getAsJsonObjectOrNull(CURRENT_MODEL_WIRE_KEY) ?: return null
-        val model = currentModel.getAsString("model")?.trim()?.takeUnless { it.isBlank() } ?: return null
+        val model = currentModel.getAsStringPrimitive("model")?.trim()?.takeUnless { it.isBlank() } ?: return null
         return CurrentPhaseModel(
             model = model.take(120),
-            effort = currentModel.getAsString("effort")?.trim()?.takeUnless { it.isBlank() }?.take(40),
+            effort = currentModel.getAsStringPrimitive("effort")?.trim()?.takeUnless { it.isBlank() }?.take(40),
         )
     }
 
     private fun JsonObject.getAsString(key: String): String? =
         get(key)?.takeUnless { it.isJsonNull }?.asStringOrNull()
+
+    /** Strict: a JSON number or boolean is a type error, not text. */
+    private fun JsonObject.getAsStringPrimitive(key: String): String? =
+        get(key)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
 
     private fun JsonObject.getAsInt(key: String): Int? =
         get(key)?.takeUnless { it.isJsonNull }?.let {

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
@@ -6,6 +6,8 @@ import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
 import dev.skillbill.intellij.domain.ACTIVE_DURATION_AS_OF_WIRE_KEY
 import dev.skillbill.intellij.domain.ACTIVE_DURATION_MS_WIRE_KEY
+import dev.skillbill.intellij.domain.CURRENT_MODEL_WIRE_KEY
+import dev.skillbill.intellij.domain.CurrentPhaseModel
 import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.IDE_STATUS_CONTRACT_VERSION
 import dev.skillbill.intellij.domain.NO_MATCHING_WORK_REASON_CODE
@@ -99,6 +101,7 @@ object IdeStatusJsonMapper {
         val subtaskStartedAt = subtask?.getAsInstant("started_at")
         val updatedAt = root.getAsInstant("updated_at")
         val planning = root.parsePlanning()
+        val currentModel = root.parseCurrentModel()
         // Both optional and goal-family-only: a missing key stays null, never false.
         val pauseRequested = root.getAsBoolean(PAUSE_REQUESTED_WIRE_KEY)
         val pausedAt = root.getAsInstant(PAUSED_AT_WIRE_KEY)
@@ -156,6 +159,7 @@ object IdeStatusJsonMapper {
                 planning = planning,
                 activeDurationMs = activeDurationMs,
                 activeDurationAsOf = activeDurationAsOf,
+                currentModel = currentModel,
             )
         }
 
@@ -184,6 +188,7 @@ object IdeStatusJsonMapper {
                         pausedAt = pausedAt,
                         activeDurationMs = activeDurationMs,
                         activeDurationAsOf = activeDurationAsOf,
+                        currentModel = currentModel,
                     )
                 } else {
                     SkillBillStatusOutcome.Active(
@@ -206,6 +211,7 @@ object IdeStatusJsonMapper {
                         pausedAt = pausedAt,
                         activeDurationMs = activeDurationMs,
                         activeDurationAsOf = activeDurationAsOf,
+                        currentModel = currentModel,
                     )
                 }
             }
@@ -224,6 +230,7 @@ object IdeStatusJsonMapper {
                 stale = isStale,
                 activeDurationMs = activeDurationMs,
                 activeDurationAsOf = activeDurationAsOf,
+                currentModel = currentModel,
             )
 
             "failed" -> SkillBillStatusOutcome.Failed(
@@ -240,6 +247,7 @@ object IdeStatusJsonMapper {
                 stale = isStale,
                 activeDurationMs = activeDurationMs,
                 activeDurationAsOf = activeDurationAsOf,
+                currentModel = currentModel,
             )
 
             "idle" -> SkillBillStatusOutcome.Idle(
@@ -316,6 +324,21 @@ object IdeStatusJsonMapper {
             currentPlanningSubtaskId = planning.getAsString("current_planning_subtask_id")
                 ?.takeUnless { it.isBlank() },
             reason = planning.getAsString("reason")?.let { safeSummary(it, "") }?.takeUnless { it.isEmpty() },
+        )
+    }
+
+    /**
+     * Same degradation rule as [parsePlanning]: the launched model is optional context, so a
+     * missing block, a non-object, or a blank/mistyped field degrades to null and the
+     * surrounding outcome still maps normally. A model id carries no path, so a trim plus a
+     * bounded take is the whole sanitization.
+     */
+    private fun JsonObject.parseCurrentModel(): CurrentPhaseModel? {
+        val currentModel = getAsJsonObjectOrNull(CURRENT_MODEL_WIRE_KEY) ?: return null
+        val model = currentModel.getAsString("model")?.trim()?.takeUnless { it.isBlank() } ?: return null
+        return CurrentPhaseModel(
+            model = model.take(120),
+            effort = currentModel.getAsString("effort")?.trim()?.takeUnless { it.isBlank() }?.take(40),
         )
     }
 

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/infrastructure/cli/IdeStatusJsonMapper.kt
@@ -8,6 +8,9 @@ import dev.skillbill.intellij.domain.ACTIVE_DURATION_AS_OF_WIRE_KEY
 import dev.skillbill.intellij.domain.ACTIVE_DURATION_MS_WIRE_KEY
 import dev.skillbill.intellij.domain.CURRENT_MODEL_WIRE_KEY
 import dev.skillbill.intellij.domain.CurrentPhaseModel
+import dev.skillbill.intellij.domain.EFFORT_MAX_LENGTH
+import dev.skillbill.intellij.domain.MODEL_MAX_LENGTH
+import dev.skillbill.intellij.domain.PHASE_ID_MAX_LENGTH
 import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.IDE_STATUS_CONTRACT_VERSION
 import dev.skillbill.intellij.domain.NO_MATCHING_WORK_REASON_CODE
@@ -329,18 +332,30 @@ object IdeStatusJsonMapper {
 
     /**
      * Same degradation rule as [parsePlanning]: the launched model is optional context, so a
-     * missing block, a non-object, or a blank/mistyped field degrades to null and the
-     * surrounding outcome still maps normally. A model id carries no path, so a trim plus a
-     * bounded take is the whole sanitization.
+     * missing block, a non-object, or a blank/mistyped field degrades to null and the surrounding
+     * outcome still maps normally.
+     *
+     * Over-length values degrade rather than truncate. Truncating would render a model identifier
+     * that never existed — worse than showing nothing, because the operator cannot tell it was
+     * clipped. The bounds mirror the schema's own `maxLength`, so the producer already rejects an
+     * over-length value at its emit gate and this is the client-side floor, not the enforcement.
+     *
+     * A present-but-unparseable block leaves no client-side record: this mapper is deliberately
+     * platform-free so it stays unit-testable, and the plugin has no logging seam that does not
+     * pull in the IntelliJ platform. The producer's schema gate is where such a payload is caught.
      */
     private fun JsonObject.parseCurrentModel(): CurrentPhaseModel? {
         val currentModel = getAsJsonObjectOrNull(CURRENT_MODEL_WIRE_KEY) ?: return null
-        val model = currentModel.getAsStringPrimitive("model")?.trim()?.takeUnless { it.isBlank() } ?: return null
+        val model = currentModel.boundedString("model", MODEL_MAX_LENGTH) ?: return null
         return CurrentPhaseModel(
-            model = model.take(120),
-            effort = currentModel.getAsStringPrimitive("effort")?.trim()?.takeUnless { it.isBlank() }?.take(40),
+            model = model,
+            effort = currentModel.boundedString("effort", EFFORT_MAX_LENGTH),
+            phaseId = currentModel.boundedString("phase_id", PHASE_ID_MAX_LENGTH),
         )
     }
+
+    private fun JsonObject.boundedString(key: String, maxLength: Int): String? =
+        getAsStringPrimitive(key)?.trim()?.takeIf { it.isNotBlank() && it.length <= maxLength }
 
     private fun JsonObject.getAsString(key: String): String? =
         get(key)?.takeUnless { it.isJsonNull }?.asStringOrNull()

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
@@ -28,6 +28,10 @@ object SkillBillStatusBarPresentation {
             "${renderedPosition(anchored, completed, total)}/$total"
         }
         val planning = anchored.planning
+        // Popup-only: the bar, tooltip, and accessibility text stay byte-identical.
+        val modelText = anchored.currentModel?.let { current ->
+            current.effort?.let { "${current.model} (effort: $it)" } ?: current.model
+        }
         val planningSegment = planning?.let { "Planning ${it.plannedSubtaskCount}/${it.totalSubtaskCount}" }
 
         val fullBar = when (anchored) {
@@ -88,6 +92,7 @@ object SkillBillStatusBarPresentation {
                 workflowId = anchored.workflowId,
                 lifecycleState = lifecycle,
                 stepLabel = step ?: anchored.stepLabel,
+                modelText = modelText,
                 progressText = progressText,
                 goalElapsedText = goalText,
                 subtaskElapsedText = subtaskText,
@@ -280,6 +285,8 @@ object SkillBillStatusBarPresentation {
         val workflowId: String?,
         val lifecycleState: String,
         val stepLabel: String?,
+        /** Pre-resolved model row for the details popup; null renders no row at all. */
+        val modelText: String? = null,
         val progressText: String?,
         val goalElapsedText: String,
         val subtaskElapsedText: String,

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentation.kt
@@ -1,5 +1,7 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.FEATURE_GOAL_WORKFLOW_FAMILY
+import dev.skillbill.intellij.domain.MODEL_TEXT_MAX_LENGTH
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
@@ -29,8 +31,22 @@ object SkillBillStatusBarPresentation {
         }
         val planning = anchored.planning
         // Popup-only: the bar, tooltip, and accessibility text stay byte-identical.
+        // The phase is appended for the goal family only, where the Step row shows a goal-level
+        // label (often "Planning") and would otherwise leave the model attributed to nothing. For
+        // the runtime family the Step row already names that phase.
         val modelText = anchored.currentModel?.let { current ->
-            current.effort?.let { "${current.model} (effort: $it)" } ?: current.model
+            val qualifier = listOfNotNull(
+                current.phaseId?.takeIf { anchored.workflowFamily == FEATURE_GOAL_WORKFLOW_FAMILY },
+                current.effort?.let { "effort: $it" },
+            )
+            val composed = if (qualifier.isEmpty()) {
+                current.model
+            } else {
+                "${current.model} (${qualifier.joinToString(", ")})"
+            }
+            // Unlike barText this lands in a non-wrapping JLabel inside a popup with no width cap,
+            // so an unbounded value widens the whole popup and can clip the action row off-screen.
+            normalizeLabel(composed)?.let { truncateForBar(it, MODEL_TEXT_MAX_LENGTH) }
         }
         val planningSegment = planning?.let { "Planning ${it.plannedSubtaskCount}/${it.totalSubtaskCount}" }
 

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusUiState.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusUiState.kt
@@ -1,5 +1,6 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.CurrentPhaseModel
 import dev.skillbill.intellij.domain.GoalPlanningInfo
 import java.time.Duration
 import java.time.Instant
@@ -46,6 +47,9 @@ sealed class SkillBillStatusUiState {
      * in [StatusUiMapper]; renderers must not re-derive it.
      */
     open val planning: GoalPlanningInfo? get() = null
+
+    /** Model the current phase launched with; null on states that carry no current step. */
+    open val currentModel: CurrentPhaseModel? get() = null
 
     /** True when this state is not live. Always true for [Stale]; a modifier elsewhere. */
     open val stale: Boolean get() = this is Stale
@@ -94,6 +98,7 @@ sealed class SkillBillStatusUiState {
         override val planning: GoalPlanningInfo? = null,
         override val workflowFamily: String? = null,
         override val pauseRequested: Boolean? = null,
+        override val currentModel: CurrentPhaseModel? = null,
         /** Retained so the 1s ticker re-anchors the active clock without a new poll. */
         val activeDurationMs: Long? = null,
         val activeDurationAsOf: Instant? = null,
@@ -122,6 +127,7 @@ sealed class SkillBillStatusUiState {
         override val planning: GoalPlanningInfo? = null,
         override val workflowFamily: String? = null,
         override val pauseRequested: Boolean? = null,
+        override val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusUiState() {
         override val accessibilityText: String = "$headline (paused)"
     }
@@ -141,6 +147,7 @@ sealed class SkillBillStatusUiState {
         override val lastUpdated: Instant? = null,
         override val problemSummary: String? = "Cached status is stale",
         override val planning: GoalPlanningInfo? = null,
+        override val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusUiState() {
         override val accessibilityText: String = "$headline (stale)"
     }
@@ -160,6 +167,7 @@ sealed class SkillBillStatusUiState {
         override val lastUpdated: Instant? = null,
         override val problemSummary: String? = null,
         override val stale: Boolean = false,
+        override val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusUiState() {
         override val accessibilityText: String = "$headline (blocked)"
     }
@@ -179,6 +187,7 @@ sealed class SkillBillStatusUiState {
         override val lastUpdated: Instant? = null,
         override val problemSummary: String? = null,
         override val stale: Boolean = false,
+        override val currentModel: CurrentPhaseModel? = null,
     ) : SkillBillStatusUiState() {
         override val accessibilityText: String = "$headline (failed)"
     }

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
@@ -123,6 +123,10 @@ object StatusUiMapper {
                         outcome.currentSubtaskId,
                         outcome.progressCompleted,
                     ),
+                    // A Stale built from the persisted display cache carries no model — the cache
+                    // deliberately stores none, so a phase's model is never resurrected from disk
+                    // after a restart. The Model row is therefore absent until a live poll lands;
+                    // that missing row is the cache being honest, not a parse failure.
                     currentModel = outcome.currentModel,
                 )
 

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/presentation/StatusUiMapper.kt
@@ -64,6 +64,7 @@ object StatusUiMapper {
                     ),
                     workflowFamily = outcome.workflowFamily,
                     pauseRequested = outcome.pauseRequested,
+                    currentModel = outcome.currentModel,
                     activeDurationMs = outcome.activeDurationMs,
                     activeDurationAsOf = outcome.activeDurationAsOf,
                 )
@@ -94,6 +95,7 @@ object StatusUiMapper {
                     ),
                     workflowFamily = outcome.workflowFamily,
                     pauseRequested = outcome.pauseRequested,
+                    currentModel = outcome.currentModel,
                 )
 
             is SkillBillStatusOutcome.Stale ->
@@ -121,6 +123,7 @@ object StatusUiMapper {
                         outcome.currentSubtaskId,
                         outcome.progressCompleted,
                     ),
+                    currentModel = outcome.currentModel,
                 )
 
             is SkillBillStatusOutcome.Blocked ->
@@ -142,6 +145,7 @@ object StatusUiMapper {
                     lastUpdated = outcome.updatedAt ?: outcome.observedAt,
                     problemSummary = outcome.summary,
                     stale = outcome.stale,
+                    currentModel = outcome.currentModel,
                 )
 
             is SkillBillStatusOutcome.Failed ->
@@ -163,6 +167,7 @@ object StatusUiMapper {
                     lastUpdated = outcome.updatedAt ?: outcome.observedAt,
                     problemSummary = outcome.summary,
                     stale = outcome.stale,
+                    currentModel = outcome.currentModel,
                 )
 
             is SkillBillStatusOutcome.Unavailable ->

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/ui/StatusDetailsPopupContent.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/ui/StatusDetailsPopupContent.kt
@@ -36,6 +36,7 @@ object StatusDetailsPopupContent {
             details.issueKey?.let { add("Issue" to it) }
             details.workflowId?.let { add("Workflow" to it) }
             details.stepLabel?.let { add("Step" to it) }
+            details.modelText?.let { add("Model" to it) }
             details.progressText?.let { add("Progress" to it) }
             add("Goal ${details.elapsedNoun}" to details.goalElapsedText)
             add("Subtask ${details.elapsedNoun}" to details.subtaskElapsedText)

--- a/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/ui/StatusDetailsPopupContent.kt
+++ b/intellij-plugin/src/main/kotlin/dev/skillbill/intellij/ui/StatusDetailsPopupContent.kt
@@ -28,7 +28,12 @@ import javax.swing.SwingConstants
  * pre-resolved on [SkillBillStatusBarPresentation.MappedPresentation.controls].
  */
 object StatusDetailsPopupContent {
-    /** Label/value pairs, identical in content and order to the previous popup lines. */
+    /**
+     * Label/value pairs in display order: lifecycle state, the optional identity and step rows, the
+     * optional model row when the snapshot reported one, then progress, clocks, and notes. The
+     * byte-identity guarantee belongs to the bar, tooltip, and accessibility text — not to this list,
+     * which grows as the popup gains rows.
+     */
     fun statusLines(presentation: SkillBillStatusBarPresentation.MappedPresentation): List<Pair<String, String>> {
         val details = presentation.details
         return buildList {
@@ -64,7 +69,8 @@ object StatusDetailsPopupContent {
             border = JBUI.Borders.empty(8, 0, 4, 0)
             foreground = JBColor.border()
         }
-        val messageLabel = JLabel("").apply {
+        // Carries showMessage's bounded failure summary, which is runtime output like every value row.
+        val messageLabel = plainLabel("").apply {
             isVisible = false
             foreground = UIUtil.getErrorForeground()
             border = JBUI.Borders.emptyTop(4)
@@ -104,7 +110,7 @@ object StatusDetailsPopupContent {
 
     private fun statusBlock(presentation: SkillBillStatusBarPresentation.MappedPresentation): JPanel {
         val block = JPanel(GridBagLayout()).apply { isOpaque = false }
-        val title = JLabel("Skill Bill details").apply {
+        val title = plainLabel("Skill Bill details").apply {
             font = font.deriveFont(java.awt.Font.BOLD)
             border = JBUI.Borders.emptyBottom(4)
         }
@@ -121,7 +127,7 @@ object StatusDetailsPopupContent {
             val row = index + 1
             if (label.isEmpty()) {
                 block.add(
-                    JLabel(value).apply { foreground = UIUtil.getContextHelpForeground() },
+                    plainLabel(value).apply { foreground = UIUtil.getContextHelpForeground() },
                     GridBagConstraints().apply {
                         gridx = 0
                         gridy = row
@@ -133,7 +139,7 @@ object StatusDetailsPopupContent {
                 return@forEachIndexed
             }
             block.add(
-                JLabel("$label:").apply { foreground = UIUtil.getContextHelpForeground() },
+                plainLabel("$label:").apply { foreground = UIUtil.getContextHelpForeground() },
                 GridBagConstraints().apply {
                     gridx = 0
                     gridy = row
@@ -142,7 +148,7 @@ object StatusDetailsPopupContent {
                 },
             )
             block.add(
-                JLabel(value),
+                plainLabel(value),
                 GridBagConstraints().apply {
                     gridx = 1
                     gridy = row
@@ -154,6 +160,18 @@ object StatusDetailsPopupContent {
             )
         }
         return block
+    }
+
+    /**
+     * Most text here is runtime-supplied — a model id, a workflow id, a failure summary — and Swing
+     * parses a label whose text starts with `<html>` as markup, so an `<img src=…>` would make the
+     * IDE fetch it and a `<b>` would silently restyle the value the row exists to report. Applied
+     * uniformly, including to the static labels, so a row added later cannot miss it.
+     */
+    private fun plainLabel(text: String): JLabel = JLabel(text).apply {
+        // Swing's own key for opting a component out of HTML rendering. Spelled out because
+        // BasicHTML.htmlDisable is not public API on every JDK this plugin builds against.
+        putClientProperty("html.disable", true)
     }
 
     /** The built panel plus the pieces tests and the click handler need to address. */

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/fakes/TestFakes.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/fakes/TestFakes.kt
@@ -7,6 +7,7 @@ import dev.skillbill.intellij.application.GoalStopRepository
 import dev.skillbill.intellij.application.PreferenceCachePort
 import dev.skillbill.intellij.application.StatusRepository
 import dev.skillbill.intellij.domain.DEFAULT_REFRESH_INTERVAL_SECONDS
+import dev.skillbill.intellij.domain.CurrentPhaseModel
 import dev.skillbill.intellij.domain.FEATURE_GOAL_WORKFLOW_FAMILY
 import dev.skillbill.intellij.domain.LastKnownDisplayCache
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
@@ -187,6 +188,7 @@ fun activeUiState(
     issueKey: String? = "SKILL-168",
     workflowFamily: String? = FEATURE_GOAL_WORKFLOW_FAMILY,
     pauseRequested: Boolean? = null,
+    currentModel: CurrentPhaseModel? = null,
 ): SkillBillStatusUiState.Active =
     SkillBillStatusUiState.Active(
         headline = "Skill Bill: goal",
@@ -203,4 +205,5 @@ fun activeUiState(
         lastUpdated = null,
         workflowFamily = workflowFamily,
         pauseRequested = pauseRequested,
+        currentModel = currentModel,
     )

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/fakes/TestFakes.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/fakes/TestFakes.kt
@@ -6,8 +6,8 @@ import dev.skillbill.intellij.application.GoalStopOutcome
 import dev.skillbill.intellij.application.GoalStopRepository
 import dev.skillbill.intellij.application.PreferenceCachePort
 import dev.skillbill.intellij.application.StatusRepository
-import dev.skillbill.intellij.domain.DEFAULT_REFRESH_INTERVAL_SECONDS
 import dev.skillbill.intellij.domain.CurrentPhaseModel
+import dev.skillbill.intellij.domain.DEFAULT_REFRESH_INTERVAL_SECONDS
 import dev.skillbill.intellij.domain.FEATURE_GOAL_WORKFLOW_FAMILY
 import dev.skillbill.intellij.domain.LastKnownDisplayCache
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
@@ -268,9 +268,12 @@ class IdeStatusJsonMapperTest {
     }
 
     @Test
-    fun `goal payload carrying a current model maps model and effort onto the outcome`() {
+    fun `goal payload carrying a current model maps model effort and phase onto the outcome`() {
         val outcome = IdeStatusJsonMapper.map(
-            goalPayload(planning = null, currentModel = """"current_model": {"model": "opus-5", "effort": "high"}"""),
+            goalPayload(
+                planning = null,
+                currentModel = """"current_model": {"model": "opus-5", "effort": "high", "phase_id": "implement"}""",
+            ),
             now,
             0,
         )
@@ -278,20 +281,26 @@ class IdeStatusJsonMapperTest {
         val currentModel = (outcome as SkillBillStatusOutcome.Active).currentModel
         assertEquals("opus-5", currentModel?.model)
         assertEquals("high", currentModel?.effort)
+        // A goal's step is a goal-level label, so this is the only thing that says which phase the
+        // model belongs to; dropping it leaves the popup naming a model attributed to nothing.
+        assertEquals("implement", currentModel?.phaseId)
         assertEquals("implement", outcome.currentStepId)
     }
 
     @Test
     fun `unusable current model degrades to null while the outcome maps normally`() {
+        // One case per parse rule the mapper applies: the key's absence, the object check, the
+        // non-blank-string check on `model`, its isString check, and the length bound. Extra
+        // literals for a rule already covered cost tokens on every future change and detect
+        // nothing more.
         val unusable = mapOf(
             "absent" to null,
-            "non-object string" to """"current_model": "opus-5"""",
-            "non-object array" to """"current_model": ["opus-5"]""",
-            "blank model" to """"current_model": {"model": "   "}""",
+            "non-object" to """"current_model": "opus-5"""",
+            "missing or blank model" to """"current_model": {"model": "   "}""",
             "non-string model" to """"current_model": {"model": ["opus-5"]}""",
-            "numeric model" to """"current_model": {"model": 5}""",
-            "boolean model" to """"current_model": {"model": true}""",
-            "missing model" to """"current_model": {"effort": "high"}""",
+            // Degrades rather than truncating: a clipped id would render a model that never
+            // existed, and the operator could not tell it had been cut.
+            "over-length model" to """"current_model": {"model": "${"m".repeat(121)}"}""",
         )
         for ((case, block) in unusable) {
             val outcome = IdeStatusJsonMapper.map(goalPayload(planning = null, currentModel = block), now, 0)
@@ -307,8 +316,6 @@ class IdeStatusJsonMapperTest {
         val unusable = mapOf(
             "blank effort" to """"current_model": {"model": "opus-5", "effort": "  "}""",
             "non-string effort" to """"current_model": {"model": "opus-5", "effort": {"level": "high"}}""",
-            "numeric effort" to """"current_model": {"model": "opus-5", "effort": 3}""",
-            "boolean effort" to """"current_model": {"model": "opus-5", "effort": false}""",
         )
         for ((case, block) in unusable) {
             val outcome = IdeStatusJsonMapper.map(goalPayload(planning = null, currentModel = block), now, 0)

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
@@ -268,6 +268,63 @@ class IdeStatusJsonMapperTest {
     }
 
     @Test
+    fun `goal payload carrying a current model maps model and effort onto the outcome`() {
+        val outcome = IdeStatusJsonMapper.map(
+            goalPayload(planning = null, currentModel = """"current_model": {"model": "opus-5", "effort": "high"}"""),
+            now,
+            0,
+        )
+        assertTrue(outcome is SkillBillStatusOutcome.Active)
+        val currentModel = (outcome as SkillBillStatusOutcome.Active).currentModel
+        assertEquals("opus-5", currentModel?.model)
+        assertEquals("high", currentModel?.effort)
+        assertEquals("implement", outcome.currentStepId)
+    }
+
+    @Test
+    fun `unusable current model degrades to null while the outcome maps normally`() {
+        val unusable = mapOf(
+            "absent" to null,
+            "non-object string" to """"current_model": "opus-5"""",
+            "non-object array" to """"current_model": ["opus-5"]""",
+            "blank model" to """"current_model": {"model": "   "}""",
+            "non-string model" to """"current_model": {"model": ["opus-5"]}""",
+            "missing model" to """"current_model": {"effort": "high"}""",
+        )
+        for ((case, block) in unusable) {
+            val outcome = IdeStatusJsonMapper.map(goalPayload(planning = null, currentModel = block), now, 0)
+            assertTrue("$case must still map to Active", outcome is SkillBillStatusOutcome.Active)
+            outcome as SkillBillStatusOutcome.Active
+            assertNull("$case must degrade the model to null", outcome.currentModel)
+            assertEquals("$case must keep the surrounding outcome", "implement", outcome.currentStepId)
+        }
+    }
+
+    @Test
+    fun `unusable effort degrades to a null effort while the model survives`() {
+        val unusable = mapOf(
+            "blank effort" to """"current_model": {"model": "opus-5", "effort": "  "}""",
+            "non-string effort" to """"current_model": {"model": "opus-5", "effort": {"level": "high"}}""",
+        )
+        for ((case, block) in unusable) {
+            val outcome = IdeStatusJsonMapper.map(goalPayload(planning = null, currentModel = block), now, 0)
+            assertTrue("$case must still map to Active", outcome is SkillBillStatusOutcome.Active)
+            val currentModel = (outcome as SkillBillStatusOutcome.Active).currentModel
+            assertEquals("$case must keep the model", "opus-5", currentModel?.model)
+            assertNull("$case must degrade the effort to null", currentModel?.effort)
+        }
+    }
+
+    @Test
+    fun `stale payload carrying a current model maps it onto the stale outcome`() {
+        val json = goalPayload(planning = null, currentModel = """"current_model": {"model": "opus-5"}""")
+            .replace("\"freshness\":\"fresh\"", "\"freshness\":\"stale\"")
+        val outcome = IdeStatusJsonMapper.map(json, now, 0)
+        assertTrue(outcome is SkillBillStatusOutcome.Stale)
+        assertEquals("opus-5", (outcome as SkillBillStatusOutcome.Stale).currentModel?.model)
+    }
+
+    @Test
     fun `malformed planning degrades to null without failing the mapping`() {
         val malformed = mapOf(
             "non-object" to "\"planning\": \"nope\"",
@@ -388,7 +445,7 @@ class IdeStatusJsonMapperTest {
         return replace(original, "\"$field\": \"$to\"")
     }
 
-    private fun goalPayload(planning: String?): String =
+    private fun goalPayload(planning: String?, currentModel: String? = null): String =
         buildString {
             append("{\"contract_version\":\"$IDE_STATUS_CONTRACT_VERSION\",")
             append("\"repository_identity\":\"repo-root-realpath-v1:/repo\",")
@@ -401,6 +458,7 @@ class IdeStatusJsonMapperTest {
             append("\"updated_at\":\"2026-08-06T09:59:00Z\",")
             append("\"summary\":\"Goal SKILL-165 in progress.\"")
             planning?.let { append(',').append(it) }
+            currentModel?.let { append(',').append(it) }
             append('}')
         }
 

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/infrastructure/cli/ProcessRunnerAndMapperTest.kt
@@ -289,6 +289,8 @@ class IdeStatusJsonMapperTest {
             "non-object array" to """"current_model": ["opus-5"]""",
             "blank model" to """"current_model": {"model": "   "}""",
             "non-string model" to """"current_model": {"model": ["opus-5"]}""",
+            "numeric model" to """"current_model": {"model": 5}""",
+            "boolean model" to """"current_model": {"model": true}""",
             "missing model" to """"current_model": {"effort": "high"}""",
         )
         for ((case, block) in unusable) {
@@ -305,6 +307,8 @@ class IdeStatusJsonMapperTest {
         val unusable = mapOf(
             "blank effort" to """"current_model": {"model": "opus-5", "effort": "  "}""",
             "non-string effort" to """"current_model": {"model": "opus-5", "effort": {"level": "high"}}""",
+            "numeric effort" to """"current_model": {"model": "opus-5", "effort": 3}""",
+            "boolean effort" to """"current_model": {"model": "opus-5", "effort": false}""",
         )
         for ((case, block) in unusable) {
             val outcome = IdeStatusJsonMapper.map(goalPayload(planning = null, currentModel = block), now, 0)

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
@@ -1,5 +1,6 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.CurrentPhaseModel
 import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
 import java.time.Duration
@@ -501,6 +502,22 @@ class SkillBillStatusBarPresentationTest {
         assertEquals(withoutControls.details, withControls.details)
         assertTrue(withoutControls.controls.isEmpty())
         assertFalse(withControls.controls.isEmpty())
+    }
+
+    @Test
+    fun `a carried current model leaves bar text tooltip and accessibility untouched`() {
+        val withoutModel = SkillBillStatusBarPresentation.map(active())
+        val withModel = SkillBillStatusBarPresentation.map(
+            active().copy(currentModel = CurrentPhaseModel(model = "opus-5", effort = "high")),
+        )
+
+        assertEquals(withoutModel.barText, withModel.barText)
+        assertEquals(withoutModel.tooltipText, withModel.tooltipText)
+        assertEquals(withoutModel.accessibleName, withModel.accessibleName)
+        assertEquals(withoutModel.accessibleDescription, withModel.accessibleDescription)
+        // Only the popup-facing row differs.
+        assertEquals("opus-5 (effort: high)", withModel.details.modelText)
+        assertTrue("no model text without a model", withoutModel.details.modelText == null)
     }
 
     private fun activeOutcome(

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/SkillBillStatusBarPresentationTest.kt
@@ -1,6 +1,8 @@
 package dev.skillbill.intellij.presentation
 
 import dev.skillbill.intellij.domain.CurrentPhaseModel
+import dev.skillbill.intellij.domain.FEATURE_GOAL_WORKFLOW_FAMILY
+import dev.skillbill.intellij.domain.MODEL_TEXT_MAX_LENGTH
 import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
 import java.time.Duration
@@ -518,6 +520,32 @@ class SkillBillStatusBarPresentationTest {
         // Only the popup-facing row differs.
         assertEquals("opus-5 (effort: high)", withModel.details.modelText)
         assertTrue("no model text without a model", withoutModel.details.modelText == null)
+    }
+
+    @Test
+    fun `the model row names its phase only for a goal and stays bounded for the popup`() {
+        val model = CurrentPhaseModel(model = "opus-5", effort = "high", phaseId = "implement")
+
+        // The runtime family's Step row already names the phase; repeating it there is noise.
+        val runtime = SkillBillStatusBarPresentation.map(active().copy(currentModel = model))
+        // A goal's Step row is a goal-level label, so without the phase the model is attributed to
+        // nothing the payload shows.
+        val goal = SkillBillStatusBarPresentation.map(
+            active().copy(workflowFamily = FEATURE_GOAL_WORKFLOW_FAMILY, currentModel = model),
+        )
+
+        assertEquals("opus-5 (effort: high)", runtime.details.modelText)
+        assertEquals("opus-5 (implement, effort: high)", goal.details.modelText)
+
+        // Unbounded, this lands in a non-wrapping JLabel inside a popup with no width cap and can
+        // push the action row off-screen.
+        val long = SkillBillStatusBarPresentation.map(
+            active().copy(currentModel = CurrentPhaseModel(model = "m".repeat(119))),
+        )
+        assertTrue(
+            "model row must stay bounded, was ${long.details.modelText?.length}",
+            (long.details.modelText?.length ?: 0) <= MODEL_TEXT_MAX_LENGTH,
+        )
     }
 
     private fun activeOutcome(

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/StatusUiMapperTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/presentation/StatusUiMapperTest.kt
@@ -1,5 +1,6 @@
 package dev.skillbill.intellij.presentation
 
+import dev.skillbill.intellij.domain.CurrentPhaseModel
 import dev.skillbill.intellij.domain.GoalPlanningInfo
 import dev.skillbill.intellij.domain.NO_MATCHING_WORK_REASON_CODE
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
@@ -468,6 +469,68 @@ class StatusUiMapperTest {
             assertNull(ui.pauseRequested)
         }
     }
+
+    @Test
+    fun `the current phase model survives the mapping on every outcome that carries it`() {
+        val model = CurrentPhaseModel(model = "opus-5", effort = "high", phaseId = "implement")
+        // All five branches that wire currentModel, not a hand-picked pair: a missing wire on any one
+        // of them loses the popup's Model row for that lifecycle while the UI tests — which build
+        // SkillBillStatusUiState directly — stay green. Stale matters most: it is exactly when the
+        // user wants to know what was running.
+        val carriers = listOf<Pair<String, SkillBillStatusOutcome>>(
+            "Active" to active().copy(currentModel = model),
+            "Paused" to paused(now).copy(currentModel = model),
+            "Stale" to staleOutcome().copy(currentModel = model),
+            "Blocked" to blockedOutcome().copy(currentModel = model),
+            "Failed" to failedOutcome().copy(currentModel = model),
+        )
+
+        carriers.forEach { (case, outcome) ->
+            assertEquals("$case must carry the model", model, StatusUiMapper.map(outcome, now).currentModel)
+        }
+        assertNull(StatusUiMapper.map(active(), now).currentModel)
+    }
+
+    private fun staleOutcome() = SkillBillStatusOutcome.Stale(
+        observedAt = now,
+        summary = "stale",
+        repositoryIdentity = "repo",
+        issueKey = "SKILL-148",
+        currentStepId = "implement",
+        currentStepLabel = "Implement",
+        progressCompleted = 1,
+        progressTotal = 4,
+        startedAt = started,
+        currentSubtaskId = "2",
+        subtaskStartedAt = subtaskStarted,
+        updatedAt = now,
+    )
+
+    private fun blockedOutcome() = SkillBillStatusOutcome.Blocked(
+        observedAt = now,
+        summary = "blocked",
+        repositoryIdentity = "repo",
+        issueKey = "SKILL-148",
+        currentStepId = "implement",
+        currentStepLabel = "Implement",
+        startedAt = started,
+        currentSubtaskId = "2",
+        subtaskStartedAt = subtaskStarted,
+        updatedAt = now,
+    )
+
+    private fun failedOutcome() = SkillBillStatusOutcome.Failed(
+        observedAt = now,
+        summary = "failed",
+        repositoryIdentity = "repo",
+        issueKey = "SKILL-148",
+        currentStepId = "implement",
+        currentStepLabel = "Implement",
+        startedAt = started,
+        currentSubtaskId = "2",
+        subtaskStartedAt = subtaskStarted,
+        updatedAt = now,
+    )
 
     private fun paused(updatedAt: Instant) = SkillBillStatusOutcome.Paused(
         observedAt = now,

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/ui/SkillBillStatusBarWidgetFixtureTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/ui/SkillBillStatusBarWidgetFixtureTest.kt
@@ -255,6 +255,32 @@ class SkillBillStatusBarWidgetFixtureTest : BasePlatformTestCase() {
         )
     }
 
+    fun testPopupValueLabelsDoNotRenderRuntimeTextAsHtml() {
+        val widget = newWidget()
+        val built = widget.buildPopupContent(
+            SkillBillStatusBarPresentation.map(
+                activeUiState(currentModel = CurrentPhaseModel(model = "<html><b>opus-5")),
+            ),
+        )
+
+        // Swing parses a label whose text starts with <html> as markup, so an <img src=...> would
+        // make the IDE fetch it and a <b> would restyle away the value the row exists to report.
+        // Every value here is runtime-supplied, so HTML must be off on all of them.
+        val labels = valueLabels(built.panel)
+        assertTrue("popup renders value labels", labels.isNotEmpty())
+        assertTrue(
+            "every value label opts out of HTML rendering",
+            labels.all { it.getClientProperty("html.disable") == true },
+        )
+        widget.dispose()
+    }
+
+    private fun valueLabels(component: java.awt.Component): List<javax.swing.JLabel> = when (component) {
+        is javax.swing.JLabel -> listOf(component)
+        is java.awt.Container -> component.components.flatMap { valueLabels(it) }
+        else -> emptyList()
+    }
+
     fun testDisabledPauseKeepsItsAccessibleNameAndRegisteredRequestText() {
         val widget = newWidget()
         val built = widget.buildPopupContent(

--- a/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/ui/SkillBillStatusBarWidgetFixtureTest.kt
+++ b/intellij-plugin/src/test/kotlin/dev/skillbill/intellij/ui/SkillBillStatusBarWidgetFixtureTest.kt
@@ -7,6 +7,7 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.skillbill.intellij.application.GoalStopOutcome
 import dev.skillbill.intellij.application.StatusRefreshCoordinator
 import dev.skillbill.intellij.composition.SkillBillProjectStatusService
+import dev.skillbill.intellij.domain.CurrentPhaseModel
 import dev.skillbill.intellij.domain.SkillBillStatusOutcome
 import dev.skillbill.intellij.fakes.ControllableClock
 import dev.skillbill.intellij.fakes.FakeGoalPauseRepository
@@ -232,6 +233,26 @@ class SkillBillStatusBarWidgetFixtureTest : BasePlatformTestCase() {
         assertTrue("no controls for an ineligible state", emptyBuilt.buttons.isEmpty())
         assertNull(emptyBuilt.actionRow)
         widget.dispose()
+    }
+
+    fun testPopupRendersExactlyOneModelRowOnlyWhenAModelIsPresent() {
+        val withModel = SkillBillStatusBarPresentation.map(
+            activeUiState(currentModel = CurrentPhaseModel(model = "opus-5", effort = "high")),
+        )
+        val modelRows = StatusDetailsPopupContent.statusLines(withModel).filter { it.first == "Model" }
+        assertEquals("exactly one model row", 1, modelRows.size)
+        val value = modelRows.single().second
+        assertTrue("row carries the model", value.contains("opus-5"))
+        assertTrue("row carries the effort inline", value.contains("high"))
+
+        val withoutModel = SkillBillStatusBarPresentation.map(activeUiState())
+        val lines = StatusDetailsPopupContent.statusLines(withoutModel)
+        assertTrue("no model row when absent", lines.none { it.first == "Model" })
+        // No row at all when absent: the present-model lines are today's lines plus one.
+        assertEquals(
+            lines,
+            StatusDetailsPopupContent.statusLines(withModel).filterNot { it.first == "Model" },
+        )
     }
 
     fun testDisabledPauseKeepsItsAccessibleNameAndRegisteredRequestText() {

--- a/orchestration/contracts/feature-task-runtime-persistence-schema.yaml
+++ b/orchestration/contracts/feature-task-runtime-persistence-schema.yaml
@@ -110,6 +110,10 @@ $defs:
       # FeatureTaskRuntimePhaseRecord requires the same `pass >= 1`, pinned by
       # FeatureTaskRuntimePersistenceReviewPassParityTest.
       review_pass_number: { type: integer, minimum: 1 }
+      # Absent on every pre-SKILL-183 record and on phases launched with no model directive;
+      # present-but-blank is rejected by FeatureTaskRuntimePhaseRecord's own invariants.
+      launched_model: { type: string, minLength: 1 }
+      launched_effort: { type: string, minLength: 1 }
   delivered_projection:
     type: object
     additionalProperties: false

--- a/orchestration/contracts/feature-task-runtime-persistence-schema.yaml
+++ b/orchestration/contracts/feature-task-runtime-persistence-schema.yaml
@@ -112,8 +112,13 @@ $defs:
       review_pass_number: { type: integer, minimum: 1 }
       # Absent on every pre-SKILL-183 record and on phases launched with no model directive;
       # present-but-blank is rejected by FeatureTaskRuntimePhaseRecord's own invariants.
+      # The pair moves as a unit, so an effort without a model is not representable — every reader
+      # keys the pair off the model and would silently discard a lone effort. Mirrored by
+      # FeatureTaskRuntimePhaseRecord's init.
       launched_model: { type: string, minLength: 1 }
       launched_effort: { type: string, minLength: 1 }
+    dependentRequired:
+      launched_effort: [launched_model]
   delivered_projection:
     type: object
     additionalProperties: false

--- a/orchestration/contracts/ide-status-schema.yaml
+++ b/orchestration/contracts/ide-status-schema.yaml
@@ -101,6 +101,23 @@ properties:
         description: >
           Durable current-subtask start instant. Omitted when the subtask scope
           does not exist or legacy state cannot provide it.
+  current_model:
+    type: object
+    additionalProperties: false
+    description: >
+      The model the current phase's child was launched with, as rendered to the
+      agent CLI. Omitted entirely when the current phase has no recorded model.
+      `effort` is omitted when the model string already carries it (Cursor's
+      merged `model[effort=...]` form) or when no effort was resolved.
+    required:
+      - model
+    properties:
+      model:
+        type: string
+        minLength: 1
+      effort:
+        type: string
+        minLength: 1
   planning:
     type: object
     additionalProperties: false

--- a/orchestration/contracts/ide-status-schema.yaml
+++ b/orchestration/contracts/ide-status-schema.yaml
@@ -106,18 +106,33 @@ properties:
     additionalProperties: false
     description: >
       The model the current phase's child was launched with, as rendered to the
-      agent CLI. Omitted entirely when the current phase has no recorded model.
+      agent CLI. Omitted entirely when the current phase has no recorded model,
+      and never emitted for a completed phase or a terminal goal — a finished
+      unit's model is history, not the model in force.
       `effort` is omitted when the model string already carries it (Cursor's
       merged `model[effort=...]` form) or when no effort was resolved.
+      The length bounds are the contract, not a client concern: a consumer that
+      truncated instead would display a model identifier that never existed.
     required:
       - model
     properties:
       model:
         type: string
         minLength: 1
+        maxLength: 120
       effort:
         type: string
         minLength: 1
+        maxLength: 40
+      phase_id:
+        type: string
+        minLength: 1
+        maxLength: 64
+        description: >
+          The runtime phase the model belongs to. A goal's `current_step` is a
+          goal-level label — often `planning` — so without this the payload
+          names a model whose phase appears nowhere in it. Omitted only by a
+          producer that cannot resolve the phase.
   planning:
     type: object
     additionalProperties: false

--- a/runtime-kotlin/runtime-application/agent/history.md
+++ b/runtime-kotlin/runtime-application/agent/history.md
@@ -1,3 +1,12 @@
+## [2026-08-11] SKILL-183 subtask 1 — Launched phase model is durable and IDE-visible
+Areas: runtime-application/featuretask, runtime-application/model, runtime-application/work, runtime-domain/workflow/taskruntime/model, orchestration/contracts
+- `FeatureTaskRuntimePhaseRecord` gained optional `launched_model` / `launched_effort`; the run loop records the model+effort the child was actually launched with, and records neither when no directive resolved
+- Both fields are additive-optional on the wire: `toArtifactMap()` round-trips them and pre-change artifact maps lacking both keys still parse, so no migration or backfill is needed. reusable
+- `IdeStatusSnapshot.toStatusWireMap()` emits a `current_model` object (required `model`, optional `effort`) or omits the key entirely; `ide-status-schema.yaml` extended to allow both shapes with `IDE_STATUS_CONTRACT_VERSION` intentionally unchanged since the addition is backward-compatible
+- Pattern to follow for future status surfacing: extend the persistence record optionally, project through `IdeStatusProjector`, then widen the schema — golden fixtures and the contract-version test pin the compatibility claim
+Feature flag: N/A
+Acceptance criteria: 9/9 implemented
+
 ## [2026-08-10] SKILL-176 subtask 6 — Producer-evidence identity includes agent_id
 Areas: runtime-application/featuretask, runtime-ports/persistence, runtime-infra-sqlite/db, runtime-kotlin/agent
 - Producer-output evidence identity widened to `(workflow_id, phase_id, generation, attempt, agent_id)` so a second agent re-entering the same attempt retains its own immutable row instead of Conflict-crashing phase recording

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -1493,6 +1493,9 @@ class FeatureTaskRuntimePhaseRecorder(
   ): FeatureTaskRuntimePhaseRecord {
     val firstStartedAt = previous?.firstStartedAt ?: now
     val startedAt = if (request.status == STATUS_RUNNING || previous == null) now else previous.startedAt
+    // Only the running write carries authoritative launch information; every later write for the same
+    // phase (block, pause, completion) would otherwise erase the model the child actually ran with.
+    val carryLaunched = request.status != STATUS_RUNNING
     return FeatureTaskRuntimePhaseRecord(
       phaseId = request.phaseId,
       status = request.status,
@@ -1513,8 +1516,8 @@ class FeatureTaskRuntimePhaseRecorder(
       edgeIteration = request.edgeIteration,
       reviewPassNumber = request.reviewPassNumber,
       repairEvidence = request.repairEvidence,
-      launchedModel = request.launchedModel,
-      launchedEffort = request.launchedEffort,
+      launchedModel = request.launchedModel ?: previous?.launchedModel?.takeIf { carryLaunched },
+      launchedEffort = request.launchedEffort ?: previous?.launchedEffort?.takeIf { carryLaunched },
     )
   }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -574,6 +574,10 @@ class FeatureTaskRuntimePhaseRecorder(
       val existingRecords = phaseRecordsFrom(artifacts)
       val previousReview = existingRecords[FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW]
         ?: return@transaction storedGeneration
+      // The omitted launch pair is deliberate, not an oversight: this tombstone is not a launch, and
+      // REVIEW_INVALIDATION_AGENT_ID never ran a child. Carrying the invalidated generation's model
+      // forward would attribute it to an agent that could not have launched it; the relaunch's own
+      // running write is what restores it.
       val tombstone = FeatureTaskRuntimePhaseRecord(
         phaseId = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW,
         status = STATUS_RUNNING,
@@ -1497,10 +1501,18 @@ class FeatureTaskRuntimePhaseRecorder(
     // any other write carries both forward. Resolving them independently would let a Cursor-merged
     // model (effort folded into the model string, so effort null) land over a prior record's effort
     // and produce the self-contradictory pair LaunchedModelDirective exists to prevent.
-    val launched = if (request.launchOutcomeKnown) {
-      request.launchedModel to request.launchedEffort
-    } else {
-      previous?.launchedModel to previous?.launchedEffort
+    //
+    // Carry-forward is bounded to one attempt by one agent. A write that advances attempt_count or
+    // swaps resolved_agent_id settles work the prior pair never described — a pre-launch cap block,
+    // an audit settled from durable criterion closure, a branch-setup block under a non-agent id —
+    // so inheriting it would assert a model that attempt provably never launched.
+    val carryForward = previous != null &&
+      previous.attemptCount == request.attemptCount &&
+      previous.resolvedAgentId == request.resolvedAgentId
+    val launched = when {
+      request.launchOutcomeKnown -> request.launchedModel to request.launchedEffort
+      carryForward -> previous.launchedModel to previous.launchedEffort
+      else -> null to null
     }
     return FeatureTaskRuntimePhaseRecord(
       phaseId = request.phaseId,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -1513,6 +1513,8 @@ class FeatureTaskRuntimePhaseRecorder(
       edgeIteration = request.edgeIteration,
       reviewPassNumber = request.reviewPassNumber,
       repairEvidence = request.repairEvidence,
+      launchedModel = request.launchedModel,
+      launchedEffort = request.launchedEffort,
     )
   }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -1493,9 +1493,15 @@ class FeatureTaskRuntimePhaseRecorder(
   ): FeatureTaskRuntimePhaseRecord {
     val firstStartedAt = previous?.firstStartedAt ?: now
     val startedAt = if (request.status == STATUS_RUNNING || previous == null) now else previous.startedAt
-    // Only the running write carries authoritative launch information; every later write for the same
-    // phase (block, pause, completion) would otherwise erase the model the child actually ran with.
-    val carryLaunched = request.status != STATUS_RUNNING
+    // The launch pair moves as a unit: a write that knows the launch outcome replaces both fields,
+    // any other write carries both forward. Resolving them independently would let a Cursor-merged
+    // model (effort folded into the model string, so effort null) land over a prior record's effort
+    // and produce the self-contradictory pair LaunchedModelDirective exists to prevent.
+    val launched = if (request.launchOutcomeKnown) {
+      request.launchedModel to request.launchedEffort
+    } else {
+      previous?.launchedModel to previous?.launchedEffort
+    }
     return FeatureTaskRuntimePhaseRecord(
       phaseId = request.phaseId,
       status = request.status,
@@ -1516,8 +1522,8 @@ class FeatureTaskRuntimePhaseRecorder(
       edgeIteration = request.edgeIteration,
       reviewPassNumber = request.reviewPassNumber,
       repairEvidence = request.repairEvidence,
-      launchedModel = request.launchedModel ?: previous?.launchedModel?.takeIf { carryLaunched },
-      launchedEffort = request.launchedEffort ?: previous?.launchedEffort?.takeIf { carryLaunched },
+      launchedModel = launched.first,
+      launchedEffort = launched.second,
     )
   }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -4647,29 +4647,54 @@ internal class FeatureTaskRuntimeRunLoop(
     normalizedOutput: NormalizedFeatureTaskRuntimePhaseOutput? = null,
     repairEvidence: skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutputRepairEvidence? = null,
     repositoryFingerprint: String? = null,
-  ): FeatureTaskRuntimePhaseStateRequest = FeatureTaskRuntimePhaseStateRequest(
-    workflowId = run.request.workflowId,
-    phaseId = run.phaseId,
-    status = status,
-    attemptCount = iteration,
-    resolvedAgentId = run.resolvedAgent.resolvedAgentId,
-    finished = finished,
-    outputArtifact = outputArtifact,
-    normalizedOutput = normalizedOutput,
-    repairEvidence = repairEvidence,
-    repositoryFingerprint = repositoryFingerprint,
-    fileManifestBefore = fileManifest?.before.orEmpty(),
-    fileManifestAfter = fileManifest?.after.orEmpty(),
-    fileManifestIntroduced = fileManifest?.introduced.orEmpty(),
-    loopId = run.reentry?.loopId,
-    edgeIteration = run.reentry?.edgeIteration,
-    reviewPassNumber = reviewPassNumber(run, state),
-    auditScopeCriterionRefs = if (run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_AUDIT) {
-      openAuditCriterionRefs()
-    } else {
-      emptyList()
-    },
+  ): FeatureTaskRuntimePhaseStateRequest {
+    val launched = launchedModelDirective(run)
+    return FeatureTaskRuntimePhaseStateRequest(
+      workflowId = run.request.workflowId,
+      phaseId = run.phaseId,
+      status = status,
+      attemptCount = iteration,
+      resolvedAgentId = run.resolvedAgent.resolvedAgentId,
+      finished = finished,
+      outputArtifact = outputArtifact,
+      normalizedOutput = normalizedOutput,
+      repairEvidence = repairEvidence,
+      repositoryFingerprint = repositoryFingerprint,
+      fileManifestBefore = fileManifest?.before.orEmpty(),
+      fileManifestAfter = fileManifest?.after.orEmpty(),
+      fileManifestIntroduced = fileManifest?.introduced.orEmpty(),
+      loopId = run.reentry?.loopId,
+      edgeIteration = run.reentry?.edgeIteration,
+      reviewPassNumber = reviewPassNumber(run, state),
+      auditScopeCriterionRefs = if (run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_AUDIT) {
+        openAuditCriterionRefs()
+      } else {
+        emptyList()
+      },
+      launchedModel = launched.modelOverride,
+      launchedEffort = launched.persistedEffort,
+    )
+  }
+
+  /**
+   * The model/effort the child is actually launched with. Cursor takes model and effort merged into
+   * one bracketed `--model` argument, so its [persistedEffort] is null: the merged model already
+   * carries the effort, and recording it twice would let the two drift apart.
+   */
+  private data class LaunchedModelDirective(
+    val modelOverride: String?,
+    val effortOverride: String?,
+    val persistedEffort: String?,
   )
+
+  private fun launchedModelDirective(run: PhaseRun): LaunchedModelDirective {
+    val model = run.modelDirective?.model
+    val effort = run.modelDirective?.effort
+    if (run.resolvedAgent.resolvedAgentId == InstallAgent.CURSOR.id && model != null && effort != null) {
+      return LaunchedModelDirective("$model[effort=$effort]", effort, persistedEffort = null)
+    }
+    return LaunchedModelDirective(model, effort, effort)
+  }
 
   /**
    * The active repair batch read from the durable generation authority at the launch seam, so first entry,
@@ -4802,18 +4827,7 @@ internal class FeatureTaskRuntimeRunLoop(
     val briefing = prepared.briefing
     val isReviewPhase = run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW
 
-    // Cursor requires model and effort to be merged into bracket syntax at the request level
-    val (modelOverride, effortOverride) = if (run.resolvedAgent.resolvedAgentId == InstallAgent.CURSOR.id) {
-      val model = run.modelDirective?.model
-      val effort = run.modelDirective?.effort
-      if (model != null && effort != null) {
-        "$model[effort=$effort]" to effort
-      } else {
-        model to effort
-      }
-    } else {
-      run.modelDirective?.model to run.modelDirective?.effort
-    }
+    val launched = launchedModelDirective(run)
 
     val outcome = subtaskLauncher.launch(
       GoalRunnerSubtaskLaunchRequest(
@@ -4824,8 +4838,8 @@ internal class FeatureTaskRuntimeRunLoop(
           repoRoot = run.request.repoRoot,
           dbPathOverride = run.request.dbPathOverride,
           timeout = run.request.timeout,
-          modelOverride = modelOverride,
-          effortOverride = effortOverride,
+          modelOverride = launched.modelOverride,
+          effortOverride = launched.effortOverride,
           compaction = run.compaction,
           promptOverride = prepared.prompt,
           readOnlyPhase = isReviewPhase,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -3153,9 +3153,10 @@ internal class FeatureTaskRuntimeRunLoop(
         fileManifestIntroduced = fileManifest?.introduced.orEmpty(),
         loopId = run.reentry?.loopId,
         edgeIteration = run.reentry?.edgeIteration,
-        // The only pause seam is a provider-limit refusal, so no child ran: clear the running write's
-        // stamp rather than let it report a model the phase never executed.
-        launchOutcomeKnown = true,
+        // A provider-limit refusal is reported by a child that did spawn and run under the launched
+        // model, so the running write's stamp is kept: "which model hit the usage limit" is the
+        // operative diagnostic question on a limit pause.
+        launchOutcomeKnown = false,
       ),
       run.request.dbPathOverride,
     )
@@ -3205,6 +3206,7 @@ internal class FeatureTaskRuntimeRunLoop(
     iteration: Int,
     observability: FeatureTaskRuntimeRunObservability,
     rejection: RecordRejection,
+    childNeverLaunched: Boolean,
   ): PhaseOutcome {
     val consumer = run.phaseId
     val producer = FeatureTaskRuntimePhaseWorkflowDefinition.REGENERATION_PRODUCER_BY_CONSUMER[consumer]
@@ -3215,7 +3217,15 @@ internal class FeatureTaskRuntimeRunLoop(
       }
     }
     if (producer == null || edge == null || producer !in transitions.forwardPhaseIds) {
-      return blockUnattributableRecordRejection(run, state, iteration, observability, rejection, producer)
+      return blockUnattributableRecordRejection(
+        run,
+        state,
+        iteration,
+        observability,
+        rejection,
+        producer,
+        childNeverLaunched,
+      )
     }
     val rejectedRecord = state.outputFor(producer)
     val producingIteration =
@@ -3229,6 +3239,7 @@ internal class FeatureTaskRuntimeRunLoop(
           "producer. The run blocks instead of fabricating a rejected-output diagnostic.",
         observability,
         failureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
+        childNeverLaunched = childNeverLaunched,
       )
     val producerEvidence = recorder.producerOutput(
       request.workflowId,
@@ -3245,6 +3256,7 @@ internal class FeatureTaskRuntimeRunLoop(
         "a rejected-output diagnostic from normalized workflow state.",
       observability,
       failureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
+      childNeverLaunched = childNeverLaunched,
     )
     val rejectedPayload = producerEvidence.payload ?: byteArrayOf()
     val diagnosticIdentity = recordRejectedOutput(
@@ -3297,6 +3309,7 @@ internal class FeatureTaskRuntimeRunLoop(
     observability: FeatureTaskRuntimeRunObservability,
     rejection: RecordRejection,
     producer: String?,
+    childNeverLaunched: Boolean,
   ): PhaseOutcome {
     val detail = payloadFreeRejectionReason(
       "reconciliation-${rejection.rejectionClass}",
@@ -3352,6 +3365,7 @@ internal class FeatureTaskRuntimeRunLoop(
       reason,
       observability,
       failureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
+      childNeverLaunched = childNeverLaunched,
     )
   }
 
@@ -3397,8 +3411,8 @@ internal class FeatureTaskRuntimeRunLoop(
     phaseTokenAccumulator: MutableMap<String, Pair<Int, Int>>? = null,
   ): AttemptResult {
     // The running write is what the IDE reads as current_model while the child is in flight, so it
-    // stamps the directive the launch below is rendered from. The two never-launched exits then clear
-    // it: a phase whose child the provider refused, or whose launch failed, ran no model at all.
+    // stamps the directive the launch below is rendered from. The settling exits then clear it only
+    // where the launch proved no child ever ran, via LaunchResult.childNeverLaunched.
     persistPhase(
       run,
       iteration,
@@ -3420,12 +3434,14 @@ internal class FeatureTaskRuntimeRunLoop(
           observability,
           failureDisposition = launch.failureDisposition,
           fileManifest = launch.fileManifest,
-          childNeverLaunched = true,
+          childNeverLaunched = launch.childNeverLaunched,
         ),
       )
     }
     launch.recordRejection?.let { rejection ->
-      return AttemptResult.settled(settleRecordRejection(run, state, iteration, observability, rejection))
+      return AttemptResult.settled(
+        settleRecordRejection(run, state, iteration, observability, rejection, launch.childNeverLaunched),
+      )
     }
     val fileManifest = requireNotNull(launch.fileManifest)
     return gateOutput(
@@ -4834,12 +4850,14 @@ internal class FeatureTaskRuntimeRunLoop(
     if (!before.ok) {
       return LaunchResult.infraFailure(
         "Feature-task-runtime phase '${run.phaseId}' could not capture its before-file manifest: ${before.error}",
+        childNeverLaunched = true,
       )
     }
     val beforeCommit = gitOperations.runtimePhaseHeadCommit(run.request.repoRoot)
     if (!beforeCommit.ok) {
       return LaunchResult.infraFailure(
         "Feature-task-runtime phase '${run.phaseId}' could not capture its before commit: ${beforeCommit.error}",
+        childNeverLaunched = true,
       )
     }
     val prepared = when (val preparation = prepareLaunchForCapture(run, state, priorCorrection)) {
@@ -4879,12 +4897,14 @@ internal class FeatureTaskRuntimeRunLoop(
     if (!after.ok) {
       return LaunchResult.infraFailure(
         "Feature-task-runtime phase '${run.phaseId}' could not capture its after-file manifest: ${after.error}",
+        childNeverLaunched = false,
       )
     }
     val afterCommit = gitOperations.runtimePhaseHeadCommit(run.request.repoRoot)
     if (!afterCommit.ok) {
       return LaunchResult.infraFailure(
         "Feature-task-runtime phase '${run.phaseId}' could not capture its after commit: ${afterCommit.error}",
+        childNeverLaunched = false,
       )
     }
     val committedPaths = gitOperations.runtimePhaseChangedPathsBetweenCommits(
@@ -4895,6 +4915,7 @@ internal class FeatureTaskRuntimeRunLoop(
     if (!committedPaths.ok) {
       return LaunchResult.infraFailure(
         "Feature-task-runtime phase '${run.phaseId}' could not capture committed file changes: ${committedPaths.error}",
+        childNeverLaunched = false,
       )
     }
     val fileManifest = FeatureTaskRuntimePhaseFileManifest(
@@ -5170,11 +5191,14 @@ internal class FeatureTaskRuntimeRunLoop(
     is UnsupportedAgentRunLaunch -> LaunchResult.infraFailure(
       "Feature-task-runtime phase '$phaseId' could not launch an agent: ${outcome.reason}",
       fileManifest,
+      childNeverLaunched = true,
     )
     is AgentRunLaunchFacts -> providerLimitSignal(outcome)
       ?.let { LaunchResult.providerLimited(providerLimitPauseReason(phaseId, it), fileManifest) }
       ?: infraFailureReason(phaseId, outcome)
-        ?.let { LaunchResult.infraFailure(it, fileManifest) }
+        // Only a spawn failure proves no child ran; a timeout, an interruption and a non-zero exit
+        // all happened after the process started under the launched model.
+        ?.let { LaunchResult.infraFailure(it, fileManifest, childNeverLaunched = outcome.spawnFailed) }
       ?: LaunchResult.captured(
         outcome.stdout,
         outcome.stdoutBytes,
@@ -5228,6 +5252,7 @@ internal class FeatureTaskRuntimeRunLoop(
       val reason: String,
       override val fileManifest: FeatureTaskRuntimePhaseFileManifest?,
       val disposition: FeatureTaskRuntimeFailureDisposition,
+      val neverLaunched: Boolean,
     ) : LaunchResult
     private data class RecordRejected(
       val rejection: RecordRejection,
@@ -5249,6 +5274,15 @@ internal class FeatureTaskRuntimeRunLoop(
     val infraFailureReason: String? get() = (this as? InfraFailure)?.reason
     val providerLimitReason: String? get() = (this as? ProviderLimited)?.reason
     val recordRejection: RecordRejection? get() = (this as? RecordRejected)?.rejection
+
+    /**
+     * True only where the launch provably never produced a running child: a pre-launch capture or
+     * seam rejection, or a spawn failure. A timeout, an interruption, a non-zero exit and a
+     * post-run capture failure all happened around a child that did run under the launched model,
+     * so their records must keep it.
+     */
+    val childNeverLaunched: Boolean
+      get() = (this as? InfraFailure)?.neverLaunched ?: (this is RecordRejected)
     val failureDisposition: FeatureTaskRuntimeFailureDisposition
       get() = (this as? InfraFailure)?.disposition ?: FeatureTaskRuntimeFailureDisposition.PROCESS_FAILURE
     val fileManifest: FeatureTaskRuntimePhaseFileManifest?
@@ -5269,8 +5303,12 @@ internal class FeatureTaskRuntimeRunLoop(
         stdoutSha256,
         fileManifest,
       )
-      fun infraFailure(reason: String, fileManifest: FeatureTaskRuntimePhaseFileManifest? = null): LaunchResult =
-        InfraFailure(reason, fileManifest, FeatureTaskRuntimeFailureDisposition.PROCESS_FAILURE)
+      fun infraFailure(
+        reason: String,
+        fileManifest: FeatureTaskRuntimePhaseFileManifest? = null,
+        childNeverLaunched: Boolean,
+      ): LaunchResult =
+        InfraFailure(reason, fileManifest, FeatureTaskRuntimeFailureDisposition.PROCESS_FAILURE, childNeverLaunched)
 
       /** The provider refused at a usage limit: resumable on its own clock, so the phase pauses. */
       fun providerLimited(reason: String, fileManifest: FeatureTaskRuntimePhaseFileManifest? = null): LaunchResult =
@@ -5278,7 +5316,7 @@ internal class FeatureTaskRuntimeRunLoop(
 
       /** Static declaration or configuration drift: retrying without operator action reproduces it. */
       fun projectionRejected(reason: String): LaunchResult =
-        InfraFailure(reason, null, FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION)
+        InfraFailure(reason, null, FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION, neverLaunched = true)
 
       /**
        * A durable upstream producer record was rejected at projection validation: the run quarantines

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -3199,6 +3199,10 @@ internal class FeatureTaskRuntimeRunLoop(
    * existing transition machinery re-enters the producing phase under its bounded regeneration cap. A
    * record with no attributable producer, or whose producer the resolved pipeline dropped, blocks
    * durably with an actionable reason instead of attempting an impossible re-entry.
+   *
+   * A record rejection is raised at the launch seam, before any child is spawned, so every block
+   * seam reachable from here — including [blockUnattributableRecordRejection] — settles a phase
+   * whose child provably never ran and clears the running write's model stamp.
    */
   private fun settleRecordRejection(
     run: PhaseRun,
@@ -3206,7 +3210,6 @@ internal class FeatureTaskRuntimeRunLoop(
     iteration: Int,
     observability: FeatureTaskRuntimeRunObservability,
     rejection: RecordRejection,
-    childNeverLaunched: Boolean,
   ): PhaseOutcome {
     val consumer = run.phaseId
     val producer = FeatureTaskRuntimePhaseWorkflowDefinition.REGENERATION_PRODUCER_BY_CONSUMER[consumer]
@@ -3224,7 +3227,6 @@ internal class FeatureTaskRuntimeRunLoop(
         observability,
         rejection,
         producer,
-        childNeverLaunched,
       )
     }
     val rejectedRecord = state.outputFor(producer)
@@ -3239,7 +3241,7 @@ internal class FeatureTaskRuntimeRunLoop(
           "producer. The run blocks instead of fabricating a rejected-output diagnostic.",
         observability,
         failureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
-        childNeverLaunched = childNeverLaunched,
+        childNeverLaunched = true,
       )
     val producerEvidence = recorder.producerOutput(
       request.workflowId,
@@ -3256,7 +3258,7 @@ internal class FeatureTaskRuntimeRunLoop(
         "a rejected-output diagnostic from normalized workflow state.",
       observability,
       failureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
-      childNeverLaunched = childNeverLaunched,
+      childNeverLaunched = true,
     )
     val rejectedPayload = producerEvidence.payload ?: byteArrayOf()
     val diagnosticIdentity = recordRejectedOutput(
@@ -3309,7 +3311,6 @@ internal class FeatureTaskRuntimeRunLoop(
     observability: FeatureTaskRuntimeRunObservability,
     rejection: RecordRejection,
     producer: String?,
-    childNeverLaunched: Boolean,
   ): PhaseOutcome {
     val detail = payloadFreeRejectionReason(
       "reconciliation-${rejection.rejectionClass}",
@@ -3365,7 +3366,7 @@ internal class FeatureTaskRuntimeRunLoop(
       reason,
       observability,
       failureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
-      childNeverLaunched = childNeverLaunched,
+      childNeverLaunched = true,
     )
   }
 
@@ -3440,7 +3441,7 @@ internal class FeatureTaskRuntimeRunLoop(
     }
     launch.recordRejection?.let { rejection ->
       return AttemptResult.settled(
-        settleRecordRejection(run, state, iteration, observability, rejection, launch.childNeverLaunched),
+        settleRecordRejection(run, state, iteration, observability, rejection),
       )
     }
     val fileManifest = requireNotNull(launch.fileManifest)
@@ -4726,6 +4727,8 @@ internal class FeatureTaskRuntimeRunLoop(
     val persistedEffort: String?,
   )
 
+  // Pure in [run]: both the durable running write and the launch request call it, and a shared value
+  // threaded between them would only hide that they cannot disagree.
   private fun launchedModelDirective(run: PhaseRun): LaunchedModelDirective {
     val model = run.modelDirective?.model
     val effort = run.modelDirective?.effort
@@ -5196,9 +5199,17 @@ internal class FeatureTaskRuntimeRunLoop(
     is AgentRunLaunchFacts -> providerLimitSignal(outcome)
       ?.let { LaunchResult.providerLimited(providerLimitPauseReason(phaseId, it), fileManifest) }
       ?: infraFailureReason(phaseId, outcome)
-        // Only a spawn failure proves no child ran; a timeout, an interruption and a non-zero exit
-        // all happened after the process started under the launched model.
-        ?.let { LaunchResult.infraFailure(it, fileManifest, childNeverLaunched = outcome.spawnFailed) }
+        // Only a failure before the process-start boundary proves no child ran; a timeout, an
+        // interruption and a non-zero exit all happened after it, under the launched model. Both
+        // flags are consulted because they are one fact reported two ways: the launcher adapter
+        // rejects a disagreeing pair, and reading only one of them would trust the weaker signal.
+        ?.let {
+          LaunchResult.infraFailure(
+            it,
+            fileManifest,
+            childNeverLaunched = outcome.spawnFailed || !outcome.processStarted,
+          )
+        }
       ?: LaunchResult.captured(
         outcome.stdout,
         outcome.stdoutBytes,
@@ -5276,13 +5287,17 @@ internal class FeatureTaskRuntimeRunLoop(
     val recordRejection: RecordRejection? get() = (this as? RecordRejected)?.rejection
 
     /**
-     * True only where the launch provably never produced a running child: a pre-launch capture or
-     * seam rejection, or a spawn failure. A timeout, an interruption, a non-zero exit and a
-     * post-run capture failure all happened around a child that did run under the launched model,
+     * True only where the launch provably never produced a running child: a spawn failure, or a
+     * pre-launch capture or declaration rejection. A timeout, an interruption, a non-zero exit and
+     * a post-run capture failure all happened around a child that did run under the launched model,
      * so their records must keep it.
+     *
+     * [RecordRejected] never reaches here: its seam fires before any spawn, so
+     * [settleRecordRejection] states never-launched at its own block seams rather than routing the
+     * same fact through this getter.
      */
     val childNeverLaunched: Boolean
-      get() = (this as? InfraFailure)?.neverLaunched ?: (this is RecordRejected)
+      get() = (this as? InfraFailure)?.neverLaunched == true
     val failureDisposition: FeatureTaskRuntimeFailureDisposition
       get() = (this as? InfraFailure)?.disposition ?: FeatureTaskRuntimeFailureDisposition.PROCESS_FAILURE
     val fileManifest: FeatureTaskRuntimePhaseFileManifest?

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -3081,6 +3081,7 @@ internal class FeatureTaskRuntimeRunLoop(
     normalizedOutput: NormalizedFeatureTaskRuntimePhaseOutput? = null,
     repairEvidence: skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutputRepairEvidence? = null,
     rejectedOutput: String? = null,
+    childNeverLaunched: Boolean = false,
   ): PhaseOutcome {
     val phaseState = FeatureTaskRuntimePhaseStateRequest(
       workflowId = run.request.workflowId,
@@ -3101,6 +3102,9 @@ internal class FeatureTaskRuntimeRunLoop(
       loopId = loopId,
       edgeIteration = edgeIteration,
       reviewPassNumber = reviewPassNumber(run, state),
+      // A launch that never produced a child clears the running write's stamp; every other block
+      // reason happened around a child that did run, so its recorded model carries forward.
+      launchOutcomeKnown = childNeverLaunched,
     )
     state.reserveReviewPass(phaseState.reviewPassNumber)
     recorder.recordPhaseState(
@@ -3149,6 +3153,9 @@ internal class FeatureTaskRuntimeRunLoop(
         fileManifestIntroduced = fileManifest?.introduced.orEmpty(),
         loopId = run.reentry?.loopId,
         edgeIteration = run.reentry?.edgeIteration,
+        // The only pause seam is a provider-limit refusal, so no child ran: clear the running write's
+        // stamp rather than let it report a model the phase never executed.
+        launchOutcomeKnown = true,
       ),
       run.request.dbPathOverride,
     )
@@ -3168,6 +3175,7 @@ internal class FeatureTaskRuntimeRunLoop(
     normalizedOutput: NormalizedFeatureTaskRuntimePhaseOutput? = null,
     repairEvidence: skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutputRepairEvidence? = null,
     rejectedOutput: String? = null,
+    childNeverLaunched: Boolean = false,
   ): PhaseOutcome = blockAndPersist(
     run,
     attemptCount,
@@ -3181,6 +3189,7 @@ internal class FeatureTaskRuntimeRunLoop(
     normalizedOutput = normalizedOutput,
     repairEvidence = repairEvidence,
     rejectedOutput = rejectedOutput,
+    childNeverLaunched = childNeverLaunched,
   )
 
   /**
@@ -3387,7 +3396,17 @@ internal class FeatureTaskRuntimeRunLoop(
     priorCorrection: PriorAttemptCorrection?,
     phaseTokenAccumulator: MutableMap<String, Pair<Int, Int>>? = null,
   ): AttemptResult {
-    persistPhase(run, iteration, STATUS_RUNNING, finished = false, outputArtifact = null)
+    // The running write is what the IDE reads as current_model while the child is in flight, so it
+    // stamps the directive the launch below is rendered from. The two never-launched exits then clear
+    // it: a phase whose child the provider refused, or whose launch failed, ran no model at all.
+    persistPhase(
+      run,
+      iteration,
+      STATUS_RUNNING,
+      finished = false,
+      outputArtifact = null,
+      launched = launchedModelDirective(run),
+    )
     val launch = launchAndCapture(run, state, priorCorrection, phaseTokenAccumulator)
     launch.providerLimitReason?.let { reason ->
       return AttemptResult.settled(pauseAndPersistInPhase(run, iteration, reason, observability, launch.fileManifest))
@@ -3401,6 +3420,7 @@ internal class FeatureTaskRuntimeRunLoop(
           observability,
           failureDisposition = launch.failureDisposition,
           fileManifest = launch.fileManifest,
+          childNeverLaunched = true,
         ),
       )
     }
@@ -4628,8 +4648,10 @@ internal class FeatureTaskRuntimeRunLoop(
     finished: Boolean,
     outputArtifact: String?,
     fileManifest: FeatureTaskRuntimePhaseFileManifest? = null,
+    launched: LaunchedModelDirective? = null,
   ) {
-    val phaseState = phaseStateRequest(run, iteration, status, finished, outputArtifact, fileManifest)
+    val phaseState =
+      phaseStateRequest(run, iteration, status, finished, outputArtifact, fileManifest, launched = launched)
     state.reserveReviewPass(phaseState.reviewPassNumber)
     recorder.recordPhaseState(
       phaseState,
@@ -4647,8 +4669,8 @@ internal class FeatureTaskRuntimeRunLoop(
     normalizedOutput: NormalizedFeatureTaskRuntimePhaseOutput? = null,
     repairEvidence: skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutputRepairEvidence? = null,
     repositoryFingerprint: String? = null,
+    launched: LaunchedModelDirective? = null,
   ): FeatureTaskRuntimePhaseStateRequest {
-    val launched = launchedModelDirective(run)
     return FeatureTaskRuntimePhaseStateRequest(
       workflowId = run.request.workflowId,
       phaseId = run.phaseId,
@@ -4671,8 +4693,9 @@ internal class FeatureTaskRuntimeRunLoop(
       } else {
         emptyList()
       },
-      launchedModel = launched.modelOverride,
-      launchedEffort = launched.persistedEffort,
+      launchedModel = launched?.modelOverride,
+      launchedEffort = launched?.persistedEffort,
+      launchOutcomeKnown = launched != null,
     )
   }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeStatusService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeStatusService.kt
@@ -240,6 +240,8 @@ class FeatureTaskRuntimeStatusService(
       finished = finishedAt != null,
       executionOrigin = executionOrigin.wireValue,
       continuationKind = continuationKind,
+      launchedModel = launchedModel,
+      launchedEffort = launchedEffort,
     )
   }
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
@@ -38,17 +38,24 @@ data class FeatureTaskRuntimePhaseStateRequest(
    */
   val auditScopeCriterionRefs: List<String> = emptyList(),
   /**
-   * The model/effort the phase's child was actually launched with, taken from the same resolved
-   * value the launch argument was rendered from so the record cannot drift from the child.
+   * The model/effort this attempt was launched *from*: the same resolved value the `--model` argument
+   * is rendered from, stamped by the running write before the child is spawned. It is not a
+   * post-spawn observation — a kill in the window before the spawn leaves it on a `running` record
+   * whose child never started, and it holds only as long as every agent adapter forwards
+   * `modelOverride` verbatim. Read it as "what this attempt asked for", which is what answers "which
+   * model is this phase on"; the settling writes are what turn it into a statement about a child
+   * that ran.
    */
   val launchedModel: String? = null,
   val launchedEffort: String? = null,
   /**
    * True when this write knows the phase's launch outcome, making [launchedModel] and
-   * [launchedEffort] authoritative *as a pair* — including their joint absence, for a child that
-   * provably never launched (a provider-limit refusal or a pre-launch infra/seam failure). False
-   * leaves the prior record's pair untouched, so a later block/pause/completion write cannot erase
-   * or half-overwrite it.
+   * [launchedEffort] authoritative *as a pair* — including their joint absence. Two writes set it:
+   * the running write, which stamps the directive the launch argument is rendered from, and the
+   * settling writes for exactly the launch exits where `LaunchResult.childNeverLaunched` holds —
+   * that getter's KDoc owns the set, so consult it rather than restating it here. False leaves the
+   * prior record's pair untouched, so a later block/pause/completion write around a child that did
+   * run cannot erase or half-overwrite it.
    */
   val launchOutcomeKnown: Boolean = false,
 )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
@@ -46,9 +46,9 @@ data class FeatureTaskRuntimePhaseStateRequest(
   /**
    * True when this write knows the phase's launch outcome, making [launchedModel] and
    * [launchedEffort] authoritative *as a pair* — including their joint absence, for a child that
-   * provably never launched (a provider-limit refusal, an infra launch failure, or a settlement
-   * derived from durable state without launching at all). False leaves the prior record's pair
-   * untouched, so a later block/pause/completion write cannot erase or half-overwrite it.
+   * provably never launched (a provider-limit refusal or a pre-launch infra/seam failure). False
+   * leaves the prior record's pair untouched, so a later block/pause/completion write cannot erase
+   * or half-overwrite it.
    */
   val launchOutcomeKnown: Boolean = false,
 )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
@@ -43,6 +43,14 @@ data class FeatureTaskRuntimePhaseStateRequest(
    */
   val launchedModel: String? = null,
   val launchedEffort: String? = null,
+  /**
+   * True when this write knows the phase's launch outcome, making [launchedModel] and
+   * [launchedEffort] authoritative *as a pair* — including their joint absence, for a child that
+   * provably never launched (a provider-limit refusal, an infra launch failure, or a settlement
+   * derived from durable state without launching at all). False leaves the prior record's pair
+   * untouched, so a later block/pause/completion write cannot erase or half-overwrite it.
+   */
+  val launchOutcomeKnown: Boolean = false,
 )
 
 /**

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimePhaseRecordRequest.kt
@@ -37,6 +37,12 @@ data class FeatureTaskRuntimePhaseStateRequest(
    * non-audit phase.
    */
   val auditScopeCriterionRefs: List<String> = emptyList(),
+  /**
+   * The model/effort the phase's child was actually launched with, taken from the same resolved
+   * value the launch argument was rendered from so the record cannot drift from the child.
+   */
+  val launchedModel: String? = null,
+  val launchedEffort: String? = null,
 )
 
 /**

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/FeatureTaskRuntimeStatusModels.kt
@@ -27,6 +27,9 @@ data class FeatureTaskRuntimePhaseStatus(
    * malformed output or carrying partial implementation work forward.
    */
   val continuationKind: String? = null,
+  /** The model/effort the phase's child was launched with; null when the phase ran with no directive. */
+  val launchedModel: String? = null,
+  val launchedEffort: String? = null,
 )
 
 /**

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
@@ -80,6 +80,7 @@ data class IdeStatusCurrentModel(
 ) {
   init {
     require(model.isNotBlank()) { "currentModel.model must not be blank." }
+    effort?.let { require(it.isNotBlank()) { "currentModel.effort must not be blank when present." } }
   }
 }
 
@@ -206,15 +207,7 @@ data class IdeStatusSnapshot(
         },
       )
     }
-    currentModel?.let { model ->
-      put(
-        "current_model",
-        buildMap {
-          put("model", model.model)
-          model.effort?.takeIf(String::isNotBlank)?.let { put("effort", it) }
-        },
-      )
-    }
+    putCurrentModel()
     planning?.let { put("planning", planningWireMap(it)) }
     pauseRequested?.takeIf { it }?.let { put("pause_requested", true) }
     pausedAt?.let { put("paused_at", it.toString()) }
@@ -232,6 +225,21 @@ data class IdeStatusSnapshot(
         },
       )
     }
+  }
+
+  /**
+   * Omitted entirely when the current phase recorded no model, so a snapshot without it stays
+   * wire-identical. `effort` needs no blank guard here: [IdeStatusCurrentModel] rejects a blank one.
+   */
+  private fun MutableMap<String, Any?>.putCurrentModel() {
+    val model = currentModel ?: return
+    put(
+      "current_model",
+      buildMap {
+        put("model", model.model)
+        model.effort?.let { put("effort", it) }
+      },
+    )
   }
 
   /** Both keys are optional and goal-family-only, so a snapshot without them stays wire-identical. */

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
@@ -77,10 +77,16 @@ data class IdeStatusCurrentSubtask(
 data class IdeStatusCurrentModel(
   val model: String,
   val effort: String? = null,
+  /**
+   * The phase the model belongs to. A goal's `current_step` is a goal-level label — often
+   * `planning` — so without this the payload names a model whose phase appears nowhere in it.
+   */
+  val phaseId: String? = null,
 ) {
   init {
     require(model.isNotBlank()) { "currentModel.model must not be blank." }
     effort?.let { require(it.isNotBlank()) { "currentModel.effort must not be blank when present." } }
+    phaseId?.let { require(it.isNotBlank()) { "currentModel.phaseId must not be blank when present." } }
   }
 }
 
@@ -238,6 +244,7 @@ data class IdeStatusSnapshot(
       buildMap {
         put("model", model.model)
         model.effort?.let { put("effort", it) }
+        model.phaseId?.let { put("phase_id", it) }
       },
     )
   }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/model/IdeStatusModels.kt
@@ -70,6 +70,19 @@ data class IdeStatusCurrentSubtask(
   val startedAt: Instant? = null,
 )
 
+/**
+ * The model the current phase's child was launched with. [effort] is null when the model string
+ * already carries it (Cursor's merged `model[effort=…]`) or when no effort was resolved.
+ */
+data class IdeStatusCurrentModel(
+  val model: String,
+  val effort: String? = null,
+) {
+  init {
+    require(model.isNotBlank()) { "currentModel.model must not be blank." }
+  }
+}
+
 /** Goal planning progress mirrored from [skillbill.goalrunner.model.GoalPlanningStatusSnapshot]. */
 data class IdeStatusPlanning(
   val state: GoalPlanningStatusState,
@@ -136,6 +149,9 @@ data class IdeStatusSnapshot(
   val progress: IdeStatusProgress? = null,
   val startedAt: Instant? = null,
   val currentSubtask: IdeStatusCurrentSubtask? = null,
+  // Null default: optional context, so a snapshot whose current phase has no recorded model
+  // stays wire-identical.
+  val currentModel: IdeStatusCurrentModel? = null,
   // Null default: only projectGoal populates planning, so every other family stays wire-identical.
   val planning: IdeStatusPlanning? = null,
   // Null defaults: only projectGoal populates the pause signals, so every other family stays
@@ -187,6 +203,15 @@ data class IdeStatusSnapshot(
         buildMap {
           put("id", subtask.id)
           subtask.startedAt?.let { put("started_at", it.toString()) }
+        },
+      )
+    }
+    currentModel?.let { model ->
+      put(
+        "current_model",
+        buildMap {
+          put("model", model.model)
+          model.effort?.takeIf(String::isNotBlank)?.let { put("effort", it) }
         },
       )
     }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
@@ -199,18 +199,20 @@ class IdeStatusProjector(
   /**
    * The launched model of the goal's currently running child phase. The goal's own currentStep can
    * be a planning label rather than a phase id, so the child's own projection resolves the phase.
-   * Optional context must never cost a status reading: any resolution failure omits the field.
+   *
+   * The child status read is deliberately unwrapped, like the sibling goal-status read and the
+   * runtime-family read in [projectRuntime]: a quarantine-worthy child phase record surfaces as one
+   * `schema_incompatible` record through [IdeStatusService], not as a silently absent model
+   * indistinguishable from "no model was recorded".
    */
   private fun childCurrentModel(
     childWorkflowId: String?,
     context: IdeStatusProjectionContext,
   ): IdeStatusCurrentModel? {
     val workflowId = childWorkflowId?.takeIf(String::isNotBlank) ?: return null
-    val status = runCatching {
-      featureTaskRuntimeStatusService.status(
-        FeatureTaskRuntimeStatusRequest(workflowId = workflowId, dbPathOverride = context.dbOverride),
-      )
-    }.getOrNull() ?: return null
+    val status = featureTaskRuntimeStatusService.status(
+      FeatureTaskRuntimeStatusRequest(workflowId = workflowId, dbPathOverride = context.dbOverride),
+    ) ?: return null
     val currentPhaseId = status.currentPhaseId ?: return null
     return status.phases.firstOrNull { it.phaseId == currentPhaseId }?.toIdeStatusCurrentModel()
   }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
@@ -16,14 +16,19 @@ import skillbill.application.model.IdeStatusSnapshot
 import skillbill.application.model.IdeStatusStep
 import skillbill.application.model.IdeStatusWorkflowFamily
 import skillbill.application.workflow.WorkflowFamily
+import skillbill.error.ShellContentContractException
 import skillbill.goalrunner.model.ExecutionLiveness
 import skillbill.goalrunner.model.GoalPlanningStatusSnapshot
 import skillbill.goalrunner.model.GoalPlanningStatusState
 import skillbill.goalrunner.model.GoalRunnerStatusProjection
+import skillbill.ports.diagnostics.NoopRuntimeDiagnostics
+import skillbill.ports.diagnostics.RuntimeDiagnostics
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.persistence.model.WorkItemKind
 import skillbill.workflow.WorkflowEngine
 import skillbill.workflow.WorkflowSnapshotValidator
+import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PHASE_STATUS_COMPLETED
+import java.io.IOException
 import java.nio.file.Path
 import java.time.Instant
 import java.time.LocalDateTime
@@ -50,6 +55,7 @@ class IdeStatusProjector(
   workflowSnapshotValidator: WorkflowSnapshotValidator,
   private val goalRunnerStatusService: GoalRunnerStatusService,
   private val featureTaskRuntimeStatusService: FeatureTaskRuntimeStatusService,
+  private val diagnostics: RuntimeDiagnostics = NoopRuntimeDiagnostics,
 ) {
   private val workflowEngine = WorkflowEngine(workflowSnapshotValidator)
 
@@ -110,7 +116,7 @@ class IdeStatusProjector(
       progress = progress,
       startedAt = candidate.startedAt,
       currentSubtask = currentSubtask,
-      currentModel = childCurrentModel(projection?.currentChildWorkflowId, context),
+      currentModel = childCurrentModel(projection?.currentChildWorkflowId, lifecycle, context),
       planning = planning,
       pauseRequested = projection?.pauseRequested == true && projection.paused != true,
       // Durable record only: a lease-expiry-inferred pause has no recorded instant, and
@@ -198,25 +204,52 @@ class IdeStatusProjector(
 
   /**
    * The launched model of the goal's currently running child phase. The goal's own currentStep can
-   * be a planning label rather than a phase id, so the child's own projection resolves the phase.
+   * be a planning label rather than a phase id, so the child's own projection resolves the phase —
+   * which is why the emitted object carries that phase id: without it a consumer seeing
+   * `current_step: planning` has no way to learn which phase the model belongs to.
    *
    * Optional context must never cost a status reading: this is a nested read of a *different*
    * workflow's rows, so letting its failure escape would downgrade the whole goal snapshot to a
    * single `schema_incompatible` record through [IdeStatusService] — losing lifecycle, progress and
-   * pause state over an optional field. Any resolution failure omits the field instead.
+   * pause state over an optional field. The catch is bounded to the two failure modes that mean
+   * "this child's rows cannot be read" — a typed durable-record contract failure and an IO failure.
+   * A programming defect, an [Error] and a cancellation all still propagate rather than being
+   * reported as a healthy snapshot, and each degradation emits a diagnostic naming the child, so a
+   * systematically unreadable child is visible instead of silently model-less forever.
+   *
+   * A terminal goal returns before the read, for the same reason [goalStep] replaces a leftover step
+   * string with "Complete": a finished goal can still hold a non-completed child phase record, and
+   * reporting its model would show a live-looking model for work that is not running. A blocked or
+   * failed goal keeps it — "which model was running when it stopped" is the diagnostic there. That
+   * early return also skips the child's full status projection where it would buy nothing.
+   *
+   * The read deliberately sits outside [IdeStatusProjectionContext.unitOfWork]: the goal projection
+   * this builds on already reads outside it, so threading only this one read through would not make
+   * the snapshot atomic.
    */
   private fun childCurrentModel(
     childWorkflowId: String?,
+    lifecycle: IdeStatusLifecycleState,
     context: IdeStatusProjectionContext,
   ): IdeStatusCurrentModel? {
+    if (lifecycle == IdeStatusLifecycleState.TERMINAL) return null
     val workflowId = childWorkflowId?.takeIf(String::isNotBlank) ?: return null
-    val status = runCatching {
+    val degraded = "IDE status omitted current_model for child workflow '$workflowId': " +
+      "the child's durable status could not be read."
+    val status = try {
       featureTaskRuntimeStatusService.status(
         FeatureTaskRuntimeStatusRequest(workflowId = workflowId, dbPathOverride = context.dbOverride),
       )
-    }.getOrNull() ?: return null
-    val currentPhaseId = status.currentPhaseId ?: return null
-    return status.phases.firstOrNull { it.phaseId == currentPhaseId }?.toIdeStatusCurrentModel()
+    } catch (error: ShellContentContractException) {
+      diagnostics.warning(degraded, error)
+      null
+    } catch (error: IOException) {
+      diagnostics.warning(degraded, error)
+      null
+    }
+    return status?.currentPhaseId?.let { phaseId ->
+      status.phases.firstOrNull { it.phaseId == phaseId }?.toIdeStatusCurrentModel()
+    }
   }
 
   private fun projectRuntime(candidate: IdeStatusCandidate, context: IdeStatusProjectionContext): IdeStatusSnapshot {
@@ -330,10 +363,21 @@ private fun goalStep(
   }
 }
 
-private fun FeatureTaskRuntimePhaseStatus.toIdeStatusCurrentModel(): IdeStatusCurrentModel? =
-  launchedModel?.takeIf(String::isNotBlank)?.let { model ->
-    IdeStatusCurrentModel(model = model, effort = launchedEffort?.takeIf(String::isNotBlank))
+/**
+ * A completed phase's model is history, not the model in force, so it is never projected as current.
+ * A paused or blocked phase keeps it: "which model hit the usage limit" and "which model was running
+ * when it blocked" are the questions an operator asks at exactly those states.
+ */
+private fun FeatureTaskRuntimePhaseStatus.toIdeStatusCurrentModel(): IdeStatusCurrentModel? {
+  if (status == FEATURE_TASK_RUNTIME_PHASE_STATUS_COMPLETED) return null
+  return launchedModel?.takeIf(String::isNotBlank)?.let { model ->
+    IdeStatusCurrentModel(
+      model = model,
+      effort = launchedEffort?.takeIf(String::isNotBlank),
+      phaseId = phaseId.takeIf(String::isNotBlank),
+    )
   }
+}
 
 private fun GoalPlanningStatusSnapshot.toIdeStatusPlanning(): IdeStatusPlanning = IdeStatusPlanning(
   state = state,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
@@ -3,9 +3,11 @@ package skillbill.application.work
 import me.tatarka.inject.annotations.Inject
 import skillbill.application.featuretask.FeatureTaskRuntimeStatusService
 import skillbill.application.goalrunner.GoalRunnerStatusService
+import skillbill.application.model.FeatureTaskRuntimePhaseStatus
 import skillbill.application.model.FeatureTaskRuntimeStatusRequest
 import skillbill.application.model.GoalRunnerStatusRequest
 import skillbill.application.model.IdeStatusCandidate
+import skillbill.application.model.IdeStatusCurrentModel
 import skillbill.application.model.IdeStatusCurrentSubtask
 import skillbill.application.model.IdeStatusLifecycleState
 import skillbill.application.model.IdeStatusPlanning
@@ -108,6 +110,7 @@ class IdeStatusProjector(
       progress = progress,
       startedAt = candidate.startedAt,
       currentSubtask = currentSubtask,
+      currentModel = childCurrentModel(projection?.currentChildWorkflowId, context),
       planning = planning,
       pauseRequested = projection?.pauseRequested == true && projection.paused != true,
       // Durable record only: a lease-expiry-inferred pause has no recorded instant, and
@@ -193,6 +196,25 @@ class IdeStatusProjector(
     return parseInstantOrNull(snapshot?.startedAt)
   }
 
+  /**
+   * The launched model of the goal's currently running child phase. The goal's own currentStep can
+   * be a planning label rather than a phase id, so the child's own projection resolves the phase.
+   * Optional context must never cost a status reading: any resolution failure omits the field.
+   */
+  private fun childCurrentModel(
+    childWorkflowId: String?,
+    context: IdeStatusProjectionContext,
+  ): IdeStatusCurrentModel? {
+    val workflowId = childWorkflowId?.takeIf(String::isNotBlank) ?: return null
+    val status = runCatching {
+      featureTaskRuntimeStatusService.status(
+        FeatureTaskRuntimeStatusRequest(workflowId = workflowId, dbPathOverride = context.dbOverride),
+      )
+    }.getOrNull() ?: return null
+    val currentPhaseId = status.currentPhaseId ?: return null
+    return status.phases.firstOrNull { it.phaseId == currentPhaseId }?.toIdeStatusCurrentModel()
+  }
+
   private fun projectRuntime(candidate: IdeStatusCandidate, context: IdeStatusProjectionContext): IdeStatusSnapshot {
     val snapshot = WorkflowFamily.TASK_RUNTIME.get(context.unitOfWork.workflowStates, candidate.workflowId)
       ?: return incompatible(candidate, context, "Runtime workflow snapshot is missing.")
@@ -224,6 +246,9 @@ class IdeStatusProjector(
       currentStep = IdeStatusStep(id = stepId, label = stepLabel),
       progress = progress,
       startedAt = startedAt,
+      // Reuses the already-loaded projection: the model reported must belong to the phase reported
+      // as current_step, never to a neighbouring one.
+      currentModel = status?.phases?.firstOrNull { it.phaseId == stepId }?.toIdeStatusCurrentModel(),
       updatedAt = updatedAt,
       freshness = IdeStatusFreshnessClassifier.classify(updatedAt, context.observedAt),
       summary = familySummary(
@@ -300,6 +325,11 @@ private fun goalStep(
     IdeStatusStep(id = "goal", label = "Goal")
   }
 }
+
+private fun FeatureTaskRuntimePhaseStatus.toIdeStatusCurrentModel(): IdeStatusCurrentModel? =
+  launchedModel?.takeIf(String::isNotBlank)?.let { model ->
+    IdeStatusCurrentModel(model = model, effort = launchedEffort?.takeIf(String::isNotBlank))
+  }
 
 private fun GoalPlanningStatusSnapshot.toIdeStatusPlanning(): IdeStatusPlanning = IdeStatusPlanning(
   state = state,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/work/IdeStatusProjector.kt
@@ -200,19 +200,21 @@ class IdeStatusProjector(
    * The launched model of the goal's currently running child phase. The goal's own currentStep can
    * be a planning label rather than a phase id, so the child's own projection resolves the phase.
    *
-   * The child status read is deliberately unwrapped, like the sibling goal-status read and the
-   * runtime-family read in [projectRuntime]: a quarantine-worthy child phase record surfaces as one
-   * `schema_incompatible` record through [IdeStatusService], not as a silently absent model
-   * indistinguishable from "no model was recorded".
+   * Optional context must never cost a status reading: this is a nested read of a *different*
+   * workflow's rows, so letting its failure escape would downgrade the whole goal snapshot to a
+   * single `schema_incompatible` record through [IdeStatusService] — losing lifecycle, progress and
+   * pause state over an optional field. Any resolution failure omits the field instead.
    */
   private fun childCurrentModel(
     childWorkflowId: String?,
     context: IdeStatusProjectionContext,
   ): IdeStatusCurrentModel? {
     val workflowId = childWorkflowId?.takeIf(String::isNotBlank) ?: return null
-    val status = featureTaskRuntimeStatusService.status(
-      FeatureTaskRuntimeStatusRequest(workflowId = workflowId, dbPathOverride = context.dbOverride),
-    ) ?: return null
+    val status = runCatching {
+      featureTaskRuntimeStatusService.status(
+        FeatureTaskRuntimeStatusRequest(workflowId = workflowId, dbPathOverride = context.dbOverride),
+      )
+    }.getOrNull() ?: return null
     val currentPhaseId = status.currentPhaseId ?: return null
     return status.phases.firstOrNull { it.phaseId == currentPhaseId }?.toIdeStatusCurrentModel()
   }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
@@ -104,6 +104,41 @@ class FeatureTaskRuntimeModelDirectiveRunnerTest {
   }
 
   @Test
+  fun `the persisted launched model is the merged string cursor was actually launched with`() {
+    val harness = runnerHarness(agentAssignment = FeatureTaskRuntimeAgentAssignment(override = "cursor"))
+    val matrix = ExecutionMatrix(
+      agents = mapOf(
+        InstallAgent.CURSOR to mapOf(
+          ExecutionTier.REASONING to PhaseModelDirective("claude-opus-4-8", "high"),
+        ),
+      ),
+    )
+
+    assertIs<FeatureTaskRuntimeRunReport.Completed>(
+      harness.runner.run(harness.request().copy(modelAssignment = FeatureTaskRuntimeModelAssignment(matrix = matrix))),
+    )
+
+    val plan = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("plan")
+    // Not the pre-merge directive model: a recomputed merge would record a value the child never saw.
+    assertEquals(harness.requestForPhase("plan").skillRunRequest.modelOverride, plan.launchedModel)
+    assertEquals("claude-opus-4-8[effort=high]", plan.launchedModel)
+    // The merged model already carries the effort; persisting it twice would let the two drift.
+    assertEquals(null, plan.launchedEffort)
+  }
+
+  @Test
+  fun `a phase with no resolved directive persists neither launched field`() {
+    val harness = runnerHarness()
+
+    assertIs<FeatureTaskRuntimeRunReport.Completed>(harness.runner.run(harness.request()))
+
+    val plan = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("plan")
+    assertEquals(null, plan.launchedModel)
+    assertEquals(null, plan.launchedEffort)
+    assertTrue("launched_model" !in plan.toArtifactMap())
+  }
+
+  @Test
   fun `cursor invoked-agent route selects cursor adapter`() {
     val harness = runnerHarness(agentAssignment = FeatureTaskRuntimeAgentAssignment(override = "cursor"))
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
@@ -8,6 +8,7 @@ import skillbill.config.model.ExecutionMatrix
 import skillbill.config.model.ExecutionTier
 import skillbill.config.model.PhaseModelDirective
 import skillbill.install.model.InstallAgent
+import skillbill.ports.agentrun.model.AgentRunLaunchFacts
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -136,6 +137,43 @@ class FeatureTaskRuntimeModelDirectiveRunnerTest {
     assertEquals(null, plan.launchedModel)
     assertEquals(null, plan.launchedEffort)
     assertTrue("launched_model" !in plan.toArtifactMap())
+  }
+
+  @Test
+  fun `a phase blocked after its child ran keeps the model the child was launched with`() {
+    val harness = runnerHarness(
+      launcher = RuntimeRecordingLauncher {
+        AgentRunLaunchFacts(
+          agent = InstallAgent.CLAUDE,
+          exitStatus = 1,
+          stdout = "",
+          stderr = "boom",
+          timedOut = false,
+          spawnFailed = false,
+        )
+      },
+      agentAssignment = FeatureTaskRuntimeAgentAssignment(override = "claude"),
+    )
+    val matrix = ExecutionMatrix(
+      agents = mapOf(
+        InstallAgent.CLAUDE to mapOf(
+          ExecutionTier.REASONING to PhaseModelDirective("claude-opus", "high"),
+          ExecutionTier.IMPLEMENTATION to PhaseModelDirective("claude-sonnet", "medium"),
+        ),
+      ),
+    )
+
+    val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(
+      harness.runner.run(harness.request().copy(modelAssignment = FeatureTaskRuntimeModelAssignment(matrix = matrix))),
+    )
+
+    // A non-zero exit is a child that provably launched and ran, so the blocked record must still
+    // answer "which model ran?" rather than clearing the running write's stamp.
+    assertEquals("preplan", blocked.lastIncompletePhase)
+    val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("preplan")
+    assertEquals(harness.launcher.requests.last().skillRunRequest.modelOverride, record.launchedModel)
+    assertEquals("claude-sonnet", record.launchedModel)
+    assertEquals("medium", record.launchedEffort)
   }
 
   @Test

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeModelDirectiveRunnerTest.kt
@@ -136,7 +136,42 @@ class FeatureTaskRuntimeModelDirectiveRunnerTest {
     val plan = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("plan")
     assertEquals(null, plan.launchedModel)
     assertEquals(null, plan.launchedEffort)
-    assertTrue("launched_model" !in plan.toArtifactMap())
+  }
+
+  @Test
+  fun `a phase whose child never spawned clears the running write's model`() {
+    val harness = runnerHarness(
+      launcher = RuntimeRecordingLauncher {
+        AgentRunLaunchFacts(
+          agent = InstallAgent.CLAUDE,
+          exitStatus = null,
+          stdout = "",
+          stderr = "Error: the agent executable could not be spawned",
+          timedOut = false,
+          spawnFailed = true,
+        )
+      },
+      agentAssignment = FeatureTaskRuntimeAgentAssignment(override = "claude"),
+    )
+    val matrix = ExecutionMatrix(
+      agents = mapOf(
+        InstallAgent.CLAUDE to mapOf(
+          ExecutionTier.IMPLEMENTATION to PhaseModelDirective("claude-sonnet", "medium"),
+        ),
+      ),
+    )
+
+    val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(
+      harness.runner.run(harness.request().copy(modelAssignment = FeatureTaskRuntimeModelAssignment(matrix = matrix))),
+    )
+
+    // The clearing branch of childNeverLaunched, driven through the run loop that computes it rather
+    // than by poking the recorder. Hard-wiring it to false would leave this record reporting which
+    // model "ran" for a process that never started, with the rest of the suite green.
+    assertEquals("preplan", blocked.lastIncompletePhase)
+    val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("preplan")
+    assertEquals(null, record.launchedModel)
+    assertEquals(null, record.launchedEffort)
   }
 
   @Test
@@ -172,6 +207,42 @@ class FeatureTaskRuntimeModelDirectiveRunnerTest {
     assertEquals("preplan", blocked.lastIncompletePhase)
     val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("preplan")
     assertEquals(harness.launcher.requests.last().skillRunRequest.modelOverride, record.launchedModel)
+    assertEquals("claude-sonnet", record.launchedModel)
+    assertEquals("medium", record.launchedEffort)
+  }
+
+  @Test
+  fun `a phase paused at a provider usage limit keeps the model the child was launched with`() {
+    val harness = runnerHarness(
+      launcher = RuntimeRecordingLauncher {
+        AgentRunLaunchFacts(
+          agent = InstallAgent.CLAUDE,
+          exitStatus = 1,
+          stdout = "",
+          stderr = "You've hit your session limit · resets 3:40am (Europe/Berlin)",
+          timedOut = false,
+          spawnFailed = false,
+        )
+      },
+      agentAssignment = FeatureTaskRuntimeAgentAssignment(override = "claude"),
+    )
+    val matrix = ExecutionMatrix(
+      agents = mapOf(
+        InstallAgent.CLAUDE to mapOf(
+          ExecutionTier.IMPLEMENTATION to PhaseModelDirective("claude-sonnet", "medium"),
+        ),
+      ),
+    )
+
+    val paused = assertIs<FeatureTaskRuntimeRunReport.Paused>(
+      harness.runner.run(harness.request().copy(modelAssignment = FeatureTaskRuntimeModelAssignment(matrix = matrix))),
+    )
+
+    // "Which model hit the usage limit" is the operative diagnostic on a limit pause, so the pause
+    // write must leave the running write's stamp alone instead of settling it as never-launched.
+    assertEquals("preplan", paused.pausedPhase)
+    val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("preplan")
+    assertEquals("paused", record.status)
     assertEquals("claude-sonnet", record.launchedModel)
     assertEquals("medium", record.launchedEffort)
   }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
@@ -101,9 +101,7 @@ class FeatureTaskRuntimeStatusServiceTest {
     val records = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID))
     assertEquals("claude-opus-4-8[effort=high]", records.getValue("implement").launchedModel)
     assertNull(records.getValue("implement").launchedEffort)
-    // A phase recorded with no directive stays wire-identical to the pre-change shape.
     assertNull(records.getValue("plan").launchedModel)
-    assertTrue("launched_model" !in records.getValue("plan").toArtifactMap())
 
     val projection = requireNotNull(
       harness.service.status(FeatureTaskRuntimeStatusRequest(workflowId = WORKFLOW_ID)),
@@ -185,6 +183,50 @@ class FeatureTaskRuntimeStatusServiceTest {
     assertNull(record.launchedModel)
     assertNull(record.launchedEffort)
     assertTrue("launched_model" !in record.toArtifactMap())
+  }
+
+  @Test
+  fun `a settle that advances the attempt or swaps the agent does not inherit the prior launch pair`() {
+    // Two pre-launch seams that never call the launcher: a cap-exhaustion block writes the *next*
+    // attempt, and a branch-setup block writes under a non-agent id. Both leave launchOutcomeKnown
+    // false, so without the identity gate they inherit the prior attempt's pair and the record — and
+    // the IDE popup reading it — asserts a model that attempt provably never launched.
+    listOf(
+      "advanced attempt" to Pair(2, "claude"),
+      "swapped agent" to Pair(1, "branch-setup"),
+    ).forEach { (case, identity) ->
+      val (attemptCount, agentId) = identity
+      val harness = statusHarness()
+      harness.recorder.ensureWorkflowOpen(WORKFLOW_ID, SESSION_ID)
+      harness.recorder.recordPhaseState(
+        FeatureTaskRuntimePhaseStateRequest(
+          workflowId = WORKFLOW_ID,
+          phaseId = "implement",
+          status = "running",
+          attemptCount = 1,
+          resolvedAgentId = "claude",
+          finished = false,
+          launchedModel = "claude-opus-4-8",
+          launchedEffort = "high",
+          launchOutcomeKnown = true,
+        ),
+      )
+      harness.recorder.recordPhaseState(
+        FeatureTaskRuntimePhaseStateRequest(
+          workflowId = WORKFLOW_ID,
+          phaseId = "implement",
+          status = "blocked",
+          attemptCount = attemptCount,
+          resolvedAgentId = agentId,
+          finished = false,
+          blockedReason = "settled before any launch",
+        ),
+      )
+
+      val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("implement")
+      assertNull(record.launchedModel, "$case must not inherit the model")
+      assertNull(record.launchedEffort, "$case must not inherit the effort")
+    }
   }
 
   @Test

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
@@ -37,6 +37,7 @@ import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * F-001 / F-008: unit coverage for [FeatureTaskRuntimeStatusService]'s projection
@@ -77,6 +78,39 @@ class FeatureTaskRuntimeStatusServiceTest {
     assertEquals(0, projection.blockedCount)
     assertEquals("preplan", projection.currentPhaseId)
     assertEquals(List(10) { "pending" }, projection.phases.map { it.status })
+  }
+
+  @Test
+  fun `the launched model rides the advancing phase write and reaches the phase status`() {
+    val harness = statusHarness()
+    harness.recorder.ensureWorkflowOpen(WORKFLOW_ID, SESSION_ID)
+    harness.recorder.recordPhaseState(
+      FeatureTaskRuntimePhaseStateRequest(
+        workflowId = WORKFLOW_ID,
+        phaseId = "implement",
+        status = "running",
+        attemptCount = 1,
+        resolvedAgentId = "cursor",
+        finished = false,
+        launchedModel = "claude-opus-4-8[effort=high]",
+      ),
+    )
+    harness.recordRunning("plan", attemptCount = 1)
+
+    val records = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID))
+    assertEquals("claude-opus-4-8[effort=high]", records.getValue("implement").launchedModel)
+    assertNull(records.getValue("implement").launchedEffort)
+    // A phase recorded with no directive stays wire-identical to the pre-change shape.
+    assertNull(records.getValue("plan").launchedModel)
+    assertTrue("launched_model" !in records.getValue("plan").toArtifactMap())
+
+    val projection = requireNotNull(
+      harness.service.status(FeatureTaskRuntimeStatusRequest(workflowId = WORKFLOW_ID)),
+    )
+    assertEquals(
+      "claude-opus-4-8[effort=high]",
+      projection.phases.single { it.phaseId == "implement" }.launchedModel,
+    )
   }
 
   @Test

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
@@ -93,6 +93,7 @@ class FeatureTaskRuntimeStatusServiceTest {
         resolvedAgentId = "cursor",
         finished = false,
         launchedModel = "claude-opus-4-8[effort=high]",
+        launchOutcomeKnown = true,
       ),
     )
     harness.recordRunning("plan", attemptCount = 1)
@@ -126,6 +127,7 @@ class FeatureTaskRuntimeStatusServiceTest {
         resolvedAgentId = "cursor",
         finished = false,
         launchedModel = "claude-opus-4-8[effort=high]",
+        launchOutcomeKnown = true,
       ),
     )
     harness.recorder.recordPhaseState(
@@ -147,6 +149,77 @@ class FeatureTaskRuntimeStatusServiceTest {
       requireNotNull(harness.service.status(FeatureTaskRuntimeStatusRequest(workflowId = WORKFLOW_ID)))
         .phases.single { it.phaseId == "implement" }.launchedModel,
     )
+  }
+
+  @Test
+  fun `a settle write that knows no child launched clears the running write's model`() {
+    val harness = statusHarness()
+    harness.recorder.ensureWorkflowOpen(WORKFLOW_ID, SESSION_ID)
+    harness.recorder.recordPhaseState(
+      FeatureTaskRuntimePhaseStateRequest(
+        workflowId = WORKFLOW_ID,
+        phaseId = "implement",
+        status = "running",
+        attemptCount = 1,
+        resolvedAgentId = "claude",
+        finished = false,
+        launchedModel = "claude-opus-4-8",
+        launchedEffort = "high",
+        launchOutcomeKnown = true,
+      ),
+    )
+    harness.recorder.recordPhaseState(
+      FeatureTaskRuntimePhaseStateRequest(
+        workflowId = WORKFLOW_ID,
+        phaseId = "implement",
+        status = "paused",
+        attemptCount = 1,
+        resolvedAgentId = "claude",
+        finished = false,
+        blockedReason = "provider usage limit refused the launch",
+        launchOutcomeKnown = true,
+      ),
+    )
+
+    val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("implement")
+    assertNull(record.launchedModel)
+    assertNull(record.launchedEffort)
+    assertTrue("launched_model" !in record.toArtifactMap())
+  }
+
+  @Test
+  fun `a Cursor-merged write replaces the launch pair instead of retaining the prior effort`() {
+    val harness = statusHarness()
+    harness.recorder.ensureWorkflowOpen(WORKFLOW_ID, SESSION_ID)
+    harness.recorder.recordPhaseState(
+      FeatureTaskRuntimePhaseStateRequest(
+        workflowId = WORKFLOW_ID,
+        phaseId = "implement",
+        status = "running",
+        attemptCount = 1,
+        resolvedAgentId = "claude",
+        finished = false,
+        launchedModel = "claude-opus-4-8",
+        launchedEffort = "medium",
+        launchOutcomeKnown = true,
+      ),
+    )
+    harness.recorder.recordPhaseState(
+      FeatureTaskRuntimePhaseStateRequest(
+        workflowId = WORKFLOW_ID,
+        phaseId = "implement",
+        status = "running",
+        attemptCount = 2,
+        resolvedAgentId = "cursor",
+        finished = false,
+        launchedModel = "claude-opus-4-8[effort=high]",
+        launchOutcomeKnown = true,
+      ),
+    )
+
+    val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID)).getValue("implement")
+    assertEquals("claude-opus-4-8[effort=high]", record.launchedModel)
+    assertNull(record.launchedEffort)
   }
 
   @Test

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
@@ -114,6 +114,42 @@ class FeatureTaskRuntimeStatusServiceTest {
   }
 
   @Test
+  fun `a later block write keeps the launched model the phase actually ran with`() {
+    val harness = statusHarness()
+    harness.recorder.ensureWorkflowOpen(WORKFLOW_ID, SESSION_ID)
+    harness.recorder.recordPhaseState(
+      FeatureTaskRuntimePhaseStateRequest(
+        workflowId = WORKFLOW_ID,
+        phaseId = "implement",
+        status = "running",
+        attemptCount = 1,
+        resolvedAgentId = "cursor",
+        finished = false,
+        launchedModel = "claude-opus-4-8[effort=high]",
+      ),
+    )
+    harness.recorder.recordPhaseState(
+      FeatureTaskRuntimePhaseStateRequest(
+        workflowId = WORKFLOW_ID,
+        phaseId = "implement",
+        status = "blocked",
+        attemptCount = 1,
+        resolvedAgentId = "cursor",
+        finished = true,
+        blockedReason = "operator review",
+      ),
+    )
+
+    val records = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID))
+    assertEquals("claude-opus-4-8[effort=high]", records.getValue("implement").launchedModel)
+    assertEquals(
+      "claude-opus-4-8[effort=high]",
+      requireNotNull(harness.service.status(FeatureTaskRuntimeStatusRequest(workflowId = WORKFLOW_ID)))
+        .phases.single { it.phaseId == "implement" }.launchedModel,
+    )
+  }
+
+  @Test
   fun `phase whose latest ledger entry is blocked is reported blocked and current`() {
     val harness = statusHarness()
     harness.recorder.ensureWorkflowOpen(WORKFLOW_ID, SESSION_ID)

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeStatusServiceTest.kt
@@ -172,11 +172,11 @@ class FeatureTaskRuntimeStatusServiceTest {
       FeatureTaskRuntimePhaseStateRequest(
         workflowId = WORKFLOW_ID,
         phaseId = "implement",
-        status = "paused",
+        status = "blocked",
         attemptCount = 1,
         resolvedAgentId = "claude",
         finished = false,
-        blockedReason = "provider usage limit refused the launch",
+        blockedReason = "the agent process could not be spawned",
         launchOutcomeKnown = true,
       ),
     )

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/model/IdeStatusModelsTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/model/IdeStatusModelsTest.kt
@@ -104,6 +104,31 @@ class IdeStatusModelsTest {
     assertTrue(keys.indexOf("paused_at") < keys.indexOf("updated_at"))
   }
 
+  @Test
+  fun `toStatusWireMap emits current_model as a nested object and omits effort when unset`() {
+    val withEffort = snapshot(planning = null)
+      .copy(currentModel = IdeStatusCurrentModel(model = "claude-opus-4-8", effort = "high"))
+      .toStatusWireMap()
+    val withoutEffort = snapshot(planning = null)
+      .copy(currentModel = IdeStatusCurrentModel(model = "claude-opus-4-8[effort=high]"))
+      .toStatusWireMap()
+
+    assertEquals(
+      linkedMapOf("model" to "claude-opus-4-8", "effort" to "high"),
+      withEffort["current_model"],
+    )
+    // Never a null effort value: the schema pins effort as a non-empty string when present.
+    assertEquals(linkedMapOf("model" to "claude-opus-4-8[effort=high]"), withoutEffort["current_model"])
+  }
+
+  @Test
+  fun `toStatusWireMap omits the current_model key entirely when no model is recorded`() {
+    val wire = snapshot(planning = null).toStatusWireMap()
+
+    // A present-but-empty object would fail the schema's required model; assert true absence.
+    assertFalse(wire.containsKey("current_model"))
+  }
+
   private fun snapshot(planning: IdeStatusPlanning?): IdeStatusSnapshot = IdeStatusSnapshot(
     repositoryIdentity = "repo-root-realpath-v1:/repo",
     issueKey = "SKILL-165",

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
@@ -62,6 +62,7 @@ import skillbill.workflow.model.DecompositionManifest
 import skillbill.workflow.model.DecompositionSubtask
 import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
 import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY
+import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_RUN_INVARIANTS_ARTIFACT_KEY
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseRecord
 import skillbill.workflow.verify.FeatureVerifyWorkflowDefinition
 import java.nio.file.Files
@@ -72,6 +73,7 @@ import java.time.ZoneOffset
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 /**
@@ -323,7 +325,78 @@ class IdeStatusServiceTest {
 
     assertEquals("claude-opus-4-8[effort=high]", withChild.snapshot.currentModel?.model)
     assertNull(withChild.snapshot.currentModel?.effort)
+    // The goal's current_step is a goal-level label, so the phase id is the only thing in the
+    // payload that says which phase the model belongs to.
+    assertEquals("implement", withChild.snapshot.currentModel?.phaseId)
+    // Anchored so the null is attributable to the absent child id rather than to a snapshot that
+    // carries no goal projection at all — the guard could be deleted and this would still hold.
+    assertEquals("goal-1", withoutChild.snapshot.workflowId)
+    assertEquals(IdeStatusWorkflowFamily.FEATURE_GOAL, withoutChild.snapshot.workflowFamily)
     assertNull(withoutChild.snapshot.currentModel)
+  }
+
+  @Test
+  fun `a finished run reports no current_model for the completed phase its step falls back to`() {
+    val fixture = gitRepoFixture("ide-status-current-model-settled")
+    val identity = goalRepositoryIdentity(fixture)
+    val workflows = IdeStatusWorkflowStates()
+    // Every phase terminal, so the projection resolves no current phase and current_step falls back
+    // to the workflow row's `pr`. That phase completed carrying a model — history, not the model in
+    // force — so a finished run must not report it as current.
+    val allCompleted = FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds.map { phaseId ->
+      phaseId to phaseRecordWire(phaseId, "completed", "claude-opus-4-8".takeIf { phaseId == "pr" })
+    }
+    workflows.saveFeatureImplementWorkflow(
+      runtimeRecord("w-settled", "2026-08-06T10:00:00Z", currentStep = "pr")
+        .copy(artifactsJson = phaseRecordsArtifactsJson(*allCompleted.toTypedArray())),
+    )
+    workflows.saveFeatureTaskExecutionIdentity(identityFor("w-settled", identity))
+    val database = TrackingDatabase(
+      work = listOf(workItem("w-settled", WorkItemKind.FEATURE_TASK_RUNTIME, "completed", "2026-08-06T10:00:00Z")),
+      workflows = workflows,
+    )
+
+    val result = service(database).status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    assertEquals("w-settled", result.snapshot.workflowId)
+    assertEquals("pr", result.snapshot.currentStep.id)
+    assertNull(result.snapshot.currentModel)
+  }
+
+  @Test
+  fun `a goal whose child status read fails schema validation keeps its status and omits only current_model`() {
+    val fixture = gitRepoFixture("ide-status-goal-child-schema-invalid")
+    val identity = goalRepositoryIdentity(fixture)
+    // Run invariants that do not decode to a map. The goal's own agent attribution reads the child's
+    // phase records and ledger, which stay valid here; only the nested child status projection reads
+    // this artifact, so the failure lands exactly where resolving the model does and nowhere else.
+    val database = goalWithLaunchedChildDatabase(
+      identity,
+      Instant.parse("2026-08-06T09:15:00Z"),
+      childArtifactsJson = JsonSupport.mapToJsonString(
+        mapOf(
+          FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to mapOf(
+            "implement" to phaseRecordWire("implement", "running", "claude-opus-4-8"),
+          ),
+          FEATURE_TASK_RUNTIME_RUN_INVARIANTS_ARTIFACT_KEY to "not-a-map",
+        ),
+      ),
+    )
+
+    val result = service(
+      database,
+      manifestStore = StubGoalManifestStore(goalManifestState(fixture, identity, childWorkflowId = "w-child")),
+    ).status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    // Resolving the model is a nested read of a *different* workflow's rows. Letting its failure
+    // escape would downgrade the whole goal snapshot to one schema_incompatible record, trading
+    // lifecycle, progress and pause state for an optional field.
+    // A degraded snapshot carries no workflow id and no progress, only the problem — so these three
+    // together prove the goal reading survived rather than collapsing into an incompatible record.
+    assertEquals("goal-1", result.snapshot.workflowId)
+    assertNull(result.snapshot.problem)
+    assertNotNull(result.snapshot.progress)
+    assertNull(result.snapshot.currentModel)
   }
 
   @Test

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/work/IdeStatusServiceTest.kt
@@ -14,6 +14,7 @@ import skillbill.application.model.IdeStatusProblemCode
 import skillbill.application.model.IdeStatusRequest
 import skillbill.application.model.IdeStatusResult
 import skillbill.application.model.IdeStatusWorkflowFamily
+import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.goalrunner.model.GoalPlanningStatusSnapshot
 import skillbill.goalrunner.model.GoalPlanningStatusState
@@ -60,6 +61,8 @@ import skillbill.workflow.model.CurrentSubtaskIntent
 import skillbill.workflow.model.DecompositionManifest
 import skillbill.workflow.model.DecompositionSubtask
 import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
+import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseRecord
 import skillbill.workflow.verify.FeatureVerifyWorkflowDefinition
 import java.nio.file.Files
 import java.nio.file.Path
@@ -247,6 +250,80 @@ class IdeStatusServiceTest {
     assertEquals("goal-1", result.snapshot.workflowId)
     assertEquals(IdeStatusWorkflowFamily.FEATURE_GOAL, result.snapshot.workflowFamily)
     assertEquals(IdeStatusLifecycleState.ACTIVE, result.snapshot.lifecycleState)
+  }
+
+  @Test
+  fun `runtime current_model reports the model of the phase reported as current_step`() {
+    val fixture = gitRepoFixture("ide-status-current-model")
+    val identity = goalRepositoryIdentity(fixture)
+    val workflows = IdeStatusWorkflowStates()
+    workflows.saveFeatureImplementWorkflow(
+      runtimeRecord("w-model", "2026-08-06T10:00:00Z").copy(
+        // The neighbouring plan phase carries a DIFFERENT model: reporting it would be the bug.
+        artifactsJson = phaseRecordsArtifactsJson(
+          "preplan" to phaseRecordWire("preplan", "completed", null),
+          "plan" to phaseRecordWire("plan", "completed", "plan-model"),
+          "implement" to phaseRecordWire("implement", "running", "claude-opus-4-8", effort = "high"),
+        ),
+      ),
+    )
+    workflows.saveFeatureTaskExecutionIdentity(identityFor("w-model", identity))
+    val database = TrackingDatabase(
+      work = listOf(workItem("w-model", WorkItemKind.FEATURE_TASK_RUNTIME, "running", "2026-08-06T10:00:00Z")),
+      workflows = workflows,
+    )
+
+    val result = service(database).status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    assertEquals("implement", result.snapshot.currentStep.id)
+    assertEquals("claude-opus-4-8", result.snapshot.currentModel?.model)
+    assertEquals("high", result.snapshot.currentModel?.effort)
+  }
+
+  @Test
+  fun `runtime current_model is omitted when the current phase has no recorded model`() {
+    val fixture = gitRepoFixture("ide-status-current-model-absent")
+    val identity = goalRepositoryIdentity(fixture)
+    val workflows = IdeStatusWorkflowStates()
+    workflows.saveFeatureImplementWorkflow(runtimeRecord("w-nomodel", "2026-08-06T10:00:00Z"))
+    workflows.saveFeatureTaskExecutionIdentity(identityFor("w-nomodel", identity))
+    val database = TrackingDatabase(
+      work = listOf(workItem("w-nomodel", WorkItemKind.FEATURE_TASK_RUNTIME, "running", "2026-08-06T10:00:00Z")),
+      workflows = workflows,
+    )
+
+    val result = service(database).status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    assertNull(result.snapshot.currentModel)
+  }
+
+  @Test
+  fun `goal current_model comes from the launched child's current phase and is omitted without one`() {
+    val fixture = gitRepoFixture("ide-status-goal-current-model")
+    val identity = goalRepositoryIdentity(fixture)
+    val childStarted = Instant.parse("2026-08-06T09:15:00Z")
+    val database = goalWithLaunchedChildDatabase(
+      identity,
+      childStarted,
+      childArtifactsJson = phaseRecordsArtifactsJson(
+        "preplan" to phaseRecordWire("preplan", "completed", null),
+        "plan" to phaseRecordWire("plan", "completed", null),
+        "implement" to phaseRecordWire("implement", "running", "claude-opus-4-8[effort=high]"),
+      ),
+    )
+    val withChild = service(
+      database,
+      manifestStore = StubGoalManifestStore(goalManifestState(fixture, identity, childWorkflowId = "w-child")),
+    ).status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    // The goal's own currentStep can be a planning label, never a phase-record key; with no child
+    // workflow id there is nothing to resolve and the field must be absent rather than mismatched.
+    val withoutChild = service(database)
+      .status(IdeStatusRequest(repoRoot = fixture.toString(), observedAt = observedAt))
+
+    assertEquals("claude-opus-4-8[effort=high]", withChild.snapshot.currentModel?.model)
+    assertNull(withChild.snapshot.currentModel?.effort)
+    assertNull(withoutChild.snapshot.currentModel)
   }
 
   @Test
@@ -527,10 +604,15 @@ class IdeStatusServiceTest {
     )
   }
 
-  private fun goalWithLaunchedChildDatabase(identity: String, childStarted: Instant): TrackingDatabase {
+  private fun goalWithLaunchedChildDatabase(
+    identity: String,
+    childStarted: Instant,
+    childArtifactsJson: String = "{}",
+  ): TrackingDatabase {
     val workflows = IdeStatusWorkflowStates()
     workflows.saveFeatureImplementWorkflow(
-      runtimeRecord("w-child", "2026-08-06T11:00:00Z").copy(startedAt = childStarted.toString()),
+      runtimeRecord("w-child", "2026-08-06T11:00:00Z")
+        .copy(startedAt = childStarted.toString(), artifactsJson = childArtifactsJson),
     )
     workflows.saveFeatureTaskExecutionIdentity(
       identityFor("w-child", identity).copy(routeScope = FeatureTaskRouteScope.GOAL_CHILD),
@@ -962,6 +1044,27 @@ private fun identityFor(workflowId: String, repositoryIdentity: String): Feature
     repositoryIdentity = repositoryIdentity,
     governedSpecPath = "spec.md",
     mode = FeatureTaskWorkflowMode.RUNTIME,
+  )
+
+private fun phaseRecordWire(
+  phaseId: String,
+  status: String,
+  launchedModel: String?,
+  effort: String? = null,
+): Map<String, Any?> = FeatureTaskRuntimePhaseRecord(
+  phaseId = phaseId,
+  status = status,
+  attemptCount = 1,
+  startedAt = "2026-08-06T09:00:00Z",
+  finishedAt = if (status == "completed") "2026-08-06T09:30:00Z" else null,
+  resolvedAgentId = "claude",
+  launchedModel = launchedModel,
+  launchedEffort = effort,
+).toArtifactMap()
+
+private fun phaseRecordsArtifactsJson(vararg records: Pair<String, Map<String, Any?>>): String =
+  JsonSupport.mapToJsonString(
+    mapOf(FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to records.toMap()),
   )
 
 private fun runtimeRecord(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/ExecutionMatrixModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/ExecutionMatrixModels.kt
@@ -43,12 +43,18 @@ data class PhaseModelDirective(
 data class ExecutionMatrix(
   val phaseTiers: Map<String, ExecutionTier> = emptyMap(),
   val agents: Map<InstallAgent, Map<ExecutionTier, PhaseModelDirective>> = emptyMap(),
+  val agentPhaseOverrides: Map<InstallAgent, Map<String, PhaseModelDirective>> = emptyMap(),
 ) {
   fun tierOf(phaseId: String): ExecutionTier = phaseTiers[phaseId] ?: DEFAULT_PHASE_TIERS.getValue(phaseId)
 
+  /**
+   * A per-phase directive under the agent block wins over that agent's tier directive, so
+   * `reasoning` stays the one-line way to route every reasoning phase while a single phase can
+   * opt out without restructuring the tier map.
+   */
   fun directiveFor(agentId: String, phaseId: String): PhaseModelDirective? {
     val agent = InstallAgent.entries.firstOrNull { it.id == agentId.trim().lowercase() } ?: return null
-    return agents[agent]?.get(tierOf(phaseId))
+    return agentPhaseOverrides[agent]?.get(phaseId) ?: agents[agent]?.get(tierOf(phaseId))
   }
 }
 
@@ -75,7 +81,12 @@ private fun parseExecutionMatrixMapping(raw: Any?): ExecutionMatrix {
     invalidExecutionMatrix("$EXECUTION_MATRIX_KEY.$key", value, "is not a supported execution_matrix field.")
   }
   val phaseTiers = if (PHASE_TIERS_KEY in fields) parsePhaseTiers(fields[PHASE_TIERS_KEY]) else emptyMap()
-  return ExecutionMatrix(phaseTiers = phaseTiers, agents = parseAgents(fields[AGENTS_KEY]))
+  val agents = parseAgents(fields[AGENTS_KEY])
+  return ExecutionMatrix(
+    phaseTiers = phaseTiers,
+    agents = agents.mapValues { (_, directives) -> directives.tiers },
+    agentPhaseOverrides = agents.mapValues { (_, directives) -> directives.phases }.filterValues { it.isNotEmpty() },
+  )
 }
 
 private fun parsePhaseTiers(raw: Any?): Map<String, ExecutionTier> {
@@ -102,7 +113,12 @@ private fun parsePhaseTiers(raw: Any?): Map<String, ExecutionTier> {
   }
 }
 
-private fun parseAgents(raw: Any?): Map<InstallAgent, Map<ExecutionTier, PhaseModelDirective>> {
+private class AgentDirectives(
+  val tiers: Map<ExecutionTier, PhaseModelDirective>,
+  val phases: Map<String, PhaseModelDirective>,
+)
+
+private fun parseAgents(raw: Any?): Map<InstallAgent, AgentDirectives> {
   val agents = raw as? Map<*, *> ?: invalidExecutionMatrix(
     "$EXECUTION_MATRIX_KEY.$AGENTS_KEY",
     raw,
@@ -119,29 +135,38 @@ private fun parseAgents(raw: Any?): Map<InstallAgent, Map<ExecutionTier, PhaseMo
       rawTiers,
       "is not a supported install agent.",
     )
-    agent to parseAgentTiers(agentId, rawTiers)
+    agent to parseAgentDirectives(agentId, rawTiers)
   }
 }
 
-private fun parseAgentTiers(agentId: String, raw: Any?): Map<ExecutionTier, PhaseModelDirective> {
-  val tiers = raw as? Map<*, *> ?: invalidExecutionMatrix(
+private fun parseAgentDirectives(agentId: String, raw: Any?): AgentDirectives {
+  val entries = raw as? Map<*, *> ?: invalidExecutionMatrix(
     "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId",
     raw,
     "must be a mapping.",
   )
-  return tiers.entries.associate { (rawTierId, rawDirective) ->
-    val tierId = rawTierId as? String
-    val tier = tierId?.let(ExecutionTier::fromId) ?: invalidExecutionMatrix(
-      "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId.$rawTierId",
-      rawDirective,
-      "must be reasoning or implementation.",
-    )
-    tier to parseDirective(agentId, tier, rawDirective)
+  val tiers = mutableMapOf<ExecutionTier, PhaseModelDirective>()
+  val phases = mutableMapOf<String, PhaseModelDirective>()
+  entries.forEach { (rawKey, rawDirective) ->
+    val key = rawKey as? String
+    val path = "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId.$rawKey"
+    val tier = key?.let(ExecutionTier::fromId)
+    when {
+      tier != null -> tiers[tier] = parseDirective(path, rawDirective)
+      key != null && key in FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds ->
+        phases[key] = parseDirective(path, rawDirective)
+
+      else -> invalidExecutionMatrix(
+        path,
+        rawDirective,
+        "must be reasoning, implementation, or a runtime phase.",
+      )
+    }
   }
+  return AgentDirectives(tiers = tiers, phases = phases)
 }
 
-private fun parseDirective(agentId: String, tier: ExecutionTier, raw: Any?): PhaseModelDirective {
-  val path = "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId.${tier.id}"
+private fun parseDirective(path: String, raw: Any?): PhaseModelDirective {
   val directive = raw as? Map<*, *> ?: invalidExecutionMatrix(path, raw, "must be a mapping.")
   val fields = directive.entries.associate { (key, value) -> key.toString() to value }
   if (MODEL_KEY !in fields) invalidExecutionMatrix("$path.$MODEL_KEY", "<missing>", "is required.")
@@ -154,7 +179,7 @@ private fun parseDirective(agentId: String, tier: ExecutionTier, raw: Any?): Pha
     invalidExecutionMatrix("$path.$EFFORT_KEY", effort, "must be a non-blank string when provided.")
   }
   fields.entries.firstOrNull { (key, _) -> key !in DIRECTIVE_FIELDS }?.let { (key, value) ->
-    invalidExecutionMatrix("$path.$key", value, "is not a supported tier field.")
+    invalidExecutionMatrix("$path.$key", value, "is not a supported model directive field.")
   }
   return PhaseModelDirective(model = model, effort = effort as? String)
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/ExecutionMatrixModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/config/model/ExecutionMatrixModels.kt
@@ -139,7 +139,20 @@ private fun parseAgents(raw: Any?): Map<InstallAgent, AgentDirectives> {
   }
 }
 
+/**
+ * Tier ids and runtime phase ids share one key namespace under an agent, and the tier is resolved
+ * first. That is only safe while the two sets are disjoint: a phase id equal to `reasoning` or
+ * `implementation` would leave every existing config parsing while silently turning a single-phase
+ * override into a whole-tier directive. The guard fails the parse instead of re-routing a tier.
+ */
+private val COLLIDING_PHASE_IDS: List<String> =
+  FeatureTaskRuntimePhaseWorkflowDefinition.definition.stepIds.filter { ExecutionTier.fromId(it) != null }
+
 private fun parseAgentDirectives(agentId: String, raw: Any?): AgentDirectives {
+  require(COLLIDING_PHASE_IDS.isEmpty()) {
+    "Runtime phase ids $COLLIDING_PHASE_IDS collide with execution-tier ids, so an agent's " +
+      "per-phase override key would silently resolve as a tier directive."
+  }
   val entries = raw as? Map<*, *> ?: invalidExecutionMatrix(
     "$EXECUTION_MATRIX_KEY.$AGENTS_KEY.$agentId",
     raw,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
@@ -472,6 +472,13 @@ data class FeatureTaskRuntimePhaseRecord(
   val edgeIteration: Int? = null,
   val reviewPassNumber: Int? = null,
   val repairEvidence: FeatureTaskRuntimePhaseOutputRepairEvidence? = null,
+  /**
+   * The model the phase's child was actually launched with, exactly as handed to the agent CLI —
+   * including Cursor's merged `model[effort=…]` form. Null when the phase ran with no model
+   * directive, which is also the shape every record written before this field holds.
+   */
+  val launchedModel: String? = null,
+  val launchedEffort: String? = null,
 ) {
   init {
     require(phaseId.isNotBlank()) { "FeatureTaskRuntimePhaseRecord.phaseId must be non-blank." }
@@ -494,6 +501,12 @@ data class FeatureTaskRuntimePhaseRecord(
       require(phaseId == "review" && pass >= 1) {
         "FeatureTaskRuntimePhaseRecord.reviewPassNumber must be >= 1 and present only for review."
       }
+    }
+    launchedModel?.let { model ->
+      require(model.isNotBlank()) { "FeatureTaskRuntimePhaseRecord.launchedModel must be non-blank when present." }
+    }
+    launchedEffort?.let { effort ->
+      require(effort.isNotBlank()) { "FeatureTaskRuntimePhaseRecord.launchedEffort must be non-blank when present." }
     }
   }
 
@@ -521,6 +534,8 @@ data class FeatureTaskRuntimePhaseRecord(
     edgeIteration?.let { put("edge_iteration", it) }
     reviewPassNumber?.let { put("review_pass_number", it) }
     repairEvidence?.let { put("repair_evidence", it.toArtifactMap()) }
+    launchedModel?.let { put("launched_model", it) }
+    launchedEffort?.let { put("launched_effort", it) }
   }
 
   companion object {
@@ -535,7 +550,7 @@ data class FeatureTaskRuntimePhaseRecord(
         "finished_at", "duration_millis", "output_artifact", "blocked_reason",
         "failure_disposition", "file_manifest_before", "file_manifest_after", "file_manifest_introduced",
         "loop_id", "edge_iteration", "review_pass_number", "rejected_output",
-        "repair_evidence",
+        "repair_evidence", "launched_model", "launched_effort",
       )
       val hasCompatibleFields = raw.keys.containsAll(required) && allowed.containsAll(raw.keys)
       val hasCompatibleIdentity =
@@ -577,6 +592,8 @@ data class FeatureTaskRuntimePhaseRecord(
               evidence.entries.associate { (key, item) -> key.toString() to item },
             )
           },
+          launchedModel = raw.optionalStringField("launched_model"),
+          launchedEffort = raw.optionalStringField("launched_effort"),
         )
       } catch (_: InvalidWorkflowStateSchemaError) {
         incompatiblePhaseRecord()

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
@@ -435,6 +435,9 @@ const val FEATURE_TASK_RUNTIME_PHASE_STATUS_BLOCKED: String = "blocked"
 /** Non-terminal and resumable: the subtask waits on a bounded operator decision, it is not blocked. */
 const val FEATURE_TASK_RUNTIME_PHASE_STATUS_PAUSED: String = "paused"
 
+/** Terminal success. A completed phase's launch context is history, never current state. */
+const val FEATURE_TASK_RUNTIME_PHASE_STATUS_COMPLETED: String = "completed"
+
 /**
  * Durable per-phase record: one entry per phase id holding its latest persisted state.
  * `finishedAt`/`durationMillis`/`outputArtifact` are nullable because a phase may be
@@ -507,6 +510,11 @@ data class FeatureTaskRuntimePhaseRecord(
     }
     launchedEffort?.let { effort ->
       require(effort.isNotBlank()) { "FeatureTaskRuntimePhaseRecord.launchedEffort must be non-blank when present." }
+      // An effort without a model is unrepresentable rather than merely odd: every reader keys the
+      // pair off the model, so a lone effort would decode cleanly and then be silently discarded.
+      require(launchedModel != null) {
+        "FeatureTaskRuntimePhaseRecord.launchedEffort requires launchedModel; the launch pair moves as a unit."
+      }
     }
   }
 
@@ -602,20 +610,39 @@ data class FeatureTaskRuntimePhaseRecord(
         "loop_id", "edge_iteration", "review_pass_number", "rejected_output",
         "repair_evidence", "launched_model", "launched_effort",
       )
-      val hasCompatibleFields = raw.keys.containsAll(required) && allowed.containsAll(raw.keys)
-      val hasCompatibleIdentity =
-        raw["contract_version"] == FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION &&
-          raw["record_kind"] == "private_phase_record"
-      if (!hasCompatibleFields || !hasCompatibleIdentity) {
-        incompatiblePhaseRecord()
+      val missing = required - raw.keys
+      val unknown = raw.keys - allowed
+      val identityDetail = when {
+        raw["record_kind"] != "private_phase_record" -> "record_kind was '${raw["record_kind"]}'"
+        raw["contract_version"] != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION ->
+          "contract_version was '${raw["contract_version"]}'"
+
+        else -> null
+      }
+      if (missing.isNotEmpty() || unknown.isNotEmpty() || identityDetail != null) {
+        // The cause must be named. The contract version is shared across record kinds, so an
+        // additive key on this record alone cannot bump it — meaning a newer row read by an older
+        // build fails on `unknown` while its version string matches. Reporting only the version
+        // would send the operator hunting a migration that does not exist.
+        incompatiblePhaseRecord(
+          listOfNotNull(
+            identityDetail,
+            missing.takeIf { it.isNotEmpty() }?.let { "missing required keys ${it.sorted()}" },
+            unknown.takeIf { it.isNotEmpty() }?.let {
+              "unknown keys ${it.sorted()} (a row written by a newer runtime than this build)"
+            },
+          ),
+        )
       }
     }
 
-    private fun incompatiblePhaseRecord(): Nothing = throw InvalidWorkflowStateSchemaError(
-      "Private feature-task-runtime phase record is incompatible with persistence contract " +
-        "$FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION; " +
-        "$FEATURE_TASK_RUNTIME_INCOMPATIBLE_RECORD_GUIDANCE.",
-    )
+    private fun incompatiblePhaseRecord(details: List<String> = emptyList()): Nothing =
+      throw InvalidWorkflowStateSchemaError(
+        "Private feature-task-runtime phase record is incompatible with persistence contract " +
+          "$FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION" +
+          details.takeIf { it.isNotEmpty() }?.joinToString(prefix = " (", postfix = ")").orEmpty() +
+          "; $FEATURE_TASK_RUNTIME_INCOMPATIBLE_RECORD_GUIDANCE.",
+      )
   }
 }
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePersistenceModels.kt
@@ -534,6 +534,10 @@ data class FeatureTaskRuntimePhaseRecord(
     edgeIteration?.let { put("edge_iteration", it) }
     reviewPassNumber?.let { put("review_pass_number", it) }
     repairEvidence?.let { put("repair_evidence", it.toArtifactMap()) }
+    putLaunchPair()
+  }
+
+  private fun MutableMap<String, Any?>.putLaunchPair() {
     launchedModel?.let { put("launched_model", it) }
     launchedEffort?.let { put("launched_effort", it) }
   }
@@ -542,23 +546,7 @@ data class FeatureTaskRuntimePhaseRecord(
     /** Strict decode; loud-fails on any missing or malformed required field. */
     @OpenBoundaryMap("Feature-task-runtime per-phase record decode from the durable workflow-artifact map")
     fun fromArtifactMap(raw: Map<String, Any?>): FeatureTaskRuntimePhaseRecord {
-      val required = setOf(
-        "contract_version", "record_kind", "phase_id", "status", "attempt_count", "started_at",
-        "first_started_at", "resolved_agent_id", "execution_origin",
-      )
-      val allowed = required + setOf(
-        "finished_at", "duration_millis", "output_artifact", "blocked_reason",
-        "failure_disposition", "file_manifest_before", "file_manifest_after", "file_manifest_introduced",
-        "loop_id", "edge_iteration", "review_pass_number", "rejected_output",
-        "repair_evidence", "launched_model", "launched_effort",
-      )
-      val hasCompatibleFields = raw.keys.containsAll(required) && allowed.containsAll(raw.keys)
-      val hasCompatibleIdentity =
-        raw["contract_version"] == FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION &&
-          raw["record_kind"] == "private_phase_record"
-      if (!hasCompatibleFields || !hasCompatibleIdentity) {
-        incompatiblePhaseRecord()
-      }
+      requireCompatibleShape(raw)
       return try {
         FeatureTaskRuntimePhaseRecord(
           phaseId = raw.requireStringField("phase_id"),
@@ -598,6 +586,27 @@ data class FeatureTaskRuntimePhaseRecord(
       } catch (_: InvalidWorkflowStateSchemaError) {
         incompatiblePhaseRecord()
       } catch (_: IllegalArgumentException) {
+        incompatiblePhaseRecord()
+      }
+    }
+
+    /** Key-shape and identity guard: an unknown key is drift, not a field to ignore. */
+    private fun requireCompatibleShape(raw: Map<String, Any?>) {
+      val required = setOf(
+        "contract_version", "record_kind", "phase_id", "status", "attempt_count", "started_at",
+        "first_started_at", "resolved_agent_id", "execution_origin",
+      )
+      val allowed = required + setOf(
+        "finished_at", "duration_millis", "output_artifact", "blocked_reason",
+        "failure_disposition", "file_manifest_before", "file_manifest_after", "file_manifest_introduced",
+        "loop_id", "edge_iteration", "review_pass_number", "rejected_output",
+        "repair_evidence", "launched_model", "launched_effort",
+      )
+      val hasCompatibleFields = raw.keys.containsAll(required) && allowed.containsAll(raw.keys)
+      val hasCompatibleIdentity =
+        raw["contract_version"] == FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION &&
+          raw["record_kind"] == "private_phase_record"
+      if (!hasCompatibleFields || !hasCompatibleIdentity) {
         incompatiblePhaseRecord()
       }
     }

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/config/model/ExecutionMatrixModelsTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/config/model/ExecutionMatrixModelsTest.kt
@@ -59,9 +59,7 @@ class ExecutionMatrixModelsTest {
               "reasoning" to mapOf("model" to "gpt-5.6-luna-xhigh"),
               "implementation" to mapOf("model" to "cursor-grok-4.5-medium"),
               "preplan" to mapOf("model" to "gpt-5.6-luna-high"),
-              "plan" to mapOf("model" to "claude-opus-5-thinking-high"),
               "review" to mapOf("model" to "claude-opus-5-thinking-max", "effort" to "max"),
-              "implement" to mapOf("model" to "composer-2.5"),
             ),
           ),
         ),
@@ -69,35 +67,13 @@ class ExecutionMatrixModelsTest {
     )
     val matrix = parsed.matrix
 
+    // An override beats an explicit phase_tiers entry, carries an effort, and leaves every
+    // non-overridden phase on its tier. The remaining override keys would only re-exercise the
+    // same branch with different literals.
     assertEquals(PhaseModelDirective("gpt-5.6-luna-high"), matrix.directiveFor("cursor", "preplan"))
-    assertEquals(PhaseModelDirective("claude-opus-5-thinking-high"), matrix.directiveFor("cursor", "plan"))
     assertEquals(PhaseModelDirective("claude-opus-5-thinking-max", "max"), matrix.directiveFor("cursor", "review"))
-    assertEquals(PhaseModelDirective("composer-2.5"), matrix.directiveFor("cursor", "implement"))
     assertEquals(PhaseModelDirective("gpt-5.6-luna-xhigh"), matrix.directiveFor("cursor", "audit"))
     assertEquals(PhaseModelDirective("cursor-grok-4.5-medium"), matrix.directiveFor("cursor", "pr"))
-  }
-
-  @Test
-  fun `agents without per-phase overrides keep resolving through their tier`() {
-    val parsed = assertIs<ExecutionMatrixParse.Valid>(
-      parseExecutionMatrix(
-        mapOf(
-          "agents" to mapOf(
-            "claude" to mapOf("reasoning" to mapOf("model" to "claude-opus-5", "effort" to "high")),
-            "cursor" to mapOf(
-              "reasoning" to mapOf("model" to "gpt-5.6-luna-xhigh"),
-              "review" to mapOf("model" to "claude-opus-5-thinking-max"),
-            ),
-          ),
-        ),
-      ),
-    )
-
-    assertEquals(PhaseModelDirective("claude-opus-5", "high"), parsed.matrix.directiveFor("claude", "review"))
-    assertEquals(
-      PhaseModelDirective("claude-opus-5-thinking-max"),
-      parsed.matrix.directiveFor("cursor", "review"),
-    )
   }
 
   @Test

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/config/model/ExecutionMatrixModelsTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/config/model/ExecutionMatrixModelsTest.kt
@@ -49,6 +49,58 @@ class ExecutionMatrixModelsTest {
   }
 
   @Test
+  fun `per-phase agent overrides win over the tier directive for that phase only`() {
+    val parsed = assertIs<ExecutionMatrixParse.Valid>(
+      parseExecutionMatrix(
+        mapOf(
+          "phase_tiers" to mapOf("preplan" to "reasoning"),
+          "agents" to mapOf(
+            "cursor" to mapOf(
+              "reasoning" to mapOf("model" to "gpt-5.6-luna-xhigh"),
+              "implementation" to mapOf("model" to "cursor-grok-4.5-medium"),
+              "preplan" to mapOf("model" to "gpt-5.6-luna-high"),
+              "plan" to mapOf("model" to "claude-opus-5-thinking-high"),
+              "review" to mapOf("model" to "claude-opus-5-thinking-max", "effort" to "max"),
+              "implement" to mapOf("model" to "composer-2.5"),
+            ),
+          ),
+        ),
+      ),
+    )
+    val matrix = parsed.matrix
+
+    assertEquals(PhaseModelDirective("gpt-5.6-luna-high"), matrix.directiveFor("cursor", "preplan"))
+    assertEquals(PhaseModelDirective("claude-opus-5-thinking-high"), matrix.directiveFor("cursor", "plan"))
+    assertEquals(PhaseModelDirective("claude-opus-5-thinking-max", "max"), matrix.directiveFor("cursor", "review"))
+    assertEquals(PhaseModelDirective("composer-2.5"), matrix.directiveFor("cursor", "implement"))
+    assertEquals(PhaseModelDirective("gpt-5.6-luna-xhigh"), matrix.directiveFor("cursor", "audit"))
+    assertEquals(PhaseModelDirective("cursor-grok-4.5-medium"), matrix.directiveFor("cursor", "pr"))
+  }
+
+  @Test
+  fun `agents without per-phase overrides keep resolving through their tier`() {
+    val parsed = assertIs<ExecutionMatrixParse.Valid>(
+      parseExecutionMatrix(
+        mapOf(
+          "agents" to mapOf(
+            "claude" to mapOf("reasoning" to mapOf("model" to "claude-opus-5", "effort" to "high")),
+            "cursor" to mapOf(
+              "reasoning" to mapOf("model" to "gpt-5.6-luna-xhigh"),
+              "review" to mapOf("model" to "claude-opus-5-thinking-max"),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    assertEquals(PhaseModelDirective("claude-opus-5", "high"), parsed.matrix.directiveFor("claude", "review"))
+    assertEquals(
+      PhaseModelDirective("claude-opus-5-thinking-max"),
+      parsed.matrix.directiveFor("cursor", "review"),
+    )
+  }
+
+  @Test
   fun `rejects every malformed matrix layer with its dotted key path`() {
     val cases = listOf(
       "root" to Pair(listOf("not", "a", "map"), "execution_matrix"),
@@ -122,6 +174,14 @@ class ExecutionMatrixModelsTest {
       Pair(
         mapOf("agents" to mapOf("claude" to mapOf("reasoning" to mapOf("model" to "m", "effort" to 1)))),
         "execution_matrix.agents.claude.reasoning.effort",
+      ),
+      Pair(
+        mapOf("agents" to mapOf("claude" to mapOf("review" to mapOf("effort" to "high")))),
+        "execution_matrix.agents.claude.review.model",
+      ),
+      Pair(
+        mapOf("agents" to mapOf("claude" to mapOf("planning" to mapOf("model" to "m")))),
+        "execution_matrix.agents.claude.planning",
       ),
     )
 

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePersistenceModelsTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePersistenceModelsTest.kt
@@ -32,6 +32,56 @@ import kotlin.test.assertTrue
 
 class FeatureTaskRuntimePersistenceModelsTest {
   @Test
+  fun `launched model and effort round-trip through the phase record artifact map`() {
+    val wire = FeatureTaskRuntimePhaseRecord(
+      phaseId = "implement",
+      status = "running",
+      attemptCount = 1,
+      startedAt = "2026-08-11T12:00:00Z",
+      resolvedAgentId = "cursor",
+      launchedModel = "claude-opus-4-8[effort=high]",
+      launchedEffort = "high",
+    ).toArtifactMap()
+
+    val decoded = FeatureTaskRuntimePhaseRecord.fromArtifactMap(wire)
+
+    assertEquals("claude-opus-4-8[effort=high]", decoded.launchedModel)
+    assertEquals("high", decoded.launchedEffort)
+  }
+
+  @Test
+  fun `phase record written before the launched model fields still decodes`() {
+    // The shape every live workflow row holds: neither key present, and neither may be required.
+    val preChangeWire = FeatureTaskRuntimePhaseRecord(
+      phaseId = "implement",
+      status = "running",
+      attemptCount = 1,
+      startedAt = "2026-08-11T12:00:00Z",
+      resolvedAgentId = "claude",
+    ).toArtifactMap()
+
+    assertTrue("launched_model" !in preChangeWire)
+    assertTrue("launched_effort" !in preChangeWire)
+    val decoded = FeatureTaskRuntimePhaseRecord.fromArtifactMap(preChangeWire)
+    assertNull(decoded.launchedModel)
+    assertNull(decoded.launchedEffort)
+  }
+
+  @Test
+  fun `a present-but-blank launched model or effort fails record construction`() {
+    val base = FeatureTaskRuntimePhaseRecord(
+      phaseId = "implement",
+      status = "running",
+      attemptCount = 1,
+      startedAt = "2026-08-11T12:00:00Z",
+      resolvedAgentId = "claude",
+    )
+
+    assertFailsWith<IllegalArgumentException> { base.copy(launchedModel = " ") }
+    assertFailsWith<IllegalArgumentException> { base.copy(launchedEffort = " ") }
+  }
+
+  @Test
   fun `legacy rejected output is consumed and discarded during phase record migration`() {
     val current = FeatureTaskRuntimePhaseRecord(
       phaseId = "implement",

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/agentrun/AgentRunAdapters.kt
@@ -42,6 +42,15 @@ class ProcessAgentRunAdapter(
       // operator was told the agent wrote bad output when it had written none we could read.
       DecodedAgentRunOutput(text = "", rawOutputPreview = result.stdout.take(RAW_OUTPUT_PREVIEW_MAX_CHARS))
     }
+    // The two flags are one fact read two ways, and downstream code depends on that: the run loop
+    // decides whether a settled phase keeps its launched-model stamp from `spawnFailed`, while
+    // `processStarted` is the field documented as the process-start boundary. A runner that reports
+    // a pre-start failure as anything but a spawn failure would silently attribute a model to a
+    // child that never ran, so the disagreement fails here rather than becoming a durable lie.
+    require(result.spawnFailed != result.processStarted) {
+      "AgentRunProcessRunner result must report exactly one of spawnFailed/processStarted; got " +
+        "spawnFailed=${result.spawnFailed}, processStarted=${result.processStarted}."
+    }
     val normalizedStdout = decoded.text
     val decodedBodyBytes = if (normalizedStdout == result.stdout) {
       result.stdoutBytes

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/AgentRunProcessRunner.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/launcher/process/AgentRunProcessRunner.kt
@@ -123,7 +123,10 @@ data class AgentRunProcessResult(
   val interrupted: Boolean,
   val spawnFailed: Boolean,
   val liveness: AgentRunLivenessSnapshot? = null,
-  val processStarted: Boolean = false,
+  // Defaulted from spawnFailed rather than to a bare false: the two are one fact, and a runner that
+  // omitted this used to report "never started" for a child that ran — which downstream turns into a
+  // cleared launched-model stamp. Deriving the default makes the coherent value the automatic one.
+  val processStarted: Boolean = !spawnFailed,
   val mcpStartupObserved: Boolean = false,
   /** True when raw output exceeded the retention cap, so [stdout] is missing trailing content. */
   val stdoutTruncated: Boolean = false,

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePersistenceReviewPassParityTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePersistenceReviewPassParityTest.kt
@@ -44,6 +44,26 @@ class FeatureTaskRuntimePersistenceReviewPassParityTest {
     }
   }
 
+  /**
+   * `private_phase_record` is additionalProperties:false and the root schema is a closed oneOf, so a
+   * launch pair the model writes but the schema does not declare makes the record match neither branch.
+   * Same drift class as the review-pass ceiling above, pinned before it can go latent again.
+   */
+  @Test
+  fun `schema accepts the launch pair the model records`() {
+    val merged = reviewRecord(1).copy(launchedModel = "claude-opus-4-8[effort=high]")
+    val split = reviewRecord(1).copy(launchedModel = "claude-opus-4-8", launchedEffort = "high")
+
+    listOf(merged, split).forEach { record ->
+      FeatureTaskRuntimePersistenceSchemaValidator.validate(record.toArtifactMap(), "review.record")
+      assertEquals(
+        record.launchedModel to record.launchedEffort,
+        FeatureTaskRuntimePhaseRecord.fromArtifactMap(record.toArtifactMap())
+          .let { it.launchedModel to it.launchedEffort },
+      )
+    }
+  }
+
   private fun reviewRecord(pass: Int): FeatureTaskRuntimePhaseRecord = FeatureTaskRuntimePhaseRecord(
     phaseId = "review",
     status = "running",

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusGoldenFixturesTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusGoldenFixturesTest.kt
@@ -28,6 +28,56 @@ class IdeStatusGoldenFixturesTest {
     )
   }
 
+  /**
+   * SKILL-183: the model-present shape. The model-absent shape stays pinned by every other
+   * fixture here, which carries no `current_model` key at all.
+   */
+  @Test
+  fun `feature-task-runtime current-model golden validates`() {
+    IdeStatusSchemaValidator.validate(
+      linkedMapOf(
+        "contract_version" to IDE_STATUS_CONTRACT_VERSION,
+        "repository_identity" to "repo-root-realpath-v1:/repo",
+        "issue_key" to "SKILL-183",
+        "workflow_id" to "wfl-runtime-2",
+        "workflow_family" to "feature-task-runtime",
+        "lifecycle_state" to "active",
+        "current_step" to linkedMapOf("id" to "implement", "label" to "Implement"),
+        "progress" to linkedMapOf("completed" to 3, "total" to 9),
+        "started_at" to "2026-08-06T08:00:00Z",
+        "current_model" to linkedMapOf("model" to "claude-opus-4-8", "effort" to "high"),
+        "updated_at" to "2026-08-06T10:00:00Z",
+        "freshness" to "fresh",
+        "summary" to "feature-task-runtime SKILL-183 is active on Implement.",
+      ),
+      "golden-runtime-current-model",
+    )
+  }
+
+  /** Cursor's merged form carries the effort inside the model string, so no `effort` key is emitted. */
+  @Test
+  fun `feature-goal current-model without effort golden validates`() {
+    IdeStatusSchemaValidator.validate(
+      linkedMapOf(
+        "contract_version" to IDE_STATUS_CONTRACT_VERSION,
+        "repository_identity" to "repo-root-realpath-v1:/repo",
+        "issue_key" to "SKILL-183",
+        "workflow_id" to "goal-6",
+        "workflow_family" to "feature-goal",
+        "lifecycle_state" to "active",
+        "current_step" to linkedMapOf("id" to "implement", "label" to "Implement"),
+        "progress" to linkedMapOf("completed" to 1, "total" to 3),
+        "started_at" to "2026-08-06T08:00:00Z",
+        "current_subtask" to linkedMapOf("id" to "2"),
+        "current_model" to linkedMapOf("model" to "claude-opus-4-8[effort=high]"),
+        "updated_at" to "2026-08-06T10:00:00Z",
+        "freshness" to "fresh",
+        "summary" to "Goal SKILL-183 is active on Implement.",
+      ),
+      "golden-goal-current-model",
+    )
+  }
+
   @Test
   fun `feature-verify golden validates`() {
     IdeStatusSchemaValidator.validate(

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusGoldenFixturesTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusGoldenFixturesTest.kt
@@ -54,7 +54,11 @@ class IdeStatusGoldenFixturesTest {
     )
   }
 
-  /** Cursor's merged form carries the effort inside the model string, so no `effort` key is emitted. */
+  /**
+   * Cursor's merged form carries the effort inside the model string, so no `effort` key is emitted.
+   * The goal-level `current_step` is why `phase_id` exists: without it this payload names a model
+   * whose phase appears nowhere in it.
+   */
   @Test
   fun `feature-goal current-model without effort golden validates`() {
     IdeStatusSchemaValidator.validate(
@@ -65,14 +69,17 @@ class IdeStatusGoldenFixturesTest {
         "workflow_id" to "goal-6",
         "workflow_family" to "feature-goal",
         "lifecycle_state" to "active",
-        "current_step" to linkedMapOf("id" to "implement", "label" to "Implement"),
+        "current_step" to linkedMapOf("id" to "planning", "label" to "Planning"),
         "progress" to linkedMapOf("completed" to 1, "total" to 3),
         "started_at" to "2026-08-06T08:00:00Z",
         "current_subtask" to linkedMapOf("id" to "2"),
-        "current_model" to linkedMapOf("model" to "claude-opus-4-8[effort=high]"),
+        "current_model" to linkedMapOf(
+          "model" to "claude-opus-4-8[effort=high]",
+          "phase_id" to "implement",
+        ),
         "updated_at" to "2026-08-06T10:00:00Z",
         "freshness" to "fresh",
-        "summary" to "Goal SKILL-183 is active on Implement.",
+        "summary" to "Goal SKILL-183 is active on Planning.",
       ),
       "golden-goal-current-model",
     )

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaContractVersionTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaContractVersionTest.kt
@@ -47,6 +47,17 @@ class IdeStatusSchemaContractVersionTest {
   }
 
   @Test
+  fun `additive current_model property did not bump the contract version`() {
+    val schema = classpathSchema()
+    assertEquals("0.1", schema.path("properties").path("contract_version").path("const").asText())
+    assertEquals("0.1", IDE_STATUS_CONTRACT_VERSION)
+    assertTrue(
+      !schema.path("properties").path("current_model").isMissingNode,
+      "current_model must be present in the schema this parity test pins.",
+    )
+  }
+
+  @Test
   fun `schema id matches IdeStatusSchemaPaths EXPECTED_SCHEMA_ID`() {
     val schema = classpathSchema()
     assertEquals(IdeStatusSchemaPaths.EXPECTED_SCHEMA_ID, schema.path("\$id").asText())

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaContractVersionTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/IdeStatusSchemaContractVersionTest.kt
@@ -47,17 +47,6 @@ class IdeStatusSchemaContractVersionTest {
   }
 
   @Test
-  fun `additive current_model property did not bump the contract version`() {
-    val schema = classpathSchema()
-    assertEquals("0.1", schema.path("properties").path("contract_version").path("const").asText())
-    assertEquals("0.1", IDE_STATUS_CONTRACT_VERSION)
-    assertTrue(
-      !schema.path("properties").path("current_model").isMissingNode,
-      "current_model must be present in the schema this parity test pins.",
-    )
-  }
-
-  @Test
   fun `schema id matches IdeStatusSchemaPaths EXPECTED_SCHEMA_ID`() {
     val schema = classpathSchema()
     assertEquals(IdeStatusSchemaPaths.EXPECTED_SCHEMA_ID, schema.path("\$id").asText())

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/agentrun/model/AgentRunLauncherModels.kt
@@ -233,8 +233,13 @@ data class AgentRunLaunchFacts(
   val spawnFailed: Boolean,
   val stdoutBytes: ByteArray = stdout.encodeToByteArray(),
   val liveness: AgentRunLivenessSnapshot? = null,
-  /** True only when the launcher crossed the process-start boundary. */
-  val processStarted: Boolean = false,
+  /**
+   * True only when the launcher crossed the process-start boundary. Defaulted from [spawnFailed]
+   * because the two are one fact: the run loop decides whether a settled phase keeps its
+   * launched-model stamp from [spawnFailed], so a bare `false` default let a facts producer that
+   * omitted this report "never started" for a child that ran.
+   */
+  val processStarted: Boolean = !spawnFailed,
   /** True only when an MCP startup observation was explicitly emitted by the launcher. */
   val mcpStartupObserved: Boolean = false,
   val childSessionPath: String? = null,


### PR DESCRIPTION
Goal: phase-model-visibility

Subtasks:
- 1. Record the launched model on the durable phase record and emit it on the IDE status contract (3a2669288eb21c1d81e62865247447f2260130a3)
- 2. Surface the current phase's recorded model in the IntelliJ plugin status popup (98837d7b41c52b2918f57d9f7d09506063402df3)
