### PR TITLE
Keep runtime review findings on a fallback lane

### DIFF
--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt
@@ -3036,6 +3036,11 @@ internal class FeatureTaskRuntimeRunLoop(
     ReviewDriverFailed(
       "Runtime-owned review produced an invalid review-context envelope: ${error.message.orEmpty()}",
     )
+  } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+    ReviewDriverFailed(
+      "Runtime-owned review failed: ${error::class.simpleName}: ${error.message.orEmpty()}",
+      FeatureTaskRuntimeFailureDisposition.RETRYABLE,
+    )
   }
 
   private fun settleReviewDriverResult(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeWorkerCoordinator.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeWorkerCoordinator.kt
@@ -64,15 +64,39 @@ class FeatureTaskRuntimeWorkerCoordinator(
   }
 
   private fun acquireUnowned(workflowId: String, dbOverride: String?): FeatureTaskRuntimeWorkerOwnership {
-    val row = database.read(dbOverride) { it.workflowStates.getFeatureTaskRuntimeWorkflow(workflowId) }
-      ?: throw InvalidWorkflowStateSchemaError("Feature-task runtime worker workflow '$workflowId' is missing.")
-    val ownership = newOwnership(workflowId, generation = 1, phaseId = row.currentStepId, phaseAttempt = 1)
-    val acquired = database.selfManagedWrite(dbOverride) {
-      it.workflowStates.acquireFeatureTaskRuntimeWorker(ownership, row.updatedAt)
+    repeat(UNOWNED_ACQUIRE_ATTEMPTS) {
+      when (val claim = claimUnowned(workflowId, dbOverride)) {
+        is UnownedClaim.Owned -> return claim.ownership
+        is UnownedClaim.Recover -> return recoverOwned(claim.existing, dbOverride)
+        UnownedClaim.Lost -> Unit
+      }
     }
-    if (!acquired) error("Workflow '$workflowId' changed before worker ownership could be acquired.")
-    return ownership
+    error("Workflow '$workflowId' changed before worker ownership could be acquired.")
   }
+
+  private fun claimUnowned(workflowId: String, dbOverride: String?): UnownedClaim =
+    database.selfManagedWrite(dbOverride) { unitOfWork ->
+      val existing = unitOfWork.workflowStates.getFeatureTaskRuntimeWorkerOwnership(workflowId)
+      if (existing != null) return@selfManagedWrite UnownedClaim.Recover(existing)
+      val row = unitOfWork.workflowStates.getFeatureTaskRuntimeWorkflow(workflowId)
+        ?: throw InvalidWorkflowStateSchemaError("Feature-task runtime worker workflow '$workflowId' is missing.")
+      if (row.workflowStatus in TERMINAL_WORKFLOW_STATUSES) {
+        error(
+          "Cannot acquire worker ownership for terminal workflow '$workflowId' (${row.workflowStatus}).",
+        )
+      }
+      val ownership = newOwnership(
+        workflowId,
+        generation = 1,
+        phaseId = row.currentStepId,
+        phaseAttempt = 1,
+      )
+      if (unitOfWork.workflowStates.acquireFeatureTaskRuntimeWorker(ownership, row.updatedAt)) {
+        UnownedClaim.Owned(ownership)
+      } else {
+        UnownedClaim.Lost
+      }
+    }
 
   private fun recoverOwned(
     existing: FeatureTaskRuntimeWorkerOwnership,
@@ -171,5 +195,13 @@ class FeatureTaskRuntimeWorkerCoordinator(
     const val HEARTBEAT_SECONDS: Long = 10
     const val GRACE_POLLS: Int = 20
     const val GRACE_POLL_MILLIS: Long = 100
+    const val UNOWNED_ACQUIRE_ATTEMPTS: Int = 3
+    val TERMINAL_WORKFLOW_STATUSES: Set<String> = setOf("completed", "failed", "abandoned")
   }
+}
+
+private sealed interface UnownedClaim {
+  data class Owned(val ownership: FeatureTaskRuntimeWorkerOwnership) : UnownedClaim
+  data class Recover(val existing: FeatureTaskRuntimeWorkerOwnership) : UnownedClaim
+  data object Lost : UnownedClaim
 }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
@@ -268,23 +268,25 @@ class ParallelCodeReviewRunner(
       )
     }
     val agent2Id = initial.agent2Id ?: return ParallelReviewLaneRunResult(
-      lane1 = lane1(),
+      lane1 = captureLane(lane1),
       lane2 = ParallelReviewLaneOutcome(success = true, rawOutput = ""),
     )
     val timeoutSec = request.timeout?.inWholeSeconds ?: DEFAULT_TIMEOUT_MINUTES * SECONDS_PER_MINUTE
     return parallelLaneRunner.runTwoLanes(
       ParallelReviewLaneRunRequest(
-        lane1 = lane1,
+        lane1 = { captureLane(lane1) },
         lane2 = {
-          launchParentLane(
-            agent2Id,
-            byAgent[agent2Id].orEmpty(),
-            initial.detection.routed,
-            initial.budget,
-            request,
-            request.agent2Model,
-            initial.resolvedMode,
-          )
+          captureLane {
+            launchParentLane(
+              agent2Id,
+              byAgent[agent2Id].orEmpty(),
+              initial.detection.routed,
+              initial.budget,
+              request,
+              request.agent2Model,
+              initial.resolvedMode,
+            )
+          }
         },
         timeout = (timeoutSec + TIMEOUT_BUFFER_SECONDS).seconds,
       ),
@@ -1375,35 +1377,59 @@ class ParallelCodeReviewRunner(
     )
   }
 
+  private fun captureLane(lane: () -> ParallelReviewLaneOutcome): ParallelReviewLaneOutcome = try {
+    lane()
+  } catch (@Suppress("TooGenericExceptionCaught") thrown: Exception) {
+    ParallelReviewLaneOutcome(
+      success = false,
+      rawOutput = "",
+      failureReason = "lane launch threw ${thrown::class.simpleName}: ${thrown.message ?: "no detail"}",
+    )
+  }
+
   private fun attributeInlineFindings(
     stdout: String,
     selected: List<ReviewSpecialistLaunchRequest>,
-  ): List<ParallelReviewRawFinding> = ParallelReviewFindingParser.parse(stdout).map { finding ->
-    val findingPath = requireNotNull(finding.repositoryPath)
-    val owners = selected.filter { launch ->
-      launch.assignment.assignedPaths.any { path -> path == findingPath }
-    }
-    require(owners.isNotEmpty()) {
-      "Inline finding location '${finding.location}' is outside the authoritative assignment ownership."
-    }
-    val distinctOwners = owners.distinctBy { it.assignment.laneDecision.specialistSkillName }
-    val declaredSpecialist = finding.specialistSkillName
-    require(declaredSpecialist != null || distinctOwners.size == 1) {
-      "Inline finding location '${finding.location}' has overlapping ownership and must name its specialist."
-    }
-    val owner = if (declaredSpecialist == null) {
-      distinctOwners.single()
-    } else {
-      distinctOwners.singleOrNull {
-        it.assignment.laneDecision.specialistSkillName == declaredSpecialist
-      } ?: error(
-        "Inline finding specialist '$declaredSpecialist' does not own '${finding.location}'.",
+  ): List<ParallelReviewRawFinding> {
+    val fallbackLane = selected.minByOrNull { it.assignment.laneDecision.orderIndex }
+    val fallbackPath = fallbackLane?.assignment?.assignedPaths?.firstOrNull()
+      ?: ParallelReviewFindingParser.UNASSIGNED_REPOSITORY_PATH
+    val parsed = runCatching { ParallelReviewFindingParser.parse(stdout) }.getOrDefault(emptyList())
+    return parsed.map { finding ->
+      val findingPath = finding.repositoryPath
+      val pathOwners = selected.filter { launch ->
+        findingPath != null && launch.assignment.assignedPaths.any { path -> path == findingPath }
+      }.distinctBy { it.assignment.laneDecision.specialistSkillName }
+      val owner = resolveInlineFindingOwner(finding.specialistSkillName, pathOwners, selected)
+        ?: fallbackLane
+      val path = when {
+        findingPath != null &&
+          findingPath != ParallelReviewFindingParser.UNASSIGNED_REPOSITORY_PATH -> findingPath
+        else -> fallbackPath
+      }
+      val line = finding.line ?: FIRST_SOURCE_LINE
+      finding.copy(
+        specialistSkillName = owner?.assignment?.laneDecision?.specialistSkillName
+          ?: finding.specialistSkillName,
+        originLayerChains = owner?.assignment?.laneDecision?.originLayerChains.orEmpty(),
+        repositoryPath = path,
+        line = line,
+        location = "$path:$line",
       )
     }
-    finding.copy(
-      specialistSkillName = owner.assignment.laneDecision.specialistSkillName,
-      originLayerChains = owner.assignment.laneDecision.originLayerChains,
-    )
+  }
+
+  private fun resolveInlineFindingOwner(
+    declaredSpecialist: String?,
+    pathOwners: List<ReviewSpecialistLaunchRequest>,
+    selected: List<ReviewSpecialistLaunchRequest>,
+  ): ReviewSpecialistLaunchRequest? {
+    val selectedByName = selected.distinctBy { it.assignment.laneDecision.specialistSkillName }
+    if (declaredSpecialist != null) {
+      selectedByName.singleOrNull { it.assignment.laneDecision.specialistSkillName == declaredSpecialist }
+        ?.let { return it }
+    }
+    return pathOwners.minByOrNull { it.assignment.laneDecision.orderIndex }
   }
 
   private fun laneOwnedPaths(lane: ReviewLaunchLane, files: List<ReviewChangedFileEvidence>): List<String> {

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -7130,6 +7130,12 @@ internal class InMemoryRuntimeWorkflowRepository : WorkflowStateRepository {
     taskRuntimeRows[row.workflowId] = row
   }
 
+  fun bumpUpdatedAt(workflowId: String) {
+    val row = taskRuntimeRows[workflowId] ?: return
+    val current = java.time.Instant.parse(row.updatedAt ?: "2026-01-01T00:00:00Z")
+    taskRuntimeRows[workflowId] = row.copy(updatedAt = current.plusSeconds(1).toString())
+  }
+
   override fun getFeatureTaskRuntimeWorkflow(workflowId: String): WorkflowStateRecord? = taskRuntimeRows[workflowId]
 
   override fun listFeatureTaskRuntimeWorkflows(limit: Int): List<WorkflowStateRecord> =

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeWorkerCoordinatorTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeWorkerCoordinatorTest.kt
@@ -3,6 +3,10 @@ package skillbill.application
 import skillbill.application.featuretask.FeatureTaskRuntimeWorkerCoordinator
 import skillbill.ports.persistence.model.FeatureTaskRuntimeWorkerLeaseState
 import skillbill.ports.persistence.model.FeatureTaskRuntimeWorkerOwnership
+import skillbill.ports.persistence.model.FeatureTaskWorkflowMode
+import skillbill.ports.persistence.model.WorkflowStateRecord
+import skillbill.ports.persistence.DatabaseSessionFactory
+import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.taskruntime.FeatureTaskRuntimeHeartbeat
 import skillbill.ports.taskruntime.FeatureTaskRuntimeWorkerSupervisor
 import skillbill.ports.taskruntime.model.FeatureTaskRuntimeHeartbeatPlan
@@ -18,6 +22,24 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class FeatureTaskRuntimeWorkerCoordinatorTest {
+  @Test
+  fun `unowned acquire still claims after a concurrent updated_at bump`() {
+    val repository = InMemoryRuntimeWorkflowRepository()
+    repository.saveFeatureTaskRuntimeWorkflow(unownedRuntimeRow(updatedAt = "2026-08-15T20:57:11Z"))
+    val coordinator = FeatureTaskRuntimeWorkerCoordinator(
+      BumpUpdatedAtAfterReadDatabase(repository),
+      FakeWorkerSupervisor(FeatureTaskRuntimeProcessInspection.NotRunning),
+    )
+
+    coordinator.runOwned(WORKFLOW_ID, null) {
+      val owned = requireNotNull(repository.getFeatureTaskRuntimeWorkerOwnership(WORKFLOW_ID))
+      assertEquals(1, owned.generation)
+      assertEquals("implement", owned.phaseId)
+    }
+
+    assertNull(repository.getFeatureTaskRuntimeWorkerOwnership(WORKFLOW_ID))
+  }
+
   @Test
   fun `orphaned worker lease is atomically reclaimed with a new generation`() {
     val repository = InMemoryRuntimeWorkflowRepository()
@@ -187,6 +209,43 @@ private class FakeWorkerSupervisor(
 
   override fun pause(durationMillis: Long) = Unit
 }
+
+private class BumpUpdatedAtAfterReadDatabase(
+  private val workflows: InMemoryRuntimeWorkflowRepository,
+) : DatabaseSessionFactory {
+  private val inner = RuntimeFakeDatabaseSessionFactory(workflows)
+
+  override fun resolveDbPath(dbOverride: String?) = inner.resolveDbPath(dbOverride)
+
+  override fun databaseExists(dbOverride: String?) = inner.databaseExists(dbOverride)
+
+  override fun <T> read(dbOverride: String?, block: (UnitOfWork) -> T): T {
+    val result = inner.read(dbOverride, block)
+    workflows.bumpUpdatedAt(WORKFLOW_ID)
+    return result
+  }
+
+  override fun <T> transaction(dbOverride: String?, block: (UnitOfWork) -> T): T =
+    inner.transaction(dbOverride, block)
+
+  override fun <T> selfManagedWrite(dbOverride: String?, block: (UnitOfWork) -> T): T =
+    inner.selfManagedWrite(dbOverride, block)
+}
+
+private fun unownedRuntimeRow(updatedAt: String) = WorkflowStateRecord(
+  workflowId = WORKFLOW_ID,
+  sessionId = "ftr-unowned",
+  workflowName = "bill-feature-task",
+  contractVersion = "0.1",
+  workflowStatus = "pending",
+  currentStepId = "implement",
+  stepsJson = "[]",
+  artifactsJson = "{}",
+  startedAt = "2026-08-15T20:57:11Z",
+  updatedAt = updatedAt,
+  finishedAt = null,
+  mode = FeatureTaskWorkflowMode.RUNTIME,
+)
 
 private fun ownership(
   expiresAt: String = "2999-01-01T00:00:30Z",

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/ParallelCodeReviewRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/ParallelCodeReviewRunnerTest.kt
@@ -436,6 +436,158 @@ class ParallelCodeReviewRunnerTest {
   }
 
   @Test
+  fun `inline review keeps a rubric-tagged finding on a path owned by another selected specialist`() {
+    val persistencePath =
+      "application/src/test/kotlin/dev/skillbill/application/slot/InMemoryPersistencePorts.kt"
+    val finding =
+      "[F-001] Major | High | specialist=bill-kotlin-code-review-persistence | " +
+        "path=\"$persistencePath\" | line=956 | RunStateConflict hides a cancelled committed attempt"
+    val runner = runner(
+      alwaysSuccessLauncher(finding),
+      catalogGateway = stubCatalogGateway(
+        listOf(
+          PlatformManifest(
+            slug = "kotlin",
+            packRoot = Path.of("platform-packs/kotlin"),
+            contractVersion = "1.3",
+            routingSignals = RoutingSignals(strong = listOf("*.kt"), tieBreakers = emptyList()),
+            declaredCodeReviewAreas = listOf("architecture", "persistence"),
+            declaredFiles = DeclaredFiles(
+              baseline = Path.of("content.md"),
+              areas = mapOf(
+                "architecture" to Path.of("architecture.md"),
+                "persistence" to Path.of("persistence.md"),
+              ),
+            ),
+            areaMetadata = emptyMap(),
+            laneConditions = mapOf(
+              "architecture" to ReviewLaneCondition(required = true),
+              "persistence" to ReviewLaneCondition(
+                content = listOf("transaction", "hibernate", "exposed", "database"),
+              ),
+            ),
+          ),
+        ),
+      ),
+      diffResolver = RecordingDiffResolver(
+        default = """
+          +++ b/$persistencePath
+          @@ -950,1 +950,1 @@
+          - old
+          + RunStateConflict
+          +++ b/src/Dao.kt
+          @@ -1,1 +1,1 @@
+          - old
+          + transaction {
+        """.trimIndent(),
+      ),
+      rubricResolver = ReviewRubricResolver {
+        ResolvedReviewRubric(
+          "bill-kotlin-code-review",
+          "parent routing rubric",
+          specialists = listOf(
+            ResolvedReviewRubric(
+              "bill-kotlin-code-review-architecture",
+              "architecture specialist rubric",
+              area = "architecture",
+            ),
+            ResolvedReviewRubric(
+              "bill-kotlin-code-review-persistence",
+              "persistence specialist rubric",
+              area = "persistence",
+            ),
+          ),
+        )
+      },
+    )
+
+    val result = runner.run(baseRequest(agent2Id = null, scope = ParallelReviewScope.STAGED))
+
+    assertTrue(result.lane1.success, result.lane1.failureReason.orEmpty())
+    assertEquals(
+      listOf("bill-kotlin-code-review-persistence"),
+      result.mergeResult.findings.single().specialistSkillNames,
+    )
+  }
+
+  @Test
+  fun `inline review assigns an unknown specialist tag to a path-owning lane and still reports the finding`() {
+    val finding =
+      "[F-001] Major | High | specialist=bill-kotlin-code-review-unknown | " +
+        "path=\"src/FooTest.kt\" | line=12 | test dispatcher never advances"
+    val runner = runner(
+      alwaysSuccessLauncher(finding),
+      catalogGateway = stubCatalogGateway(listOf(platformManifest("kotlin", listOf("*.kt")))),
+      diffResolver = RecordingDiffResolver(default = diffFor("src/FooTest.kt")),
+      rubricResolver = ReviewRubricResolver {
+        ResolvedReviewRubric(
+          "bill-kotlin-code-review",
+          "parent routing rubric",
+          specialists = listOf(
+            ResolvedReviewRubric(
+              "bill-kotlin-code-review-architecture",
+              "architecture specialist rubric",
+              area = "architecture",
+            ),
+            ResolvedReviewRubric(
+              "bill-kotlin-code-review-testing",
+              "testing specialist rubric",
+              area = "testing",
+            ),
+          ),
+        )
+      },
+    )
+
+    val result = runner.run(baseRequest(agent2Id = null, scope = ParallelReviewScope.STAGED))
+
+    assertTrue(result.lane1.success, result.lane1.failureReason.orEmpty())
+    assertEquals(1, result.mergeResult.findings.size)
+    assertEquals(
+      listOf("bill-kotlin-code-review-architecture"),
+      result.mergeResult.findings.single().specialistSkillNames,
+    )
+  }
+
+  @Test
+  fun `inline review keeps an unowned path finding on the default lane without failing the run`() {
+    val finding =
+      "[F-001] Major | High | specialist=bill-kotlin-code-review-unknown | " +
+        "path=\"docs/OUTSIDE.md\" | line=3 | cited a file the packet does not own"
+    val runner = runner(
+      alwaysSuccessLauncher(finding),
+      catalogGateway = stubCatalogGateway(listOf(platformManifest("kotlin", listOf("*.kt")))),
+      diffResolver = RecordingDiffResolver(default = diffFor("src/FooTest.kt")),
+      rubricResolver = ReviewRubricResolver {
+        ResolvedReviewRubric(
+          "bill-kotlin-code-review",
+          "parent routing rubric",
+          specialists = listOf(
+            ResolvedReviewRubric(
+              "bill-kotlin-code-review-architecture",
+              "architecture specialist rubric",
+              area = "architecture",
+            ),
+            ResolvedReviewRubric(
+              "bill-kotlin-code-review-testing",
+              "testing specialist rubric",
+              area = "testing",
+            ),
+          ),
+        )
+      },
+    )
+
+    val result = runner.run(baseRequest(agent2Id = null, scope = ParallelReviewScope.STAGED))
+
+    assertTrue(result.lane1.success, result.lane1.failureReason.orEmpty())
+    val reported = result.mergeResult.findings.single()
+    assertEquals("docs/OUTSIDE.md:3", reported.location)
+    assertEquals("docs/OUTSIDE.md", reported.repositoryPath)
+    assertEquals(listOf("bill-kotlin-code-review-architecture"), reported.specialistSkillNames)
+  }
+
+  @Test
   fun `inline mode accounting carries the parent prompt and stdout as one specialist-free turn`() {
     val launcher = GoalRunnerSubtaskLauncher { request ->
       AgentRunLaunchFacts(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ParallelReviewFindingParser.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ParallelReviewFindingParser.kt
@@ -24,17 +24,25 @@ object ParallelReviewFindingParser {
     RegexOption.MULTILINE,
   )
 
+  const val UNASSIGNED_REPOSITORY_PATH = "unassigned"
+
   fun parse(text: String): List<ParallelReviewRawFinding> = parallelFindingPattern.findAll(text).mapNotNull { match ->
+    runCatching { parseMatch(match) }.getOrNull()
+  }.toList()
+
+  private fun parseMatch(match: MatchResult): ParallelReviewRawFinding? {
     val severityStr = match.groups["severity"]?.value.orEmpty()
-    val severity = mapSeverity(severityStr) ?: return@mapNotNull null
+    val severity = mapSeverity(severityStr) ?: return null
     val structuredPath = match.groups["path"]?.value
-    val path = structuredPath?.let(::decodeStructuredString)
-      ?: match.groups["legacyPath"]?.value?.trim().orEmpty()
-    requireRepositoryRelativePath(path)
+    val decodedPath = runCatching {
+      structuredPath?.let(::decodeStructuredString)
+        ?: match.groups["legacyPath"]?.value?.trim().orEmpty()
+    }.getOrDefault("")
+    val path = admittedRepositoryPath(decodedPath)
     val lineText = match.groups["line"]?.value ?: match.groups["legacyLine"]?.value
-    val line = lineText?.toIntOrNull()?.takeIf { it > 0 } ?: return@mapNotNull null
+    val line = lineText?.toIntOrNull()?.takeIf { it > 0 } ?: return null
     val peeled = peelTrailingStructuredFields(match.groups["description"]?.value.orEmpty().trim())
-    ParallelReviewRawFinding(
+    return ParallelReviewRawFinding(
       severity = severity,
       confidence = match.groups["confidenceLevel"]?.value.orEmpty(),
       location = "$path:$line",
@@ -48,7 +56,18 @@ object ParallelReviewFindingParser {
       citations = peeled.citations,
       severityAdjustment = peeled.severityAdjustment,
     )
-  }.toList()
+  }
+
+  private fun admittedRepositoryPath(path: String): String {
+    if (path.isNotEmpty()) {
+      try {
+        requireRepositoryRelativePath(path)
+        return path
+      } catch (_: IllegalArgumentException) {
+      }
+    }
+    return UNASSIGNED_REPOSITORY_PATH
+  }
 
   private fun parseCommitShas(raw: String?): List<String> {
     if (raw.isNullOrBlank()) return emptyList()

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/ParallelReviewFindingParserTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/ParallelReviewFindingParserTest.kt
@@ -126,4 +126,19 @@ class ParallelReviewFindingParserTest {
 
     assertEquals(listOf("src/Legacy.kt", "src/Structured.kt"), findings.map { it.repositoryPath })
   }
+
+  @Test
+  fun `invalid path still parses and does not abort later findings`() {
+    val findings = ParallelReviewFindingParser.parse(
+      """
+      - [F-001] Major | High | path="/tmp/outside.kt" | line=3 | outside the packet
+      - [F-002] Minor | Low | path="src/Ok.kt" | line=4 | inside the packet
+      """.trimIndent(),
+    )
+
+    assertEquals(
+      listOf(ParallelReviewFindingParser.UNASSIGNED_REPOSITORY_PATH, "src/Ok.kt"),
+      findings.map { it.repositoryPath },
+    )
+  }
 }


### PR DESCRIPTION
# Summary

Inline review no longer crashes or drops findings when a specialist tag is unknown or a path is outside assignment ownership. Those findings stay in the merge on a known lane (and a default path when the reported path is illegal). Feature-task review also maps leftover driver exceptions to a retryable block instead of killing the child. Unowned worker claim now happens in one transaction so a concurrent `updated_at` bump cannot fail ownership CAS.

## Feature Flags

N/A

# How Has This Been Tested?

Unit tests for unowned-path attribution, unknown specialist remapping, parser invalid-path continuation, and unowned worker claim after an `updated_at` bump.

1. `cd runtime-kotlin && ./gradlew :runtime-domain:test --tests skillbill.review.ParallelReviewFindingParserTest :runtime-application:test --tests skillbill.application.ParallelCodeReviewRunnerTest --tests skillbill.application.FeatureTaskRuntimeWorkerCoordinatorTest`
2. Expect those suites green.
3. After install, resume a goal child that previously died in review on a persistence-tagged finding; the finding should appear instead of `NO_TERMINAL_STORE_OUTCOME`.


Made with [Cursor](https://cursor.com)