### PR TITLE
Fix runtime self-conflicts that burned goal-child retries

### DIFF
--- a/orchestration/shell-content-contract/PLAYBOOK.md
+++ b/orchestration/shell-content-contract/PLAYBOOK.md
@@ -271,9 +271,13 @@ and missing manifest-declared quality-check content always fails loudly.
 The shell loader, validator, and stack-routing playbook all share a common
 discovery algorithm:
 
-1. Walk `platform-packs/` for immediate subdirectories.
+1. Walk `platform-packs/` for immediate subdirectories, resolving that root
+   from the skill-adjacent installed `platform-packs` link (or
+   `~/.skill-bill/platform-packs/` / the install-published review catalog) —
+   not from the reviewed repository unless it is the Skill Bill source tree.
 2. For each candidate slug, load `platform-packs/<slug>/platform.yaml` via the
-   loader.
+   loader. Loud-fail rules apply; missing content must name the slot key and
+   the fully resolved absolute path.
 3. Validate each pack against this contract.
 4. The routed skill name for a platform pack with slug `<slug>` is
    `bill-<slug>-code-review`. Installers and runtime skills must preserve this

--- a/orchestration/skill-classes/code-review-shell.yaml
+++ b/orchestration/skill-classes/code-review-shell.yaml
@@ -47,7 +47,7 @@ sections:
 
   - heading: Routing Rules
     body: |
-      Stack detection and routing are manifest-driven. The shell discovers every `platform-packs/<slug>/platform.yaml`, reads each pack's declared routing signals, and chooses the dominant stack using manifest-declared tie-breakers. The shell does not enumerate platform names inline.
+      Stack detection and routing are manifest-driven. The shell discovers every `platform-packs/<slug>/platform.yaml` from the skill-adjacent installed `platform-packs` link (or `~/.skill-bill/platform-packs/` / the install-published review catalog), not from the reviewed repository root unless that repository is itself the Skill Bill source tree. It reads each pack's declared routing signals and chooses the dominant stack using manifest-declared tie-breakers. The shell does not enumerate platform names inline.
 
       - Generate a `routed_skill` value of `bill-<slug>-code-review` for the dominant pack. This contract is preserved exactly so existing user-facing commands keep working.
       - If the review scope is mixed and multiple packs have strong signals, route to each matching pack and merge the results using delegated execution.
@@ -62,7 +62,7 @@ sections:
       - `MissingManifestError` — the pack has no `platform.yaml`.
       - `InvalidManifestSchemaError` — the manifest fails schema validation.
       - `ContractVersionMismatchError` — `contract_version` does not match the shell's target version; print both versions and the offending pack slug.
-      - `MissingContentFileError` — a declared content file does not exist.
+      - `MissingContentFileError` — a declared content file does not exist; the message must name the slot key and the fully resolved absolute path.
       - `MissingRequiredSectionError` — a declared content file is missing a required H2 section.
 
       The shell never silently substitutes a default reviewer. A broken pack must be repaired before `/bill-code-review` can complete.

--- a/orchestration/skill-classes/quality-check-shell.yaml
+++ b/orchestration/skill-classes/quality-check-shell.yaml
@@ -36,7 +36,7 @@ sections:
 
   - heading: Routing Rules
     body: |
-      Stack detection and routing are manifest-driven. The shell discovers every `platform-packs/<slug>/platform.yaml`, reads each pack's declared routing signals, and chooses the dominant stack using manifest-declared tie-breakers. The shell does not enumerate platform names inline.
+      Stack detection and routing are manifest-driven. The shell discovers every `platform-packs/<slug>/platform.yaml` from the skill-adjacent installed `platform-packs` link (or `~/.skill-bill/platform-packs/` / the install-published review catalog), not from the reviewed repository root unless that repository is itself the Skill Bill source tree. It reads each pack's declared routing signals and chooses the dominant stack using manifest-declared tie-breakers. The shell does not enumerate platform names inline.
 
       - For the dominant pack, read the optional top-level `declared_quality_check_file` key from the manifest. The runtime authority is `skillbill.scaffold.platformpack.routeQualityCheck` in `runtime-infra-fs`; it discovers manifests dynamically and loud-fails ambiguous or invalid routes.
       - The routed skill name is the `name:` frontmatter field of the declared quality-check `content.md`. The declared content must also carry `internal-for: bill-code-check`, so the routed checker installs as a sibling `<routed-skill-name>.md` sidecar inside `bill-code-check` rather than as a separately listed skill.

--- a/orchestration/stack-routing/PLAYBOOK.md
+++ b/orchestration/stack-routing/PLAYBOOK.md
@@ -23,11 +23,16 @@ required unless the discovery algorithm itself changes.
 
 Every router, reviewer, and validator agrees on the following procedure:
 
-1. Enumerate every immediate subdirectory of `platform-packs/`.
+1. Enumerate every immediate subdirectory of `platform-packs/`, resolved from
+   the skill-adjacent `platform-packs` link installed next to this skill (or
+   from `~/.skill-bill/platform-packs/` / the install-published review catalog).
+   Do **not** treat the reviewed repository root's `platform-packs/` as the
+   discovery root unless that repository is itself the Skill Bill source tree.
 2. For each candidate slug, load
    `platform-packs/<slug>/platform.yaml` via the shell+content contract
    loader. Loud-fail rules apply — see
-   [shell-content-contract.md](../shell-content-contract/PLAYBOOK.md).
+   [shell-content-contract.md](../shell-content-contract/PLAYBOOK.md). The
+   loud-fail must name the slot key and the fully resolved absolute path.
 3. Each loaded manifest contributes:
    - `platform` — the stack slug.
    - `routing_signals.strong` — list of strong detection signals (path

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointScope.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointScope.kt
@@ -5,6 +5,8 @@ import skillbill.application.featuretask.model.FeatureTaskRuntimeCheckpointScope
 import java.util.Locale
 
 private const val GOVERNED_SPEC_ROOT = ".feature-specs/"
+private const val RUNTIME_PRIVATE_ROOT = ".skill-bill/"
+private const val RUNTIME_TRACKABLE_CONFIG = ".skill-bill/config.yaml"
 
 /** Bounds a block message so one pathological inventory cannot flood a durable blocked reason. */
 private const val MAX_REPORTED_PATHS = 10
@@ -18,11 +20,13 @@ internal object FeatureTaskRuntimeCheckpointScope {
     // ownership is not a licence to commit another workflow's authority. Evicting it here also keeps
     // an inventory that already carries one from blocking every later checkpoint of this run.
     val owned = declared.filterNot { isForeignGovernedSpecPath(it, input.issueKey) }
+      .filterNot(::isRuntimePrivatePath)
     val ownedAliases = owned.associateBy(::normalizeForAliasComparison)
 
     blockingDecision(input, ownedAliases, declaredAliases)?.let { return it }
 
     val deltaAliases = input.worktreeDeltaPaths.filter(String::isNotBlank)
+      .filterNot(::isRuntimePrivatePath)
       .map(::normalizeForAliasComparison)
       .toSet()
     val adopted = adoptedDivergentPaths(input, ownedAliases)
@@ -76,6 +80,9 @@ internal object FeatureTaskRuntimeCheckpointScope {
       ?.let { blockForeignGovernedSpec(input.issueKey, it) }
     val outside = input.phaseIntroducedPaths.filter(String::isNotBlank).distinct()
       .filterNot { isForeignGovernedSpecPath(it, input.issueKey) }
+      // Runtime-private evidence under `.skill-bill/` is written by the runtime itself; treating it as
+      // phase-introduced feature work is a self-conflict (shared review evidence is the usual case).
+      .filterNot(::isRuntimePrivatePath)
       .filterNot { path -> normalizeForAliasComparison(path) in ownedAliases }
       .sorted().takeIf { it.isNotEmpty() }
       ?.let { blockOutsideInventory(input.issueKey, it) }
@@ -91,12 +98,30 @@ internal object FeatureTaskRuntimeCheckpointScope {
    * everything dirty in the tree.
    */
   fun phaseWrittenPaths(worktreeDeltaPaths: List<String>, phaseManifestPaths: List<String>): List<String> {
-    val manifest = phaseManifestPaths.filter(String::isNotBlank).map(::normalizeForAliasComparison)
+    val manifest = phaseManifestPaths.filter(String::isNotBlank)
+      .filterNot(::isRuntimePrivatePath)
+      .map(::normalizeForAliasComparison)
     if (manifest.isEmpty()) return emptyList()
-    return worktreeDeltaPaths.filter(String::isNotBlank).filter { path ->
-      val normalized = normalizeForAliasComparison(path)
-      manifest.any { entry -> normalized == entry || normalized.startsWith("$entry/") }
-    }.distinct().sorted()
+    return worktreeDeltaPaths.filter(String::isNotBlank)
+      .filterNot(::isRuntimePrivatePath)
+      .filter { path ->
+        val normalized = normalizeForAliasComparison(path)
+        manifest.any { entry -> normalized == entry || normalized.startsWith("$entry/") }
+      }.distinct().sorted()
+  }
+
+  /**
+   * Runtime-private paths the install-time ignore rule is supposed to hide. Ownership and review
+   * still exclude them explicitly: consumer repos may lack that ignore, and the runtime writes
+   * shared evidence mid-phase regardless.
+   *
+   * `.skill-bill/config.yaml` stays trackable and is not private.
+   */
+  fun isRuntimePrivatePath(path: String): Boolean {
+    val normalized = normalizeForAliasComparison(path)
+    if (normalized == RUNTIME_TRACKABLE_CONFIG) return false
+    return normalized == RUNTIME_PRIVATE_ROOT.trimEnd('/') ||
+      normalized.startsWith(RUNTIME_PRIVATE_ROOT)
   }
 
   /**

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeFixLoopPolicy.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeFixLoopPolicy.kt
@@ -123,8 +123,16 @@ object FeatureTaskRuntimeFixLoopPolicy {
   }
 
   private fun blockedReason(phaseId: String, currentIteration: Int): String = if (participatesInFixLoop(phaseId)) {
+    val remediationNote =
+      if (phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW) {
+        " This cap bounds schema/output correction for the review phase itself; the review_fix " +
+          "remediation edge remains uncapped."
+      } else {
+        ""
+      }
     "Phase '$phaseId' exhausted the bounded fix loop after $currentIteration attempts " +
-      "(cap=$MAX_FIX_LOOP_ITERATIONS); the run blocks rather than advancing on invalid output."
+      "(cap=$MAX_FIX_LOOP_ITERATIONS); the run blocks rather than advancing on invalid output." +
+      remediationNote
   } else {
     "Phase '$phaseId' produced schema-invalid output and does not participate in a fix loop; " +
       "the run blocks rather than advancing on invalid output."

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseSafetyPolicy.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseSafetyPolicy.kt
@@ -24,6 +24,7 @@ internal object FeatureTaskRuntimePhaseSafetyPolicy {
     .filter { it.length >= PORCELAIN_PATH_OFFSET }
     .map { line -> line.substring(PORCELAIN_PATH_OFFSET).substringAfterLast(" -> ").trim('"') }
     .filter(String::isNotBlank)
+    .filterNot(FeatureTaskRuntimeCheckpointScope::isRuntimePrivatePath)
     .distinct()
     .sorted()
     .toList()

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -1070,6 +1070,7 @@ internal class FeatureTaskRuntimeRunLoop(
       .map(String::trim)
       .filter(String::isNotBlank)
       .filterNot { it in baseline }
+      .filterNot(FeatureTaskRuntimeCheckpointScope::isRuntimePrivatePath)
       .distinct()
       .sorted()
   }
@@ -3566,8 +3567,12 @@ internal class FeatureTaskRuntimeRunLoop(
     outputByteSize: Long,
     outputSha256: String,
   ): AttemptResult {
-    val outputText = normalizedOutput.canonicalJson
-    val outputMap = normalizedOutput.envelope
+    // Absent-gate validate: agents are told not to invent gate_run_count/gate_runs, but the
+    // validation_receipt consumer projection requires them. Attest measured-absent counts here so
+    // the first completed attempt satisfies write_history without burning a fix-loop retry.
+    val attested = attestAbsentGateValidationReceipt(run, normalizedOutput)
+    val outputText = attested.canonicalJson
+    val outputMap = attested.envelope
     fun reject(rule: String, detail: String): AttemptResult {
       val structuredIdentity = structuredRepairDiagnosticIdentity(detail)
       val diagnosticRule = structuredIdentity?.first ?: rule
@@ -3607,7 +3612,7 @@ internal class FeatureTaskRuntimeRunLoop(
           observability,
           failureDisposition = FeatureTaskRuntimeFailureDisposition.NEEDS_USER_ACTION,
           fileManifest = fileManifest,
-          normalizedOutput = normalizedOutput,
+          normalizedOutput = attested,
           repairEvidence = repairEvidence,
         ),
       )
@@ -3618,7 +3623,7 @@ internal class FeatureTaskRuntimeRunLoop(
         iteration,
         reason,
         outputMap,
-        normalizedOutput,
+        attested,
         repairEvidence,
         observability,
         fileManifest,
@@ -3630,7 +3635,7 @@ internal class FeatureTaskRuntimeRunLoop(
       run,
       iteration,
       outputMap,
-      normalizedOutput,
+      attested,
       repairEvidence,
       repositoryFingerprint,
     )?.let { (rule, reason) -> return reject(rule, reason) }
@@ -3648,7 +3653,7 @@ internal class FeatureTaskRuntimeRunLoop(
         operatorReason = reason,
         continuationReason = reason,
         fileManifest = fileManifest,
-        normalizedOutput = normalizedOutput,
+        normalizedOutput = attested,
       )
     }
     recorder.retainProducerOutput(
@@ -3670,12 +3675,42 @@ internal class FeatureTaskRuntimeRunLoop(
     return persistAcceptedOutput(
       run,
       iteration,
-      normalizedOutput,
+      attested,
       repairEvidence,
       observability,
       fileManifest,
       repositoryFingerprint,
     )
+  }
+
+  /**
+   * Packs without `validation_gate` fall back to agent-run validate. That path must never publish
+   * agent-authored gate measurements: overwrite (or supply) `gate_run_count`/`gate_runs` with the
+   * degradation attestation before consumer projection and persist.
+   */
+  private fun attestAbsentGateValidationReceipt(
+    run: PhaseRun,
+    normalizedOutput: NormalizedFeatureTaskRuntimePhaseOutput,
+  ): NormalizedFeatureTaskRuntimePhaseOutput {
+    val eligible = run.agentRunValidateFallback &&
+      run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE &&
+      normalizedOutput.envelope["status"] == STATUS_COMPLETED
+    if (!eligible) return normalizedOutput
+    val produced = JsonSupport.anyToStringAnyMap(normalizedOutput.envelope["produced_outputs"])
+      ?.toMutableMap()
+      ?: return normalizedOutput
+    val validationResult = JsonSupport.anyToStringAnyMap(produced["validation_result"])
+      ?.toMutableMap()
+      ?: return normalizedOutput
+    validationResult["gate_run_count"] = 0
+    validationResult["gate_runs"] = emptyList<Any?>()
+    produced["validation_result"] = validationResult
+    val envelope = normalizedOutput.envelope.toMutableMap()
+    envelope["produced_outputs"] = produced
+    return outputValidator.validatePhaseOutput(
+      JsonSupport.mapToJsonString(envelope),
+      sourceLabel = run.phaseId,
+    ).requireAcceptedOutput(run.phaseId).normalizedOutput
   }
 
   /**

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeFixLoopPolicyTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeFixLoopPolicyTest.kt
@@ -122,6 +122,10 @@ class FeatureTaskRuntimeFixLoopPolicyTest {
         blocked.blockedReason.contains("exhausted the bounded fix loop"),
         "block reason for '$phaseId' must name fix-loop exhaustion",
       )
+      if (phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW) {
+        assertContains(blocked.blockedReason, "review_fix")
+        assertContains(blocked.blockedReason, "remains uncapped")
+      }
     }
   }
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhaseSafetyPolicyTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhaseSafetyPolicyTest.kt
@@ -20,4 +20,18 @@ class FeatureTaskRuntimePhaseSafetyPolicyTest {
       paths,
     )
   }
+
+  @Test
+  fun `runtime-private skill-bill paths are omitted from phase manifests`() {
+    val paths = FeatureTaskRuntimePhaseSafetyPolicy.changedPaths(
+      """
+       M src/Main.kt
+      ?? .skill-bill/run-evidence/wf/fp/evidence.json
+      ?? .skill-bill/run-evidence/wf/fp/diff.patch
+      ?? .skill-bill/config.yaml
+      """.trimIndent(),
+    )
+
+    assertEquals(listOf(".skill-bill/config.yaml", "src/Main.kt"), paths)
+  }
 }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -869,6 +869,43 @@ class FeatureTaskRuntimeRunnerTest {
     assertContains(validateOutput, "Validation satisfied by runtime-owned gate execution.")
   }
 
+  @Test
+  fun `absent-gate validate without gate_run_count completes on first attempt`() {
+    // Packs without validation_gate use agent-run validate. Agents are told not to invent
+    // gate_run_count; the runtime must attest measured-absent counts before consumer projection.
+    val harness = runnerHarness(
+      agentAssignment = phasePerAgentAssignment(),
+      // Empty manifests → ValidationGateResolution.Absent → agent-run fallback.
+      runtimeConfig = RuntimeHarnessConfig(validationGatePlatformManifests = emptyList()),
+      launcher = RuntimeRecordingLauncher { request ->
+        val phaseId = phaseIdFromPrompt(requireNotNull(request.skillRunRequest.promptOverride))
+        facts(
+          if (phaseId == "validate") {
+            VALIDATE_REPAIR_WITHOUT_GATE_COUNTS
+          } else {
+            validJsonOutput(phaseId)
+          },
+        )
+      },
+    )
+    harness.seedPhase("preplan", "completed", 1, phaseAgent("preplan"), PREPLAN_OUTPUT)
+    harness.seedPhase("plan", "completed", 1, phaseAgent("plan"), PLAN_OUTPUT)
+    harness.seedPhase("implement", "completed", 1, phaseAgent("implement"), IMPLEMENT_OUTPUT)
+    harness.seedPhase("audit", "completed", 1, phaseAgent("audit"), VALID_AUDIT_OUTPUT)
+    harness.seedPhase("review", "completed", 1, phaseAgent("review"), VALID_OUTPUT)
+
+    val report = harness.runner.run(harness.request())
+
+    assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
+    assertEquals(1, harness.launchedPhaseOrder().count { it == "validate" })
+    assertTrue(harness.launchedPhaseOrder().contains("write_history"))
+    val validateRecord = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID).orEmpty()["validate"])
+    assertEquals(1, validateRecord.attemptCount)
+    val validateOutput = requireNotNull(validateRecord.outputArtifact)
+    assertContains(validateOutput, """"gate_run_count":0""")
+    assertContains(validateOutput, """"gate_runs":[]""")
+  }
+
   // --- Subtask 2: bounded cyclic phase executor (AC10) ---
 
   @Test

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointScopeTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointScopeTest.kt
@@ -304,6 +304,39 @@ class FeatureTaskRuntimeCheckpointScopeTest {
     assertContains(reviewRemediation, "generation=2")
   }
 
+  @Test
+  fun `runtime-private run-evidence does not block outside-inventory ownership`() {
+    val evidence = ".skill-bill/run-evidence/wftr-1/fp/evidence.json"
+    val patch = ".skill-bill/run-evidence/wftr-1/fp/diff.patch"
+    val decision = decide(
+      ownedPaths = listOf("src/Owned.kt"),
+      phaseIntroducedPaths = listOf("src/Owned.kt", evidence, patch, ".skill-bill/"),
+    )
+
+    val stage = assertIs<FeatureTaskRuntimeCheckpointDecision.Stage>(decision)
+    assertEquals(listOf("src/Owned.kt"), stage.ownedPaths)
+  }
+
+  @Test
+  fun `runtime-private paths are stripped from phaseWrittenPaths even when the manifest collapses the tree`() {
+    val written = FeatureTaskRuntimeCheckpointScope.phaseWrittenPaths(
+      worktreeDeltaPaths = listOf(
+        "src/Owned.kt",
+        ".skill-bill/run-evidence/wf/fp/diff.patch",
+        ".skill-bill/run-evidence/wf/fp/evidence.json",
+      ),
+      phaseManifestPaths = listOf("src/Owned.kt", ".skill-bill/"),
+    )
+
+    assertEquals(listOf("src/Owned.kt"), written)
+  }
+
+  @Test
+  fun `trackable skill-bill config is not treated as runtime-private`() {
+    assertFalse(FeatureTaskRuntimeCheckpointScope.isRuntimePrivatePath(".skill-bill/config.yaml"))
+    assertTrue(FeatureTaskRuntimeCheckpointScope.isRuntimePrivatePath(".skill-bill/run-evidence/a/b"))
+  }
+
   // The delta defaults to everything owned or introduced, so each case names only what it is about.
   private fun decide(
     ownedPaths: List<String>,


### PR DESCRIPTION
## Summary
- Exclude `.skill-bill/**` runtime-private paths (except trackable `config.yaml`) from checkpoint ownership, phase manifests, and worktree delta so shared run-evidence cannot block its own phase.
- Attest `gate_run_count: 0` / `gate_runs: []` on absent-gate agent-run validate before consumer projection, eliminating the mandatory first-attempt reject on packs without `validation_gate` (e.g. PHP).
- Clarify that review's hard fix-loop cap is schema/output correction only; `review_fix` remediation stays uncapped. Point pack discovery at the skill-adjacent / install / review-catalog root and require slot + absolute path on missing-content loud-fails.

## Test plan
- [x] `:runtime-application:detekt` / `spotlessCheck` / focused tests for checkpoint scope, safety policy, fix-loop policy, and absent-gate validate
- [ ] Re-run a PHP (or other absent-gate) goal child and confirm validate completes on attempt 1 with attested counts
- [ ] Confirm audit/shared-evidence write no longer needs `.git/info/exclude` for `.skill-bill/run-evidence/`
- [ ] After `./install.sh`, confirm installed stack-routing / shell pointers carry the discovery-root wording


Made with [Cursor](https://cursor.com)