### PR TITLE
Resolve platform packs from the installation, not the reviewed repo

### DIFF
--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeValidationGateCoordinator.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeValidationGateCoordinator.kt
@@ -60,8 +60,9 @@ class FeatureTaskRuntimeValidationGateCoordinator(
     val validationDepth = cycle.validationDepth
     val changedPaths = cycle.changedPaths
     val agentRepairLauncher = cycle.agentRepairLauncher
-    when (val resolution = resolver.resolve(repoRoot, changedPaths)) {
+    when (val resolution = resolver.resolve(changedPaths)) {
       is ValidationGateResolution.Absent -> return ValidationGateCycleResult.AbsentFallback
+      is ValidationGateResolution.Incompatible -> return terminalBlocked(resolution.reason)
       is ValidationGateResolution.Declared -> {
         val declaration = resolution.declaration
         val measurements = mutableListOf<FeatureTaskRuntimeValidationGateRunRecord>()

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/validation/ValidationGateResolver.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/validation/ValidationGateResolver.kt
@@ -2,19 +2,28 @@ package skillbill.application.featuretask.validation
 
 import me.tatarka.inject.annotations.Inject
 import skillbill.application.featuretask.validation.model.ValidationGateResolution
-import skillbill.application.scaffold.ScaffoldCatalogService
+import skillbill.error.ShellContentContractException
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.review.plan.ReviewStackRouting
 import skillbill.review.plan.model.ReviewRoutingChangedFile
 import skillbill.scaffold.model.PlatformManifest
-import java.nio.file.Path
 
 @Inject
 class ValidationGateResolver(
-  private val scaffoldCatalogService: ScaffoldCatalogService,
+  private val installedCatalog: InstalledPlatformPackCatalogPort,
 ) {
-  fun resolve(repoRoot: Path, changedPaths: List<String>): ValidationGateResolution {
-    val packsRoot = repoRoot.resolve("platform-packs")
-    val manifests = scaffoldCatalogService.discoverPlatformManifests(packsRoot)
+  fun resolve(changedPaths: List<String>): ValidationGateResolution {
+    val manifests = try {
+      installedCatalog.manifests()
+    } catch (e: ShellContentContractException) {
+      // Blocks rather than degrading to the agent-run fallback: unreadable packs are not the same
+      // as no declared gate, and reporting validate as satisfied without pack-attested execution
+      // would be worse than stopping.
+      return ValidationGateResolution.Incompatible(
+        "Installed platform pack discovery failed: ${e.message ?: e.javaClass.simpleName}. " +
+          "Repair the installed platform packs before running validation.",
+      )
+    }
     if (manifests.isEmpty()) {
       return ValidationGateResolution.Absent(null)
     }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/validation/model/ValidationGateCycleModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/validation/model/ValidationGateCycleModels.kt
@@ -17,6 +17,9 @@ sealed interface ValidationGateResolution {
 
   /** Missing pack gate declaration — agent-run validate fallback with surfaced degradation. */
   data class Absent(val routedPackSlug: String?) : ValidationGateResolution
+
+  /** Installed packs exist but could not be read against this runtime's contract. */
+  data class Incompatible(val reason: String) : ValidationGateResolution
 }
 
 data class ValidationFindingSetProjection(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
@@ -16,7 +16,6 @@ import skillbill.application.model.StackDetectionException
 import skillbill.application.model.UsageValidationException
 import skillbill.application.review.model.ReviewRubricProjection
 import skillbill.application.review.model.ReviewSpecialistLaunchRequest
-import skillbill.application.scaffold.ScaffoldCatalogService
 import skillbill.application.workflow.repoRoot
 import skillbill.install.model.InstallAgent
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
@@ -31,7 +30,6 @@ import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
 import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.persistence.model.ReviewAccountingRecord
 import skillbill.ports.persistence.model.ReviewIntegrationPassRecord
-import skillbill.ports.review.InstalledReviewCatalogPort
 import skillbill.ports.review.ParallelReviewLaneRunner
 import skillbill.ports.review.ReviewRubricResolver
 import skillbill.ports.review.ReviewSpecialistContractProvider
@@ -41,6 +39,7 @@ import skillbill.ports.review.model.ParallelReviewLaneRunResult
 import skillbill.ports.review.model.ReviewIntegrationPassOutcome
 import skillbill.ports.review.model.ReviewLaneAccounting
 import skillbill.ports.review.model.ReviewOwnedFileEvidence
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.ports.taskruntime.FeatureTaskRuntimeSharedEvidenceResolverPort
 import skillbill.review.ParallelReviewFindingParser
 import skillbill.review.ParallelReviewMerger
@@ -92,7 +91,6 @@ import kotlin.time.Duration.Companion.seconds
 @Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
 class ParallelCodeReviewRunner(
   private val parentReviewLauncher: GoalRunnerSubtaskLauncher,
-  private val scaffoldCatalogService: ScaffoldCatalogService,
   private val diffResolver: DiffResolverPort,
   private val parallelLaneRunner: ParallelReviewLaneRunner,
   private val repoLocalConfig: RepoLocalConfigPort,
@@ -100,7 +98,7 @@ class ParallelCodeReviewRunner(
   private val reviewRubricResolver: ReviewRubricResolver,
   private val reviewSpecialistContractProvider: ReviewSpecialistContractProvider,
   private val database: DatabaseSessionFactory,
-  private val installedReviewCatalog: InstalledReviewCatalogPort = InstalledReviewCatalogPort.NONE,
+  private val installedPackCatalog: InstalledPlatformPackCatalogPort = InstalledPlatformPackCatalogPort.NONE,
   /**
    * Absent in a fixture that wires no store: the review then derives its evidence in line exactly as
    * it did before the hoist, which is also the degradation path a cache miss takes.
@@ -179,7 +177,7 @@ class ParallelCodeReviewRunner(
     ) { resolveDiff(originalRequest, revisions) }
     val diffText = sharedEvidence.aggregateDiff
     val evidence = ReviewDiffEvidence.parse(diffText)
-    val detection = detectStack(evidence, originalRequest.repoRoot)
+    val detection = detectStack(evidence)
     val budget = repoLocalConfig.readRepoLocalConfig(ReadRepoLocalConfigRequest(originalRequest.repoRoot))
       .config.reviewContextBudget
     val lane1ResolvedMode = resolvedMode(originalRequest)
@@ -633,7 +631,7 @@ class ParallelCodeReviewRunner(
     manifests: List<PlatformManifest>,
     ownedPathsBySlug: Map<String, Set<String>>,
   ): List<PlannedReviewRubric> = if (routedManifests.isEmpty()) {
-    val installed = installedReviewCatalog.manifests()
+    val installed = installedPackCatalog.manifests()
     if (installed.isNotEmpty()) {
       val routing = ReviewStackRouting.route(
         installed,
@@ -763,21 +761,19 @@ class ParallelCodeReviewRunner(
       "Command failed: ${args.joinToString(" ")}",
     )
 
-  private fun detectStack(evidence: ReviewDiffEvidence, repoRoot: Path): StackDetection {
-    val packsRoot = repoRoot.resolve("platform-packs")
-    // A missing platform-packs directory yields an empty list (no exception) and degrades to a
-    // generic rubric. A directory that exists but is out of contract (corrupt platform.yaml,
-    // invalid composition) throws; surface that loudly instead of silently dropping the
-    // stack-specific specialists, per the shell's "never silently fall back" contract.
+  private fun detectStack(evidence: ReviewDiffEvidence): StackDetection {
+    // Packs come from the Skill Bill installation, never from the repository under review: that
+    // directory belongs to the reviewed project and may hold packs for a different contract.
+    // No installation yields an empty list (no exception) and degrades to a generic rubric.
+    // Installed packs that exist but are out of contract throw; surface that loudly instead of
+    // silently dropping the stack-specific specialists, per the shell's "never silently fall back"
+    // contract.
     val manifests = try {
-      installedReviewCatalog.manifests().ifEmpty {
-        scaffoldCatalogService.discoverPlatformManifests(packsRoot)
-      }
+      installedPackCatalog.manifests()
     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-      val displayPath = runCatching { repoRoot.relativize(packsRoot) }.getOrDefault(packsRoot)
       throw StackDetectionException(
-        "Platform pack discovery failed for $displayPath: ${e.message ?: e.javaClass.simpleName}. " +
-          "Repair the platform pack before running parallel review.",
+        "Installed platform pack discovery failed: ${e.message ?: e.javaClass.simpleName}. " +
+          "Repair the installed platform packs before running parallel review.",
         e,
       )
     }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -5418,11 +5418,8 @@ private fun runtimePhaseGates(
   validationGateRunnerOverride: skillbill.ports.validation.ValidationGateRunner? = null,
   validationGatePlatformManifests: List<skillbill.scaffold.model.PlatformManifest> = emptyList(),
 ): FeatureTaskRuntimePhaseGates {
-  val validationGateResolver = skillbill.application.featuretask.validation.ValidationGateResolver(
-    skillbill.application.scaffold.ScaffoldCatalogService(
-      scaffoldCatalogGateway(validationGatePlatformManifests),
-    ),
-  )
+  val validationGateResolver =
+    skillbill.application.featuretask.validation.ValidationGateResolver { validationGatePlatformManifests }
   val validationGateRunner = validationGateRunnerOverride
     ?: object : skillbill.ports.validation.ValidationGateRunner {
       override fun run(request: skillbill.ports.validation.model.ValidationGateRunRequest) =
@@ -5449,30 +5446,18 @@ private fun runtimePhaseGates(
       validationGateRunner,
       skillbill.application.featuretask.validation.FeatureTaskRuntimeValidationGateProgressStore(recorder),
       skillbill.application.featuretask.validation.FeatureTaskRuntimeSuppressionDeltaService(gitOperations),
-      object : skillbill.ports.config.RepoLocalConfigPort {
-        override fun readRepoLocalConfig(request: skillbill.ports.config.model.ReadRepoLocalConfigRequest) =
-          skillbill.ports.config.model.ReadRepoLocalConfigResult(skillbill.config.model.RepoLocalConfig.defaults())
-      },
+      defaultRepoLocalConfigPort(),
     ),
     sharedEvidenceResolver,
     diffResolver,
   )
 }
 
-private fun scaffoldCatalogGateway(
-  platformManifests: List<skillbill.scaffold.model.PlatformManifest> = emptyList(),
-): skillbill.ports.scaffold.ScaffoldCatalogGateway = object : skillbill.ports.scaffold.ScaffoldCatalogGateway {
-  override fun approvedCodeReviewAreas() = emptySet<String>()
-  override fun preShellFamilies() = emptySet<String>()
-  override fun shelledFamilies() = emptySet<String>()
-  override fun platformPackPresets() = emptyMap<String, String>()
-  override fun scaffoldPayloadVersion() = "test"
-  override fun discoverPilotedPlatformPacks(packsRoot: java.nio.file.Path) =
-    emptyList<skillbill.ports.scaffold.model.PilotedPlatformPackProjection>()
-  override fun discoverPlatformManifests(packsRoot: java.nio.file.Path) = platformManifests
-  override fun discoverBaselineReviewCatalog(packsRoot: java.nio.file.Path) =
-    skillbill.scaffold.model.BaselineReviewCatalog(emptyList(), emptyList())
-}
+private fun defaultRepoLocalConfigPort(): skillbill.ports.config.RepoLocalConfigPort =
+  object : skillbill.ports.config.RepoLocalConfigPort {
+    override fun readRepoLocalConfig(request: skillbill.ports.config.model.ReadRepoLocalConfigRequest) =
+      skillbill.ports.config.model.ReadRepoLocalConfigResult(skillbill.config.model.RepoLocalConfig.defaults())
+  }
 
 private fun testSpecGate(
   specScratchStore: SpecScratchStore = RecordingSpecScratchStore(),

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/ParallelCodeReviewRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/ParallelCodeReviewRunnerTest.kt
@@ -5,7 +5,6 @@ import skillbill.application.model.ParallelReviewScope
 import skillbill.application.model.StackDetectionException
 import skillbill.application.model.UsageValidationException
 import skillbill.application.review.ParallelCodeReviewRunner
-import skillbill.application.scaffold.ScaffoldCatalogService
 import skillbill.application.workflow.repoRoot
 import skillbill.config.model.RepoLocalConfig
 import skillbill.install.model.InstallAgent
@@ -20,7 +19,6 @@ import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
 import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.persistence.ReviewRepository
 import skillbill.ports.persistence.UnitOfWork
-import skillbill.ports.review.InstalledReviewCatalogPort
 import skillbill.ports.review.ParallelReviewLaneRunner
 import skillbill.ports.review.ReviewRubricResolver
 import skillbill.ports.review.ReviewSpecialistContractProvider
@@ -28,6 +26,7 @@ import skillbill.ports.review.model.ParallelReviewLaneOutcome
 import skillbill.ports.review.model.ParallelReviewLaneRunRequest
 import skillbill.ports.review.model.ParallelReviewLaneRunResult
 import skillbill.ports.review.model.ResolvedReviewRubric
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.ports.scaffold.ScaffoldCatalogGateway
 import skillbill.ports.scaffold.model.PilotedPlatformPackProjection
 import skillbill.review.ParallelReviewFindingParser
@@ -781,7 +780,7 @@ class ParallelCodeReviewRunnerFailureTest {
     val error = assertFailsWith<StackDetectionException> {
       runner.run(baseRequest(agent1Id = "claude", agent2Id = "codex", scope = ParallelReviewScope.STAGED))
     }
-    assertContains(error.message.orEmpty(), "Platform pack discovery failed")
+    assertContains(error.message.orEmpty(), "Installed platform pack discovery failed")
     assertTrue(launcher.requests.isEmpty(), "lanes must not launch when stack detection fails")
   }
 
@@ -833,9 +832,7 @@ class ParallelCodeReviewRunnerFailureTest {
           resolvedSlug = manifest?.slug
           ResolvedReviewRubric("parallel-code-review", "horizontal base rubric")
         },
-        installedReviewCatalog = InstalledReviewCatalogPort {
-          listOf(platformManifest("typescript", listOf("*.ts", ".ts")))
-        },
+        catalogGateway = stubCatalogGateway(listOf(platformManifest("typescript", listOf("*.ts", ".ts")))),
       ),
     )
 
@@ -1040,10 +1037,12 @@ private data class RunnerFixtureConfig(
   val rubricResolver: ReviewRubricResolver = ReviewRubricResolver {
     ResolvedReviewRubric("parallel-code-review", "governed generic rubric")
   },
-  val installedReviewCatalog: InstalledReviewCatalogPort = InstalledReviewCatalogPort.NONE,
   val database: RecordingReviewDatabase = RecordingReviewDatabase(),
   val budget: ReviewContextBudgetPolicy = ReviewContextBudgetPolicy.DEFAULT,
-)
+) {
+  val installedPackCatalog: InstalledPlatformPackCatalogPort =
+    InstalledPlatformPackCatalogPort { catalogGateway.discoverPlatformManifests(Path.of(".")) }
+}
 
 private fun runner(
   launcher: GoalRunnerSubtaskLauncher,
@@ -1073,7 +1072,6 @@ private fun runnerWithParallelLane(
 private fun createRunner(launcher: GoalRunnerSubtaskLauncher, config: RunnerFixtureConfig): ParallelCodeReviewRunner =
   ParallelCodeReviewRunner(
     parentReviewLauncher = launcher,
-    scaffoldCatalogService = ScaffoldCatalogService(config.catalogGateway),
     diffResolver = config.diffResolver,
     parallelLaneRunner = config.parallelLaneRunner,
     repoLocalConfig = object : RepoLocalConfigPort {
@@ -1086,7 +1084,7 @@ private fun createRunner(launcher: GoalRunnerSubtaskLauncher, config: RunnerFixt
     reviewRubricResolver = config.rubricResolver,
     reviewSpecialistContractProvider = ReviewSpecialistContractProvider { TEST_SPECIALIST_CONTRACT },
     database = config.database,
-    installedReviewCatalog = config.installedReviewCatalog,
+    installedPackCatalog = config.installedPackCatalog,
   )
 
 private class RecordingReviewDatabase : DatabaseSessionFactory {

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeSuppressionGateTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeSuppressionGateTest.kt
@@ -8,10 +8,7 @@ import skillbill.application.featuretask.validation.model.ValidationGateCycleRes
 import skillbill.application.featuretask.validation.model.ValidationGateCycleTerminalOutcome
 import skillbill.application.featuretask.validation.model.ValidationGateProgressStore
 import skillbill.application.model.FeatureTaskRuntimeRunRequest
-import skillbill.application.scaffold.ScaffoldCatalogService
 import skillbill.contracts.JsonSupport
-import skillbill.ports.scaffold.ScaffoldCatalogGateway
-import skillbill.ports.scaffold.model.PilotedPlatformPackProjection
 import skillbill.ports.validation.ValidationGateRunner
 import skillbill.ports.validation.model.ValidationGateCacheMode
 import skillbill.ports.validation.model.ValidationGateFinding
@@ -24,7 +21,6 @@ import skillbill.ports.workflow.SuppressionEvidenceGitOperationsProvider
 import skillbill.ports.workflow.WorkflowGitOperations
 import skillbill.ports.workflow.model.WorkflowScopedPathContent
 import skillbill.ports.workflow.model.WorkflowScopedPathContentsResult
-import skillbill.scaffold.model.BaselineReviewCatalog
 import skillbill.scaffold.model.DeclaredFiles
 import skillbill.scaffold.model.PlatformManifest
 import skillbill.scaffold.model.RoutingSignals
@@ -266,10 +262,7 @@ class FeatureTaskRuntimeSuppressionGateTest {
       runner = runner,
       progressStore = ValidationGateProgressStore { _, p, _ -> progress += p },
       suppressionDeltaService = FeatureTaskRuntimeSuppressionDeltaService(git),
-      repoLocalConfig = object : skillbill.ports.config.RepoLocalConfigPort {
-        override fun readRepoLocalConfig(request: skillbill.ports.config.model.ReadRepoLocalConfigRequest) =
-          skillbill.ports.config.model.ReadRepoLocalConfigResult(skillbill.config.model.RepoLocalConfig.defaults())
-      },
+      repoLocalConfig = defaultRepoLocalConfigPort(),
     )
     return coordinator.execute(
       ValidationGateCycleRequest(
@@ -307,35 +300,27 @@ class FeatureTaskRuntimeSuppressionGateTest {
     )
   }
 
-  private fun declaredResolver(declaration: ValidationGateDeclaration): ValidationGateResolver = ValidationGateResolver(
-    ScaffoldCatalogService(
-      object : ScaffoldCatalogGateway {
-        override fun approvedCodeReviewAreas() = emptySet<String>()
-        override fun preShellFamilies() = emptySet<String>()
-        override fun shelledFamilies() = emptySet<String>()
-        override fun platformPackPresets() = emptyMap<String, String>()
-        override fun scaffoldPayloadVersion() = "test"
-        override fun discoverPilotedPlatformPacks(packsRoot: Path): List<PilotedPlatformPackProjection> = emptyList()
-        override fun discoverPlatformManifests(packsRoot: Path) = listOf(
-          PlatformManifest(
-            slug = "kotlin",
-            packRoot = repoRoot.resolve("platform-packs/kotlin"),
-            contractVersion = "1.4",
-            routingSignals = RoutingSignals(
-              strong = listOf("src"),
-              tieBreakers = emptyList(),
-              path = listOf("src"),
-            ),
-            declaredCodeReviewAreas = emptyList(),
-            declaredFiles = DeclaredFiles(null, emptyMap()),
-            areaMetadata = emptyMap(),
-            validationGate = declaration,
-          ),
-        )
-        override fun discoverBaselineReviewCatalog(packsRoot: Path) = BaselineReviewCatalog(emptyList(), emptyList())
-      },
-    ),
-  )
+  private fun declaredResolver(declaration: ValidationGateDeclaration): ValidationGateResolver =
+    ValidationGateResolver {
+      listOf(
+        PlatformManifest(
+          slug = "kotlin",
+          packRoot = repoRoot.resolve("platform-packs/kotlin"),
+          contractVersion = "1.4",
+          routingSignals = RoutingSignals(strong = listOf("src"), tieBreakers = emptyList(), path = listOf("src")),
+          declaredCodeReviewAreas = emptyList(),
+          declaredFiles = DeclaredFiles(null, emptyMap()),
+          areaMetadata = emptyMap(),
+          validationGate = declaration,
+        ),
+      )
+    }
+
+  private fun defaultRepoLocalConfigPort(): skillbill.ports.config.RepoLocalConfigPort =
+    object : skillbill.ports.config.RepoLocalConfigPort {
+      override fun readRepoLocalConfig(request: skillbill.ports.config.model.ReadRepoLocalConfigRequest) =
+        skillbill.ports.config.model.ReadRepoLocalConfigResult(skillbill.config.model.RepoLocalConfig.defaults())
+    }
 
   private fun minimalRequest(): FeatureTaskRuntimeRunRequest = FeatureTaskRuntimeRunRequest(
     issueKey = "SKILL-180",

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeValidationGateTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeValidationGateTest.kt
@@ -8,16 +8,13 @@ import skillbill.application.featuretask.validation.model.ValidationGateCycleTer
 import skillbill.application.featuretask.validation.model.ValidationGateProgressStore
 import skillbill.application.featuretask.validation.model.ValidationGateResolution
 import skillbill.application.model.FeatureTaskRuntimeRunRequest
-import skillbill.application.scaffold.ScaffoldCatalogService
-import skillbill.ports.scaffold.ScaffoldCatalogGateway
-import skillbill.ports.scaffold.model.PilotedPlatformPackProjection
+import skillbill.error.ContractVersionMismatchError
 import skillbill.ports.validation.ValidationGateRunner
 import skillbill.ports.validation.model.ValidationGateCacheMode
 import skillbill.ports.validation.model.ValidationGateFinding
 import skillbill.ports.validation.model.ValidationGateRunOutcome
 import skillbill.ports.validation.model.ValidationGateRunRequest
 import skillbill.ports.validation.model.ValidationGateRunResult
-import skillbill.scaffold.model.BaselineReviewCatalog
 import skillbill.scaffold.model.DeclaredFiles
 import skillbill.scaffold.model.PlatformManifest
 import skillbill.scaffold.model.RoutingSignals
@@ -184,22 +181,31 @@ class FeatureTaskRuntimeValidationGateTest {
 
   @Test
   fun `absent gate resolution returns absent for pack without declaration`() {
-    val resolver = ValidationGateResolver(
-      ScaffoldCatalogService(
-        object : ScaffoldCatalogGateway {
-          override fun approvedCodeReviewAreas() = emptySet<String>()
-          override fun preShellFamilies() = emptySet<String>()
-          override fun shelledFamilies() = emptySet<String>()
-          override fun platformPackPresets() = emptyMap<String, String>()
-          override fun scaffoldPayloadVersion() = "test"
-          override fun discoverPilotedPlatformPacks(packsRoot: Path): List<PilotedPlatformPackProjection> = emptyList()
-          override fun discoverPlatformManifests(packsRoot: Path) = listOf(kotlinPackWithoutGate())
-          override fun discoverBaselineReviewCatalog(packsRoot: Path) = BaselineReviewCatalog(emptyList(), emptyList())
-        },
-      ),
-    )
-    val resolution = resolver.resolve(repoRoot, listOf("runtime-kotlin/foo.kt"))
+    val resolver = ValidationGateResolver { listOf(kotlinPackWithoutGate()) }
+    val resolution = resolver.resolve(listOf("runtime-kotlin/foo.kt"))
     assertTrue(resolution is ValidationGateResolution.Absent)
+  }
+
+  @Test
+  fun `out of contract packs block terminally instead of degrading or crashing`() {
+    val cycle = coordinator(outOfContractResolver(), neverRunsGate(), mutableListOf())
+      .execute(cycle = outOfContractCycle())
+    assertIs<ValidationGateCycleResult.Terminal>(cycle)
+    val blocked = assertIs<ValidationGateCycleTerminalOutcome.Blocked>(cycle.outcome)
+    assertTrue(blocked.reason.contains("contract_version '0.1'"))
+    assertTrue(blocked.reason.contains("Repair the installed platform packs"))
+  }
+
+  @Test
+  fun `gate declarations come from the installed pack selection`() {
+    // Only the packs the user installed are offered; a pack that ships but was not selected is
+    // simply absent from the catalog, so routing can never reach its gate.
+    val selected = ValidationGateResolver { listOf(kotlinPackWithoutGate().copy(validationGate = gateDeclaration)) }
+    val declared = assertIs<ValidationGateResolution.Declared>(selected.resolve(listOf("runtime-kotlin/foo.kt")))
+    assertEquals("kotlin", declared.packSlug)
+
+    val notSelected = ValidationGateResolver { emptyList() }
+    assertIs<ValidationGateResolution.Absent>(notSelected.resolve(listOf("runtime-kotlin/foo.kt")))
   }
 
   @Test
@@ -306,6 +312,28 @@ class FeatureTaskRuntimeValidationGateTest {
     assertTrue(progress.last().remainingFindings.isEmpty())
   }
 
+  private fun outOfContractResolver(): ValidationGateResolver = ValidationGateResolver {
+    throw ContractVersionMismatchError(
+      "Platform pack 'fallback': declares contract_version '0.1' but the shell expects '1.4'.",
+    )
+  }
+
+  private fun neverRunsGate(): ValidationGateRunner = object : ValidationGateRunner {
+    override fun run(request: ValidationGateRunRequest): ValidationGateRunResult =
+      error("validation gate must not launch when platform packs are out of contract")
+  }
+
+  private fun outOfContractCycle(): ValidationGateCycleRequest = ValidationGateCycleRequest(
+    repoRoot = repoRoot,
+    request = minimalRequest(),
+    validationDepth = ValidationDepth.DEFAULT,
+    changedPaths = listOf("runtime-kotlin/foo.kt"),
+    repositoryCheckpoint = "checkpoint",
+    agentRepairLauncher = ValidationGateAgentRepairLauncher { _, _ ->
+      error("repair must not launch when platform packs are out of contract")
+    },
+  )
+
   private fun coordinator(
     resolver: ValidationGateResolver,
     runner: ValidationGateRunner,
@@ -332,22 +360,7 @@ class FeatureTaskRuntimeValidationGateTest {
     }
 
   private fun declaredResolver(declaration: ValidationGateDeclaration = gateDeclaration): ValidationGateResolver =
-    ValidationGateResolver(
-      ScaffoldCatalogService(
-        object : ScaffoldCatalogGateway {
-          override fun approvedCodeReviewAreas() = emptySet<String>()
-          override fun preShellFamilies() = emptySet<String>()
-          override fun shelledFamilies() = emptySet<String>()
-          override fun platformPackPresets() = emptyMap<String, String>()
-          override fun scaffoldPayloadVersion() = "test"
-          override fun discoverPilotedPlatformPacks(packsRoot: Path): List<PilotedPlatformPackProjection> = emptyList()
-          override fun discoverPlatformManifests(packsRoot: Path) = listOf(
-            kotlinPackWithoutGate().copy(validationGate = declaration),
-          )
-          override fun discoverBaselineReviewCatalog(packsRoot: Path) = BaselineReviewCatalog(emptyList(), emptyList())
-        },
-      ),
-    )
+    ValidationGateResolver { listOf(kotlinPackWithoutGate().copy(validationGate = declaration)) }
 
   private fun minimalRequest(): FeatureTaskRuntimeRunRequest = FeatureTaskRuntimeRunRequest(
     issueKey = "SKILL-180",

--- a/runtime-kotlin/runtime-application/src/testFixtures/kotlin/skillbill/application/review/ReviewRecordingHarness.kt
+++ b/runtime-kotlin/runtime-application/src/testFixtures/kotlin/skillbill/application/review/ReviewRecordingHarness.kt
@@ -3,7 +3,6 @@ package skillbill.application.review
 import skillbill.application.model.ParallelCodeReviewRequest
 import skillbill.application.model.ParallelReviewScope
 import skillbill.application.model.ReviewPrelaunchExpansion
-import skillbill.application.scaffold.ScaffoldCatalogService
 import skillbill.config.model.RepoLocalConfig
 import skillbill.infrastructure.fs.ClasspathReviewSpecialistContractProvider
 import skillbill.infrastructure.fs.JdkParallelReviewLaneRunner
@@ -29,6 +28,7 @@ import skillbill.ports.review.model.ParallelReviewLaneOutcome
 import skillbill.ports.review.model.ParallelReviewLaneRunRequest
 import skillbill.ports.review.model.ParallelReviewLaneRunResult
 import skillbill.ports.review.model.ResolvedReviewRubric
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.ports.scaffold.ScaffoldCatalogGateway
 import skillbill.ports.scaffold.model.PilotedPlatformPackProjection
 import skillbill.review.context.ReviewContextEnvelopeValidator
@@ -137,7 +137,7 @@ fun reviewHarness(config: ReviewHarnessConfig, recorder: ReviewRecorder): Parall
         providerUsageEnforceable = response.usageEnforceable,
       ) as AgentRunLaunchOutcome
     },
-    scaffoldCatalogService = ScaffoldCatalogService(recordingCatalogGateway(config.manifests)),
+    installedPackCatalog = InstalledPlatformPackCatalogPort { config.manifests },
     diffResolver = object : DiffResolverPort {
       override fun runProcess(args: List<String>, workDir: Path): String? {
         recorder.diffCommands += args

--- a/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
+++ b/runtime-kotlin/runtime-core/src/main/kotlin/skillbill/di/RuntimeComponent.kt
@@ -91,7 +91,7 @@ import skillbill.infrastructure.fs.FileSystemInstallReconcileApply
 import skillbill.infrastructure.fs.FileSystemInstallSelectionPersistence
 import skillbill.infrastructure.fs.FileSystemInstallSkillLink
 import skillbill.infrastructure.fs.FileSystemInstallStagingIntent
-import skillbill.infrastructure.fs.FileSystemInstalledReviewCatalog
+import skillbill.infrastructure.fs.FileSystemInstalledPlatformPackCatalog
 import skillbill.infrastructure.fs.FileSystemInstalledWorkspaceBaselineStatus
 import skillbill.infrastructure.fs.FileSystemRepoLocalConfig
 import skillbill.infrastructure.fs.FileSystemRepoSourceDiscoveryGateway
@@ -175,7 +175,6 @@ import skillbill.ports.persistence.DatabaseSessionFactory
 import skillbill.ports.persistence.ProducerOutputEvidenceValidator
 import skillbill.ports.persistence.RejectedOutputDiagnosticMetadataValidator
 import skillbill.ports.review.DeclaredReviewSpecialistsPort
-import skillbill.ports.review.InstalledReviewCatalogPort
 import skillbill.ports.review.ParallelReviewLaneRunner
 import skillbill.ports.review.ReviewAttributionPort
 import skillbill.ports.review.ReviewEvidenceBrokerFactory
@@ -185,6 +184,7 @@ import skillbill.ports.review.ReviewNativeAgentPreflightPort
 import skillbill.ports.review.ReviewRubricResolver
 import skillbill.ports.review.ReviewSnapshotGateway
 import skillbill.ports.review.ReviewSpecialistContractProvider
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.ports.scaffold.RepoSourceDiscoveryGateway
 import skillbill.ports.scaffold.ScaffoldCatalogGateway
 import skillbill.ports.scaffold.ScaffoldGateway
@@ -475,8 +475,9 @@ abstract class RuntimeComponent(
 
   @Provides
   @JvmSynthetic
-  internal fun installedReviewCatalogPort(adapter: FileSystemInstalledReviewCatalog): InstalledReviewCatalogPort =
-    adapter
+  internal fun installedPlatformPackCatalogPort(
+    adapter: FileSystemInstalledPlatformPackCatalog,
+  ): InstalledPlatformPackCatalogPort = adapter
 
   @Provides
   @JvmSynthetic

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemDeclaredReviewSpecialists.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemDeclaredReviewSpecialists.kt
@@ -1,28 +1,20 @@
 package skillbill.infrastructure.fs
 
 import me.tatarka.inject.annotations.Inject
-import skillbill.error.MissingManifestError
-import skillbill.install.nativeagent.NativeAgentLinkInventory
-import skillbill.model.EnvironmentContext
 import skillbill.ports.review.DeclaredReviewSpecialistsPort
-import skillbill.ports.review.InstalledReviewCatalogPort
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.review.plan.ReviewLaneInclusionPolicy
 import skillbill.review.plan.ReviewLaunchPlanPolicy
 import skillbill.review.plan.ReviewStackRouting
 import skillbill.review.plan.model.ReviewRoutingChangedFile
-import skillbill.scaffold.model.PlatformManifest
-import skillbill.scaffold.platformpack.loadPlatformManifest
-import skillbill.scaffold.platformpack.validatePlatformPackFallbacks
-import java.nio.file.Files
-import java.nio.file.Path
 
 @Inject
 class FileSystemDeclaredReviewSpecialists(
-  private val installedCatalog: InstalledReviewCatalogPort = InstalledReviewCatalogPort.NONE,
+  private val installedCatalog: InstalledPlatformPackCatalogPort = InstalledPlatformPackCatalogPort.NONE,
 ) : DeclaredReviewSpecialistsPort {
-  override fun routedSpecialists(repoRoot: Path, changedFiles: List<ReviewRoutingChangedFile>): List<String> {
+  override fun routedSpecialists(changedFiles: List<ReviewRoutingChangedFile>): List<String> {
     if (changedFiles.isEmpty()) return emptyList()
-    val manifests = installedCatalog.manifests().ifEmpty { discoverManifests(repoRoot) }
+    val manifests = installedCatalog.manifests()
     if (manifests.isEmpty()) return emptyList()
     val routing = ReviewStackRouting.route(manifests, changedFiles)
     val selectedAreas = manifests.flatMap { it.declaredCodeReviewAreas }.toSet()
@@ -34,39 +26,5 @@ class FileSystemDeclaredReviewSpecialists(
         }
         .map { it.skillName }
     }.distinct()
-  }
-
-  private fun discoverManifests(repoRoot: Path): List<PlatformManifest> {
-    val platformPacksRoot = repoRoot.resolve("platform-packs")
-    if (!Files.isDirectory(platformPacksRoot)) return emptyList()
-    val packDirs = Files.list(platformPacksRoot).use { stream ->
-      stream
-        .filter { Files.isDirectory(it) && !it.fileName.toString().startsWith(".") }
-        .sorted()
-        .toList()
-    }
-    return packDirs.mapNotNull { packDir ->
-      try {
-        loadPlatformManifest(packDir)
-      } catch (_: MissingManifestError) {
-        null
-      }
-    }.also(::validatePlatformPackFallbacks)
-  }
-}
-
-@Inject
-class FileSystemInstalledReviewCatalog(
-  private val environment: EnvironmentContext,
-) : InstalledReviewCatalogPort {
-  override fun manifests(): List<PlatformManifest> {
-    val catalogRoots = NativeAgentLinkInventory.read(environment.userHome, emptyList())
-      .map { it.cacheTargetPath.parent.parent.resolve("review-catalog/platform-packs") }
-      .distinct()
-      .filter(Files::isDirectory)
-    val root = catalogRoots.maxByOrNull { Files.getLastModifiedTime(it).toMillis() } ?: return emptyList()
-    return Files.list(root).use { stream ->
-      stream.filter(Files::isDirectory).sorted().map(::loadPlatformManifest).toList()
-    }.also(::validatePlatformPackFallbacks)
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstalledPlatformPackCatalog.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstalledPlatformPackCatalog.kt
@@ -1,0 +1,35 @@
+package skillbill.infrastructure.fs
+
+import me.tatarka.inject.annotations.Inject
+import skillbill.install.nativeagent.NativeAgentLinkInventory
+import skillbill.model.EnvironmentContext
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
+import skillbill.scaffold.model.PlatformManifest
+import skillbill.scaffold.platformpack.loadPlatformManifest
+import skillbill.scaffold.platformpack.validatePlatformPackFallbacks
+import java.nio.file.Files
+
+/**
+ * Reads the pack selection published at install time. The on-disk directory is still named
+ * `review-catalog/platform-packs` because install writes it under that name; the contents are the
+ * selected packs and serve every consumer, review and validate alike.
+ */
+@Inject
+class FileSystemInstalledPlatformPackCatalog(
+  private val environment: EnvironmentContext,
+) : InstalledPlatformPackCatalogPort {
+  override fun manifests(): List<PlatformManifest> {
+    val catalogRoots = NativeAgentLinkInventory.read(environment.userHome, emptyList())
+      .map { it.cacheTargetPath.parent.parent.resolve("review-catalog/platform-packs") }
+      .distinct()
+      .filter(Files::isDirectory)
+    val root = catalogRoots.maxByOrNull { Files.getLastModifiedTime(it).toMillis() } ?: return emptyList()
+    return Files.list(root).use { stream ->
+      stream
+        .filter { Files.isDirectory(it) && !it.fileName.toString().startsWith(".") }
+        .sorted()
+        .map(::loadPlatformManifest)
+        .toList()
+    }.also(::validatePlatformPackFallbacks)
+  }
+}

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemReviewAttribution.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemReviewAttribution.kt
@@ -1,9 +1,8 @@
 package skillbill.infrastructure.fs
 
 import me.tatarka.inject.annotations.Inject
-import skillbill.model.EnvironmentContext
-import skillbill.ports.review.InstalledReviewCatalogPort
 import skillbill.ports.review.ReviewAttributionPort
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.review.plan.ReviewLaunchPlanPolicy
 import skillbill.review.plan.model.ReviewLaunchPlan
 import skillbill.scaffold.model.PlatformManifest
@@ -14,14 +13,18 @@ import java.nio.file.Path
 
 @Inject
 class FileSystemReviewAttribution(
-  private val context: EnvironmentContext,
-  private val installedCatalog: InstalledReviewCatalogPort = InstalledReviewCatalogPort.NONE,
+  private val installedCatalog: InstalledPlatformPackCatalogPort = InstalledPlatformPackCatalogPort.NONE,
 ) : ReviewAttributionPort {
+  /**
+   * Telemetry attribution only, and an absent installation legitimately yields no mappings — so an
+   * unreadable pack degrades here instead of failing the unrelated command that is reporting. Review
+   * routing reads the same catalog and still surfaces contract failures loudly.
+   */
   override fun routedSkillPlatformSlugs(): Map<String, String> =
-    platformReviewAttributionMappings(repoRoot().resolve("platform-packs"))
+    runCatching { platformReviewAttributionMappings(installedCatalog.manifests()) }.getOrDefault(emptyMap())
 
   override fun composedLaunchPlan(routedPackSlug: String): ReviewLaunchPlan {
-    val manifests = installedCatalog.manifests().ifEmpty { discoverManifests() }
+    val manifests = installedCatalog.manifests()
     if (manifests.none { it.slug == routedPackSlug }) return ReviewLaunchPlan(routedPackSlug, emptyList())
     // The routed pack's own composition, never the union across every installed manifest: that union
     // put areas this pack never declares into its plan, and the completeness ledger reads a plan lane
@@ -29,16 +32,6 @@ class FileSystemReviewAttribution(
     val selectedAreas = ReviewLaunchPlanPolicy.composedAreas(routedPackSlug, manifests)
     return ReviewLaunchPlanPolicy.flatten(routedPackSlug, manifests, selectedAreas)
   }
-
-  private fun discoverManifests(): List<PlatformManifest> {
-    val platformPacksRoot = repoRoot().resolve("platform-packs")
-    if (!Files.isDirectory(platformPacksRoot)) return emptyList()
-    return discoverPlatformPackManifests(platformPacksRoot)
-  }
-
-  private fun repoRoot(): Path = Path.of(context.environment["SKILL_BILL_REPO_ROOT"] ?: System.getProperty("user.dir"))
-    .toAbsolutePath()
-    .normalize()
 }
 
 fun platformReviewAttributionMappings(platformPacksRoot: Path): Map<String, String> {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/InstallNativeAgentOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/install/nativeagent/InstallNativeAgentOperations.kt
@@ -233,67 +233,94 @@ object InstallNativeAgentOperations {
     }
   }
 
+  /**
+   * Staged into a sibling directory and swapped in with two renames, rather than pruned and
+   * recopied in place. The in-memory [ProviderMutationJournal] cannot roll back an abrupt process
+   * death, and an in-place rewrite leaves a pack whose `platform.yaml` is deleted but not yet
+   * recopied — which every reader loads as a corrupt pack. With the swap the only externally
+   * visible states are the previous catalog, the new catalog, and briefly no catalog at all;
+   * readers degrade on absence and never observe a partially written pack.
+   */
   private fun publishInstalledReviewCatalog(
     platformPacksRoot: Path,
     selectedPlatforms: List<String>?,
     cacheRoot: Path,
     journal: ProviderMutationJournal,
   ) {
-    val catalogRoot = cacheRoot.resolve("review-catalog/platform-packs")
+    val catalogParent = cacheRoot.resolve("review-catalog")
+    val catalogRoot = catalogParent.resolve("platform-packs")
+    val staging = catalogParent.resolve(".platform-packs.staging")
+    val superseded = catalogParent.resolve(".platform-packs.superseded")
     val selected = selectedPlatforms?.toSet()
     val desiredPacks = Files.list(platformPacksRoot).use { packs ->
       packs.filter(Files::isDirectory)
         .filter { selected == null || it.fileName.toString() in selected }
         .toList()
     }
-    val desiredSlugs = desiredPacks.mapTo(mutableSetOf()) { it.fileName.toString() }
-    journal.beforeMutation(catalogRoot)
-    Files.createDirectories(catalogRoot)
-    Files.list(catalogRoot).use { installed ->
-      installed.filter(Files::isDirectory)
-        .filter { it.fileName.toString() !in desiredSlugs }
-        .forEach { stalePack ->
-          Files.walk(stalePack).use { paths ->
-            paths.sorted(Comparator.reverseOrder()).forEach { path ->
-              journal.beforeMutation(path)
-              Files.delete(path)
-            }
-          }
-        }
-    }
+
+    journal.beforeMutation(catalogParent)
+    Files.createDirectories(catalogParent)
+    // A prior crash can leave either scratch directory behind; neither is readable as a catalog.
+    deleteRecursively(staging)
+    deleteRecursively(superseded)
+    journal.afterTemporaryCreation(staging)
+    Files.createDirectories(staging)
+
+    // Staging holds exactly the desired packs, so deselected packs are pruned by the swap itself.
     desiredPacks.forEach { source ->
-      val targetPack = catalogRoot.resolve(source.fileName.toString())
-      if (Files.exists(targetPack, LinkOption.NOFOLLOW_LINKS)) {
-        Files.walk(targetPack).use { paths ->
-          paths.sorted(Comparator.reverseOrder()).forEach { path ->
-            journal.beforeMutation(path)
-            Files.delete(path)
-          }
-        }
-      }
+      val stagedPack = staging.resolve(source.fileName.toString())
       val manifest = loadPlatformManifest(source)
       val runtimeFiles = buildList {
         add(source.resolve("platform.yaml"))
         manifest.declaredFiles.baseline?.let(::add)
         addAll(manifest.declaredFiles.areas.values)
+        // The published manifest is reloaded by every consumer, and loading validates that declared
+        // add-on pointers resolve. Publishing the manifest without them made the pack unloadable.
+        manifest.featureAddonUsage.forEach { usage ->
+          usage.addons.forEach { addon ->
+            add(source.resolve("addons").resolve(addon.entrypoint))
+            addon.companionPointers.forEach { pointer -> add(source.resolve("addons").resolve(pointer)) }
+          }
+        }
       }.distinct()
       runtimeFiles.forEach { path ->
         val relative = source.relativize(path.toAbsolutePath().normalize())
         require(!relative.startsWith("..")) {
           "Installed review catalog path escapes platform pack '${manifest.slug}'."
         }
-        val target = targetPack.resolve(relative).normalize()
-        require(target.startsWith(catalogRoot)) { "Installed review catalog path escapes its cache root." }
+        val target = stagedPack.resolve(relative).normalize()
+        require(target.startsWith(staging)) { "Installed review catalog path escapes its cache root." }
         require(Files.isRegularFile(path) && !Files.isSymbolicLink(path)) {
           "Installed review catalog source must be a regular manifest-declared file: '$path'."
         }
-        journal.beforeMutation(target)
-        target.parent?.let {
-          journal.beforeMutation(it)
-          Files.createDirectories(it)
-        }
+        target.parent?.let(Files::createDirectories)
         Files.copy(path, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
       }
+    }
+
+    // Journal the outgoing and incoming trees path by path, parents first, so an in-process failure
+    // after the swap still unwinds: pre-existing paths keep their captured snapshot and are
+    // rewritten, paths only the new catalog introduces record as absent and are deleted.
+    if (Files.exists(catalogRoot, LinkOption.NOFOLLOW_LINKS)) {
+      Files.walk(catalogRoot).use { paths -> paths.sorted().forEach(journal::beforeMutation) }
+    }
+    Files.walk(staging).use { paths ->
+      paths.sorted().forEach { staged ->
+        journal.beforeMutation(catalogRoot.resolve(staging.relativize(staged)))
+      }
+    }
+
+    if (Files.exists(catalogRoot, LinkOption.NOFOLLOW_LINKS)) {
+      Files.move(catalogRoot, superseded, java.nio.file.StandardCopyOption.ATOMIC_MOVE)
+    }
+    Files.move(staging, catalogRoot, java.nio.file.StandardCopyOption.ATOMIC_MOVE)
+    deleteRecursively(superseded)
+  }
+
+  private fun deleteRecursively(root: Path) {
+    if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) return
+    Files.walk(root).use { paths ->
+      paths.sorted(Comparator.reverseOrder()).forEach(Files::delete)
     }
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemDeclaredReviewSpecialistsTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemDeclaredReviewSpecialistsTest.kt
@@ -1,9 +1,9 @@
 package skillbill.infrastructure.fs
 
 import skillbill.error.InvalidFallbackCapabilityError
-import skillbill.ports.review.InstalledReviewCatalogPort
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.review.plan.model.ReviewRoutingChangedFile
-import skillbill.scaffold.platformpack.loadPlatformManifest
+import skillbill.scaffold.platformpack.discoverPlatformPackManifests
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -17,13 +17,8 @@ class FileSystemDeclaredReviewSpecialistsTest {
     val installedRoot = Files.createTempDirectory("installed-review-catalog")
     val packsRoot = Files.createDirectories(installedRoot.resolve("platform-packs"))
     writePack(packsRoot, "neutral-review", emptyList(), listOf("architecture", "security"))
-    val catalog = InstalledReviewCatalogPort {
-      listOf(loadPlatformManifest(packsRoot.resolve("neutral-review")))
-    }
-    val reviewedRepo = Files.createTempDirectory("external-reviewed-repo")
-
-    val specialists = FileSystemDeclaredReviewSpecialists(catalog)
-      .routedSpecialists(reviewedRepo, changed("docs/guide.md"))
+    val specialists = FileSystemDeclaredReviewSpecialists(installedCatalog(packsRoot))
+      .routedSpecialists(changed("docs/guide.md"))
 
     assertEquals(
       listOf(
@@ -35,30 +30,32 @@ class FileSystemDeclaredReviewSpecialistsTest {
   }
 
   @Test
-  fun `no platform-packs directory yields no specialists`() {
-    val repoRoot = Files.createTempDirectory("declared-specialists-empty")
-    val specialists = FileSystemDeclaredReviewSpecialists().routedSpecialists(repoRoot, changed("src/Main.kt"))
+  fun `no installed packs yields no specialists`() {
+    val specialists = FileSystemDeclaredReviewSpecialists().routedSpecialists(changed("src/Main.kt"))
     assertEquals(emptyList(), specialists)
   }
 
   @Test
   fun `a pack directory without a manifest contributes no specialists`() {
-    val repoRoot = Files.createTempDirectory("declared-specialists-absent")
-    val packsRoot = Files.createDirectories(repoRoot.resolve("platform-packs"))
+    val packsRoot = Files.createTempDirectory("declared-specialists-absent")
     Files.createDirectory(packsRoot.resolve("kotlin"))
-    val specialists = FileSystemDeclaredReviewSpecialists().routedSpecialists(repoRoot, changed("src/Main.kt"))
-    assertEquals(emptyList(), specialists)
+    var threw = false
+    try {
+      FileSystemDeclaredReviewSpecialists(installedCatalog(packsRoot)).routedSpecialists(changed("src/Main.kt"))
+    } catch (_: Exception) {
+      threw = true
+    }
+    assertTrue(threw, "an installed pack directory without a manifest must loud-fail")
   }
 
   @Test
   fun `a malformed manifest loud-fails instead of being silently swallowed`() {
-    val repoRoot = Files.createTempDirectory("declared-specialists-malformed")
-    val packsRoot = Files.createDirectories(repoRoot.resolve("platform-packs"))
+    val packsRoot = Files.createTempDirectory("declared-specialists-malformed")
     val packDir = Files.createDirectory(packsRoot.resolve("broken"))
     Files.writeString(packDir.resolve("platform.yaml"), "areas: [unclosed")
     var threw = false
     try {
-      FileSystemDeclaredReviewSpecialists().routedSpecialists(repoRoot, changed("src/Main.kt"))
+      FileSystemDeclaredReviewSpecialists(installedCatalog(packsRoot)).routedSpecialists(changed("src/Main.kt"))
     } catch (_: Exception) {
       threw = true
     }
@@ -67,9 +64,8 @@ class FileSystemDeclaredReviewSpecialistsTest {
 
   @Test
   fun `only packs the changed paths route to contribute specialists`() {
-    val repoRoot = repoWithPacks()
-    val specialists = FileSystemDeclaredReviewSpecialists()
-      .routedSpecialists(repoRoot, changed("runtime/src/main/kotlin/Runner.kt"))
+    val specialists = FileSystemDeclaredReviewSpecialists(installedCatalog(packsWithKotlinAndGo()))
+      .routedSpecialists(changed("runtime/src/main/kotlin/Runner.kt"))
     assertEquals(
       listOf("bill-kotlin-code-review-architecture", "bill-kotlin-code-review-security"),
       specialists.sorted(),
@@ -78,8 +74,7 @@ class FileSystemDeclaredReviewSpecialistsTest {
 
   @Test
   fun `preflight excludes an unconditioned non-required specialist that launch does not own`() {
-    val repoRoot = Files.createTempDirectory("declared-specialists-unconditioned")
-    val packsRoot = Files.createDirectories(repoRoot.resolve("platform-packs"))
+    val packsRoot = Files.createTempDirectory("declared-specialists-unconditioned")
     writePack(
       packsRoot,
       "kotlin",
@@ -88,17 +83,16 @@ class FileSystemDeclaredReviewSpecialistsTest {
       options = PackOptions(includeLaneConditions = false),
     )
 
-    val specialists = FileSystemDeclaredReviewSpecialists()
-      .routedSpecialists(repoRoot, changed("runtime/src/main/kotlin/Runner.kt"))
+    val specialists = FileSystemDeclaredReviewSpecialists(installedCatalog(packsRoot))
+      .routedSpecialists(changed("runtime/src/main/kotlin/Runner.kt"))
 
     assertEquals(emptyList(), specialists)
   }
 
   @Test
   fun `a vendored pack that no changed path routes to is never required`() {
-    val repoRoot = repoWithPacks()
-    val specialists = FileSystemDeclaredReviewSpecialists()
-      .routedSpecialists(repoRoot, changed("runtime/src/main/kotlin/Runner.kt"))
+    val specialists = FileSystemDeclaredReviewSpecialists(installedCatalog(packsWithKotlinAndGo()))
+      .routedSpecialists(changed("runtime/src/main/kotlin/Runner.kt"))
     assertTrue(
       specialists.none { it.startsWith("bill-go-") },
       "a Kotlin-only delta must not demand the vendored Go pack's specialists: $specialists",
@@ -107,14 +101,13 @@ class FileSystemDeclaredReviewSpecialistsTest {
 
   @Test
   fun `no changed paths yields no specialists`() {
-    val repoRoot = repoWithPacks()
-    assertEquals(emptyList(), FileSystemDeclaredReviewSpecialists().routedSpecialists(repoRoot, emptyList()))
+    val catalog = installedCatalog(packsWithKotlinAndGo())
+    assertEquals(emptyList(), FileSystemDeclaredReviewSpecialists(catalog).routedSpecialists(emptyList()))
   }
 
   @Test
   fun `preflight reads changed content to break overlapping path signal ties`() {
-    val repoRoot = Files.createTempDirectory("declared-specialists-content")
-    val packsRoot = Files.createDirectories(repoRoot.resolve("platform-packs"))
+    val packsRoot = Files.createTempDirectory("declared-specialists-content")
     writePack(packsRoot, "kotlin", listOf(".kt", "*.kt"), listOf("architecture"))
     writePack(
       packsRoot,
@@ -123,37 +116,36 @@ class FileSystemDeclaredReviewSpecialistsTest {
       listOf("platform-correctness"),
       options = PackOptions(contentSignals = listOf("expect class")),
     )
-    val source = repoRoot.resolve("src/commonMain/kotlin/Shared.kt")
-    Files.createDirectories(source.parent)
-    Files.writeString(source, "expect class Shared")
-
-    val specialists = FileSystemDeclaredReviewSpecialists()
-      .routedSpecialists(repoRoot, changed("src/commonMain/kotlin/Shared.kt", "expect class Shared"))
+    val specialists = FileSystemDeclaredReviewSpecialists(installedCatalog(packsRoot))
+      .routedSpecialists(changed("src/commonMain/kotlin/Shared.kt", "expect class Shared"))
 
     assertEquals(listOf("bill-kmp-code-review-platform-correctness"), specialists)
   }
 
   @Test
   fun `preflight rejects duplicate fallback owners before concrete routing`() {
-    val repoRoot = Files.createTempDirectory("declared-specialists-duplicate-fallback")
-    val packsRoot = Files.createDirectories(repoRoot.resolve("platform-packs"))
+    val packsRoot = Files.createTempDirectory("declared-specialists-duplicate-fallback")
     writePack(packsRoot, "kotlin", listOf("*.kt"), listOf("architecture"))
     writePack(packsRoot, "first-neutral", emptyList(), listOf("architecture"))
     writePack(packsRoot, "second-neutral", emptyList(), listOf("security"))
 
     assertFailsWith<InvalidFallbackCapabilityError> {
-      FileSystemDeclaredReviewSpecialists()
-        .routedSpecialists(repoRoot, changed("src/main/kotlin/Runner.kt"))
+      FileSystemDeclaredReviewSpecialists(installedCatalog(packsRoot))
+        .routedSpecialists(changed("src/main/kotlin/Runner.kt"))
     }
   }
 
-  private fun repoWithPacks(): Path {
-    val repoRoot = Files.createTempDirectory("declared-specialists-routed")
-    val packsRoot = Files.createDirectories(repoRoot.resolve("platform-packs"))
+  private fun packsWithKotlinAndGo(): Path {
+    val packsRoot = Files.createTempDirectory("declared-specialists-routed")
     writePack(packsRoot, "kotlin", listOf(".kt", "*.kt"), listOf("architecture", "security"))
     writePack(packsRoot, "go", listOf(".go", "*.go"), listOf("architecture", "api-contracts"))
-    return repoRoot
+    return packsRoot
   }
+
+  // Mirrors FileSystemInstalledPlatformPackCatalog: the installed selection is where pack discovery
+  // and its loud-fail validation now live, so these cases exercise it through the same seam.
+  private fun installedCatalog(packsRoot: Path) =
+    InstalledPlatformPackCatalogPort { discoverPlatformPackManifests(packsRoot) }
 
   private fun changed(path: String, content: String = "") = listOf(ReviewRoutingChangedFile(path, content))
 

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemReviewAttributionTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemReviewAttributionTest.kt
@@ -1,6 +1,7 @@
 package skillbill.infrastructure.fs
 
-import skillbill.model.EnvironmentContext
+import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
+import skillbill.scaffold.platformpack.discoverPlatformPackManifests
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -32,9 +33,7 @@ class FileSystemReviewAttributionTest {
   fun `composed launch plan carries baseline sourced lanes with their owning pack and depth`() {
     val repoRoot = composedPackFixture()
 
-    val plan = FileSystemReviewAttribution(
-      EnvironmentContext(environment = mapOf("SKILL_BILL_REPO_ROOT" to repoRoot.toString())),
-    ).composedLaunchPlan("kmp")
+    val plan = FileSystemReviewAttribution(installedCatalog(repoRoot)).composedLaunchPlan("kmp")
 
     assertEquals(
       listOf("kmp" to "architecture", "kotlin" to "testing"),
@@ -52,12 +51,14 @@ class FileSystemReviewAttributionTest {
   fun `an unknown routed pack slug yields an empty plan rather than failing`() {
     val repoRoot = composedPackFixture()
 
-    val plan = FileSystemReviewAttribution(
-      EnvironmentContext(environment = mapOf("SKILL_BILL_REPO_ROOT" to repoRoot.toString())),
-    ).composedLaunchPlan("nowhere")
+    val plan = FileSystemReviewAttribution(installedCatalog(repoRoot)).composedLaunchPlan("nowhere")
 
     assertEquals("nowhere", plan.routedPackSlug)
     assertEquals(emptyList(), plan.lanes)
+  }
+
+  private fun installedCatalog(repoRoot: Path) = InstalledPlatformPackCatalogPort {
+    discoverPlatformPackManifests(repoRoot.resolve("platform-packs"))
   }
 
   private fun composedPackFixture(): Path {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallNativeAgentLinkApplyTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/install/InstallNativeAgentLinkApplyTest.kt
@@ -767,6 +767,36 @@ class InstallNativeAgentLinkApplyTest : InstallApplyTestSupport() {
   }
 
   @Test
+  fun `failed replacement apply restores the previously published review catalog`() {
+    val fixture = setupApplyFixture()
+    Files.createDirectories(fixture.home.resolve(".codex"))
+    val firstPlan = InstallOperations.planInstall(
+      fixture.request(selectedPlatforms = setOf("kotlin"), agents = setOf(InstallAgent.CODEX)),
+    )
+    assertEquals(InstallApplyStatus.SUCCESS, InstallOperations.applyInstall(firstPlan).status)
+    val catalog = currentNativeAgentApplyCacheRoot(
+      fixture.home,
+      fixture.repoRoot.resolve("platform-packs"),
+      fixture.repoRoot.resolve("skills"),
+    ).resolve("review-catalog/platform-packs")
+    val publishedManifest = Files.readString(catalog.resolve("kotlin/platform.yaml"))
+
+    // The catalog swap moves the outgoing tree aside and deletes it, so a failure after the swap
+    // can only be undone from the journal's captured snapshots.
+    val inventory = fixture.home.resolve(".skill-bill/native-agent-link-inventory.json")
+    Files.writeString(inventory, "not-json")
+    val replacementPlan = InstallOperations.planInstall(
+      fixture.request(selectedPlatforms = setOf("kmp"), agents = setOf(InstallAgent.CODEX)),
+    )
+
+    val result = InstallOperations.applyInstall(replacementPlan)
+
+    assertEquals(InstallApplyStatus.FAILURE, result.status)
+    assertEquals(publishedManifest, Files.readString(catalog.resolve("kotlin/platform.yaml")))
+    assertFalse(Files.exists(catalog.resolve("kmp"), LinkOption.NOFOLLOW_LINKS))
+  }
+
+  @Test
   fun `installed review catalog contains only manifest and declared review content`() {
     val fixture = setupApplyFixture()
     Files.createDirectories(fixture.home.resolve(".codex"))

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/review/DeclaredReviewSpecialistsPort.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/review/DeclaredReviewSpecialistsPort.kt
@@ -1,27 +1,17 @@
 package skillbill.ports.review
 
 import skillbill.review.plan.model.ReviewRoutingChangedFile
-import skillbill.scaffold.model.PlatformManifest
-import java.nio.file.Path
 
 fun interface DeclaredReviewSpecialistsPort {
   /**
-   * Specialists a review over [changedFiles] will actually route to. Scoping by the review's own
-   * diff evidence is required, not an optimization: a repo that vendors packs it never installed
-   * (skill-bill's own tree ships every pack) would otherwise be asked for every pack's specialists
-   * and fail preflight on a pack the review never launches.
+   * Specialists a review over [changedFiles] will actually route to, resolved against the installed
+   * pack selection. Scoping by the review's own diff evidence is required, not an optimization:
+   * asking for every installed pack's specialists fails preflight on a pack the review never
+   * launches. No repository path is taken — packs never come from the project under review.
    */
-  fun routedSpecialists(repoRoot: Path, changedFiles: List<ReviewRoutingChangedFile>): List<String>
+  fun routedSpecialists(changedFiles: List<ReviewRoutingChangedFile>): List<String>
 
   companion object {
-    val NONE = DeclaredReviewSpecialistsPort { _, _ -> emptyList() }
-  }
-}
-
-fun interface InstalledReviewCatalogPort {
-  fun manifests(): List<PlatformManifest>
-
-  companion object {
-    val NONE = InstalledReviewCatalogPort { emptyList() }
+    val NONE = DeclaredReviewSpecialistsPort { _ -> emptyList() }
   }
 }

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/scaffold/InstalledPlatformPackCatalogPort.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/scaffold/InstalledPlatformPackCatalogPort.kt
@@ -1,0 +1,17 @@
+package skillbill.ports.scaffold
+
+import skillbill.scaffold.model.PlatformManifest
+
+/**
+ * Platform packs the user actually installed — the selection recorded at install time, not every
+ * pack that ships. Both code review and the validate gate resolve from here, so neither can reach
+ * a pack the user declined; consult this rather than discovering packs under the repository being
+ * worked on, which belongs to that project and may not describe this runtime at all.
+ */
+fun interface InstalledPlatformPackCatalogPort {
+  fun manifests(): List<PlatformManifest>
+
+  companion object {
+    val NONE = InstalledPlatformPackCatalogPort { emptyList() }
+  }
+}


### PR DESCRIPTION
# Summary

Platform packs ship with Skill Bill and install to `~/.skill-bill/platform-packs`, but review and validate resolved them from `<repoRoot>/platform-packs` — the directory of whatever project was being worked on. That was wrong in two ways. An ordinary project has no such directory, so the pack-declared validation gate silently degraded to agent-run validate; it only ever engaged when Skill Bill ran on its own checkout. And a project that happened to own a directory by that name had its files parsed against this runtime's pack contract, where `ContractVersionMismatchError` escaped uncaught, killed the child process with exit 1, and cost the goal its terminal workflow outcome.

- All four review/validate call sites now read `InstalledPlatformPackCatalogPort` — the pack *selection* chosen at install time, so a gate can never come from a pack the user declined to install.
- `ValidationGateResolver.resolve` and `DeclaredReviewSpecialistsPort.routedSpecialists` no longer accept a repository path, making "never reads the project" structural rather than conventional.
- Contract failures at that seam become a typed `ValidationGateResolution.Incompatible` that the run loop records as a durable block instead of crashing.
- Renames `skillbill.ports.review.InstalledReviewCatalogPort` to `skillbill.ports.scaffold.InstalledPlatformPackCatalogPort`; it is no longer review-specific now that validate resolves from it too.

Two defects surfaced once the installed catalog became the only source:

- `publishInstalledReviewCatalog` published `platform.yaml` without the `addons/` files its `feature_addon_usage` pointers declare, and loading a manifest validates that those pointers resolve — so the installed `kmp` pack was unloadable. The previous repo fallback never masked this: the exception propagates before `.ifEmpty` is reached.
- That unloadable pack failed unrelated CLI commands (`triage`, `learnings`, `import-review`) through telemetry attribution. `routedSkillPlatformSlugs` now degrades to no mappings, where empty is already the documented normal case. Review routing reads the same catalog and still fails loudly.

The catalog is also now published by staging into a sibling directory and swapping it in with two renames. The mutation journal is in-memory and cannot roll back an abrupt process death, so the previous in-place prune-and-recopy could leave a pack whose `platform.yaml` was deleted but not yet recopied — which every reader loads as corrupt. After the swap the only externally visible states are the previous catalog, the new catalog, or briefly none at all, and absence degrades rather than blocking.

## Reviewer notes — behaviour changes

1. **Kotlin and KMP projects will start running their pack-declared gate** (`./gradlew check`) under runtime-owned validate, where they previously fell through to agent-run validate. Only `kotlin` and `kmp` declare a `validation_gate`, so iOS/TS/Python/Go/PHP/Rust projects are unaffected. A monorepo target needs `.skill-bill/config.yaml` with `validation_gate.gradle_wrapper`, or the gate runs `./gradlew` at the git root.
2. **Pack authoring in this repo no longer takes effect until reinstall**, for review or validate. This is the principle applied consistently, but it does slow the pack dev loop.
3. **An existing installed catalog stays broken until you reinstall.** The add-on fix only changes what future installs publish.

## Feature Flags

N/A — no flag. The behaviour change is guarded by which packs declare a `validation_gate`, not by a toggle.

# How Has This Been Tested?

`./gradlew check` (full gate: build, tests, detekt, spotless) and `skill-bill validate` (`status: pass`, no issues).

Tests added or reworked:

- `FeatureTaskRuntimeValidationGateTest` — gate declarations come from the installed pack selection; an out-of-contract catalog blocks terminally instead of degrading or crashing.
- `InstallNativeAgentLinkApplyTest` — a failed replacement apply restores the previously published catalog. Mutation-verified: removing the journaling loops makes it fail, so it is not vacuous.
- `FileSystemDeclaredReviewSpecialistsTest` / `FileSystemReviewAttributionTest` — fixtures now feed the installed catalog instead of temp repo trees, keeping malformed-manifest loud-fail, duplicate-fallback rejection, and content-signal tie-breaking exercised at the seam where discovery now lives.

To reproduce the original crash on `main`:

1. Point a feature-task goal at a checkout that owns a `platform-packs/` directory authored against a different `contract_version` (e.g. a Skill Bill rewrite tree).
2. Drive it to a `validate` phase.
3. On `main` the child exits 1 with an uncaught `ContractVersionMismatchError` and the goal is left without a terminal workflow outcome. On this branch the repo directory is never read, so the phase proceeds against the installed packs.

To verify the gate now engages:

1. `./install.sh` with `kotlin` selected, then run a feature-task goal to a `validate` phase in a Kotlin Gradle project.
2. Confirm validate runs the pack gate (`./gradlew check`) rather than reporting an agent-run validate fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
