### PR TITLE
SKILL-185: key gate repair turns, degrade diagnostic write failures

### DIFF
--- a/.feature-specs/SKILL-186-diagnostic-degradation-observability/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-186-diagnostic-degradation-observability/decomposition-manifest.yaml
@@ -1,0 +1,37 @@
+contract_version: "0.5"
+issue_key: "SKILL-186"
+feature_name: "diagnostic-degradation-observability"
+parent_spec_path: ".feature-specs/SKILL-186-diagnostic-degradation-observability/spec.md"
+execution_model: same_branch_commit_per_subtask
+base_branch: main
+feature_branch: feat/SKILL-186-diagnostic-degradation-observability
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: none
+subtasks:
+  - id: 1
+    name: "Degradation operator seam: telemetry, status projection, honest block reason"
+    spec_path: ".feature-specs/SKILL-186-diagnostic-degradation-observability/spec_subtask_1_degradation-operator-seam.md"
+    status: pending
+    branch: null
+    commit_sha: null
+    workflow_id: null
+    blocked_reason: null
+    last_resumable_step: null
+    linear_issue_id: null
+    dependencies: []
+  - id: 2
+    name: "Quarantine identity integrity: never name an unwritten diagnostic row"
+    spec_path: ".feature-specs/SKILL-186-diagnostic-degradation-observability/spec_subtask_2_quarantine-identity-integrity.md"
+    status: pending
+    branch: null
+    commit_sha: null
+    workflow_id: null
+    blocked_reason: null
+    last_resumable_step: null
+    linear_issue_id: null
+    dependencies:
+      - subtask_id: 1
+        optional: true
+        skipped: false

--- a/.feature-specs/SKILL-186-diagnostic-degradation-observability/spec.md
+++ b/.feature-specs/SKILL-186-diagnostic-degradation-observability/spec.md
@@ -1,0 +1,180 @@
+# SKILL-186 — Degraded diagnostic signals are write-only and can point at evidence that was never written
+
+## Context
+
+SKILL-185 stopped a validation-gate repair cycle from killing a run: repair turns
+within one phase attempt now key their evidence by a repair-turn ordinal, and a
+diagnostic-persistence failure degrades to a durable payload-free
+`FeatureTaskRuntimeDiagnosticSignal` instead of propagating an uncaught
+`RejectedOutputDiagnosticError.Conflict`.
+
+That fix traded a crash for two diagnosability gaps. Both were raised by the
+review of SKILL-185 (run `rvw-20260812-064823-k4qm`, findings F-003 and F-004),
+verified against the code, and deliberately deferred because each needs work the
+crash fix did not.
+
+### Gap 1 — the degraded signal is write-only, and the read path misattributes it
+
+`FeatureTaskRuntimePhaseRecorder.degradeDiagnosticFailure`
+(`FeatureTaskRuntimePhaseRecorder.kt:278`) appends a
+`FeatureTaskRuntimeDiagnosticSignal` under
+`FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_ARTIFACT_KEY` and returns null. Three
+things follow from that:
+
+- `loadDiagnosticSignals` (`FeatureTaskRuntimePhaseRecorder.kt:349`) has no
+  production caller. Only tests read it, so nothing an operator or the IDE can
+  see reports that evidence was lost. `FeatureTaskRuntimeStatusProjection`
+  (`FeatureTaskRuntimeStatusModels.kt`) already surfaces audit-repair progress
+  and gate-run counts and is the natural reader.
+- No telemetry field is emitted, even though `recordRejectionMeasurement`
+  (`FeatureTaskRuntimePhaseRecorder.kt`) sits immediately beside it and is the
+  established content-free seam
+  (`LifecycleTelemetryRepository.featureTaskRuntimeRejection`,
+  `LifecycleTelemetryRepository.kt:27`). The failure class is therefore not
+  countable across runs.
+- On the read path the degradation changes what the operator is told.
+  `producerOutput` converts `Corrupt`, `Permission`, and `Persistence` into null,
+  and the caller at `FeatureTaskRuntimeRunLoop.kt:3262` blocks with
+  `NEEDS_USER_ACTION` and the reason "exact raw evidence for attempt N is
+  unavailable". The store actually threw; the operator reads "absent".
+
+`docs/observability-policy.md` requires a record at exactly this seam — "a
+`runCatching` or `catch` that continues instead of rethrowing" — naming the seam,
+the value used, the value expected, and why. It also requires each record to name
+a specific cause, and warns that a substitution changing a contract the caller
+depends on should loud-fail rather than log-and-continue. The current block reason
+substitutes "unreadable" with "absent" in the operator's only visible artifact.
+
+A second-order hole: `persistDiagnosticSignal`
+(`FeatureTaskRuntimePhaseRecorder.kt:322`) swallows its own failure with a bare
+`catch` and leaves no record at all. That is intentional — the store that just
+rejected the evidence is the same store the signal would land in — but it is
+currently invisible even in aggregate.
+
+### Gap 2 — a quarantine entry can name a diagnostic row that was never written
+
+The run loop's `recordRejectedOutput` returns
+`RejectedOutputDiagnosticService.stableIdentity(...)` unconditionally
+(`FeatureTaskRuntimeRunLoop.kt:3548`). When the recorder degrades, the whole
+`database.transaction` around the retain and the insert has rolled back, so no
+`rejected_output_diagnostics` row exists — but the caller still receives a
+well-formed `rod_<sha256>` string.
+
+That string is then persisted as `diagnosticIdentity` on a
+`FeatureTaskRuntimeQuarantineEntry` (`FeatureTaskRuntimeRunLoop.kt:3306`). The
+quarantine contract requires the field to be a non-blank stable identity
+(`orchestration/contracts/feature-task-runtime-quarantine-schema.yaml`,
+`diagnostic_identity`, `minLength: 1`), and the store is append-only and never
+repaired. Reachable path: a reconciliation-class rejection whose producer-evidence
+retain conflicts leaves a permanent quarantine entry pointing at an identity that
+resolves to nothing, with no field on the entry saying the diagnostic degraded.
+
+This is the inverse of the SKILL-185 constraint that already-persisted identities
+stay resolvable: SKILL-185 protected old identities and then allowed a new
+dangling one.
+
+## Intended Outcome
+
+Every degraded diagnostic-persistence failure is visible where an operator
+already looks and countable across runs; a block reason distinguishes evidence
+that is absent from evidence the store refused to hand over; and no durable
+quarantine entry ever names a diagnostic row that was not written.
+
+## Acceptance Criteria
+
+1. A degraded diagnostic-persistence failure emits a content-free telemetry
+   measurement carrying at minimum the workflow, the phase, the attempt, the
+   repair turn when scoped to one, the generation, the operation, the typed
+   failure class, and the conflicting key — through the same
+   `LifecycleTelemetryRepository` seam `recordRejectionMeasurement` already uses.
+2. The telemetry emission cannot fail the run: a throwing telemetry sink leaves
+   the degradation behavior and the durable signal unchanged, matching the rule
+   `recordRejectionMeasurement` already applies.
+3. `FeatureTaskRuntimeStatusProjection` reports the degraded-signal count and the
+   most recent signal's typed failure class, phase, and attempt, so the condition
+   is visible from the existing status surface without reading the database
+   directly.
+4. A phase blocked because producer evidence could not be read distinguishes
+   "no evidence was retained for this attempt" from "retained evidence exists but
+   the diagnostic store refused it", and names the typed failure class in the
+   second case. The reason stays payload-free.
+5. A quarantine entry is never persisted with a `diagnosticIdentity` whose
+   diagnostic row was not written. Either the entry records that the diagnostic
+   degraded, or the quarantine append is refused with a durable block naming the
+   degradation — never a silently dangling identity.
+6. Every `diagnosticIdentity` already persisted on an existing quarantine entry
+   keeps resolving exactly as it does today, and an existing entry stays readable
+   under whatever contract shape this feature lands.
+7. Any change to the quarantine wire shape lands as a schema change in
+   `orchestration/contracts/feature-task-runtime-quarantine-schema.yaml` with its
+   Kotlin `FEATURE_TASK_RUNTIME_QUARANTINE_CONTRACT_VERSION` pin, its parity
+   test, and loud-fail decode at every parse seam, per the runtime contract
+   convention in `AGENTS.md`.
+8. Every new or changed record stays payload-free: no agent output, prompt text,
+   database path, or process output reaches telemetry, the status projection, a
+   block reason, or a quarantine entry.
+9. Regression coverage exercises: a degraded conflict emitting telemetry, a
+   throwing telemetry sink not altering the outcome, the status projection
+   reporting a degraded signal, both block-reason branches, a quarantine append
+   whose diagnostic degraded, and an existing quarantine entry decoding unchanged.
+10. The runtime check suite passes.
+
+## Constraints
+
+- Do not undo the SKILL-185 degradation. A diagnostic-persistence failure must
+  still never terminate a run that has otherwise progressed; this feature makes
+  the degradation visible, it does not make it fatal again.
+- Keep `InvalidRequest` and `InvalidConfiguration` loud. SKILL-185 deliberately
+  excluded them from `degradableFailureClass`, and they must keep propagating as
+  typed failures rather than becoming signals.
+- Telemetry must stay content-free per
+  `orchestration/telemetry-contract/PLAYBOOK.md`: identifiers, counts, and
+  sanitized labels only, never prompts, payloads, transcripts, or tool output.
+- The quarantine store is append-only and never mutated or deleted by any runtime
+  path. Do not repair existing entries in place, and do not delete evidence.
+- `persistDiagnosticSignal` must remain best-effort. If the store that rejected
+  the evidence also rejects the signal, the run still proceeds.
+- Migrations and contract changes must self-heal on existing databases, per the
+  runtime's unconditional column-ensure convention.
+
+## Non-Goals
+
+- No change to the repair-turn keying, the producer-evidence primary key, the
+  `rejected_output_diagnostics` unique key, or `stableIdentity`. SKILL-185 owns
+  those and they are correct.
+- No change to which failure classes degrade versus propagate.
+- No change to the validation-gate repair policy, its cap, or its findings
+  projection.
+- No change to evidence retention windows, cleanup, or the oversized/expired
+  lifecycle rules.
+- No new operator command surface beyond the existing status projection and the
+  `rejected-output` CLI; a dedicated inspection command is out of scope.
+
+## Subtasks
+
+1. Give the degraded diagnostic-persistence signal a real operator seam:
+   content-free telemetry, a status-projection reader, and a block reason that
+   distinguishes unreadable evidence from absent evidence.
+2. Stop a quarantine entry from recording a `diagnosticIdentity` whose row was
+   never written, without mutating any entry already persisted.
+
+## Validation Strategy
+
+```bash
+cd /home/sermilion/StudioProjects/skill-bill/runtime-kotlin
+./gradlew check -x sourcesJar
+```
+
+Focused suites to exercise directly:
+`FeatureTaskRuntimeDiagnosticDegradationTest`,
+`FeatureTaskRuntimeStatusServiceTest`,
+`FeatureTaskRuntimeQuarantineRegenerateTest`,
+`FeatureTaskRuntimeProjectionRejectionTest`, and
+`RejectedOutputDiagnosticServiceTest`.
+
+## Next Path
+
+After both subtasks land, confirm from durable state that a forced
+diagnostic-persistence conflict produces a telemetry row, a status projection
+entry, and either a marked or refused quarantine append — and that no quarantine
+entry in the store names an identity that does not resolve.

--- a/.feature-specs/SKILL-186-diagnostic-degradation-observability/spec_subtask_1_degradation-operator-seam.md
+++ b/.feature-specs/SKILL-186-diagnostic-degradation-observability/spec_subtask_1_degradation-operator-seam.md
@@ -1,0 +1,110 @@
+# SKILL-186 · Subtask 1 — Give the degraded diagnostic-persistence signal a real operator seam
+
+## Scope
+
+Make a degraded diagnostic-persistence failure visible where an operator already
+looks, countable across runs, and honestly attributed in the block reason it
+causes.
+
+In scope:
+
+- `FeatureTaskRuntimePhaseRecorder.degradeDiagnosticFailure`
+  (`runtime-application/.../featuretask/FeatureTaskRuntimePhaseRecorder.kt:278`)
+  gains a content-free telemetry emission alongside the durable
+  `FeatureTaskRuntimeDiagnosticSignal` append it already performs.
+- A new content-free measurement model in `runtime-domain` beside
+  `FeatureTaskRuntimeRejectionMeasurement`
+  (`runtime-domain/.../taskruntime/model/FeatureTaskRuntimeHandoffFoundationModels.kt:140`),
+  with its `toTelemetryMap()` and contract-version pin, plus the matching
+  default-implemented method on `LifecycleTelemetryRepository`
+  (`runtime-ports/.../persistence/LifecycleTelemetryRepository.kt:27`) and its
+  SQLite binding.
+- `FeatureTaskRuntimeStatusProjection`
+  (`runtime-application/.../model/FeatureTaskRuntimeStatusModels.kt`) and
+  `FeatureTaskRuntimeStatusService.status`
+  (`runtime-application/.../featuretask/FeatureTaskRuntimeStatusService.kt:34`)
+  read the durable signal list via the existing
+  `FeatureTaskRuntimePhaseRecorder.loadDiagnosticSignals`
+  (`FeatureTaskRuntimePhaseRecorder.kt:349`), which currently has no production
+  caller.
+- The producer-evidence read block at
+  `runtime-application/.../featuretask/FeatureTaskRuntimeRunLoop.kt:3262`
+  distinguishes "no evidence retained" from "the diagnostic store refused it".
+
+The read-path distinction needs a signal the run loop can act on. Today
+`recorder.producerOutput` returns null for both "absent row" and "store threw",
+so the run loop cannot tell them apart. Resolving that — a richer return, an
+out-parameter, or a post-hoc `loadDiagnosticSignals` consultation keyed to the
+operation — is part of this subtask.
+
+## Acceptance Criteria
+
+1. A degraded diagnostic-persistence failure emits one content-free telemetry
+   measurement through `LifecycleTelemetryRepository`, carrying the workflow, the
+   phase, the attempt, the repair turn when the failure was scoped to one, the
+   generation, the operation label, the typed failure class, and the conflicting
+   key.
+2. A telemetry sink that throws does not change the degradation outcome: the
+   durable `FeatureTaskRuntimeDiagnosticSignal` is still appended, the caller
+   still receives null, and the run still proceeds — the same rule
+   `FeatureTaskRuntimePhaseRecorder.recordRejectionMeasurement` already applies.
+3. The new measurement model pins a contract version, exposes a `toTelemetryMap()`
+   whose keys are asserted by a parity test, and is registered in the
+   `@OpenBoundaryMap` allow-list in both `runtime-kotlin/ARCHITECTURE.md` and
+   `RAW_MAP_OPEN_BOUNDARY_ALLOWLIST` so the architecture tests stay green.
+4. `FeatureTaskRuntimeStatusProjection` reports the degraded-signal count and the
+   most recent signal's typed failure class, phase, and attempt; a workflow with
+   no degraded signals reports the absent state rather than a fabricated zero-value
+   entry.
+5. `FeatureTaskRuntimeStatusService.status` populates that field from durable
+   state, and a malformed durable signal list loud-fails through the existing
+   typed workflow-state error rather than being silently dropped.
+6. A phase blocked because producer evidence could not be read states which case
+   it hit: no retained evidence for that attempt, or retained evidence the
+   diagnostic store refused. The second case names the typed failure class.
+7. Both block-reason branches keep the existing `NEEDS_USER_ACTION` disposition
+   and `childNeverLaunched` behavior, so resume semantics are unchanged.
+8. Every new record is payload-free: no agent output, prompt text, database path,
+   or process output reaches the measurement, the status projection, or the block
+   reason.
+9. Regression coverage exercises: a degraded conflict emitting exactly one
+   measurement with the expected content-free fields, a throwing telemetry sink
+   leaving the durable signal and the null return intact, the status projection
+   reporting a degraded signal and reporting absence when there is none, and both
+   block-reason branches.
+10. `./gradlew check -x sourcesJar` passes from `runtime-kotlin`.
+
+## Non-Goals
+
+- No change to which failure classes degrade versus propagate;
+  `degradableFailureClass` stays as SKILL-185 left it.
+- No new operator command; the existing status projection and `rejected-output`
+  CLI are the only surfaces.
+- No change to the quarantine store or `diagnosticIdentity`; subtask 2 owns that.
+- `persistDiagnosticSignal`'s best-effort `catch` stays best-effort. Do not make
+  it fatal and do not add a durable record inside it — the store it would write to
+  is the one that just failed.
+- No change to the repair-turn keying, evidence keys, or `stableIdentity`.
+
+## Dependency Notes
+
+Independent of subtask 2 and safe to land first. Subtask 2 may reuse this
+subtask's telemetry model and any signal-inspection helper this subtask adds, so
+landing this first reduces subtask 2's surface; the reverse order also works with
+a small amount of duplication.
+
+## Validation Strategy
+
+```bash
+cd /home/sermilion/StudioProjects/skill-bill/runtime-kotlin
+./gradlew check -x sourcesJar
+```
+
+Focused suites: `FeatureTaskRuntimeDiagnosticDegradationTest`,
+`FeatureTaskRuntimeStatusServiceTest`, `FeatureTaskRuntimeProjectionRejectionTest`.
+
+## Next Path
+
+Hand off to subtask 2 with the telemetry model and any signal-inspection helper in
+place, so the quarantine path can report a degraded diagnostic without inventing a
+second mechanism.

--- a/.feature-specs/SKILL-186-diagnostic-degradation-observability/spec_subtask_2_quarantine-identity-integrity.md
+++ b/.feature-specs/SKILL-186-diagnostic-degradation-observability/spec_subtask_2_quarantine-identity-integrity.md
@@ -1,0 +1,99 @@
+# SKILL-186 · Subtask 2 — Stop a quarantine entry from naming a diagnostic row that was never written
+
+## Scope
+
+Close the path where a durable, append-only quarantine entry permanently records a
+`diagnosticIdentity` that resolves to nothing.
+
+The mechanism, verified in code:
+
+- The run loop's `recordRejectedOutput`
+  (`runtime-application/.../featuretask/FeatureTaskRuntimeRunLoop.kt:3548`)
+  returns `RejectedOutputDiagnosticService.stableIdentity(...)` unconditionally.
+- `FeatureTaskRuntimePhaseRecorder.recordRejectedOutput`
+  (`FeatureTaskRuntimePhaseRecorder.kt:179`) wraps the retain, the insert, and the
+  rejection measurement in one `database.transaction`. When
+  `degradeDiagnosticFailure` catches, that whole transaction has already rolled
+  back, so no `rejected_output_diagnostics` row exists.
+- The caller persists the returned string as `diagnosticIdentity` on a
+  `FeatureTaskRuntimeQuarantineEntry` (`FeatureTaskRuntimeRunLoop.kt:3306`). The
+  contract requires it non-blank
+  (`orchestration/contracts/feature-task-runtime-quarantine-schema.yaml`,
+  `diagnostic_identity`, `minLength: 1`), the store is append-only, and no runtime
+  path ever repairs an entry.
+
+In scope: making the degradation observable to the caller, and choosing between
+recording the degradation on the entry or refusing the append with a durable
+block. Both are acceptable under the parent spec; the entry-marking route needs a
+quarantine contract change and the refusal route does not, so weigh that when
+deciding.
+
+## Acceptance Criteria
+
+1. The run loop can tell whether a diagnostic write degraded. The identity-returning
+   seam no longer reports a well-formed identity for a write that did not land.
+2. A quarantine append whose diagnostic degraded either records that fact on the
+   entry or is refused with a durable block naming the degradation and its typed
+   failure class. A silently dangling `diagnosticIdentity` is not a reachable
+   outcome.
+3. Whichever route is taken, the outcome is durable: after a crash and resume, the
+   state still shows either a marked entry or the block, never an unmarked entry
+   pointing at a missing row.
+4. Every `diagnosticIdentity` already persisted on an existing quarantine entry
+   keeps resolving exactly as it does today, and an existing entry decodes without
+   error under the shape this subtask lands.
+5. If the quarantine wire shape changes, the change lands in
+   `orchestration/contracts/feature-task-runtime-quarantine-schema.yaml` with the
+   `FEATURE_TASK_RUNTIME_QUARANTINE_CONTRACT_VERSION` pin
+   (`runtime-contracts/.../workflow/FeatureTaskRuntimeSchemaPaths.kt:140`), its
+   parity test, `additionalProperties: false` preserved at every object, and
+   loud-fail decode at every parse seam.
+6. The quarantine store stays append-only: no existing entry is mutated, deleted,
+   or rewritten by any runtime path, including on resume and reconciliation.
+7. A quarantine append whose diagnostic wrote normally is unchanged in shape and
+   behavior, and the regeneration edge it drives still fires as it does today.
+8. Every new field or block reason is payload-free: identities, counts, typed
+   classes, and sanitized labels only.
+9. Regression coverage exercises: a quarantine append whose diagnostic degraded
+   reaching the chosen outcome, an unaffected append staying byte-identical in
+   shape, an existing pre-change quarantine entry decoding unchanged, and — if the
+   contract changed — the schema parity test and a loud-fail on an undeclared wire
+   field.
+10. `./gradlew check -x sourcesJar` passes from `runtime-kotlin`.
+
+## Non-Goals
+
+- No repair of quarantine entries already written with a dangling identity.
+  Existing evidence is not rewritten; only out-of-band operator action may remove
+  it.
+- No change to the quarantine regeneration cap, the rejection classes, or the
+  `REGENERATION_PRODUCER_BY_CONSUMER` edge map.
+- No change to which failure classes degrade versus propagate.
+- No change to the repair-turn keying, evidence keys, or `stableIdentity`.
+- No new operator command surface.
+
+## Dependency Notes
+
+Depends on subtask 1 only for reuse, not correctness: subtask 1's telemetry model
+and any signal-inspection helper make reporting a degraded diagnostic cheaper here.
+Declared as an optional dependency so this subtask can land first if subtask 1
+stalls, at the cost of duplicating a small amount of the reporting path.
+
+## Validation Strategy
+
+```bash
+cd /home/sermilion/StudioProjects/skill-bill/runtime-kotlin
+./gradlew check -x sourcesJar
+```
+
+Focused suites: `FeatureTaskRuntimeQuarantineRegenerateTest`,
+`FeatureTaskRuntimeDiagnosticDegradationTest`,
+`RejectedOutputDiagnosticServiceTest`, and the quarantine schema contract-version
+and decode tests.
+
+## Next Path
+
+Verify against durable state that a forced diagnostic-persistence conflict on a
+reconciliation-class rejection produces either a marked quarantine entry or a
+durable block, and that every `diagnosticIdentity` in the store resolves to a real
+row.

--- a/orchestration/contracts/producer-output-evidence-schema.yaml
+++ b/orchestration/contracts/producer-output-evidence-schema.yaml
@@ -1,7 +1,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://skill-bill.dev/contracts/producer-output-evidence-schema.yaml
 title: Producer output evidence
-description: Safe metadata for one retained producer phase output, keyed by review generation and attempt. Raw bytes are stored separately and never validated here.
+description: Safe metadata for one retained producer phase output, keyed by review generation, attempt, and repair turn. Raw bytes are stored separately and never validated here.
 type: object
 additionalProperties: false
 required:
@@ -10,6 +10,7 @@ required:
   - phase_id
   - generation
   - attempt
+  - repair_turn
   - agent_id
   - model
   - recorded_at
@@ -30,6 +31,11 @@ properties:
   attempt:
     type: integer
     minimum: 1
+  # An ordinary attempt records turn 0 — the same logical capture it always was — so every instance
+  # carries the ordinal and a missing one is a producer defect, not a legacy record.
+  repair_turn:
+    type: integer
+    minimum: 0
   agent_id:
     type: string
     minLength: 1

--- a/orchestration/contracts/rejected-output-diagnostic-schema.yaml
+++ b/orchestration/contracts/rejected-output-diagnostic-schema.yaml
@@ -10,6 +10,7 @@ required:
   - workflow_id
   - phase_id
   - attempt
+  - repair_turn
   - rule
   - path
   - reason
@@ -34,6 +35,11 @@ properties:
   attempt:
     type: integer
     minimum: 1
+  # An ordinary attempt records turn 0 and keeps the identity it was already persisted under, so every
+  # instance carries the ordinal and a missing one is a producer defect, not a legacy record.
+  repair_turn:
+    type: integer
+    minimum: 0
   rule:
     type: string
     minLength: 1

--- a/runtime-kotlin/ARCHITECTURE.md
+++ b/runtime-kotlin/ARCHITECTURE.md
@@ -440,6 +440,9 @@ runtime-ports
     - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry.fromArtifactMap`
     - `skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineRecordToWire`
     - `skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineEntriesFromWire`
+    - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticSignal.toArtifactMap`
+    - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticSignal.fromArtifactMap`
+    - `skillbill.workflow.taskruntime.model.featureTaskRuntimeDiagnosticSignalsFromWire`
     - `skillbill.workflow.FeatureTaskRuntimeImplementationAttemptValidator.validateImplementationAttemptRecord`
     - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeImplementationAttempt.toArtifactMap`
     - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeImplementationAttempt.fromArtifactMap`
@@ -1223,6 +1226,9 @@ Categories:
 - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry.fromArtifactMap`
 - `skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineRecordToWire`
 - `skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineEntriesFromWire`
+- `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticSignal.toArtifactMap`
+- `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticSignal.fromArtifactMap`
+- `skillbill.workflow.taskruntime.model.featureTaskRuntimeDiagnosticSignalsFromWire`
 - `skillbill.workflow.FeatureTaskRuntimeImplementationAttemptValidator.validateImplementationAttemptRecord`
 - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeImplementationAttempt.toArtifactMap`
 - `skillbill.workflow.taskruntime.model.FeatureTaskRuntimeImplementationAttempt.fromArtifactMap`

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseRecorder.kt
@@ -11,6 +11,8 @@ import skillbill.application.workflow.WorkflowFamily
 import skillbill.application.workflow.toRecord
 import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidFeatureTaskRuntimeHandoffProjectionError
+import skillbill.error.InvalidProducerOutputEvidenceSchemaError
+import skillbill.error.InvalidRejectedOutputDiagnosticSchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.error.ShellContentContractException
 import skillbill.error.WorkflowIssueKeyConflictError
@@ -23,6 +25,7 @@ import skillbill.ports.persistence.WorkflowStateRepository
 import skillbill.ports.persistence.model.FeatureTaskRuntimeWorkerOwnership
 import skillbill.ports.persistence.model.FeatureTaskWorkflowMode
 import skillbill.ports.persistence.model.RejectedOutputDiagnosticError
+import skillbill.ports.persistence.model.evidenceKey
 import skillbill.workflow.FeatureTaskRuntimeHandoffEnvelopeValidator
 import skillbill.workflow.FeatureTaskRuntimeHandoffFoundationValidator
 import skillbill.workflow.FeatureTaskRuntimeImplementationAttemptValidator
@@ -39,6 +42,7 @@ import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_AUDIT_REPAIR_ST
 import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITIES_ARTIFACT_KEY
 import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_DECOMPOSE_TERMINAL_ARTIFACT_KEY
 import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_DELIVERED_PROJECTIONS_ARTIFACT_KEY
+import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_ARTIFACT_KEY
 import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_IMPLEMENTATION_ATTEMPTS_ARTIFACT_KEY
 import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PHASE_BRIEFINGS_ARTIFACT_KEY
 import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PHASE_LEDGER_ARTIFACT_KEY
@@ -55,6 +59,8 @@ import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeAuditRepairState
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeCheckpointIdentity
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDecomposeTerminal
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDeliveredProjectionRecord
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticFailureClass
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticSignal
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeEvidence
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeGoalContinuationArtifact
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeImplementationAttempt
@@ -84,9 +90,11 @@ import skillbill.workflow.taskruntime.model.GoalSubtaskReviewCompactFinding
 import skillbill.workflow.taskruntime.model.GoalSubtaskReviewState
 import skillbill.workflow.taskruntime.model.PhaseHandoffProjectionDeclaration
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeAppendCheckpointIdentity
+import skillbill.workflow.taskruntime.model.featureTaskRuntimeAppendDiagnosticSignal
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeAppendImplementationAttempt
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeCheckpointIdentitiesFromArtifact
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeCheckpointIdentitiesToArtifact
+import skillbill.workflow.taskruntime.model.featureTaskRuntimeDiagnosticSignalsFromWire
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeImplementationAttemptRecordToWire
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeImplementationAttemptsFromWire
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeOwnedPathDigest
@@ -96,6 +104,28 @@ import skillbill.workflow.taskruntime.model.featureTaskRuntimeRejectionCapOf
 import skillbill.workflow.taskruntime.model.featureTaskRuntimeRejectionViolationClassOf
 import java.time.Duration
 import java.time.Instant
+
+/**
+ * The degradable classes are the environmental ones: the store rejected, could not be reached, or
+ * handed back an unusable row. `InvalidRequest` and `InvalidConfiguration` are deliberately absent —
+ * those name a caller-construction defect or a wiring fault, which must keep failing loudly rather
+ * than becoming a signal the run walks past.
+ */
+private fun RejectedOutputDiagnosticError.degradableFailureClass(): FeatureTaskRuntimeDiagnosticFailureClass? =
+  when (this) {
+    is RejectedOutputDiagnosticError.Conflict -> FeatureTaskRuntimeDiagnosticFailureClass.CONFLICT
+    is RejectedOutputDiagnosticError.Permission -> FeatureTaskRuntimeDiagnosticFailureClass.PERMISSION
+    is RejectedOutputDiagnosticError.Corrupt -> FeatureTaskRuntimeDiagnosticFailureClass.CORRUPT
+    is RejectedOutputDiagnosticError.Persistence,
+    is RejectedOutputDiagnosticError.Retrieval,
+    is RejectedOutputDiagnosticError.Expired,
+    is RejectedOutputDiagnosticError.Oversized,
+    is RejectedOutputDiagnosticError.Absent,
+    -> FeatureTaskRuntimeDiagnosticFailureClass.PERSISTENCE
+    is RejectedOutputDiagnosticError.InvalidRequest,
+    is RejectedOutputDiagnosticError.InvalidConfiguration,
+    -> null
+  }
 
 internal data class FeatureTaskRuntimeProjectionRejection(
   val workflowId: String,
@@ -132,24 +162,37 @@ class FeatureTaskRuntimePhaseRecorder(
     request: RejectedOutputDiagnosticRequest,
     dbOverride: String? = null,
     producerGeneration: Int = 0,
-  ) = database.transaction(dbOverride) { unitOfWork ->
-    val service = diagnosticService(unitOfWork)
-    service.retainProducerOutput(
-      ProducerOutputEvidence(
-        workflowId = request.workflowId,
-        phaseId = request.phaseId,
-        attempt = request.attempt,
-        agentId = request.agentId,
-        model = request.model,
-        recordedAt = java.time.Instant.now(),
-        byteSize = request.observedByteSize,
-        sha256 = request.observedSha256,
-        payload = request.rawResponse.takeUnless { request.truncated },
-        generation = producerGeneration,
-      ),
+  ) {
+    val evidence = ProducerOutputEvidence(
+      workflowId = request.workflowId,
+      phaseId = request.phaseId,
+      attempt = request.attempt,
+      agentId = request.agentId,
+      model = request.model,
+      recordedAt = Instant.now(),
+      byteSize = request.observedByteSize,
+      sha256 = request.observedSha256,
+      payload = request.rawResponse.takeUnless { request.truncated },
+      generation = producerGeneration,
+      repairTurn = request.repairTurn,
     )
-    service.record(request)
-    recordRejectionMeasurement(unitOfWork, request)
+    degradeDiagnosticFailure(
+      workflowId = request.workflowId,
+      operation = "record-rejected-output",
+      conflictingKey = evidence.evidenceKey(),
+      phaseId = request.phaseId,
+      attempt = request.attempt,
+      repairTurn = request.repairTurn,
+      generation = producerGeneration,
+      dbOverride = dbOverride,
+    ) {
+      database.transaction(dbOverride) { unitOfWork ->
+        val service = diagnosticService(unitOfWork)
+        service.retainProducerOutput(evidence)
+        service.record(request)
+        recordRejectionMeasurement(unitOfWork, request)
+      }
+    }
   }
 
   /**
@@ -180,10 +223,22 @@ class FeatureTaskRuntimePhaseRecorder(
     }
   }
 
-  fun retainProducerOutput(evidence: ProducerOutputEvidence, dbOverride: String? = null) =
-    database.transaction(dbOverride) { unitOfWork ->
-      diagnosticService(unitOfWork).retainProducerOutput(evidence)
+  fun retainProducerOutput(evidence: ProducerOutputEvidence, dbOverride: String? = null) {
+    degradeDiagnosticFailure(
+      workflowId = evidence.workflowId,
+      operation = "retain-producer-output",
+      conflictingKey = evidence.evidenceKey(),
+      phaseId = evidence.phaseId,
+      attempt = evidence.attempt,
+      repairTurn = evidence.repairTurn,
+      generation = evidence.generation,
+      dbOverride = dbOverride,
+    ) {
+      database.transaction(dbOverride) { unitOfWork ->
+        diagnosticService(unitOfWork).retainProducerOutput(evidence)
+      }
     }
+  }
 
   fun producerOutput(
     workflowId: String,
@@ -192,9 +247,113 @@ class FeatureTaskRuntimePhaseRecorder(
     agentId: String,
     dbOverride: String? = null,
     generation: Int = 0,
-  ) = database.read(dbOverride) {
-    it.rejectedOutputDiagnostics?.readProducerOutput(workflowId, phaseId, attempt, agentId, generation)
+  ): ProducerOutputEvidence? = degradeDiagnosticFailure(
+    workflowId = workflowId,
+    operation = "read-producer-output",
+    // A newest-turn read is not scoped to one turn, so the turn slot stays a wildcard rather than
+    // claiming turn 0; the rest of the key still correlates with the write-path signals by prefix.
+    conflictingKey = "$workflowId:$phaseId:$generation:$attempt:*:$agentId",
+    phaseId = phaseId,
+    attempt = attempt,
+    repairTurn = null,
+    generation = generation,
+    dbOverride = dbOverride,
+  ) {
+    database.read(dbOverride) {
+      it.rejectedOutputDiagnostics?.readProducerOutput(workflowId, phaseId, attempt, agentId, generation)
+    }
   }
+
+  /**
+   * Runs a diagnostic-evidence write or read and degrades every typed diagnostic failure — conflict,
+   * permission, corruption, schema, plain persistence — into a durable payload-free operator signal,
+   * returning null instead of propagating.
+   *
+   * This is the same rule [recordRejectionMeasurement] already applies to telemetry, applied to the
+   * evidence store itself. A diagnostic is private evidence *about* a run; a failure to write one is
+   * never a reason to kill a run that has otherwise progressed. The degraded signal lands in its own
+   * transaction, because the failing write's transaction has already rolled back by the time it runs.
+   */
+  @Suppress("LongParameterList")
+  private fun <T> degradeDiagnosticFailure(
+    workflowId: String,
+    operation: String,
+    conflictingKey: String,
+    phaseId: String,
+    attempt: Int,
+    repairTurn: Int?,
+    generation: Int,
+    dbOverride: String?,
+    block: () -> T,
+  ): T? {
+    fun degrade(failureClass: FeatureTaskRuntimeDiagnosticFailureClass): T? {
+      persistDiagnosticSignal(
+        workflowId,
+        FeatureTaskRuntimeDiagnosticSignal(
+          operation = operation,
+          failureClass = failureClass,
+          conflictingKey = conflictingKey,
+          phaseId = phaseId,
+          attempt = attempt.coerceAtLeast(0),
+          repairTurn = repairTurn?.coerceAtLeast(0),
+          generation = generation.coerceAtLeast(0),
+          recordedAt = Instant.now().toString(),
+        ),
+        dbOverride,
+      )
+      return null
+    }
+    return try {
+      block()
+    } catch (error: RejectedOutputDiagnosticError) {
+      degrade(error.degradableFailureClass() ?: throw error)
+    } catch (_: InvalidProducerOutputEvidenceSchemaError) {
+      degrade(FeatureTaskRuntimeDiagnosticFailureClass.SCHEMA)
+    } catch (_: InvalidRejectedOutputDiagnosticSchemaError) {
+      degrade(FeatureTaskRuntimeDiagnosticFailureClass.SCHEMA)
+    }
+  }
+
+  /**
+   * Appends the degraded-failure signal to the workflow row. Best-effort by design: if the store that
+   * just rejected the evidence also rejects this append, the run still proceeds — the alternative is
+   * exactly the crash this seam exists to prevent.
+   */
+  private fun persistDiagnosticSignal(
+    workflowId: String,
+    signal: FeatureTaskRuntimeDiagnosticSignal,
+    dbOverride: String?,
+  ) {
+    try {
+      database.transaction(dbOverride) { unitOfWork ->
+        val record = WorkflowFamily.TASK_RUNTIME.get(unitOfWork.workflowStates, workflowId)
+          ?: return@transaction
+        val existing = featureTaskRuntimeDiagnosticSignalsFromWire(
+          decodeArtifacts(record.artifactsJson)[FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_ARTIFACT_KEY],
+        )
+        persistPatch(
+          unitOfWork.workflowStates,
+          record,
+          mapOf(
+            FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_ARTIFACT_KEY to
+              featureTaskRuntimeAppendDiagnosticSignal(existing, signal).map { it.toArtifactMap() },
+          ),
+        )
+      }
+    } catch (@Suppress("TooGenericExceptionCaught") _: Exception) {
+      // The signal is a diagnosability aid, not a run invariant.
+    }
+  }
+
+  /** Strict read of the durable degraded-diagnostic signals; an absent key yields none. */
+  fun loadDiagnosticSignals(workflowId: String, dbOverride: String? = null): List<FeatureTaskRuntimeDiagnosticSignal> =
+    database.read(dbOverride) { unitOfWork ->
+      val record = WorkflowFamily.TASK_RUNTIME.get(unitOfWork.workflowStates, workflowId)
+        ?: return@read emptyList()
+      featureTaskRuntimeDiagnosticSignalsFromWire(
+        decodeArtifacts(record.artifactsJson)[FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_ARTIFACT_KEY],
+      )
+    }
 
   private fun diagnosticService(unitOfWork: UnitOfWork): RejectedOutputDiagnosticService {
     val repository = unitOfWork.rejectedOutputDiagnostics

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -2609,7 +2609,7 @@ internal class FeatureTaskRuntimeRunLoop(
         changedPaths = changedPaths,
         repositoryCheckpoint = checkpoint,
         baseRef = baseRef,
-        agentRepairLauncher = ValidationGateAgentRepairLauncher { findings, _ ->
+        agentRepairLauncher = ValidationGateAgentRepairLauncher { findings, repairIteration ->
           launchValidationGateRepair(
             run = run,
             state = state,
@@ -2617,6 +2617,7 @@ internal class FeatureTaskRuntimeRunLoop(
             observability = observability,
             phaseTokenAccumulator = phaseTokenAccumulator,
             findings = findings,
+            repairTurn = repairIteration,
           )
         },
       ),
@@ -2649,6 +2650,7 @@ internal class FeatureTaskRuntimeRunLoop(
     }
   }
 
+  @Suppress("LongParameterList")
   private fun launchValidationGateRepair(
     run: PhaseRun,
     state: FeatureTaskRuntimeRunState,
@@ -2656,8 +2658,12 @@ internal class FeatureTaskRuntimeRunLoop(
     observability: FeatureTaskRuntimeRunObservability,
     phaseTokenAccumulator: MutableMap<String, Pair<Int, Int>>?,
     findings: ValidationFindingSetProjection,
+    repairTurn: Int,
   ): ValidationGateAgentRepairResult {
-    val repairRun = run.copy(validationGateFindings = findings)
+    // The phase attempt deliberately does NOT advance across repair turns: it feeds the durable
+    // watermark and the semantic fix-loop budget, and charging honest gate repairs to that budget
+    // would block runs early. The turn ordinal is what separates each turn's evidence instead.
+    val repairRun = run.copy(validationGateFindings = findings, validationGateRepairTurn = repairTurn)
     val attempt = attemptOnce(
       repairRun,
       state,
@@ -3280,6 +3286,8 @@ internal class FeatureTaskRuntimeRunLoop(
       outputByteSize = producerEvidence.byteSize,
       outputSha256 = producerEvidence.sha256,
       outputTruncated = producerEvidence.payload == null,
+      // The diagnostic names the exact capture that was rejected, which is the turn the read resolved.
+      repairTurn = producerEvidence.repairTurn,
     )
     val regenerationAttempt = (state.edgeIterationCount(edge.loopId) + 1).coerceAtLeast(1)
     recorder.appendQuarantineEntry(
@@ -3347,6 +3355,7 @@ internal class FeatureTaskRuntimeRunLoop(
         outputByteSize = it.byteSize,
         outputSha256 = it.sha256,
         outputTruncated = it.payload == null,
+        repairTurn = it.repairTurn,
       )
     }
     val reason = if (producer == null) {
@@ -3512,6 +3521,10 @@ internal class FeatureTaskRuntimeRunLoop(
     outputTruncated: Boolean = false,
     outputByteSize: Long = outputBytes.size.toLong(),
     outputSha256: String = RejectedOutputDiagnosticService.sha256(outputBytes),
+    // A repair turn belongs to the phase this run is executing. A rejection attributed to some other
+    // producer phase is that producer's own capture, so it stays at turn 0 unless the caller knows
+    // otherwise from the producer's retained evidence.
+    repairTurn: Int = if (phaseId == run.phaseId) run.validationGateRepairTurn else 0,
   ): String {
     recorder.recordRejectedOutput(
       RejectedOutputDiagnosticRequest(
@@ -3527,6 +3540,7 @@ internal class FeatureTaskRuntimeRunLoop(
         observedByteSize = outputByteSize,
         observedSha256 = outputSha256,
         truncated = outputTruncated,
+        repairTurn = repairTurn,
       ),
       run.request.dbPathOverride,
       state.evidenceGeneration(phaseId),
@@ -3535,6 +3549,7 @@ internal class FeatureTaskRuntimeRunLoop(
       run.request.workflowId,
       phaseId,
       iteration.coerceAtLeast(1),
+      repairTurn,
     )
   }
 
@@ -3648,6 +3663,7 @@ internal class FeatureTaskRuntimeRunLoop(
         sha256 = outputSha256,
         payload = outputBytes.takeUnless { outputTruncated },
         generation = state.evidenceGeneration(run.phaseId),
+        repairTurn = run.validationGateRepairTurn,
       ),
       run.request.dbPathOverride,
     )
@@ -5233,6 +5249,12 @@ internal class FeatureTaskRuntimeRunLoop(
     val validationGateFindings: ValidationFindingSetProjection? = null,
     /** True only when validate falls back because the pack declares no validation_gate. */
     val agentRunValidateFallback: Boolean = false,
+    /**
+     * 1-based ordinal of the validation-gate repair turn this launch is, zero outside a repair cycle.
+     * A repair cycle deliberately re-runs an agent under one unchanged phase attempt, so this is the
+     * only thing separating one turn's retained evidence and diagnostics from the next turn's.
+     */
+    val validationGateRepairTurn: Int = 0,
   )
 
   private data class PreLaunchBlock(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/RejectedOutputDiagnosticService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/RejectedOutputDiagnosticService.kt
@@ -30,7 +30,7 @@ class RejectedOutputDiagnosticService(
 ) {
   fun record(request: RejectedOutputDiagnosticRequest): RejectedOutputDiagnostic {
     validate(request)
-    val identity = stableIdentity(request.workflowId, request.phaseId, request.attempt)
+    val identity = stableIdentity(request.workflowId, request.phaseId, request.attempt, request.repairTurn)
     existing(identity)?.let { record ->
       if (!record.matches(request)) throw RejectedOutputDiagnosticError.Conflict(identity)
       metadataValidator.validate(record.metadata)
@@ -52,6 +52,7 @@ class RejectedOutputDiagnosticService(
       byteSize = request.observedByteSize,
       sha256 = request.observedSha256,
       lifecycle = if (oversized) RejectedOutputLifecycle.OVERSIZED else RejectedOutputLifecycle.STORED,
+      repairTurn = request.repairTurn,
     )
     metadataValidator.validate(metadata)
     applyRestrictivePermissions()
@@ -126,8 +127,17 @@ class RejectedOutputDiagnosticService(
     // SKILL-152: this identity stays generation-blind. It is stored durably on quarantine entries as
     // `diagnosticIdentity`, so adding the review generation would rewrite already-persisted identities.
     // A review-generation restart can therefore still collide here; that widening is tracked separately.
-    fun stableIdentity(workflowId: String, phaseId: String, attempt: Int): String =
-      "rod_${sha256("$workflowId\u0000$phaseId\u0000$attempt".encodeToByteArray())}"
+    //
+    // SKILL-185: the repair-turn ordinal is folded into the preimage only when it is non-zero. A gate
+    // repair cycle re-runs an agent under one unchanged attempt, so two consecutively rejected turns
+    // need distinct identities; every ordinary attempt stays at turn 0 and therefore keeps hashing the
+    // exact preimage it always did, which is what keeps an identity already persisted on a quarantine
+    // entry resolvable.
+    fun stableIdentity(workflowId: String, phaseId: String, attempt: Int, repairTurn: Int = 0): String {
+      val base = "$workflowId\u0000$phaseId\u0000$attempt"
+      val preimage = if (repairTurn == 0) base else "$base\u0000$repairTurn"
+      return "rod_${sha256(preimage.encodeToByteArray())}"
+    }
 
     fun sha256(bytes: ByteArray): String =
       MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
@@ -158,6 +168,7 @@ private fun requestValidationIssue(request: RejectedOutputDiagnosticRequest): St
   return when {
     blankField != null -> "$blankField must be non-blank"
     request.attempt <= 0 -> "attempt must be positive"
+    request.repairTurn < 0 -> "repairTurn must be non-negative"
     request.observedByteSize < request.rawResponse.size || request.observedByteSize < 0 ->
       "observedByteSize must include all retained bytes"
     !Regex("[0-9a-f]{64}").matches(request.observedSha256) ->
@@ -187,6 +198,7 @@ private fun RejectedOutputDiagnosticRecord.matches(request: RejectedOutputDiagno
   metadata.workflowId == request.workflowId &&
     metadata.phaseId == request.phaseId &&
     metadata.attempt == request.attempt &&
+    metadata.repairTurn == request.repairTurn &&
     metadata.rule == request.rule &&
     metadata.path == request.path &&
     metadata.reason == request.reason &&

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/model/RejectedOutputDiagnosticModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/model/RejectedOutputDiagnosticModels.kt
@@ -34,4 +34,9 @@ data class RejectedOutputDiagnosticRequest(
   val observedByteSize: Long = rawResponse.size.toLong(),
   val observedSha256: String = RejectedOutputDiagnosticService.sha256(rawResponse),
   val truncated: Boolean = false,
+  /**
+   * Repair turn within [attempt], zero for an ordinary attempt. A validation-gate repair cycle
+   * launches several agent turns under one attempt, and each turn's rejection is its own diagnostic.
+   */
+  val repairTurn: Int = 0,
 )

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -6528,6 +6528,7 @@ internal data class ProducerEvidenceKey(
   val generation: Int,
   val attempt: Int,
   val agentId: String,
+  val repairTurn: Int = 0,
 )
 
 internal fun samePayload(left: ByteArray?, right: ByteArray?): Boolean =
@@ -6561,14 +6562,16 @@ internal class RuntimeFakeDatabaseSessionFactory(
     unitOfWork().rejectedOutputDiagnostics!!.retainProducerOutput(evidence)
   }
 
+  @Suppress("LongParameterList")
   fun producerEvidenceAt(
     workflowId: String,
     phaseId: String,
     attempt: Int,
     generation: Int,
     agentId: String,
+    repairTurn: Int = 0,
   ): skillbill.ports.persistence.ProducerOutputEvidence? =
-    producerEvidence[ProducerEvidenceKey(workflowId, phaseId, generation, attempt, agentId)]
+    producerEvidence[ProducerEvidenceKey(workflowId, phaseId, generation, attempt, agentId, repairTurn)]
 
   override fun resolveDbPath(dbOverride: String?): Path = dbPath
 
@@ -6651,6 +6654,7 @@ internal class RuntimeFakeDatabaseSessionFactory(
           evidence.generation,
           evidence.attempt,
           evidence.agentId,
+          evidence.repairTurn,
         )
         producerEvidence.putIfAbsent(key, evidence)
         val retained = producerEvidence.getValue(key)
@@ -6658,7 +6662,8 @@ internal class RuntimeFakeDatabaseSessionFactory(
           !samePayload(retained.payload, evidence.payload)
         ) {
           throw skillbill.ports.persistence.model.RejectedOutputDiagnosticError.Conflict(
-            "${evidence.workflowId}:${evidence.phaseId}:${evidence.generation}:${evidence.attempt}:${evidence.agentId}",
+            "${evidence.workflowId}:${evidence.phaseId}:${evidence.generation}:${evidence.attempt}:" +
+              "${evidence.repairTurn}:${evidence.agentId}",
           )
         }
       }
@@ -6669,16 +6674,14 @@ internal class RuntimeFakeDatabaseSessionFactory(
         attempt: Int,
         agentId: String,
         generation: Int,
-      ): skillbill.ports.persistence.ProducerOutputEvidence? =
-        producerEvidence[ProducerEvidenceKey(workflowId, phaseId, generation, attempt, agentId)]
-          ?: producerEvidence.entries
-            .filter {
-              it.key.workflowId == workflowId && it.key.phaseId == phaseId &&
-                it.key.attempt == attempt && it.key.agentId == agentId &&
-                it.key.generation <= generation
-            }
-            .maxByOrNull { it.key.generation }
-            ?.value
+      ): skillbill.ports.persistence.ProducerOutputEvidence? = producerEvidence.entries
+        .filter {
+          it.key.workflowId == workflowId && it.key.phaseId == phaseId &&
+            it.key.attempt == attempt && it.key.agentId == agentId &&
+            it.key.generation <= generation
+        }
+        .maxWithOrNull(compareBy({ it.key.generation }, { it.key.repairTurn }))
+        ?.value
     }
     override val unaddressedFindings = object : skillbill.ports.persistence.UnaddressedFindingsRepository {
       override fun replaceLedgerForPass(

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeDiagnosticDegradationTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeDiagnosticDegradationTest.kt
@@ -1,0 +1,158 @@
+package skillbill.application.featuretask
+
+import skillbill.application.InMemoryRuntimeWorkflowRepository
+import skillbill.application.RecordingLifecycleTelemetryRepository
+import skillbill.application.RuntimeFakeDatabaseSessionFactory
+import skillbill.ports.persistence.ProducerOutputEvidence
+import skillbill.ports.persistence.model.RejectedOutputDiagnosticError
+import skillbill.workflow.WorkflowSnapshotValidator
+import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticFailureClass
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * SKILL-185. A validation-gate repair cycle re-runs an agent inside one phase attempt, so its turns
+ * used to address the identical producer-evidence key and the second turn killed the process with an
+ * uncaught `Conflict`. These cover both halves of the fix: turns are independently addressable, and a
+ * diagnostic-persistence failure degrades instead of terminating the run.
+ */
+class FeatureTaskRuntimeDiagnosticDegradationTest {
+  @Test
+  fun `three repair turns of one attempt each retain their own evidence row`() {
+    val database = database()
+    val recorder = recorder(database)
+    recorder.ensureWorkflowOpen(WORKFLOW_ID, "session-1")
+
+    (1..3).forEach { turn ->
+      recorder.retainProducerOutput(evidence("turn-$turn".encodeToByteArray(), repairTurn = turn))
+    }
+
+    assertEquals(
+      listOf(1, 2, 3),
+      database.retainedProducerEvidence().filter { it.phaseId == "validate" }.map { it.repairTurn },
+    )
+    // The consumer-facing read resolves the newest turn without knowing how many turns ran.
+    assertContentEquals(
+      "turn-3".encodeToByteArray(),
+      recorder.producerOutput(WORKFLOW_ID, "validate", 1, "cursor")?.payload,
+    )
+    assertTrue(recorder.loadDiagnosticSignals(WORKFLOW_ID).isEmpty())
+  }
+
+  @Test
+  fun `two consecutively rejected repair turns each record a diagnostic`() {
+    val database = database()
+    val recorder = recorder(database)
+    recorder.ensureWorkflowOpen(WORKFLOW_ID, "session-1")
+
+    recorder.recordRejectedOutput(rejection("turn-1".encodeToByteArray(), repairTurn = 1))
+    recorder.recordRejectedOutput(rejection("turn-2".encodeToByteArray(), repairTurn = 2))
+
+    assertEquals(listOf(1, 2), database.rejectedDiagnostics().map { it.metadata.repairTurn })
+    assertEquals(2, database.rejectedDiagnostics().map { it.metadata.identity }.distinct().size)
+    assertTrue(recorder.loadDiagnosticSignals(WORKFLOW_ID).isEmpty())
+  }
+
+  @Test
+  fun `a forced evidence conflict degrades to a durable payload-free signal instead of failing the run`() {
+    val database = database()
+    val recorder = recorder(database)
+    recorder.ensureWorkflowOpen(WORKFLOW_ID, "session-1")
+    val retained = "first-bytes".encodeToByteArray()
+    recorder.retainProducerOutput(evidence(retained, repairTurn = 1))
+
+    // Same key, different bytes: the store's immutability guard raises Conflict. Before SKILL-185 this
+    // escaped the run loop uncaught and exited the process with status 1.
+    recorder.retainProducerOutput(evidence("divergent-bytes".encodeToByteArray(), repairTurn = 1))
+
+    val signal = recorder.loadDiagnosticSignals(WORKFLOW_ID).single()
+    assertEquals(FeatureTaskRuntimeDiagnosticFailureClass.CONFLICT, signal.failureClass)
+    assertEquals("validate", signal.phaseId)
+    assertEquals(1, signal.attempt)
+    assertEquals(1, signal.repairTurn)
+    assertContains(signal.conflictingKey, "$WORKFLOW_ID:validate:0:1:1:cursor")
+    // The committed evidence is never overwritten by the divergent write.
+    assertContentEquals(retained, recorder.producerOutput(WORKFLOW_ID, "validate", 1, "cursor")?.payload)
+  }
+
+  @Test
+  fun `a caller-construction defect still fails loudly instead of degrading`() {
+    val database = database()
+    val recorder = recorder(database)
+    recorder.ensureWorkflowOpen(WORKFLOW_ID, "session-1")
+
+    // A blank agent id is a defect in the calling seam, not an environmental store fault. Degrading
+    // it would let a run write evidence attributable to nobody and walk past the bug.
+    assertFailsWith<RejectedOutputDiagnosticError.InvalidRequest> {
+      recorder.recordRejectedOutput(rejection(byteArrayOf(1), repairTurn = 1).copy(agentId = ""))
+    }
+    assertTrue(recorder.loadDiagnosticSignals(WORKFLOW_ID).isEmpty())
+  }
+
+  @Test
+  fun `a degraded signal never carries agent bytes`() {
+    val database = database()
+    val recorder = recorder(database)
+    recorder.ensureWorkflowOpen(WORKFLOW_ID, "session-1")
+    recorder.retainProducerOutput(evidence("secret-agent-output".encodeToByteArray(), repairTurn = 1))
+
+    recorder.retainProducerOutput(evidence("other-secret-output".encodeToByteArray(), repairTurn = 1))
+
+    val summary = recorder.loadDiagnosticSignals(WORKFLOW_ID).single().operatorSummary()
+    assertTrue("secret-agent-output" !in summary)
+    assertTrue("other-secret-output" !in summary)
+    assertContains(summary, "attempt 1")
+    assertContains(summary, "repair turn 1")
+  }
+
+  private fun database() = RuntimeFakeDatabaseSessionFactory(
+    InMemoryRuntimeWorkflowRepository(),
+    RecordingLifecycleTelemetryRepository(),
+  )
+
+  private fun recorder(database: RuntimeFakeDatabaseSessionFactory) = FeatureTaskRuntimePhaseRecorder(
+    database,
+    NoopSnapshotValidator,
+    AcceptingFeatureTaskRuntimeHandoffEnvelopeValidator,
+    AcceptingFeatureTaskRuntimeHandoffFoundationValidator,
+  )
+
+  private fun evidence(payload: ByteArray, repairTurn: Int) = ProducerOutputEvidence(
+    workflowId = WORKFLOW_ID,
+    phaseId = "validate",
+    attempt = 1,
+    agentId = "cursor",
+    model = "gpt",
+    recordedAt = Instant.parse("2026-08-11T21:07:48Z"),
+    byteSize = payload.size.toLong(),
+    sha256 = RejectedOutputDiagnosticService.sha256(payload),
+    payload = payload,
+    repairTurn = repairTurn,
+  )
+
+  private fun rejection(payload: ByteArray, repairTurn: Int) = RejectedOutputDiagnosticRequest(
+    workflowId = WORKFLOW_ID,
+    phaseId = "validate",
+    attempt = 1,
+    rule = "phase-output-schema",
+    path = "/status",
+    reason = "rejected",
+    agentId = "cursor",
+    model = "gpt",
+    rawResponse = payload,
+    repairTurn = repairTurn,
+  )
+
+  private object NoopSnapshotValidator : WorkflowSnapshotValidator {
+    override fun validate(snapshot: Map<String, Any?>, slug: String) = Unit
+  }
+
+  private companion object {
+    const val WORKFLOW_ID: String = "wftr-skill-185"
+  }
+}

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/RejectedOutputDiagnosticServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/RejectedOutputDiagnosticServiceTest.kt
@@ -46,6 +46,31 @@ class RejectedOutputDiagnosticServiceTest {
   }
 
   @Test
+  fun `two consecutively rejected repair turns of one attempt each record a diagnostic`() {
+    val repository = MemoryRepository()
+    val service = service(repository)
+
+    val first = service.record(request(byteArrayOf(1)).copy(repairTurn = 1))
+    val second = service.record(request(byteArrayOf(2)).copy(repairTurn = 2))
+
+    assertNotEquals(first.identity, second.identity)
+    assertEquals(2, repository.records.size)
+    assertEquals(listOf(1, 2), repository.records.values.map { it.metadata.repairTurn })
+  }
+
+  @Test
+  fun `an ordinary attempt keeps the identity it was persisted under before repair turns existed`() {
+    assertEquals(
+      "rod_20d2d05b2eb34fe4ceff7ebda0df27707b6efdd817b212e94399b33c4babfc6a",
+      RejectedOutputDiagnosticService.stableIdentity("workflow-1", "validate", 1),
+    )
+    assertEquals(
+      RejectedOutputDiagnosticService.stableIdentity("workflow-1", "validate", 1),
+      RejectedOutputDiagnosticService.stableIdentity("workflow-1", "validate", 1, repairTurn = 0),
+    )
+  }
+
+  @Test
   fun `ceiling stores tombstone and read reports oversized`() {
     val service = service(MemoryRepository(), maximumPayloadBytes = 1)
     val metadata = service.record(request(byteArrayOf(1, 2)))
@@ -212,13 +237,15 @@ private class MemoryRepository : RejectedOutputDiagnosticRepository {
       evidence.phaseId,
       evidence.generation,
       evidence.attempt,
+      evidence.repairTurn,
       evidence.agentId,
     )
     producerEvidence.putIfAbsent(key, evidence)
     val retained = producerEvidence.getValue(key)
     if (retained.sha256 != evidence.sha256 || retained.byteSize != evidence.byteSize) {
       throw RejectedOutputDiagnosticError.Conflict(
-        "${evidence.workflowId}:${evidence.phaseId}:${evidence.generation}:${evidence.attempt}:${evidence.agentId}",
+        "${evidence.workflowId}:${evidence.phaseId}:${evidence.generation}:${evidence.attempt}:" +
+          "${evidence.repairTurn}:${evidence.agentId}",
       )
     }
   }
@@ -229,12 +256,10 @@ private class MemoryRepository : RejectedOutputDiagnosticRepository {
     attempt: Int,
     agentId: String,
     generation: Int,
-  ): skillbill.ports.persistence.ProducerOutputEvidence? =
-    producerEvidence[listOf(workflowId, phaseId, generation, attempt, agentId)]
-      ?: producerEvidence.values
-        .filter {
-          it.workflowId == workflowId && it.phaseId == phaseId &&
-            it.attempt == attempt && it.agentId == agentId && it.generation <= generation
-        }
-        .maxByOrNull { it.generation }
+  ): skillbill.ports.persistence.ProducerOutputEvidence? = producerEvidence.values
+    .filter {
+      it.workflowId == workflowId && it.phaseId == phaseId &&
+        it.attempt == attempt && it.agentId == agentId && it.generation <= generation
+    }
+    .maxWithOrNull(compareBy({ it.generation }, { it.repairTurn }))
 }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeValidationGateTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/validation/FeatureTaskRuntimeValidationGateTest.kt
@@ -312,6 +312,31 @@ class FeatureTaskRuntimeValidationGateTest {
     assertTrue(progress.last().remainingFindings.isEmpty())
   }
 
+  @Test
+  fun `each repair turn is launched under its own ordinal so turns never share an evidence key`() {
+    val finding = ValidationGateFinding("m", "t", "still broken", "loc")
+    val ordinals = mutableListOf<Int>()
+    val runner = ScriptedGateRunner(List(MAX_VALIDATE_GATE_REPAIR_ITERATIONS + 1) { failedWith(finding) })
+
+    coordinator(declaredResolver(), runner, mutableListOf()).execute(
+      cycle = ValidationGateCycleRequest(
+        repoRoot = repoRoot,
+        request = minimalRequest(),
+        validationDepth = ValidationDepth.DEFAULT,
+        changedPaths = listOf("runtime-kotlin/foo.kt"),
+        repositoryCheckpoint = "checkpoint",
+        agentRepairLauncher = ValidationGateAgentRepairLauncher { _, repairIteration ->
+          ordinals += repairIteration
+          ValidationGateAgentRepairResult.Completed(
+            FeatureTaskRuntimePhaseOutput(phaseId = "validate", iteration = 1, payload = "{}"),
+          )
+        },
+      ),
+    )
+
+    assertEquals((1..MAX_VALIDATE_GATE_REPAIR_ITERATIONS).toList(), ordinals)
+  }
+
   private fun outOfContractResolver(): ValidationGateResolver = ValidationGateResolver {
     throw ContractVersionMismatchError(
       "Platform pack 'fallback': declares contract_version '0.1' but the shell expects '1.4'.",

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/RejectedOutputCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/RejectedOutputCommands.kt
@@ -25,12 +25,14 @@ data class RejectedOutputInspectRequest(
   val phaseId: String? = null,
   val attempt: Int? = null,
   val rawOutput: Boolean = false,
+  val repairTurn: Int? = null,
 )
 
 data class RejectedOutputCleanupRequest(
   val workflowId: String,
   val phaseId: String? = null,
   val attempt: Int? = null,
+  val repairTurn: Int? = null,
 )
 
 class RejectedOutputInspectCommand(
@@ -42,7 +44,9 @@ class RejectedOutputInspectCommand(
     if (request.rawOutput) {
       if (matches.size != 1) {
         throw RejectedOutputDiagnosticError.Retrieval(
-          "raw output requires a selector resolving to exactly one diagnostic",
+          "raw output requires a selector resolving to exactly one diagnostic; " +
+            "an attempt that ran a validation-gate repair cycle holds one per repair turn, " +
+            "so add --repair-turn (the metadata listing prints each turn)",
         )
       }
       output.write(service.readRaw(matches.single().identity))
@@ -72,6 +76,10 @@ class RejectedOutputInspectCliCommand(
   private val workflowId by option("--workflow", help = "Workflow identifier.").required()
   private val phaseId by option("--phase", help = "Optional phase selector.")
   private val attempt by option("--attempt", help = "Optional attempt selector.").int()
+  private val repairTurn by option(
+    "--repair-turn",
+    help = "Optional validation-gate repair-turn selector within one attempt; 0 is an ordinary attempt.",
+  ).int()
   private val rawOutput by option(
     "--raw-output",
     help = "Write the exact stored response bytes; the selector must resolve to one record.",
@@ -80,7 +88,7 @@ class RejectedOutputInspectCliCommand(
   override fun run() {
     database.selfManagedWrite(state.dbOverride) { unitOfWork ->
       RejectedOutputInspectCommand(unitOfWork.diagnosticService(metadataValidator)).execute(
-        RejectedOutputInspectRequest(workflowId, phaseId, attempt, rawOutput),
+        RejectedOutputInspectRequest(workflowId, phaseId, attempt, rawOutput, repairTurn),
         System.out,
       )
     }
@@ -99,11 +107,15 @@ class RejectedOutputCleanupCliCommand(
   private val workflowId by option("--workflow", help = "Workflow identifier.").required()
   private val phaseId by option("--phase", help = "Optional phase selector.")
   private val attempt by option("--attempt", help = "Optional attempt selector.").int()
+  private val repairTurn by option(
+    "--repair-turn",
+    help = "Optional validation-gate repair-turn selector within one attempt; 0 is an ordinary attempt.",
+  ).int()
 
   override fun run() {
     val deleted = database.transaction(state.dbOverride) { unitOfWork ->
       RejectedOutputCleanupCommand(unitOfWork.diagnosticService(metadataValidator)).execute(
-        RejectedOutputCleanupRequest(workflowId, phaseId, attempt),
+        RejectedOutputCleanupRequest(workflowId, phaseId, attempt, repairTurn),
       )
     }
     echo("deleted=$deleted")
@@ -118,15 +130,18 @@ private fun skillbill.ports.persistence.UnitOfWork.diagnosticService(
   metadataValidator,
 )
 
-private fun RejectedOutputInspectRequest.selector() = RejectedOutputDiagnosticSelector(workflowId, phaseId, attempt)
+private fun RejectedOutputInspectRequest.selector() =
+  RejectedOutputDiagnosticSelector(workflowId, phaseId, attempt, repairTurn)
 
-private fun RejectedOutputCleanupRequest.selector() = RejectedOutputDiagnosticSelector(workflowId, phaseId, attempt)
+private fun RejectedOutputCleanupRequest.selector() =
+  RejectedOutputDiagnosticSelector(workflowId, phaseId, attempt, repairTurn)
 
 private fun RejectedOutputDiagnostic.safeLine(): String = listOf(
   "identity=${identity.safeField()}",
   "workflow=${workflowId.safeField()}",
   "phase=${phaseId.safeField()}",
   "attempt=$attempt",
+  "repair_turn=$repairTurn",
   "rule=${rule.safeField()}",
   "path=${path.safeField()}",
   "reason=${reason.safeField()}",

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/RuntimeArchitectureTest.kt
@@ -2107,6 +2107,11 @@ class RuntimeArchitectureTest {
       "skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQuarantineEntry.fromArtifactMap",
       "skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineRecordToWire",
       "skillbill.workflow.taskruntime.model.featureTaskRuntimeQuarantineEntriesFromWire",
+      // SKILL-185: durable bounded record of degraded diagnostic-persistence failures. Payload-free by
+      // construction (key, phase, ordinals, typed class), and private like the quarantine store above.
+      "skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticSignal.toArtifactMap",
+      "skillbill.workflow.taskruntime.model.FeatureTaskRuntimeDiagnosticSignal.fromArtifactMap",
+      "skillbill.workflow.taskruntime.model.featureTaskRuntimeDiagnosticSignalsFromWire",
       // SKILL-150: durable append-only implementation-attempt history (the continuation projection's
       // only source of prior receipts) and its domain-owned schema validator port, mirroring the
       // quarantine store above.

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDiagnosticSignalModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDiagnosticSignalModels.kt
@@ -1,0 +1,116 @@
+package skillbill.workflow.taskruntime.model
+
+import skillbill.boundary.OpenBoundaryMap
+import skillbill.error.InvalidWorkflowStateSchemaError
+
+/**
+ * Durable, bounded record of diagnostic-evidence writes that failed and were degraded rather than
+ * thrown. A diagnostic is private evidence about a run; losing one is a diagnosability regression, and
+ * killing the run over it turns a bookkeeping fault into a lost workflow. The runtime therefore keeps
+ * the failure here and proceeds.
+ *
+ * Every field is payload-free by construction: the key, the phase, the ordinals, and a typed failure
+ * class. No agent output, prompt text, database path, or process output is ever recorded.
+ */
+const val FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_ARTIFACT_KEY: String =
+  "feature_task_runtime_diagnostic_signals"
+
+/** Oldest entries are pruned first, so a pathological run cannot grow the workflow row without bound. */
+const val FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_LIMIT: Int = 32
+
+/** Typed classes of degraded diagnostic-persistence failure; the class is what an operator triages on. */
+enum class FeatureTaskRuntimeDiagnosticFailureClass(val wireValue: String) {
+  /** Divergent evidence already committed under the same key. */
+  CONFLICT("conflict"),
+  PERMISSION("permission"),
+  CORRUPT("corrupt"),
+  SCHEMA("schema"),
+  PERSISTENCE("persistence"),
+  ;
+
+  companion object {
+    fun fromWire(raw: String): FeatureTaskRuntimeDiagnosticFailureClass = entries.firstOrNull { it.wireValue == raw }
+      ?: throw InvalidWorkflowStateSchemaError(
+        "Feature-task-runtime diagnostic failure class '$raw' is not a declared class.",
+      )
+  }
+}
+
+data class FeatureTaskRuntimeDiagnosticSignal(
+  val operation: String,
+  val failureClass: FeatureTaskRuntimeDiagnosticFailureClass,
+  val conflictingKey: String,
+  val phaseId: String,
+  val attempt: Int,
+  /** Null when the failure was not scoped to a single repair turn, as on a newest-turn read. */
+  val repairTurn: Int?,
+  val generation: Int,
+  val recordedAt: String,
+) {
+  init {
+    require(operation.isNotBlank()) { "FeatureTaskRuntimeDiagnosticSignal.operation must be non-blank." }
+    require(conflictingKey.isNotBlank()) { "FeatureTaskRuntimeDiagnosticSignal.conflictingKey must be non-blank." }
+    require(phaseId.isNotBlank()) { "FeatureTaskRuntimeDiagnosticSignal.phaseId must be non-blank." }
+    require(attempt >= 0) { "FeatureTaskRuntimeDiagnosticSignal.attempt must be >= 0." }
+    require(repairTurn == null || repairTurn >= 0) {
+      "FeatureTaskRuntimeDiagnosticSignal.repairTurn must be >= 0 when present."
+    }
+    require(generation >= 0) { "FeatureTaskRuntimeDiagnosticSignal.generation must be >= 0." }
+    require(recordedAt.isNotBlank()) { "FeatureTaskRuntimeDiagnosticSignal.recordedAt must be non-blank." }
+  }
+
+  /** The operator-facing sentence. Names the key, the phase and the attempt, and nothing else. */
+  fun operatorSummary(): String =
+    "Diagnostic evidence write '$operation' failed as '${failureClass.wireValue}' for key " +
+      "'$conflictingKey' (phase '$phaseId', attempt $attempt, repair turn ${repairTurn ?: "any"}, " +
+      "generation $generation). The evidence was not retained; the run continued."
+
+  @OpenBoundaryMap("Feature-task-runtime diagnostic signal artifact map at the durable workflow-artifact seam")
+  fun toArtifactMap(): Map<String, Any?> = linkedMapOf(
+    "operation" to operation,
+    "failure_class" to failureClass.wireValue,
+    "conflicting_key" to conflictingKey,
+    "phase_id" to phaseId,
+    "attempt" to attempt,
+    "repair_turn" to repairTurn,
+    "generation" to generation,
+    "recorded_at" to recordedAt,
+  )
+
+  companion object {
+    @OpenBoundaryMap("Feature-task-runtime diagnostic signal decode from the durable workflow-artifact map")
+    fun fromArtifactMap(raw: Map<String, Any?>): FeatureTaskRuntimeDiagnosticSignal =
+      FeatureTaskRuntimeDiagnosticSignal(
+        operation = raw.requireStringField("operation"),
+        failureClass = FeatureTaskRuntimeDiagnosticFailureClass.fromWire(raw.requireStringField("failure_class")),
+        conflictingKey = raw.requireStringField("conflicting_key"),
+        phaseId = raw.requireStringField("phase_id"),
+        attempt = raw.requireIntField("attempt"),
+        repairTurn = raw["repair_turn"]?.let { raw.requireIntField("repair_turn") },
+        generation = raw.requireIntField("generation"),
+        recordedAt = raw.requireStringField("recorded_at"),
+      )
+  }
+}
+
+/** Strict decode of the durable signal list; an absent key decodes to no signals. */
+@OpenBoundaryMap("Feature-task-runtime diagnostic signal list decode from the durable workflow-artifact map")
+fun featureTaskRuntimeDiagnosticSignalsFromWire(raw: Any?): List<FeatureTaskRuntimeDiagnosticSignal> {
+  if (raw == null) return emptyList()
+  val entries = raw as? List<*>
+    ?: throw InvalidWorkflowStateSchemaError("Feature-task-runtime diagnostic signals must be an array.")
+  return entries.map { entry ->
+    @Suppress("UNCHECKED_CAST")
+    FeatureTaskRuntimeDiagnosticSignal.fromArtifactMap(
+      entry as? Map<String, Any?>
+        ?: throw InvalidWorkflowStateSchemaError("Feature-task-runtime diagnostic signal must be an object."),
+    )
+  }
+}
+
+/** Appends one signal, pruning the oldest beyond [FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_LIMIT]. */
+fun featureTaskRuntimeAppendDiagnosticSignal(
+  existing: List<FeatureTaskRuntimeDiagnosticSignal>,
+  signal: FeatureTaskRuntimeDiagnosticSignal,
+): List<FeatureTaskRuntimeDiagnosticSignal> =
+  (existing + signal).takeLast(FEATURE_TASK_RUNTIME_DIAGNOSTIC_SIGNALS_LIMIT)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
@@ -23,6 +23,7 @@ object ProducerOutputEvidenceSchemaValidator {
       put("phase_id", evidence.phaseId)
       put("generation", evidence.generation)
       put("attempt", evidence.attempt)
+      put("repair_turn", evidence.repairTurn)
       put("agent_id", evidence.agentId)
       put("model", evidence.model)
       put("recorded_at", evidence.recordedAt.toString())
@@ -33,7 +34,7 @@ object ProducerOutputEvidenceSchemaValidator {
     if (violations.isNotEmpty()) {
       throw InvalidProducerOutputEvidenceSchemaError(
         "Producer output evidence '${evidence.workflowId}:${evidence.phaseId}:" +
-          "${evidence.generation}:${evidence.attempt}' fails canonical contract " +
+          "${evidence.generation}:${evidence.attempt}:${evidence.repairTurn}' fails canonical contract " +
           "$PRODUCER_OUTPUT_EVIDENCE_CONTRACT_VERSION.",
       )
     }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
@@ -23,6 +23,7 @@ object RejectedOutputDiagnosticSchemaValidator {
       put("workflow_id", metadata.workflowId)
       put("phase_id", metadata.phaseId)
       put("attempt", metadata.attempt)
+      put("repair_turn", metadata.repairTurn)
       put("rule", metadata.rule)
       put("path", metadata.path)
       put("reason", metadata.reason)

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseColumnMigrations.kt
@@ -52,6 +52,19 @@ internal object DatabaseColumnMigrations {
     ensureReconciliationIndexes(connection)
   }
 
+  /**
+   * Unconditional on every open, like the column ensures in [apply], because the two diagnostic-store
+   * rebuilds that came before it (versions 16 and 28) restate the pre-repair-turn DDL from an explicit
+   * column list. A store whose ledger already records the gated version-29 row but whose table was
+   * later rebuilt by one of those would otherwise keep the narrow key forever.
+   *
+   * Kept out of [apply] because that function is also wired as gated migration version 1 and therefore
+   * runs inside an open transaction, where a nested `BEGIN IMMEDIATE` fails.
+   */
+  fun healDiagnosticEvidenceKeys(connection: Connection) {
+    connection.inImmediateTransaction { rekeyDiagnosticEvidenceByRepairTurn(this) }
+  }
+
   fun applyWorkListMetadata(connection: Connection) {
     applyWorkListMetadata(connection, recoverIssueKeys = true)
   }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseMigrations.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseMigrations.kt
@@ -456,6 +456,11 @@ internal object DatabaseMigrations {
         name = "rekey-producer-output-evidence-by-agent",
         operation = ::rekeyProducerOutputEvidenceByAgent,
       ),
+      DatabaseMigration(
+        version = 29,
+        name = "rekey-diagnostic-evidence-by-repair-turn",
+        operation = ::rekeyDiagnosticEvidenceByRepairTurn,
+      ),
     ).also(::requireDeterministicMigrations)
 
   fun apply(connection: Connection) {

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseRuntime.kt
@@ -75,6 +75,7 @@ object DatabaseRuntime {
         DatabaseSchema.createBaseSchema(connection)
         DatabaseMigrations.apply(connection)
         DatabaseColumnMigrations.apply(connection)
+        DatabaseColumnMigrations.healDiagnosticEvidenceKeys(connection)
         DatabaseColumnMigrations.healWorkListMetadata(connection)
       }
       connection

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseSchema.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DatabaseSchema.kt
@@ -78,9 +78,10 @@ internal object DatabaseSchema {
         workflow_id TEXT NOT NULL, phase_id TEXT NOT NULL,
         generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
         attempt INTEGER NOT NULL CHECK (attempt > 0),
+        repair_turn INTEGER NOT NULL DEFAULT 0 CHECK (repair_turn >= 0),
         agent_id TEXT NOT NULL, model TEXT NOT NULL, recorded_at TEXT NOT NULL,
         byte_size INTEGER NOT NULL CHECK (byte_size >= 0), sha256 TEXT NOT NULL, payload BLOB,
-        PRIMARY KEY (workflow_id, phase_id, generation, attempt, agent_id)
+        PRIMARY KEY (workflow_id, phase_id, generation, attempt, repair_turn, agent_id)
       )
       """.trimIndent(),
       """
@@ -89,6 +90,7 @@ internal object DatabaseSchema {
         workflow_id TEXT NOT NULL,
         phase_id TEXT NOT NULL,
         attempt INTEGER NOT NULL CHECK (attempt > 0),
+        repair_turn INTEGER NOT NULL DEFAULT 0 CHECK (repair_turn >= 0),
         rule TEXT NOT NULL,
         rejection_path TEXT NOT NULL,
         reason TEXT NOT NULL,
@@ -99,7 +101,7 @@ internal object DatabaseSchema {
         sha256 TEXT NOT NULL,
         lifecycle TEXT NOT NULL CHECK (lifecycle IN ('stored', 'oversized', 'expired')),
         payload BLOB,
-        UNIQUE (workflow_id, phase_id, attempt),
+        UNIQUE (workflow_id, phase_id, attempt, repair_turn),
         CHECK (
           (lifecycle = 'stored' AND payload IS NOT NULL) OR
           (lifecycle IN ('oversized', 'expired') AND payload IS NULL)
@@ -108,7 +110,7 @@ internal object DatabaseSchema {
       """.trimIndent(),
       """
       CREATE INDEX IF NOT EXISTS idx_rejected_output_diagnostics_selector
-        ON rejected_output_diagnostics(workflow_id, phase_id, attempt)
+        ON rejected_output_diagnostics(workflow_id, phase_id, attempt, repair_turn)
       """.trimIndent(),
       """
       CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DiagnosticEvidenceRepairTurnMigration.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/db/core/DiagnosticEvidenceRepairTurnMigration.kt
@@ -1,0 +1,128 @@
+package skillbill.db.core
+
+import java.sql.Connection
+
+/**
+ * SKILL-185: a validation-gate repair cycle re-runs an agent inside one phase attempt without
+ * advancing `attempt`, so both diagnostic keys had to widen by the repair-turn ordinal. Every
+ * pre-existing row is carried across at turn 0, which is exactly the key an ordinary (non-repair)
+ * attempt still writes, so no identity already stored on a quarantine entry changes.
+ *
+ * Both rebuilds are guarded on the live DDL rather than on the ledger, so a store that reached the
+ * widened shape by any path is left alone and a store that did not self-heals on the next open.
+ */
+internal fun rekeyDiagnosticEvidenceByRepairTurn(connection: Connection) {
+  rekeyProducerOutputEvidenceByRepairTurn(connection)
+  rekeyRejectedOutputDiagnosticsByRepairTurn(connection)
+}
+
+private fun rekeyProducerOutputEvidenceByRepairTurn(connection: Connection) {
+  if (tableDdlMentions(connection, "producer_output_evidence", "repair_turn")) return
+  connection.createStatement().use {
+    it.execute("ALTER TABLE producer_output_evidence RENAME TO producer_output_evidence_pre_repair_turn")
+    it.execute(
+      """
+      CREATE TABLE IF NOT EXISTS producer_output_evidence (
+        workflow_id TEXT NOT NULL, phase_id TEXT NOT NULL,
+        generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+        attempt INTEGER NOT NULL CHECK (attempt > 0),
+        repair_turn INTEGER NOT NULL DEFAULT 0 CHECK (repair_turn >= 0),
+        agent_id TEXT NOT NULL, model TEXT NOT NULL, recorded_at TEXT NOT NULL,
+        byte_size INTEGER NOT NULL CHECK (byte_size >= 0), sha256 TEXT NOT NULL, payload BLOB,
+        PRIMARY KEY (workflow_id, phase_id, generation, attempt, repair_turn, agent_id)
+      )
+      """.trimIndent(),
+    )
+    it.execute(
+      """
+      INSERT INTO producer_output_evidence (
+        workflow_id, phase_id, generation, attempt, repair_turn, agent_id, model, recorded_at,
+        byte_size, sha256, payload
+      )
+      SELECT workflow_id, phase_id, generation, attempt, 0, agent_id, model, recorded_at,
+             byte_size, sha256, payload
+      FROM producer_output_evidence_pre_repair_turn
+      """.trimIndent(),
+    )
+    it.execute("DROP TABLE producer_output_evidence_pre_repair_turn")
+  }
+}
+
+private fun rekeyRejectedOutputDiagnosticsByRepairTurn(connection: Connection) {
+  if (tableDdlMentions(connection, "rejected_output_diagnostics", "repair_turn")) return
+  connection.createStatement().use {
+    it.execute("DROP INDEX IF EXISTS idx_rejected_output_diagnostics_selector")
+    it.execute("ALTER TABLE rejected_output_diagnostics RENAME TO rejected_output_diagnostics_pre_repair_turn")
+    it.execute(
+      """
+      CREATE TABLE IF NOT EXISTS rejected_output_diagnostics (
+        identity TEXT PRIMARY KEY,
+        workflow_id TEXT NOT NULL,
+        phase_id TEXT NOT NULL,
+        attempt INTEGER NOT NULL CHECK (attempt > 0),
+        repair_turn INTEGER NOT NULL DEFAULT 0 CHECK (repair_turn >= 0),
+        rule TEXT NOT NULL,
+        rejection_path TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        recorded_at TEXT NOT NULL,
+        byte_size INTEGER NOT NULL CHECK (byte_size >= 0),
+        sha256 TEXT NOT NULL,
+        lifecycle TEXT NOT NULL CHECK (lifecycle IN ('stored', 'oversized', 'expired')),
+        payload BLOB,
+        UNIQUE (workflow_id, phase_id, attempt, repair_turn),
+        CHECK (
+          (lifecycle = 'stored' AND payload IS NOT NULL) OR
+          (lifecycle IN ('oversized', 'expired') AND payload IS NULL)
+        )
+      )
+      """.trimIndent(),
+    )
+    it.execute(
+      """
+      INSERT INTO rejected_output_diagnostics (
+        identity, workflow_id, phase_id, attempt, repair_turn, rule, rejection_path, reason,
+        agent_id, model, recorded_at, byte_size, sha256, lifecycle, payload
+      )
+      SELECT identity, workflow_id, phase_id, attempt, 0, rule, rejection_path, reason,
+             agent_id, model, recorded_at, byte_size, sha256, lifecycle, payload
+      FROM rejected_output_diagnostics_pre_repair_turn
+      """.trimIndent(),
+    )
+    it.execute("DROP TABLE rejected_output_diagnostics_pre_repair_turn")
+    it.execute(
+      """
+      CREATE INDEX IF NOT EXISTS idx_rejected_output_diagnostics_selector
+        ON rejected_output_diagnostics(workflow_id, phase_id, attempt, repair_turn)
+      """.trimIndent(),
+    )
+    // DROP TABLE takes every index with it, including the two version-14 indexes the base schema
+    // does not declare. Version 14 is already in the ledger on any store reaching this point, so
+    // nothing else would put them back: without this, a migrated store would lose the retention
+    // index that keeps markExpired off a full scan of a table holding raw agent-output blobs, and
+    // would diverge from a freshly created store.
+    it.execute(
+      "CREATE INDEX IF NOT EXISTS idx_rejected_output_diagnostic_selection " +
+        "ON rejected_output_diagnostics(workflow_id, phase_id, attempt)",
+    )
+    it.execute(
+      "CREATE INDEX IF NOT EXISTS idx_rejected_output_diagnostic_retention " +
+        "ON rejected_output_diagnostics(lifecycle, recorded_at)",
+    )
+  }
+}
+
+private fun tableDdlMentions(connection: Connection, table: String, column: String): Boolean {
+  val ddl = connection.prepareStatement(
+    "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).use { statement ->
+    statement.setString(1, table)
+    statement.executeQuery().use { rows ->
+      // An absent table is created in its widened shape by the base schema, so there is nothing to rebuild.
+      if (!rows.next()) return true
+      rows.getString("sql").orEmpty()
+    }
+  }
+  return Regex("""\b$column\b""", RegexOption.IGNORE_CASE).containsMatchIn(ddl)
+}

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepository.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepository.kt
@@ -8,7 +8,9 @@ import skillbill.ports.persistence.RejectedOutputDiagnosticRepository
 import skillbill.ports.persistence.RejectedOutputDiagnosticSelector
 import skillbill.ports.persistence.RejectedOutputLifecycle
 import skillbill.ports.persistence.model.RejectedOutputDiagnosticError
+import skillbill.ports.persistence.model.evidenceKey
 import java.sql.Connection
+import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.time.Instant
@@ -29,9 +31,9 @@ class SqliteRejectedOutputDiagnosticRepository(
       connection.prepareStatement(
         """
         INSERT INTO rejected_output_diagnostics (
-          identity, workflow_id, phase_id, attempt, rule, rejection_path, reason, agent_id, model,
+          identity, workflow_id, phase_id, attempt, repair_turn, rule, rejection_path, reason, agent_id, model,
           recorded_at, byte_size, sha256, lifecycle, payload
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """.trimIndent(),
       ).use { statement ->
         val metadata = record.metadata
@@ -40,6 +42,7 @@ class SqliteRejectedOutputDiagnosticRepository(
         statement.setString(index++, metadata.workflowId)
         statement.setString(index++, metadata.phaseId)
         statement.setInt(index++, metadata.attempt)
+        statement.setInt(index++, metadata.repairTurn)
         statement.setString(index++, metadata.rule)
         statement.setString(index++, metadata.path)
         statement.setString(index++, metadata.reason)
@@ -62,16 +65,10 @@ class SqliteRejectedOutputDiagnosticRepository(
 
   override fun select(selector: RejectedOutputDiagnosticSelector): List<RejectedOutputDiagnostic> {
     return persistence("select") {
-      val clauses = mutableListOf("workflow_id = ?")
-      if (selector.phaseId != null) clauses += "phase_id = ?"
-      if (selector.attempt != null) clauses += "attempt = ?"
       connection.prepareStatement(
-        "${selectColumns()} WHERE ${clauses.joinToString(" AND ")} ORDER BY phase_id, attempt",
+        "${selectColumns()} WHERE ${selector.whereClause()} ORDER BY phase_id, attempt, repair_turn",
       ).use { statement ->
-        var index = 1
-        statement.setString(index++, selector.workflowId)
-        selector.phaseId?.let { statement.setString(index++, it) }
-        selector.attempt?.let { statement.setInt(index, it) }
+        selector.bind(statement)
         statement.executeQuery().use { rows ->
           buildList { while (rows.next()) add(rows.toRecord().metadata) }
         }
@@ -97,16 +94,10 @@ class SqliteRejectedOutputDiagnosticRepository(
   }
 
   override fun delete(selector: RejectedOutputDiagnosticSelector): Int = persistence("delete") {
-    val clauses = mutableListOf("workflow_id = ?")
-    if (selector.phaseId != null) clauses += "phase_id = ?"
-    if (selector.attempt != null) clauses += "attempt = ?"
     connection.prepareStatement(
-      "DELETE FROM rejected_output_diagnostics WHERE ${clauses.joinToString(" AND ")}",
+      "DELETE FROM rejected_output_diagnostics WHERE ${selector.whereClause()}",
     ).use { statement ->
-      var index = 1
-      statement.setString(index++, selector.workflowId)
-      selector.phaseId?.let { statement.setString(index++, it) }
-      selector.attempt?.let { statement.setInt(index, it) }
+      selector.bind(statement)
       statement.executeUpdate()
     }
   }
@@ -116,8 +107,9 @@ class SqliteRejectedOutputDiagnosticRepository(
       connection.prepareStatement(
         """
         INSERT OR IGNORE INTO producer_output_evidence
-        (workflow_id, phase_id, generation, attempt, agent_id, model, recorded_at, byte_size, sha256, payload)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (workflow_id, phase_id, generation, attempt, repair_turn, agent_id, model, recorded_at,
+         byte_size, sha256, payload)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """.trimIndent(),
       ).use {
         var index = 1
@@ -125,6 +117,7 @@ class SqliteRejectedOutputDiagnosticRepository(
         it.setString(index++, evidence.phaseId)
         it.setInt(index++, evidence.generation)
         it.setInt(index++, evidence.attempt)
+        it.setInt(index++, evidence.repairTurn)
         it.setString(index++, evidence.agentId)
         it.setString(index++, evidence.model)
         it.setString(index++, evidence.recordedAt.toString())
@@ -141,6 +134,7 @@ class SqliteRejectedOutputDiagnosticRepository(
           agentId = evidence.agentId,
           generation = evidence.generation,
           exactGeneration = true,
+          repairTurn = evidence.repairTurn,
         ),
       ) ?: throw RejectedOutputDiagnosticError.Persistence("retain-producer-output-readback")
       if (retained.sha256 != evidence.sha256 || retained.byteSize != evidence.byteSize ||
@@ -166,6 +160,9 @@ class SqliteRejectedOutputDiagnosticRepository(
         agentId = agentId,
         generation = generation,
         exactGeneration = false,
+        // Null means "whichever repair turn is newest": a consumer resolving a producer's evidence
+        // knows the attempt it wants, never how many repair turns that attempt ran.
+        repairTurn = null,
       ),
     )
   }
@@ -185,10 +182,25 @@ class SqliteRejectedOutputDiagnosticRepository(
   }
 
   private fun selectColumns(): String = """
-    SELECT identity, workflow_id, phase_id, attempt, rule, rejection_path, reason, agent_id, model,
+    SELECT identity, workflow_id, phase_id, attempt, repair_turn, rule, rejection_path, reason, agent_id, model,
            recorded_at, byte_size, sha256, lifecycle, payload
     FROM rejected_output_diagnostics
   """.trimIndent()
+}
+
+private fun RejectedOutputDiagnosticSelector.whereClause(): String = buildList {
+  add("workflow_id = ?")
+  if (phaseId != null) add("phase_id = ?")
+  if (attempt != null) add("attempt = ?")
+  if (repairTurn != null) add("repair_turn = ?")
+}.joinToString(" AND ")
+
+private fun RejectedOutputDiagnosticSelector.bind(statement: PreparedStatement) {
+  var index = 1
+  statement.setString(index++, workflowId)
+  phaseId?.let { statement.setString(index++, it) }
+  attempt?.let { statement.setInt(index++, it) }
+  repairTurn?.let { statement.setInt(index, it) }
 }
 
 private inline fun <T> persistence(operation: String, block: () -> T): T = try {
@@ -221,6 +233,7 @@ private fun ResultSet.toRecord(): RejectedOutputDiagnosticRecord {
         byteSize = getLong("byte_size"),
         sha256 = getString("sha256"),
         lifecycle = RejectedOutputLifecycle.valueOf(getString("lifecycle").uppercase()),
+        repairTurn = getInt("repair_turn"),
       ),
       payload = getBytes("payload"),
     )
@@ -249,8 +262,6 @@ private fun RejectedOutputDiagnosticRecord.sameImmutableEvidence(other: Rejected
 private fun payloadsEqual(left: ByteArray?, right: ByteArray?): Boolean =
   (left == null && right == null) || (left != null && right != null && left.contentEquals(right))
 
-private fun ProducerOutputEvidence.evidenceKey(): String = "$workflowId:$phaseId:$generation:$attempt:$agentId"
-
 private data class ProducerEvidenceLookup(
   val workflowId: String,
   val phaseId: String,
@@ -258,15 +269,19 @@ private data class ProducerEvidenceLookup(
   val agentId: String,
   val generation: Int,
   val exactGeneration: Boolean,
+  /** Exact turn when set; null resolves the newest turn retained for the attempt. */
+  val repairTurn: Int?,
 )
 
 private fun Connection.queryProducerEvidence(lookup: ProducerEvidenceLookup): ProducerOutputEvidence? {
-  val generationClause =
-    if (lookup.exactGeneration) "generation = ?" else "generation <= ? ORDER BY generation DESC LIMIT 1"
+  val generationPredicate = if (lookup.exactGeneration) "generation = ?" else "generation <= ?"
+  val repairTurnPredicate = if (lookup.repairTurn == null) "" else " AND repair_turn = ?"
   return prepareStatement(
     """
     SELECT * FROM producer_output_evidence
-    WHERE workflow_id = ? AND phase_id = ? AND attempt = ? AND agent_id = ? AND $generationClause
+    WHERE workflow_id = ? AND phase_id = ? AND attempt = ? AND agent_id = ?
+      AND $generationPredicate$repairTurnPredicate
+    ORDER BY generation DESC, repair_turn DESC LIMIT 1
     """.trimIndent(),
   ).use {
     var index = 1
@@ -274,7 +289,8 @@ private fun Connection.queryProducerEvidence(lookup: ProducerEvidenceLookup): Pr
     it.setString(index++, lookup.phaseId)
     it.setInt(index++, lookup.attempt)
     it.setString(index++, lookup.agentId)
-    it.setInt(index, lookup.generation)
+    it.setInt(index++, lookup.generation)
+    lookup.repairTurn?.let { turn -> it.setInt(index, turn) }
     it.executeQuery().use { row -> if (row.next()) row.toProducerEvidence() else null }
   }
 }
@@ -300,5 +316,6 @@ private fun ResultSet.toProducerEvidence(): ProducerOutputEvidence {
     sha256 = getString("sha256"),
     payload = getBytes("payload"),
     generation = generation,
+    repairTurn = getInt("repair_turn"),
   )
 }

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/db/DatabaseMigrationsTest.kt
@@ -85,6 +85,7 @@ class DatabaseMigrationsTest {
         26 to "relax-telemetry-outbox-last-error",
         27 to "add-review-finding-outcome-key",
         28 to "rekey-producer-output-evidence-by-agent",
+        29 to "rekey-diagnostic-evidence-by-repair-turn",
       ),
       migrationDefinitions,
     )
@@ -459,6 +460,152 @@ class DatabaseMigrationsTest {
 
     assertProducerEvidenceMigrationDdlParity(migratedDdl, "runtime-kotlin-db-v28-base-schema")
   }
+
+  @Test
+  fun `migration v29 rekeys both diagnostic stores by repair turn without losing a row`() {
+    val dbPath = Files.createTempDirectory("runtime-kotlin-db-v29-repair-turn").resolve("metrics.db")
+    val payload = "skill-185-validate-turn-1".encodeToByteArray()
+    val sha = "8f6ac8b0d9da".padEnd(64, '0')
+    val identity = "rod_${"e".repeat(64)}"
+
+    seedPreRepairTurnDiagnosticsForMigration29(dbPath, payload, sha, identity)
+
+    val migratedDdl = DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      assertNotNull(
+        migrationRows(connection).singleOrNull { row ->
+          row.version == 29 && row.name == "rekey-diagnostic-evidence-by-repair-turn"
+        },
+      )
+      // Every carried-across row lands at turn 0, which is the key an ordinary attempt still writes.
+      assertEquals(listOf(0), producerEvidenceRepairTurns(connection))
+      assertEquals(payload.size.toLong(), producerEvidenceByteSizes(connection).single())
+      assertEquals(listOf(identity to 0), rejectedDiagnosticIdentitiesAndTurns(connection))
+      // The rebuild drops the table, and DROP TABLE takes every index with it. The version-14
+      // retention index is not in the base schema and version 14 is already in the ledger, so
+      // nothing else would put it back — markExpired would silently regress to a full scan.
+      assertEquals(
+        listOf(
+          "idx_rejected_output_diagnostic_retention",
+          "idx_rejected_output_diagnostic_selection",
+          "idx_rejected_output_diagnostics_selector",
+        ),
+        rejectedDiagnosticIndexNames(connection),
+      )
+      producerEvidenceDdl(connection)
+    }
+
+    assertProducerEvidenceMigrationDdlParity(migratedDdl, "runtime-kotlin-db-v29-base-schema")
+  }
+
+  private fun rejectedDiagnosticIndexNames(connection: Connection): List<String> =
+    connection.createStatement().use { statement ->
+      statement.executeQuery(
+        """
+        SELECT name FROM sqlite_master
+        WHERE type = 'index' AND tbl_name = 'rejected_output_diagnostics' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name
+        """.trimIndent(),
+      ).use { rows -> buildList { while (rows.next()) add(rows.getString("name")) } }
+    }
+
+  private fun seedPreRepairTurnDiagnosticsForMigration29(
+    dbPath: Path,
+    payload: ByteArray,
+    sha: String,
+    identity: String,
+  ) {
+    DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
+      connection.createStatement().use { statement ->
+        statement.executeUpdate(
+          "DELETE FROM schema_migrations WHERE name = 'rekey-diagnostic-evidence-by-repair-turn'",
+        )
+        statement.executeUpdate("DROP TABLE producer_output_evidence")
+        statement.executeUpdate(PRE_REPAIR_TURN_PRODUCER_OUTPUT_EVIDENCE_SQL)
+        statement.executeUpdate("DROP TABLE rejected_output_diagnostics")
+        statement.executeUpdate(PRE_REPAIR_TURN_REJECTED_OUTPUT_DIAGNOSTICS_SQL)
+        // A real pre-v29 store carries the narrow selector index, so the base schema's widened
+        // CREATE INDEX IF NOT EXISTS is a name no-op on it rather than an error.
+        statement.executeUpdate(
+          """
+          CREATE INDEX idx_rejected_output_diagnostics_selector
+            ON rejected_output_diagnostics(workflow_id, phase_id, attempt)
+          """.trimIndent(),
+        )
+      }
+      connection.prepareStatement(
+        """
+        INSERT INTO producer_output_evidence
+        (workflow_id, phase_id, generation, attempt, agent_id, model, recorded_at, byte_size, sha256, payload)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent(),
+      ).use { statement ->
+        statement.setString(1, "wftr-20260811-201509-n7hz")
+        statement.setString(2, "validate")
+        statement.setInt(3, 0)
+        statement.setInt(4, 1)
+        statement.setString(5, "cursor")
+        statement.setString(6, "gpt")
+        statement.setString(7, "2026-08-11T21:07:48Z")
+        statement.setLong(8, payload.size.toLong())
+        statement.setString(9, sha)
+        statement.setBytes(10, payload)
+        statement.executeUpdate()
+      }
+      seedPreRepairTurnDiagnosticRow(connection, payload, sha, identity)
+    }
+  }
+
+  private fun seedPreRepairTurnDiagnosticRow(
+    connection: Connection,
+    payload: ByteArray,
+    sha: String,
+    identity: String,
+  ) {
+    connection.prepareStatement(
+      """
+      INSERT INTO rejected_output_diagnostics
+      (identity, workflow_id, phase_id, attempt, rule, rejection_path, reason, agent_id, model,
+       recorded_at, byte_size, sha256, lifecycle, payload)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'stored', ?)
+      """.trimIndent(),
+    ).use { statement ->
+      statement.setString(1, identity)
+      statement.setString(2, "wftr-20260811-201509-n7hz")
+      statement.setString(3, "audit")
+      statement.setInt(4, 2)
+      statement.setString(5, "phase-output-schema")
+      statement.setString(6, "/status")
+      statement.setString(7, "rejected")
+      statement.setString(8, "cursor")
+      statement.setString(9, "gpt")
+      statement.setString(10, "2026-08-11T20:55:00Z")
+      statement.setLong(11, payload.size.toLong())
+      statement.setString(12, sha)
+      statement.setBytes(13, payload)
+      statement.executeUpdate()
+    }
+  }
+
+  private fun producerEvidenceRepairTurns(connection: Connection): List<Int> =
+    connection.createStatement().use { statement ->
+      statement.executeQuery("SELECT repair_turn FROM producer_output_evidence ORDER BY repair_turn").use { rows ->
+        buildList { while (rows.next()) add(rows.getInt("repair_turn")) }
+      }
+    }
+
+  private fun producerEvidenceByteSizes(connection: Connection): List<Long> =
+    connection.createStatement().use { statement ->
+      statement.executeQuery("SELECT byte_size FROM producer_output_evidence").use { rows ->
+        buildList { while (rows.next()) add(rows.getLong("byte_size")) }
+      }
+    }
+
+  private fun rejectedDiagnosticIdentitiesAndTurns(connection: Connection): List<Pair<String, Int>> =
+    connection.createStatement().use { statement ->
+      statement.executeQuery("SELECT identity, repair_turn FROM rejected_output_diagnostics").use { rows ->
+        buildList { while (rows.next()) add(rows.getString("identity") to rows.getInt("repair_turn")) }
+      }
+    }
 
   private fun seedPreAgentProducerEvidenceForMigration28(dbPath: Path, payload: ByteArray, sha: String) {
     DatabaseRuntime.ensureDatabase(dbPath).use { connection ->
@@ -2406,6 +2553,43 @@ class DatabaseMigrationsTest {
         agent_id TEXT NOT NULL, model TEXT NOT NULL, recorded_at TEXT NOT NULL,
         byte_size INTEGER NOT NULL CHECK (byte_size >= 0), sha256 TEXT NOT NULL, payload BLOB,
         PRIMARY KEY (workflow_id, phase_id, generation, attempt)
+      )
+      """
+
+    const val PRE_REPAIR_TURN_PRODUCER_OUTPUT_EVIDENCE_SQL: String =
+      """
+      CREATE TABLE producer_output_evidence (
+        workflow_id TEXT NOT NULL, phase_id TEXT NOT NULL,
+        generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+        attempt INTEGER NOT NULL CHECK (attempt > 0),
+        agent_id TEXT NOT NULL, model TEXT NOT NULL, recorded_at TEXT NOT NULL,
+        byte_size INTEGER NOT NULL CHECK (byte_size >= 0), sha256 TEXT NOT NULL, payload BLOB,
+        PRIMARY KEY (workflow_id, phase_id, generation, attempt, agent_id)
+      )
+      """
+
+    const val PRE_REPAIR_TURN_REJECTED_OUTPUT_DIAGNOSTICS_SQL: String =
+      """
+      CREATE TABLE rejected_output_diagnostics (
+        identity TEXT PRIMARY KEY,
+        workflow_id TEXT NOT NULL,
+        phase_id TEXT NOT NULL,
+        attempt INTEGER NOT NULL CHECK (attempt > 0),
+        rule TEXT NOT NULL,
+        rejection_path TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        recorded_at TEXT NOT NULL,
+        byte_size INTEGER NOT NULL CHECK (byte_size >= 0),
+        sha256 TEXT NOT NULL,
+        lifecycle TEXT NOT NULL CHECK (lifecycle IN ('stored', 'oversized', 'expired')),
+        payload BLOB,
+        UNIQUE (workflow_id, phase_id, attempt),
+        CHECK (
+          (lifecycle = 'stored' AND payload IS NOT NULL) OR
+          (lifecycle IN ('oversized', 'expired') AND payload IS NULL)
+        )
       )
       """
 

--- a/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepositoryTest.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/test/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepositoryTest.kt
@@ -72,7 +72,7 @@ class SqliteRejectedOutputDiagnosticRepositoryTest {
         repository.retainProducerOutput(evidence(byteArrayOf(2)))
       }
 
-      assertContains(failure.message.orEmpty(), "workflow-1:review:0:1:codex")
+      assertContains(failure.message.orEmpty(), "workflow-1:review:0:1:0:codex")
       assertContentEquals(
         byteArrayOf(1),
         repository.readProducerOutput("workflow-1", "review", 1, "codex", 0)?.payload,
@@ -134,6 +134,61 @@ class SqliteRejectedOutputDiagnosticRepositoryTest {
     }
   }
 
+  @Test
+  fun `differing repair turns within one attempt retain distinct rows instead of conflicting`() {
+    withRepository("producer-evidence-repair-turns") { repository ->
+      val first = "gate-repair-turn-1".encodeToByteArray()
+      val second = "gate-repair-turn-2".encodeToByteArray()
+      val third = "gate-repair-turn-3".encodeToByteArray()
+
+      repository.retainProducerOutput(evidence(first, phaseId = "validate", repairTurn = 1))
+      repository.retainProducerOutput(evidence(second, phaseId = "validate", repairTurn = 2))
+      repository.retainProducerOutput(evidence(third, phaseId = "validate", repairTurn = 3))
+
+      // A consumer knows the attempt it wants, never how many turns that attempt ran, so the read
+      // resolves the newest retained turn.
+      val read = repository.readProducerOutput("workflow-1", "validate", 1, "codex", 0)
+      assertEquals(3, read?.repairTurn)
+      assertContentEquals(third, read?.payload)
+    }
+  }
+
+  @Test
+  fun `re-retaining a repair turn with different bytes still conflicts on its own key`() {
+    withRepository("producer-evidence-repair-turn-conflict") { repository ->
+      repository.retainProducerOutput(evidence(byteArrayOf(1), phaseId = "validate", repairTurn = 2))
+
+      val failure = assertFailsWith<RejectedOutputDiagnosticError.Conflict> {
+        repository.retainProducerOutput(evidence(byteArrayOf(2), phaseId = "validate", repairTurn = 2))
+      }
+
+      assertContains(failure.message.orEmpty(), "workflow-1:validate:0:1:2:codex")
+    }
+  }
+
+  @Test
+  fun `diagnostics for two repair turns of one attempt both persist`() {
+    withRepository("diagnostic-repair-turns") { repository ->
+      val turnOne = record(byteArrayOf(1), identity = "rod_${"a".repeat(64)}", repairTurn = 1)
+      val turnTwo = record(byteArrayOf(2), identity = "rod_${"c".repeat(64)}", repairTurn = 2)
+
+      repository.insert(turnOne)
+      repository.insert(turnTwo)
+
+      assertEquals(
+        listOf(1, 2),
+        repository.select(RejectedOutputDiagnosticSelector("workflow-1")).map { it.repairTurn }.sorted(),
+      )
+      // Without a repair-turn selector the attempt resolves to both rows, which is what makes a
+      // raw-body read ambiguous for any attempt that ran a gate repair cycle.
+      assertEquals(
+        listOf(turnTwo.metadata.identity),
+        repository.select(RejectedOutputDiagnosticSelector("workflow-1", "plan", 1, repairTurn = 2))
+          .map { it.identity },
+      )
+    }
+  }
+
   private fun withRepository(label: String, block: (SqliteRejectedOutputDiagnosticRepository) -> Unit) {
     val directory = Files.createTempDirectory(label)
     DatabaseRuntime.ensureDatabase(directory.resolve("runtime.db")).use { connection ->
@@ -141,23 +196,35 @@ class SqliteRejectedOutputDiagnosticRepositoryTest {
     }
   }
 
-  private fun evidence(payload: ByteArray, attempt: Int = 1, generation: Int = 0, agentId: String = "codex") =
-    ProducerOutputEvidence(
-      workflowId = "workflow-1",
-      phaseId = "review",
-      attempt = attempt,
-      agentId = agentId,
-      model = "gpt",
-      recordedAt = Instant.parse("2026-07-28T10:00:00Z"),
-      byteSize = payload.size.toLong(),
-      sha256 = MessageDigest.getInstance("SHA-256").digest(payload).joinToString("") { "%02x".format(it) },
-      payload = payload,
-      generation = generation,
-    )
+  @Suppress("LongParameterList")
+  private fun evidence(
+    payload: ByteArray,
+    attempt: Int = 1,
+    generation: Int = 0,
+    agentId: String = "codex",
+    phaseId: String = "review",
+    repairTurn: Int = 0,
+  ) = ProducerOutputEvidence(
+    workflowId = "workflow-1",
+    phaseId = phaseId,
+    attempt = attempt,
+    agentId = agentId,
+    model = "gpt",
+    recordedAt = Instant.parse("2026-07-28T10:00:00Z"),
+    byteSize = payload.size.toLong(),
+    sha256 = MessageDigest.getInstance("SHA-256").digest(payload).joinToString("") { "%02x".format(it) },
+    payload = payload,
+    generation = generation,
+    repairTurn = repairTurn,
+  )
 
-  private fun record(payload: ByteArray): RejectedOutputDiagnosticRecord = RejectedOutputDiagnosticRecord(
+  private fun record(
+    payload: ByteArray,
+    identity: String = "rod_${"a".repeat(64)}",
+    repairTurn: Int = 0,
+  ): RejectedOutputDiagnosticRecord = RejectedOutputDiagnosticRecord(
     RejectedOutputDiagnostic(
-      identity = "rod_${"a".repeat(64)}",
+      identity = identity,
       workflowId = "workflow-1",
       phaseId = "plan",
       attempt = 1,
@@ -170,6 +237,7 @@ class SqliteRejectedOutputDiagnosticRepositoryTest {
       byteSize = payload.size.toLong(),
       sha256 = "b".repeat(64),
       lifecycle = RejectedOutputLifecycle.STORED,
+      repairTurn = repairTurn,
     ),
     payload,
   )

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/model/RejectedOutputDiagnosticModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/persistence/model/RejectedOutputDiagnosticModels.kt
@@ -18,12 +18,27 @@ data class RejectedOutputDiagnostic(
   val byteSize: Long,
   val sha256: String,
   val lifecycle: RejectedOutputLifecycle,
-)
+  /**
+   * Ordinal of a repair turn launched inside a single phase attempt, zero for an ordinary attempt.
+   * A gate repair cycle re-runs an agent without advancing [attempt], so this is what keeps two
+   * turns of the same attempt independently addressable.
+   */
+  val repairTurn: Int = 0,
+) {
+  init {
+    require(repairTurn >= 0) { "Rejected output diagnostic repair turn must not be negative." }
+  }
+}
 
 data class RejectedOutputDiagnosticSelector(
   val workflowId: String,
   val phaseId: String? = null,
   val attempt: Int? = null,
+  /**
+   * Narrows to one repair turn within [attempt]. Without it, an attempt that ran a gate repair cycle
+   * resolves to several diagnostics, which is what makes a raw-body read ambiguous.
+   */
+  val repairTurn: Int? = null,
 )
 
 data class RejectedOutputDiagnosticRecord(
@@ -44,14 +59,23 @@ data class ProducerOutputEvidence(
   val sha256: String,
   val payload: ByteArray?,
   val generation: Int = 0,
+  /** See [RejectedOutputDiagnostic.repairTurn]; the two keys advance together. */
+  val repairTurn: Int = 0,
 ) {
   init {
     require(generation >= 0) { "Producer output evidence generation must not be negative." }
+    require(repairTurn >= 0) { "Producer output evidence repair turn must not be negative." }
   }
 
   override fun toString(): String = "ProducerOutputEvidence(workflowId=$workflowId, phaseId=$phaseId, " +
-    "generation=$generation, attempt=$attempt, payload=<hidden>)"
+    "generation=$generation, attempt=$attempt, repairTurn=$repairTurn, payload=<hidden>)"
 }
+
+/**
+ * The payload-free primary key of one retained producer capture. Safe to surface in operator text: it
+ * carries identifiers and ordinals only, never retained bytes.
+ */
+fun ProducerOutputEvidence.evidenceKey(): String = "$workflowId:$phaseId:$generation:$attempt:$repairTurn:$agentId"
 
 sealed class RejectedOutputDiagnosticError(message: String) : RuntimeException(message) {
   class Absent(identity: String) : RejectedOutputDiagnosticError("Rejected output diagnostic '$identity' is absent.")


### PR DESCRIPTION
# Summary

A SKILL-16 subtask run (`wftr-20260811-201509-n7hz`) died with an uncaught `RejectedOutputDiagnosticError$Conflict` and exit status 1, leaving the goal runner to report a non-terminal child. The validation-gate repair loop launches a fresh agent per turn without advancing the phase `attempt`, so every turn's producer-evidence write addressed the identical primary key `(workflow_id, phase_id, generation, attempt, agent_id)` with different bytes; turn 2 always conflicted with turn 1's committed row and nothing caught it. This fixes both the collision and the fact that a bookkeeping fault could kill a run at all.

Key changes:

- **The repair-turn ordinal reaches the keys.** `ValidationGateAgentRepairLauncher.launch`'s `repairIteration` was declared by the interface but discarded by the run loop's implementation. It now flows through a new `PhaseRun.validationGateRepairTurn` into both evidence writers and joins the `producer_output_evidence` primary key, the `rejected_output_diagnostics` unique key, and the `rod_` identity preimage.
- **The phase `attempt` is untouched.** It feeds the durable watermark, the fix-loop budget, and `FeatureTaskRuntimeFixLoopPolicy`, so inflating it would charge honest gate repairs to the semantic repair budget and block runs early. A phase that ran one attempt with three repair turns still records `attempt_count = 1`.
- **Already-persisted identities stay resolvable.** `stableIdentity` folds the ordinal into the preimage only when it is non-zero, so every ordinary attempt keeps hashing exactly what it hashed before — which matters because `rejected_output_diagnostics.identity` is stored durably on quarantine entries as `diagnosticIdentity`.
- **The conflict check keeps its purpose.** `readProducerOutput` resolves the newest retained turn for a consumer, while the retain read-back binds an exact turn, so genuinely divergent bytes for one logical capture still raise `Conflict` rather than being papered over by a blanket upsert.
- **Diagnostic persistence is non-fatal.** A conflict, permission, corruption, or plain persistence fault degrades to a durable payload-free `FeatureTaskRuntimeDiagnosticSignal` naming the conflicting key, the phase, and the attempt, and the run proceeds — the rule `recordRejectionMeasurement` already applies to telemetry. `InvalidRequest` and `InvalidConfiguration` keep propagating, since those name a caller defect or a wiring fault rather than an environmental one.
- **Migration 29 self-heals.** It rebuilds both tables carrying every legacy row at turn 0, restores the two version-14 indexes that `DROP TABLE` would otherwise take with it (including the retention index `markExpired` scans), and also runs unconditionally from `ensureDatabase`, because migrations 16 and 28 restate the pre-repair-turn DDL from an explicit column list and would otherwise re-narrow the key on a store whose ledger already recorded 29.
- **`--repair-turn` added to the `rejected-output` CLI.** Widening the diagnostic unique key made `--raw-output` unresolvable for exactly the repair-cycle case, since one attempt can now hold a diagnostic per turn.

The second commit adds the `SKILL-186` follow-up spec for two diagnosability gaps this change leaves open, both raised by its own review (`rvw-20260812-064823-k4qm`, F-003 and F-004): the degraded signal is durable but has no production reader or telemetry field, and a quarantine entry can still record a `diagnosticIdentity` whose row was never written. Spec only, no implementation.

## Feature Flags

N/A. The keying change is a schema-level fix with a self-healing migration; there is no runtime toggle.

# How Has This Been Tested?

`./gradlew check -x sourcesJar` and `skill-bill validate` both pass. New coverage:

- `SqliteRejectedOutputDiagnosticRepositoryTest` — three differing repair turns in one attempt retain distinct rows and the read resolves the newest; re-retaining one turn with different bytes still conflicts on its own key; two repair turns each persist a diagnostic and a `--repair-turn`-scoped select narrows to one; the pre-existing byte-identical retain stays an idempotent no-op.
- `FeatureTaskRuntimeDiagnosticDegradationTest` (new) — three turns each retain their own row; two consecutively rejected turns each record a diagnostic; a forced conflict degrades to a durable payload-free signal instead of failing the run and never overwrites the committed evidence; a caller-construction defect still fails loudly; the degraded signal carries no agent bytes.
- `FeatureTaskRuntimeValidationGateTest` — each repair turn is launched under its own ordinal 1..`MAX_VALIDATE_GATE_REPAIR_ITERATIONS`.
- `DatabaseMigrationsTest` — migration 29 carries rows across at turn 0, keeps the DDL in parity with the base schema, and leaves the migrated index set equal to a freshly created store's.

To reproduce the original crash path against a pre-change build and confirm it is gone:

1. `cd runtime-kotlin && ./gradlew check -x sourcesJar` — the full suite, including the four suites above.
2. `./gradlew :runtime-infra-sqlite:test --tests '*DatabaseMigrationsTest*'` — exercise the migration against a seeded pre-v29 store (the test drops both tables to their pre-repair-turn shape, reinstates the narrow selector index, then reopens).
3. Open an existing `review-metrics.db` with this build and confirm `PRAGMA table_info(producer_output_evidence)` reports `repair_turn` and that `sqlite_master` still lists `idx_rejected_output_diagnostic_retention`.
4. Expected result: a validation-gate cycle runs its full bounded set of repair turns with each turn's evidence independently addressable, and no diagnostic-persistence failure terminates a run.

Note for reviewers: the already-blocked `wftr-20260811-201509-n7hz` workflow is resumable under this build (its `validate` record sits at `status=running, attempt_count=2`, and `validate` participates in the fix loop), but attempt 3 is the last one `MAX_FIX_LOOP_ITERATIONS = 3` allows. Re-running that workflow is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
