### PR TITLE
fix: [SKILL-201] derive review lane coverage from real enforcement

### DIFF
--- a/.feature-specs/SKILL-202-review-single-pass-verified-findings/decomposition-manifest.yaml
+++ b/.feature-specs/SKILL-202-review-single-pass-verified-findings/decomposition-manifest.yaml
@@ -1,0 +1,65 @@
+contract_version: "0.5"
+issue_key: "SKILL-202"
+feature_name: "review-single-pass-verified-findings"
+parent_spec_path: ".feature-specs/SKILL-202-review-single-pass-verified-findings/spec.md"
+execution_model: same_branch_commit_per_subtask
+base_branch: main
+feature_branch: feat/SKILL-202-review-single-pass-verified-findings
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: none
+subtasks:
+  - id: 1
+    name: "One review pass, one bounded fix round"
+    spec_path: ".feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_1_single-review-pass-one-fix-round.md"
+    status: pending
+    branch: null
+    commit_sha: null
+    workflow_id: null
+    blocked_reason: null
+    last_resumable_step: null
+    linear_issue_id: null
+    dependencies: []
+  - id: 2
+    name: "Verify findings against the subtask's intent"
+    spec_path: ".feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_2_verify-findings-against-intent.md"
+    status: pending
+    branch: null
+    commit_sha: null
+    workflow_id: null
+    blocked_reason: null
+    last_resumable_step: null
+    linear_issue_id: null
+    dependencies:
+      - subtask_id: 1
+        optional: false
+        skipped: false
+  - id: 3
+    name: "Path-scoped boundary memory for verification"
+    spec_path: ".feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_3_scoped-boundary-memory-for-verification.md"
+    status: pending
+    branch: null
+    commit_sha: null
+    workflow_id: null
+    blocked_reason: null
+    last_resumable_step: null
+    linear_issue_id: null
+    dependencies:
+      - subtask_id: 2
+        optional: false
+        skipped: false
+  - id: 4
+    name: "Surface verification dispositions"
+    spec_path: ".feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_4_surface-verification-dispositions.md"
+    status: pending
+    branch: null
+    commit_sha: null
+    workflow_id: null
+    blocked_reason: null
+    last_resumable_step: null
+    linear_issue_id: null
+    dependencies:
+      - subtask_id: 2
+        optional: false
+        skipped: false

--- a/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec.md
+++ b/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec.md
@@ -1,0 +1,178 @@
+# SKILL-202 — One review pass, verified findings, one fix round
+
+## Intended Outcome
+
+A subtask child reviews its delta exactly once. Every finding that pass produces
+is then verified against the subtask's declared intent and against the boundary
+memory of the module the finding touches. Findings that survive verification are
+fixed in exactly one remediation round, at any severity including Minor and Nit.
+The run then advances to validate. Review never runs a second time, and no
+finding severity can reopen it.
+
+## Current Behaviour
+
+`FeatureTaskRuntimePhaseWorkflowDefinition` declares the pipeline
+`preplan, plan, implement, audit, plan_fix, implement_fix, review, validate,
+write_history, commit_push, pr`, with `plan_fix` and `implement_fix` loop-only so
+a clean run skips them. One backward edge drives review remediation:
+
+- `review --changes_requested--> plan_fix`, `loopId = review_fix`,
+  `perEdgeCap = null`, `warnAfterIterations = 3`
+  (`runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinition.kt:674`).
+  Uncapped by design: the triggering verdict is the only exit.
+- `FeatureTaskRuntimeReviewVerdict.verdict` derives `changes_requested` from
+  `severity.requiresRemediation`, and `GoalSubtaskReviewState.blocksAdvance`
+  (`.../model/GoalSubtaskReviewState.kt:136`) treats `blocker` and `major` as
+  advance-blocking. So severity, not correctness, is the re-entry signal.
+- Because `implement_fix` sits immediately before `review` in `stepIds`, the
+  round's forward edge lands back on `review`, and the whole
+  `review_base_sha`-to-worktree delta is reviewed again.
+
+## Verified Root Cause
+
+Traced in the code and in a real run; do not re-derive.
+
+The loop re-enters on a finding's severity rather than on whether the finding is
+right, and each remediation round is new code that the next pass reviews. A
+remediation can therefore mint the findings that justify the next round. Rounds
+multiply on the reviewer's own churn, and every round pays for a full re-review
+of the entire delta.
+
+Observed on capmo-android WE-4863 subtask 2. Pass one objected to test
+placement. The remediation satisfied it by deleting a ViewModel-level assertion
+and re-homing the coverage at the screen level. Pass two then raised three
+findings, all located in the files that remediation had just authored, including
+a Major for the deleted assertion. Three `review_fix` iterations went to
+test placement while the two production lines stayed untouched from the first
+commit, and the run ended at a provider spend limit.
+
+Two pieces of the wanted design already exist and must be reused rather than
+rebuilt:
+
+- `SpecIntentProjectionExtractor`
+  (`runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/SpecIntentProjectionExtractor.kt`)
+  already extracts a budgeted intent projection from a governed spec.
+- `GoalPlanningContext`
+  (`runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/model/GoalPlanningContext.kt:26`)
+  already models titles-only boundary discovery: a catalog of
+  `## [<date>] <title>` headings with stable ids and source paths, caps of 32
+  files, 64 headings per file, and 256 headings total, with bodies resolved on
+  demand for selected ids only under `MAX_SELECTED_BODIES = 24`,
+  `MAX_BODY_BYTES = 8192`, `MAX_TOTAL_BODY_BYTES = 65536`. Discovery parses each
+  file inside the runtime; unselected bodies never reach a prompt.
+
+## Target Topology
+
+```
+preplan -> plan -> implement -> audit -> review -> verify_findings -> [implement_fix] -> validate -> write_history -> commit_push -> pr
+```
+
+- `review` has no backward edge. Its verdict is recorded and never routes.
+- `verify_findings` is a new forward phase settling `findings_verified` when at
+  least one finding survived, else `no_findings_verified`.
+- One declared edge `verify_findings --findings_verified--> implement_fix` with
+  `perEdgeCap = 1` and `capExhaustionBehavior = ADVANCE`, so the fix round runs
+  once and the run advances whatever its outcome.
+- `implement_fix` stays loop-only and moves to sit immediately before `validate`,
+  so its forward edge lands on `validate` rather than on `review`.
+- A phase entry gate makes the rule structural: `implement_fix` is unreachable
+  unless `verify_findings` settled `findings_verified`.
+- `plan_fix` is removed. Its only caller was the `review_fix` edge.
+
+## Acceptance Criteria
+
+1. A subtask runs the `review` phase exactly once. No verdict, severity, or
+   finding count can re-enter it, and no code path re-reviews a remediation
+   delta.
+2. Every finding from that pass is verified individually against the subtask's
+   spec intent projection and against boundary memory scoped to the finding's
+   path, yielding a verified-or-rejected disposition plus a bounded reason.
+3. A verified finding is fixed regardless of severity. Minor and Nit findings are
+   fixed in the same round as Blocker and Major.
+4. A rejected finding is never fixed and is recorded in the unaddressed-findings
+   ledger with its rejection reason, retrievable through
+   `skill-bill goal findings --issue-key <KEY>`.
+5. The remediation round runs at most once per subtask, driven by a declared edge
+   with `perEdgeCap = 1` and `ADVANCE` exhaustion behaviour.
+6. The run advances to `validate` after the fix round regardless of whether the
+   fix resolved every verified finding. No severity blocks advancement and no
+   unresolved-finding pause remains on this path.
+7. `implement_fix` is unreachable unless `verify_findings` settled
+   `findings_verified`, enforced by a declared phase entry gate rather than by a
+   branch in the run loop.
+8. Verification reads boundary memory by title first: it receives a catalog of
+   headings with stable ids scoped to the boundaries that own the finding paths,
+   selects ids semantically, and receives only the selected bodies under
+   verification-specific caps tighter than the planning caps.
+9. No verification path delivers a whole `history.md` or `decisions.md` to a
+   prompt, and no path widens discovery to boundaries that own none of the
+   finding paths.
+10. The `audit_gap` loop and the `record_rejected` regeneration edges keep their
+    current behaviour and caps.
+11. Durable state written before this change stays decodable, and a record whose
+    shape this change invalidates loud-fails with a named error rather than being
+    coerced.
+12. Resume lands correctly when a run is interrupted inside `verify_findings` or
+    inside the single `implement_fix` round, without minting a second round.
+13. Every prompt-visible and operator-visible surface describes the new flow. No
+    surface still claims that remediation continues while findings survive, that
+    Blocker and Major reopen `implement_fix`, or that Minor and Nit merely
+    advance.
+14. The repository validation gate passes.
+
+## Constraints
+
+- Topology is declaration data. Express the change in
+  `FeatureTaskRuntimeTransitionDeclaration` (`forwardPhaseIds`, `backwardEdges`,
+  `entryGates`, `loopOnlyPhaseIds`, `loopOnlySuccessors`), not as phase-identity
+  branches in `FeatureTaskRuntimeTransitionFunction` or the run loop.
+- Reuse `SpecIntentProjectionExtractor` for intent. Do not add a second spec
+  reader.
+- Reuse the `GoalPlanningContext` heading-catalog and body-resolver machinery for
+  boundary memory. Scope it by path and tighten its caps; do not fork a parallel
+  discovery implementation and do not relax `MAX_BOUNDARY_FILE_BYTES`.
+- Verification is one child phase settling once per subtask. It never loops, and
+  it never edits the worktree.
+- Severity keeps its reporting role in findings and the ledger. It must stop
+  being control flow.
+- Parallel review stays two full lanes counting as the single pass. Neither lane
+  may recursively launch review.
+- Contract and schema changes follow the existing versioning discipline: bump
+  what the durable contract requires and loud-fail an incompatible record.
+- Validation runs through the runtime-owned gate declared in
+  `.skill-bill/config.yaml` (`validation_gate.gradle_wrapper:
+  runtime-kotlin/gradlew`). Read the gate's findings rather than trusting a
+  wrapper exit code.
+- Branch prefix `feat/`. No AI co-author footers.
+
+## Accepted Trade-off
+
+With no re-review, a verified finding whose single fix round fails to resolve it
+reaches `validate` unfixed. That is deliberate: the ledger records it, the
+validation gate still runs, and the cost of a guaranteed second full review is
+the problem this change exists to remove. Do not reintroduce a re-review to close
+this gap.
+
+## Non-Goals
+
+- Changing the `audit_gap` loop, the `record_rejected` quarantine edges, or the
+  audit-first ordering.
+- Changing planning's own boundary discovery, its caps, or its allowlist.
+- Adding a second remediation round, a conditional re-review, or an operator
+  decision gate on unresolved findings.
+- Teaching verification to consult git history, PR review comments, or other
+  subtasks' ledgers.
+- Changing review lane assembly, evidence brokering, or the review packet
+  contract.
+- Cross-subtask or cross-goal learning from rejection reasons.
+
+## Subtasks
+
+1. `spec_subtask_1_single-review-pass-one-fix-round.md` — collapse the review
+   remediation loop to one pass and one bounded fix round.
+2. `spec_subtask_2_verify-findings-against-intent.md` — add the
+   `verify_findings` phase gating the fix round on intent verification.
+3. `spec_subtask_3_scoped-boundary-memory-for-verification.md` — give
+   verification path-scoped, titles-first boundary memory under tightened caps.
+4. `spec_subtask_4_surface-verification-dispositions.md` — make the ledger, CLI,
+   status, telemetry, and skill prose describe the new flow.

--- a/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_1_single-review-pass-one-fix-round.md
+++ b/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_1_single-review-pass-one-fix-round.md
@@ -1,0 +1,99 @@
+# SKILL-202 · Subtask 1 — One review pass, one bounded fix round
+
+Parent: `spec.md`
+
+## Scope
+
+Collapse the review remediation loop. Review settles once, a single fix round
+reconciles its findings at any severity, and the run advances to `validate`.
+Verification arrives in subtask 2; until then every finding from the one pass
+feeds the one round.
+
+Files in play:
+
+- `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinition.kt`
+  — `stepIds`, `stepLabels`, the `review_fix` edge, `REVIEW_FIX_LOOP_ID`,
+  `PHASE_PLAN_FIX`, `loopOnlyPhaseIds`, `loopOnlySuccessors`, and the topology
+  KDoc that documents the removed span.
+- `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/GoalSubtaskReviewState.kt`
+  — `blocksAdvance` and its callers.
+- `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeReviewVerdict.kt`
+  — `verdict`, `remediationFindings`, `unresolvedFindings`.
+- `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt`
+  — Blocker counting at `:2102` and `:2394`, the loop warning, and the
+  unresolved-Blocker pause wiring.
+- `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeTransitionFunction.kt`
+  and `.../model/FeatureTaskRuntimeTransitionModels.kt` — the
+  `ADVANCE_UNLESS_UNRESOLVED_BLOCKER` behaviour and `TerminalPause`, if this
+  change leaves them with no declared caller.
+
+## Preferred Approach
+
+Reorder `stepIds` to `preplan, plan, implement, audit, review, implement_fix,
+validate, write_history, commit_push, pr` and delete `PHASE_PLAN_FIX`. Keep
+`implement_fix` in `loopOnlyPhaseIds` so the clean path runs
+`review -> validate`; its position immediately before `validate` makes the
+round's forward edge land on `validate` through the existing
+`forwardTransition` skip rule, with no new branch.
+
+Replace the `review_fix` edge with one edge from `review` to `implement_fix`
+carrying `perEdgeCap = 1`, `capExhaustionBehavior = ADVANCE`,
+`capScope = PER_SUBTASK`, and no `warnAfterIterations`. Subtask 2 moves this
+edge's source to `verify_findings`; keep it shaped so that move is a one-line
+change.
+
+Stop deriving control flow from severity. `FeatureTaskRuntimeReviewVerdict`
+should settle a verdict that means "findings exist" rather than "Blocker or Major
+exist", so a pass reporting only Nits still runs the round. Severity survives on
+the finding for reporting and for the ledger.
+
+Remove the unresolved-Blocker pause on this path rather than leaving it
+unreachable. If `ADVANCE_UNLESS_UNRESOLVED_BLOCKER` and `TerminalPause` end up
+with no declared caller, remove them and their tests in the same commit; a
+reachable-behaviour enum member no declaration names is dead topology.
+
+## Acceptance Criteria
+
+1. `review` declares no backward edge, and no run path re-enters it after it
+   settles.
+2. A review pass reporting at least one finding of any severity, Nit included,
+   runs exactly one `implement_fix` round and then advances to `validate`.
+3. A review pass reporting no findings advances straight to `validate` without
+   entering `implement_fix`.
+4. The fix round runs at most once per subtask across resumes, enforced by
+   `perEdgeCap = 1` with `PER_SUBTASK` scope.
+5. No severity value blocks advancement, and no unresolved-finding pause is
+   reachable from the review path.
+6. `plan_fix` no longer exists in the phase set, the labels, the topology, or the
+   prompt directives.
+7. The `audit_gap` loop and the three `record_rejected` regeneration edges keep
+   their current behaviour, caps, and tests.
+8. `review_fix` accounting that can no longer be produced is removed from the
+   run loop and from status projection, or retained only as a decode path for
+   existing durable records with a comment saying so.
+9. Durable records written by the previous topology stay decodable; a record whose
+   shape this change invalidates loud-fails with a named error.
+10. Transition-function tests cover: findings present, findings absent, cap
+    already consumed on resume, and the entry gate that keeps `review` behind a
+    satisfied `audit`.
+11. The repository validation gate passes.
+
+## Non-Goals
+
+- Adding the verification phase or any per-finding disposition.
+- Reading boundary memory.
+- Changing which findings a review pass produces, or the review packet contract.
+
+## Dependencies
+
+None. This subtask lands first.
+
+## Validation Strategy
+
+Unit tests over `FeatureTaskRuntimeTransitionFunction` with the new declaration,
+asserting the four transition cases above plus the entry gate violation. Run the
+runtime-owned validation gate.
+
+## Next Path
+
+`spec_subtask_2_verify-findings-against-intent.md`

--- a/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_2_verify-findings-against-intent.md
+++ b/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_2_verify-findings-against-intent.md
@@ -1,0 +1,95 @@
+# SKILL-202 · Subtask 2 — Verify findings against the subtask's intent
+
+Parent: `spec.md`
+
+## Scope
+
+Add the `verify_findings` phase between `review` and the fix round. It judges
+each finding from the single review pass against the subtask's declared intent
+and emits a per-finding disposition. Only verified findings reach
+`implement_fix`. Boundary memory arrives in subtask 3; this subtask verifies
+against spec intent alone.
+
+Files in play:
+
+- `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinition.kt`
+  — `PHASE_VERIFY_FINDINGS`, `stepIds`, `stepLabels`, `requiredArtifactsByStep`,
+  the edge source move, and the new entry gate.
+- `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeVerdict.kt`
+  — `FINDINGS_VERIFIED` and `NO_FINDINGS_VERIFIED`.
+- a new verification verdict model beside
+  `.../model/FeatureTaskRuntimeReviewVerdict.kt` carrying the ordered
+  dispositions.
+- `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/SpecIntentProjectionExtractor.kt`
+  — reused as-is for the intent projection.
+- `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptComposer.kt`,
+  `.../FeatureTaskRuntimePhasePromptDirectives.kt`, and
+  `.../FeatureTaskRuntimePhaseProjectionShapes.kt` — the phase's prompt, its
+  directives, and its projection shape.
+- `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeRunLoop.kt`
+  — launching the phase and persisting its output.
+
+## Preferred Approach
+
+Declare `verify_findings` as a forward phase after `review`, consuming the review
+phase's durable finding list plus the spec intent projection. Move the fix edge's
+source from `review` to `verify_findings`, triggered by `FINDINGS_VERIFIED`,
+keeping `perEdgeCap = 1` and `ADVANCE`. Add a `FeatureTaskRuntimePhaseEntryGate`
+making `implement_fix` unreachable unless `verify_findings` settled
+`FINDINGS_VERIFIED`, so "no fix without verification" is topology rather than a
+run-loop branch.
+
+One disposition per finding, in the review pass's order: the finding's identity,
+`verified` or `rejected`, and a bounded reason. Verification never edits the
+worktree and never re-runs review. It settles `FINDINGS_VERIFIED` when at least
+one disposition is `verified`, else `NO_FINDINGS_VERIFIED`.
+
+The verification prompt asks one question per finding: does acting on this
+finding serve the subtask's declared intent, or does it contradict a decision the
+spec already made? A finding that objects to something the spec explicitly
+requires, or that argues for work the spec lists as a non-goal, is rejected with
+that reason. The fix round receives only the verified subset.
+
+## Acceptance Criteria
+
+1. `verify_findings` runs once per subtask, after `review`, and never mutates the
+   worktree.
+2. It emits exactly one disposition per finding from the review pass, in the same
+   order, each carrying `verified` or `rejected` and a bounded reason.
+3. A finding that contradicts the subtask spec's declared intent, requirements,
+   or non-goals is rejected, and its reason names what it contradicts.
+4. `implement_fix` receives only verified findings, and receives them regardless
+   of severity.
+5. `implement_fix` is unreachable when no finding is verified, enforced by the
+   declared entry gate, and the run advances to `validate` instead.
+6. Rejected dispositions are persisted durably with their reasons for subtask 4
+   to surface.
+7. A review pass with no findings settles `verify_findings` as
+   `NO_FINDINGS_VERIFIED` without launching a verification agent turn.
+8. Resume inside `verify_findings` reuses the persisted review finding list and
+   does not re-run review.
+9. The phase's projection is budgeted before launch like every other phase
+   projection, and an over-budget or malformed record loud-fails.
+10. The repository validation gate passes.
+
+## Non-Goals
+
+- Reading `history.md` or `decisions.md`, which is subtask 3.
+- Surfacing dispositions through the ledger or CLI, which is subtask 4.
+- Letting verification propose its own findings or edit code.
+- Any second review pass.
+
+## Dependencies
+
+Subtask 1. The single-pass topology and the capped fix edge must exist first.
+
+## Validation Strategy
+
+Unit tests over the verdict derivation and the entry gate: all rejected, all
+verified, mixed, and empty finding lists. A prompt-composer test asserting the
+phase receives the review findings and the intent projection and nothing else.
+Run the runtime-owned validation gate.
+
+## Next Path
+
+`spec_subtask_3_scoped-boundary-memory-for-verification.md`

--- a/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_3_scoped-boundary-memory-for-verification.md
+++ b/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_3_scoped-boundary-memory-for-verification.md
@@ -1,0 +1,97 @@
+# SKILL-202 · Subtask 3 — Path-scoped boundary memory for verification
+
+Parent: `spec.md`
+
+## Scope
+
+Give `verify_findings` the historic context for the code a finding touches,
+without loading history wholesale. Verification receives a titles-only catalog
+scoped to the boundaries that own the finding paths, selects headings
+semantically, and receives only those bodies under caps tighter than planning's.
+
+Files in play:
+
+- `runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/goalrunner/model/GoalPlanningContext.kt`
+  — the catalog and body caps to reuse, and the verification-specific caps to add
+  beside them.
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/goalplanning/FileSystemGoalPlanningContextDiscovery.kt`
+  — heading discovery, to be reachable with a path-scoped boundary set.
+- `runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/goalplanning/FileSystemGoalPlanningBoundaryBodyResolver.kt`
+  — body resolution for selected ids.
+- `runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanningProjectionModels.kt`
+  — `selectedBoundaryHeadings` and
+  `FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT` as the shape to
+  mirror for the verification selection.
+- the verification phase prompt, projection shape, and disposition model from
+  subtask 2.
+
+## Preferred Approach
+
+Derive the boundary set from the findings, not from the repository. For each
+finding path, walk up to the nearest ancestor directory holding `agent/history.md`
+or `agent/decisions.md`, and take the union across findings. A boundary that owns
+no finding path contributes nothing. Feed that set through the existing discovery
+seam so heading parsing, stable ids, per-file caps, and
+`MAX_BOUNDARY_FILE_BYTES` stay exactly as they are.
+
+Run verification as a two-step exchange inside the one phase, mirroring how
+preplanning selects headings for the plan phase: the catalog goes out with titles
+only, the phase returns the heading ids it judges relevant, and the runtime
+resolves those bodies and delivers them back under the verification caps. A body
+is never delivered unselected, and the phase cannot widen its own scope.
+
+Add verification caps beside the planning caps rather than reusing the planning
+numbers: at most 3 selected headings per finding, at most 8 resolved bodies per
+phase, 4096 bytes per body, 16384 bytes total. Unresolvable ids are reported
+bounded and single-line, as planning already does, and do not fail the phase.
+
+Each disposition records the heading ids it relied on, so a rejection that leans
+on a past decision is auditable.
+
+## Acceptance Criteria
+
+1. The catalog delivered to verification contains only headings from boundaries
+   that own at least one finding path.
+2. The catalog carries headings, stable ids, source paths, and kinds. It never
+   carries bodies.
+3. Only selected heading ids have their bodies resolved and delivered, under the
+   verification caps: 3 per finding, 8 bodies, 4096 bytes per body, 16384 bytes
+   total.
+4. Exceeding a cap truncates deterministically and reports the truncation. It
+   does not fail the phase and does not silently deliver more.
+5. Heading discovery reuses the existing seam and its `MAX_BOUNDARY_FILE_BYTES`
+   read cap unchanged, and no code path delivers a whole `history.md` or
+   `decisions.md` to a prompt.
+6. A finding in a module with no `agent/history.md` and no `agent/decisions.md`
+   verifies against intent alone, with no error and no empty-catalog failure.
+7. Unresolvable selected ids are reported bounded and do not fail the phase.
+8. Each disposition records the heading ids it relied on, empty when it relied on
+   none.
+9. Planning's own discovery, caps, and allowlist are unchanged, and their tests
+   still pass untouched.
+10. A finding whose module carries a decision entry contradicting the finding is
+    rejected with a reason naming that entry.
+11. The repository validation gate passes.
+
+## Non-Goals
+
+- Changing planning's boundary discovery, caps, or allowlist.
+- Adding a new boundary-memory file kind, or a new location convention.
+- Full-text or embedding search over boundary files. Selection is the model
+  reading titles.
+- Writing to `history.md` or `decisions.md`, which `write_history` already owns.
+
+## Dependencies
+
+Subtask 2. The verification phase and its disposition model must exist first.
+
+## Validation Strategy
+
+Unit tests for boundary derivation from finding paths, including a nested module,
+a module with neither file, and two findings resolving to one boundary. Cap tests
+asserting deterministic truncation and its report. A prompt test asserting the
+catalog carries no bodies. Run the runtime-owned validation gate.
+
+## Next Path
+
+`spec_subtask_4_surface-verification-dispositions.md`

--- a/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_4_surface-verification-dispositions.md
+++ b/.feature-specs/SKILL-202-review-single-pass-verified-findings/spec_subtask_4_surface-verification-dispositions.md
@@ -1,0 +1,87 @@
+# SKILL-202 · Subtask 4 — Surface verification dispositions
+
+Parent: `spec.md`
+
+## Scope
+
+Make every operator-visible and prompt-visible surface describe the new flow:
+one review pass, per-finding verification, one fix round. Rejected findings
+become retrievable with their reasons, and the accounting that died with the
+remediation loop stops being reported.
+
+Files in play:
+
+- `runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/UnaddressedFindingsLedgerService.kt`
+  and `.../GoalRunnerLedgerRecorder.kt` — record dispositions and reasons.
+- the `goal findings` CLI command and its result mapping.
+- `goal status` and `goal watch` projection: `fix_iterations`,
+  `re_attempt_causes`, `phase_attempts`, and any `review_fix` naming.
+- telemetry and review-stats surfaces that count review passes or remediation
+  rounds.
+- `skills/` prose: the `bill-feature-goal` review contract, its audit-first
+  ordering paragraph, and any platform-pack review prose that describes
+  remediation passes or Blocker-and-Major reopening.
+
+## Preferred Approach
+
+Extend the ledger entry with the verification disposition and its reason rather
+than adding a second store. A rejected finding is a ledger row like an
+unaddressed one, distinguished by disposition, so `goal findings` stays the one
+location-bearing surface and the goal-facing summaries stay path-free.
+
+Report what now exists and drop what cannot happen. `fix_iterations` for
+`review_fix` and `re_attempt_causes: backward_edge` from the review path are
+gone; a single `verified_fix` round either ran or did not. Keep a decode path for
+existing durable records where removing the field would break them, and say so in
+a comment.
+
+Rewrite the prose to match the topology instead of patching sentences. The
+`bill-feature-goal` review contract currently states that remediation continues
+while Blocker or Major findings survive, that later passes run inline against the
+remediation delta, and that crossing iteration 3 warns and continues. All three
+statements become false.
+
+## Acceptance Criteria
+
+1. `skill-bill goal findings --issue-key <KEY>` shows each finding's verification
+   disposition and, for a rejected finding, the reason it was rejected.
+2. Goal-facing summaries stay path-free: they carry subtask id, disposition
+   counts, severity, and concise text, and no path, line number, or diff hunk.
+3. `goal status` and `goal watch` report whether the single verified fix round
+   ran, and no longer report review-pass or remediation-round counters that
+   cannot be produced.
+4. Telemetry and review-stats surfaces count one review pass per subtask and
+   report verification dispositions instead of remediation rounds.
+5. No skill or pack prose claims that remediation continues while findings
+   survive, that Blocker and Major reopen `implement_fix`, that Minor and Nit
+   merely advance, or that an advisory threshold of 3 exists on the review path.
+6. The `bill-feature-goal` review contract describes: one pass, per-finding
+   verification against intent and boundary memory, one fix round covering every
+   verified finding at any severity, then validate.
+7. Existing durable ledger records stay readable, and a row without a disposition
+   renders as such rather than as verified.
+8. The repository validation gate passes.
+
+## Non-Goals
+
+- Changing review lane assembly, evidence brokering, or the review packet
+  contract.
+- Adding a new CLI command or a new report format.
+- Cross-goal aggregation of rejection reasons.
+
+## Dependencies
+
+Subtask 2. Dispositions must exist before a surface can report them. Independent
+of subtask 3; a disposition with no cited headings renders as one that relied on
+none.
+
+## Validation Strategy
+
+CLI result-mapping tests for verified, rejected, and legacy rows. A projection
+test asserting the removed counters are absent and the round indicator is
+present. A prose check that no surface still names the removed loop. Run the
+runtime-owned validation gate.
+
+## Next Path
+
+Parent goal completion. Run `skill-bill goal SKILL-202`.

--- a/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/decomposition-manifest.yaml
+++ b/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/decomposition-manifest.yaml
@@ -3,14 +3,14 @@ contract_version: "0.5"
 issue_key: "SKILL-201"
 feature_name: "review-lane-coverage-verdict-from-real-enforcement"
 parent_spec_path: ".feature-specs/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec.md"
-status: "blocked"
+status: "in_progress"
 execution_model: "same_branch_commit_per_subtask"
 base_branch: "main"
 feature_branch: "feat/SKILL-201-review-lane-coverage-verdict-from-real-enforcement"
 stack_branches: []
 current_subtask_intent:
-  subtask_id: 4
-  action: "blocked"
+  subtask_id: 5
+  action: "resume"
 subtasks:
 - id: 1
   name: "Sever projection from completion path"
@@ -60,22 +60,12 @@ subtasks:
 - id: 4
   name: "Reporting schema and projections"
   spec_path: ".feature-specs/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_4_reporting_schema_projections.md"
-  status: "blocked"
+  status: "complete"
   branch: null
   commit_sha: null
   workflow_id: "wftr-20260820-161954-c9oy"
-  blocked_reason: "Feature-task-runtime could not re-attach to the persisted feature\
-    \ branch 'feat/SKILL-201-review-lane-coverage-verdict-from-real-enforcement' from\
-    \ 'main' (git checkout feat/SKILL-201-review-lane-coverage-verdict-from-real-enforcement\
-    \ failed with exit code 1: error: Your local changes to the following files would\
-    \ be overwritten by checkout:\n\truntime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt\n\
-    \truntime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ReviewPreparationServiceTest.kt\n\
-    \truntime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/context/model/ReviewContextModels.kt\n\
-    \truntime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/context/model/ReviewLaneBundleAssembly.kt\n\
-    \truntime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewLaneBundleAssemblyTest.kt\n\
-    Please commit your changes or stash them before you switch branches.\nAborting).\
-    \ Refusing to run file-mutating phases on the default branch."
-  last_resumable_step: "audit"
+  blocked_reason: null
+  last_resumable_step: "commit_push"
   linear_issue_id: null
   finalizing_agent_id: null
   participating_agent_ids: []
@@ -86,10 +76,10 @@ subtasks:
 - id: 5
   name: "Reproduction verification"
   spec_path: ".feature-specs/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_5_reproduction_verification.md"
-  status: "pending"
+  status: "in_progress"
   branch: null
   commit_sha: null
-  workflow_id: null
+  workflow_id: "wftr-20260820-172621-xv1w"
   blocked_reason: null
   last_resumable_step: null
   linear_issue_id: null

--- a/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec.md
+++ b/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec.md
@@ -77,7 +77,7 @@ A coverage report whose contents depend on path spelling is not a coverage repor
 
 ### Raising the limit is not the fix
 
-`.skill-bill/config.yaml` in this repository sets `max_parent_packet_bytes: 1048576` and leaves
+`../../../.skill-bill/config.yaml` in this repository sets `max_parent_packet_bytes: 1048576` and leaves
 `max_lane_evidence_bytes` at its `262_144` default (`ReviewContextModels.kt:341`). The config is
 read on the live path (`ParallelCodeReviewRunner.kt:244`) and `max_lane_evidence_bytes` is an
 accepted key (`FileSystemRepoLocalConfig.kt:229`), so a raise would take effect and would flip both
@@ -92,7 +92,7 @@ while each specialist gets the flat value. The same number means two different t
 
 The test name states the original intent: `lane evidence overflow names undelivered units and does
 not truncate a hunk`
-(`runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewLaneBundleAssemblyTest.kt`).
+(`../../../runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewLaneBundleAssemblyTest.kt`).
 Refusing to cut a hunk in half and naming what did not fit is the right instinct. The
 `asFailedLaneRun` path is the same instinct wired correctly: a lane whose worker run failed is
 downgraded to incomplete and names its whole bundle
@@ -133,12 +133,12 @@ to lanes owning 100% and 10% of the changed paths.
 9. Every per-lane byte budget that survives is derived from the lane's own assignment rather than applied as one flat value across lanes with different assigned path counts, or the flat value is documented as intentional at its definition with the reason.
 10. `max_lane_evidence_bytes` has exactly one meaning across the runtime. The `budget.maxLaneEvidenceBytes * laneCount` derivation at `ParallelCodeReviewRunner.kt:1568` either resolves to the same meaning as the specialist value or is replaced by a separately named parent budget.
 11. Re-running `mode:delegated` over the SKILL-190 branch range produces `Coverage: clean` with the same finding set, and no lane names a file the worker received.
-12. `orchestration/contracts/review-context-schema.yaml` still requires `budget_dimension` whenever `lane_disposition` is `incomplete` (the `allOf` rule at line 301), and `ReviewIntegrationPass`'s invariant that an incomplete summary must name what it left unreviewed (`ReviewIntegrationPass.kt:27`) still holds for every remaining incomplete path.
+12. `../../../orchestration/contracts/review-context-schema.yaml` still requires `budget_dimension` whenever `lane_disposition` is `incomplete` (the `allOf` rule at line 301), and `ReviewIntegrationPass`'s invariant that an incomplete summary must name what it left unreviewed (`ReviewIntegrationPass.kt:27`) still holds for every remaining incomplete path.
 13. Any schema change to the lane completion or accounting records lands as a contract version bump with a parity test and a typed rejection, per the runtime contract rules.
 14. `evidence-unreviewable` is absent from the runtime, or retained only under criterion 8 with the segment id renamed to match what it now means.
 15. Legacy accounting records carrying the old `evidence-unreviewable` segment id do not crash a read; they are quarantined or migrated in band and the degradation is recorded.
 16. Every test that pinned the removed behavior is deleted or rewritten against the new rule, not weakened to keep passing. The five suites naming this path are `ReviewLaneBundleAssemblyTest`, `ReviewPreparationServiceTest`, `ReviewContextSchemaValidatorTest`, `FileSystemRepoLocalConfigTest`, and `FileSystemReviewEvidenceBrokerTest`.
-17. `skill-bill validate`, `(cd runtime-kotlin && ./gradlew check)`, `npx --yes agnix --strict .`, and `scripts/validate_agent_configs` all pass.
+17. `skill-bill validate`, `(cd runtime-kotlin && ./gradlew check)`, `npx --yes agnix --strict .`, and `../../../scripts/validate_agent_configs` all pass.
 
 ## Scope
 
@@ -156,7 +156,7 @@ rollup that distinct-flattens incomplete lanes into the parent.
 
 `ReviewCoverageReport.kt` and `ReviewIntegrationPassRunner.kt` reporting seams.
 `ReviewAccountingProjection.kt` and `ReviewCommitEnvelopeFragments.kt` wire projections.
-`orchestration/contracts/review-context-schema.yaml` if any record shape changes.
+`../../../orchestration/contracts/review-context-schema.yaml` if any record shape changes.
 
 ## Constraints
 
@@ -174,7 +174,7 @@ Schema and durable record changes follow the runtime contract rules: YAML schema
 Kotlin `*_CONTRACT_VERSION`, then the parity test, then the typed error, then loud-fail at every
 parse seam.
 
-Do not raise `max_lane_evidence_bytes` in `.skill-bill/config.yaml` as part of this work. That would
+Do not raise `max_lane_evidence_bytes` in `../../../.skill-bill/config.yaml` as part of this work. That would
 mask the defect on this repository's current diffs and remove the reproduction.
 
 Reproduction range for verification is `a1afecd5f..feat/SKILL-190-one-commit-per-subtask`, which
@@ -237,7 +237,7 @@ Subtask 5 is the end-to-end check. Re-run `mode:delegated` over
 findings.
 
 Every subtask finishes with `skill-bill validate`, `npx --yes agnix --strict .`, and
-`scripts/validate_agent_configs`.
+`../../../scripts/validate_agent_configs`.
 
 ## Next Path
 

--- a/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_1_sever_projection_from_completion.md
+++ b/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_1_sever_projection_from_completion.md
@@ -26,14 +26,14 @@ pre-flight projection in `withLaneEvidenceBudget` no longer writes incomplete co
 4. `unreviewedUnits` is populated only from units that were withheld, refused, or lost to a failed run. No code path derives it from a size comparison against an allowance for an operation that was not attempted.
 5. `ReviewLaneBundleAssemblyTest`'s evidence-overflow case is deleted or rewritten against criterion 1, not weakened to keep passing.
 6. `(cd runtime-kotlin && ./gradlew check)` passes.
-7. `skill-bill validate`, `npx --yes agnix --strict .`, and `scripts/validate_agent_configs` pass.
+7. `skill-bill validate`, `npx --yes agnix --strict .`, and `../../../scripts/validate_agent_configs` pass.
 
 ## Non-Goals
 
 - Wiring broker refusal into lane completion (subtask 2).
 - Per-lane budget derivation or parent budget reconciliation (subtask 3).
 - Coverage report or integration-pass prompt changes (subtask 4).
-- Raising `max_lane_evidence_bytes` in `.skill-bill/config.yaml`.
+- Raising `max_lane_evidence_bytes` in `../../../.skill-bill/config.yaml`.
 - Changing `max_lane_launch_bytes`, segmentation, or `deliveredEntries`.
 
 ## Dependency Notes

--- a/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_2_broker_refusal_incomplete_verdict.md
+++ b/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_2_broker_refusal_incomplete_verdict.md
@@ -22,7 +22,7 @@ names only the units the refusal actually denied — not a greedy alphabetical t
 3. A lane with no broker refusal and a successful worker run does not report incomplete for `lane_evidence_bytes` (builds on subtask 1).
 4. `FileSystemReviewEvidenceBrokerTest` covers the refusal-to-completion wiring at the broker seam.
 5. `(cd runtime-kotlin && ./gradlew check)` passes.
-6. `skill-bill validate`, `npx --yes agnix --strict .`, and `scripts/validate_agent_configs` pass.
+6. `skill-bill validate`, `npx --yes agnix --strict .`, and `../../../scripts/validate_agent_configs` pass.
 
 ## Non-Goals
 

--- a/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_3_per_lane_budget_derivation.md
+++ b/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_3_per_lane_budget_derivation.md
@@ -22,13 +22,13 @@ the same meaning as the specialist value or is replaced by a separately named pa
 3. A test asserts two lanes with different assigned path counts receive different derived budgets when assignment-scaled derivation is the chosen approach.
 4. A test asserts one consistent meaning across specialist and parent derivations.
 5. `(cd runtime-kotlin && ./gradlew check)` passes.
-6. `skill-bill validate`, `npx --yes agnix --strict .`, and `scripts/validate_agent_configs` pass.
+6. `skill-bill validate`, `npx --yes agnix --strict .`, and `../../../scripts/validate_agent_configs` pass.
 
 ## Non-Goals
 
 - Reporting seam or schema changes (subtask 4).
 - End-to-end delegated review reproduction (subtask 5).
-- Raising `max_lane_evidence_bytes` in `.skill-bill/config.yaml`.
+- Raising `max_lane_evidence_bytes` in `../../../.skill-bill/config.yaml`.
 - Changing lane selection or which paths an area owns.
 
 ## Dependency Notes

--- a/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_4_reporting_schema_projections.md
+++ b/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_4_reporting_schema_projections.md
@@ -12,7 +12,7 @@ handling follow runtime contract rules.
 - `ReviewCoverageReport.kt` and `ReviewIntegrationPassRunner.kt` reporting seams.
 - `ReviewIntegrationPass.kt` invariant at `:27`.
 - `ReviewAccountingProjection.kt` and `ReviewCommitEnvelopeFragments.kt` wire projections.
-- `orchestration/contracts/review-context-schema.yaml` if record shape changes.
+- `../../../orchestration/contracts/review-context-schema.yaml` if record shape changes.
 - Legacy quarantine for old `evidence-unreviewable` segment ids.
 - Rewrite tests in `ReviewContextSchemaValidatorTest`, `FileSystemRepoLocalConfigTest`, and any
   remaining suites pinning removed projection behavior.
@@ -22,13 +22,13 @@ handling follow runtime contract rules.
 1. `Coverage: NOT clean` and the per-lane `left unreviewed:` line (`ReviewCoverageReport.kt:50`) are emitted only for broker refusal, segmentation unreviewable entries, and failed worker runs.
 2. The integration pass's `Coverage gap — this lane left unreviewed:` prompt line (`ReviewIntegrationPassRunner.kt:186`) is emitted on the same conditions, so the parent is never told to compensate for a gap that does not exist.
 3. If projected expansion headroom is still reported, it occupies a field distinct from `unreviewed_segment_ids`, `unreviewed_units`, and `budget_dimension`; its wording names headroom or allowance rather than unreviewed code; and it does not change `lane_disposition`.
-4. `orchestration/contracts/review-context-schema.yaml` still requires `budget_dimension` whenever `lane_disposition` is `incomplete` (the `allOf` rule at line 301), and `ReviewIntegrationPass`'s invariant that an incomplete summary must name what it left unreviewed (`ReviewIntegrationPass.kt:27`) still holds for every remaining incomplete path.
+4. `../../../orchestration/contracts/review-context-schema.yaml` still requires `budget_dimension` whenever `lane_disposition` is `incomplete` (the `allOf` rule at line 301), and `ReviewIntegrationPass`'s invariant that an incomplete summary must name what it left unreviewed (`ReviewIntegrationPass.kt:27`) still holds for every remaining incomplete path.
 5. Any schema change to lane completion or accounting records lands as a contract version bump with a parity test and a typed rejection, per the runtime contract rules.
 6. `evidence-unreviewable` is absent from the runtime, or retained only under criterion 3 with the segment id renamed to match what it now means.
 7. Legacy accounting records carrying the old `evidence-unreviewable` segment id do not crash a read; they are quarantined or migrated in band and the degradation is recorded.
 8. Every test that pinned the removed projection behavior is deleted or rewritten against the new rule, not weakened to keep passing, across `ReviewLaneBundleAssemblyTest`, `ReviewPreparationServiceTest`, `ReviewContextSchemaValidatorTest`, `FileSystemRepoLocalConfigTest`, and `FileSystemReviewEvidenceBrokerTest`.
 9. `(cd runtime-kotlin && ./gradlew check)` passes.
-10. `skill-bill validate`, `npx --yes agnix --strict .`, and `scripts/validate_agent_configs` pass.
+10. `skill-bill validate`, `npx --yes agnix --strict .`, and `../../../scripts/validate_agent_configs` pass.
 
 ## Non-Goals
 

--- a/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_5_reproduction_verification.md
+++ b/.feature-specs/done/SKILL-201-review-lane-coverage-verdict-from-real-enforcement/spec_subtask_5_reproduction_verification.md
@@ -17,12 +17,12 @@ finding set as review `rvw-20260820-052146-53de`, and no lane names a file the w
 2. `skill-bill validate` passes.
 3. `(cd runtime-kotlin && ./gradlew check)` passes.
 4. `npx --yes agnix --strict .` passes.
-5. `scripts/validate_agent_configs` passes.
+5. `../../../scripts/validate_agent_configs` passes.
 
 ## Non-Goals
 
 - Changing the SKILL-190 branch or its findings.
-- Raising `max_lane_evidence_bytes` in `.skill-bill/config.yaml` to mask the defect.
+- Raising `max_lane_evidence_bytes` in `../../../.skill-bill/config.yaml` to mask the defect.
 
 ## Dependency Notes
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointRefPrune.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointRefPrune.kt
@@ -26,10 +26,25 @@ internal fun subtaskCommitReachableOnRemote(
   val sha = commitSha.trim()
   if (branch.isBlank() || sha.isBlank()) return false
   val remoteTip = gitOperations.resolveCommit(repoRoot, "origin/$branch")
-  if (!remoteTip.ok) return false
-  val remoteSha = remoteTip.value.orEmpty().trim().takeIf(String::isNotBlank) ?: return false
+  val remoteSha = remoteTip.value.orEmpty().trim().takeIf { remoteTip.ok && it.isNotBlank() } ?: return false
   val reachable = gitOperations.isCommitAncestor(repoRoot, sha, remoteSha)
   return reachable.ok && reachable.value.orEmpty().trim().equals("true", ignoreCase = true)
+}
+
+internal fun subtaskCommitSupersededOnPublishedBranch(
+  gitOperations: WorkflowGitOperations,
+  repoRoot: Path,
+  featureBranch: String,
+  commitSha: String,
+): Boolean {
+  if (subtaskCommitReachableOnRemote(gitOperations, repoRoot, featureBranch, commitSha)) return false
+  val branch = featureBranch.trim()
+  val sha = commitSha.trim()
+  if (branch.isBlank() || sha.isBlank()) return false
+  val remoteTip = gitOperations.resolveCommit(repoRoot, "origin/$branch")
+  if (!remoteTip.ok || remoteTip.value.orEmpty().isBlank()) return false
+  val recordedCommit = gitOperations.resolveCommit(repoRoot, sha)
+  return recordedCommit.ok && recordedCommit.value.orEmpty().trim().isNotBlank()
 }
 
 internal data class FeatureTaskRuntimeCheckpointRefPruneResult(
@@ -82,7 +97,8 @@ private fun WorkflowGitOperations.pruneEligibilityResult(
   }
   val featureBranch = request.featureBranch?.trim().orEmpty()
   if (featureBranch.isNotBlank() &&
-    !subtaskCommitReachableOnRemote(this, repoRoot, featureBranch, manifestSha)
+    !subtaskCommitReachableOnRemote(this, repoRoot, featureBranch, manifestSha) &&
+    !subtaskCommitSupersededOnPublishedBranch(this, repoRoot, featureBranch, manifestSha)
   ) {
     record(
       "seam=FeatureTaskRuntimeCheckpointRefPrune.pruneSubtaskCheckpointRefs " +

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalRunnerStatusService.kt
@@ -196,7 +196,7 @@ class GoalRunnerStatusService(
         manifest = reconciled,
         gitOperations = gitOperations,
         repoRoot = repoRoot,
-        record = { message -> runCatching { diagnostics.warning(message) } },
+        record = {},
       )
     }
     return reconciled

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
@@ -1693,19 +1693,6 @@ class ParallelCodeReviewRunner(
     completion
   }
 
-  private fun completionStateFromOutcome(outcome: ParallelReviewLaneOutcome): ReviewLaneCompletionState? {
-    val disposition = outcome.reviewDisposition ?: return null
-    val digest = outcome.bundleCompositionDigest ?: return null
-    return ReviewLaneCompletionState(
-      disposition = disposition,
-      bundleCompositionDigest = digest,
-      segments = outcome.segmentAccounting,
-      unreviewedSegmentIds = outcome.unreviewedSegmentIds,
-      budgetDimension = outcome.budgetDimension,
-      unreviewedUnits = outcome.unreviewedUnits,
-    )
-  }
-
   private fun aggregateBundleCompletion(states: List<ReviewLaneCompletionState>): ReviewLaneCompletionState {
     if (states.isEmpty()) {
       return ReviewLaneCompletionState(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelCodeReviewRunner.kt
@@ -1560,15 +1560,18 @@ class ParallelCodeReviewRunner(
   ): ReviewEvidenceBroker = reviewEvidenceBrokerFactory.brokerFor(parentBrokerBinding(selected, repoRoot))
 
   /**
-   * The merged surface is one session doing the reads [laneCount] separate lanes would each have
-   * been budgeted for, so the cumulative allowances scale with it. Per-read and per-turn caps do
-   * not: inline still traverses the delta once, and one read is still one read.
+   * Parent broker allowance is the sum of each selected specialist's derived lane evidence budget,
+   * so [ReviewContextBudgetPolicy.maxLaneEvidenceBytes] means the same cumulative read_evidence cap
+   * at both seams. Per-read and per-turn caps do not scale with lane count.
    */
-  private fun mergedBudget(budget: ReviewContextBudgetPolicy, laneCount: Int): ReviewContextBudgetPolicy = budget.copy(
-    maxLaneEvidenceBytes = budget.maxLaneEvidenceBytes * laneCount,
-    maxSpecialistToolCalls = budget.maxSpecialistToolCalls * laneCount,
-    maxAssignmentExpansions = budget.maxAssignmentExpansions * laneCount,
-  )
+  private fun mergedBudget(selected: List<ReviewSpecialistLaunchRequest>): ReviewContextBudgetPolicy {
+    val primary = selected.minByOrNull { it.assignment.laneDecision.orderIndex } ?: selected.first()
+    return primary.budget.copy(
+      maxLaneEvidenceBytes = selected.sumOf { it.budget.maxLaneEvidenceBytes },
+      maxSpecialistToolCalls = primary.budget.maxSpecialistToolCalls * selected.size,
+      maxAssignmentExpansions = primary.budget.maxAssignmentExpansions * selected.size,
+    )
+  }
 
   private fun mergedBundle(packet: ReviewContextPacket, assignedHunks: Set<String>): ReviewLaneBundle =
     ReviewLaneBundle(
@@ -1608,7 +1611,7 @@ class ParallelCodeReviewRunner(
       repoRoot = repoRoot,
       assignment = merged,
       laneRubricId = primary.rubrics.first().rubricId,
-      budget = mergedBudget(primary.budget, selected.size),
+      budget = mergedBudget(selected),
       namedDependencies = selected.flatMap { it.namedDependencies }.toSet(),
       trustedExpansionLedger = expansions,
       projectedHunks = primary.packet.changedHunks.filter { it.hunkId in assigned },
@@ -1688,6 +1691,19 @@ class ParallelCodeReviewRunner(
     completion.withBrokerEvidenceRefusal(accounting.unreviewedUnits)
   } else {
     completion
+  }
+
+  private fun completionStateFromOutcome(outcome: ParallelReviewLaneOutcome): ReviewLaneCompletionState? {
+    val disposition = outcome.reviewDisposition ?: return null
+    val digest = outcome.bundleCompositionDigest ?: return null
+    return ReviewLaneCompletionState(
+      disposition = disposition,
+      bundleCompositionDigest = digest,
+      segments = outcome.segmentAccounting,
+      unreviewedSegmentIds = outcome.unreviewedSegmentIds,
+      budgetDimension = outcome.budgetDimension,
+      unreviewedUnits = outcome.unreviewedUnits,
+    )
   }
 
   private fun aggregateBundleCompletion(states: List<ReviewLaneCompletionState>): ReviewLaneCompletionState {

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelReviewPreparationCompiler.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ParallelReviewPreparationCompiler.kt
@@ -240,7 +240,7 @@ internal object ParallelReviewPreparationCompiler {
         specialistContract = specialistContract,
         rubrics = listOf(route.rubric),
         brokerId = "review-evidence-${assignment.digest}",
-        budget = budget,
+        budget = deriveSpecialistBudget(budget, assignment, preparation.packet),
         agentId = route.agentId,
         workerKind = route.workerKind,
         logicalWorkerName = route.descriptor.skillName.takeIf {

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewPreparationService.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewPreparationService.kt
@@ -378,6 +378,14 @@ private fun rejectUnknownAssignmentDigests(
   reject(label, "$subject name assignment digests that belong to no assignment in this review: $described.")
 }
 
+internal fun deriveSpecialistBudget(
+  basePolicy: ReviewContextBudgetPolicy,
+  assignment: ReviewAssignment,
+  packet: ReviewContextPacket,
+): ReviewContextBudgetPolicy = basePolicy.copy(
+  maxLaneEvidenceBytes = ReviewContextBudgetPolicy.deriveLaneEvidenceBytes(basePolicy, assignment, packet),
+)
+
 private fun reject(sourceLabel: String, reason: String): Nothing =
   throw InvalidReviewContextSchemaError(sourceLabel = sourceLabel, reason = reason)
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/ParallelCodeReviewRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/ParallelCodeReviewRunnerTest.kt
@@ -50,9 +50,11 @@ import skillbill.ports.scaffold.InstalledPlatformPackCatalogPort
 import skillbill.ports.scaffold.ScaffoldCatalogGateway
 import skillbill.ports.scaffold.model.PilotedPlatformPackProjection
 import skillbill.review.ParallelReviewFindingParser
+import skillbill.review.context.model.LANE_EVIDENCE_BYTES_DIMENSION
 import skillbill.review.context.model.REVIEW_ROUTING_ANALYSIS_PAIRS_BUDGET
 import skillbill.review.context.model.ReviewContextBudgetExceededException
 import skillbill.review.context.model.ReviewContextBudgetPolicy
+import skillbill.review.context.model.ReviewLaneReviewDisposition
 import skillbill.review.context.model.ReviewRegisterParseSeamException
 import skillbill.review.model.ParallelReviewMergedFinding
 import skillbill.review.model.ReviewPassClaimSnapshot
@@ -1003,6 +1005,29 @@ class ParallelCodeReviewRunnerFailureTest {
   }
 
   @Test
+  fun `denied units outside the lane assigned bundle never become a coverage gap`() {
+    val tempDir = createGitRepo()
+    createStagedFile(tempDir)
+    val compositionDigest = "a".repeat(64)
+    val runner = runnerWithParallelLane(
+      alwaysSuccessLauncher(),
+      RecordingDiffResolver(default = diffForChanges("src/A.kt" to "a", "src/B.kt" to "b")),
+      StaticParallelLaneRunner(
+        ParallelReviewLaneRunResult(
+          lane1 = brokerEvidenceIncompleteOutcome(compositionDigest, listOf("not-an-assigned-sha@src/A.kt")),
+          lane2 = brokerEvidenceIncompleteOutcome(compositionDigest, listOf("not-an-assigned-sha@src/B.kt")),
+        ),
+      ),
+    )
+
+    val result = runner.run(baseRequest(repoRoot = tempDir))
+
+    val coverage = assertNotNull(result.coverage)
+    assertTrue(coverage.isCleanCoverage, coverage.render())
+    assertTrue(coverage.incompleteLanes.flatMap { it.unreviewedUnits }.isEmpty())
+  }
+
+  @Test
   fun `UnsupportedAgentRunLaunch produces failed lane outcome`() {
     val launcher = GoalRunnerSubtaskLauncher { request ->
       val agent = InstallAgent.fromNormalizedId(request.invokedAgentId, label = "agentId")
@@ -1677,6 +1702,19 @@ private class StaticParallelLaneRunner(
 ) : ParallelReviewLaneRunner {
   override fun runTwoLanes(request: ParallelReviewLaneRunRequest): ParallelReviewLaneRunResult = result
 }
+
+private fun brokerEvidenceIncompleteOutcome(
+  compositionDigest: String,
+  deniedUnits: List<String>,
+): ParallelReviewLaneOutcome = ParallelReviewLaneOutcome(
+  success = true,
+  rawOutput = "NO_FINDINGS",
+  reviewDisposition = ReviewLaneReviewDisposition.INCOMPLETE,
+  bundleCompositionDigest = compositionDigest,
+  unreviewedSegmentIds = listOf("seg-evidence-refused"),
+  budgetDimension = LANE_EVIDENCE_BYTES_DIMENSION,
+  unreviewedUnits = deniedUnits,
+)
 
 private class RealProcessDiffResolver : DiffResolverPort {
   override fun runProcess(args: List<String>, workDir: Path): String? = try {

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointRefPruneTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeCheckpointRefPruneTest.kt
@@ -172,6 +172,40 @@ class FeatureTaskRuntimeCheckpointRefPruneTest {
   }
 
   @Test
+  fun `prune with superseded recorded sha on published branch deletes checkpoint refs`() {
+    val issueKey = "SKILL-201"
+    val subtaskId = "2"
+    val base = head()
+    gitCommand("checkout", "-B", "feat/skill-201", base)
+    write("owned/Subtask2.kt", "v1\n")
+    gitCommand("add", "-A")
+    gitCommand("commit", "-m", "subtask 2 v1")
+    val supersededSha = head()
+    seedRefs(issueKey, subtaskId, count = 2)
+    gitCommand("checkout", "-B", "feat/skill-201", base)
+    write("owned/Subtask2.kt", "v2\n")
+    gitCommand("add", "-A")
+    gitCommand("commit", "-m", "subtask 2 v2")
+    gitCommand("remote", "add", "origin", repo.toUri().toString())
+    gitCommand("push", "-u", "origin", "feat/skill-201")
+
+    val result = git.pruneSubtaskCheckpointRefs(
+      repoRoot = repo,
+      request = FeatureTaskRuntimeCheckpointRefPruneRequest(
+        issueKey = issueKey,
+        subtaskId = subtaskId,
+        manifestCommitSha = supersededSha,
+        featureBranch = "feat/skill-201",
+      ),
+      record = {},
+    )
+
+    assertTrue(result.attempted)
+    assertEquals(2, result.deletedRefCount)
+    assertEquals(0, listedRefCount(issueKey, subtaskId))
+  }
+
+  @Test
   fun `reset-driven prune bypasses the manifest commit_sha gate`() {
     val issueKey = "SKILL-190"
     val subtaskId = "4"

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ParallelCodeReviewEvidenceBoundaryTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ParallelCodeReviewEvidenceBoundaryTest.kt
@@ -7,7 +7,9 @@ import skillbill.ports.review.GovernedReviewEvidenceEndpointHandle
 import skillbill.ports.review.ReviewEvidenceBroker
 import skillbill.ports.review.ReviewEvidenceBrokerFactory
 import skillbill.ports.review.model.GovernedReviewEvidenceEndpointDescriptor
+import skillbill.ports.review.model.ReviewEvidenceBrokerBinding
 import skillbill.review.context.model.LANE_EVIDENCE_BYTES_DIMENSION
+import skillbill.review.context.model.ReviewContextBudgetPolicy
 import skillbill.review.context.model.ReviewLaneReviewDisposition
 import skillbill.review.model.ReviewEvidenceBoundaryAccounting
 import skillbill.review.model.ReviewStageDegradationReason
@@ -18,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ParallelCodeReviewEvidenceBoundaryTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ParallelCodeReviewEvidenceBoundaryTest.kt
@@ -120,7 +120,7 @@ class ParallelCodeReviewEvidenceBoundaryTest {
         evidenceBrokerFactory = ReviewEvidenceBrokerFactory { binding ->
           val inner = defaults.evidenceBrokerFactory.brokerFor(binding)
           object : ReviewEvidenceBroker by inner {
-            override fun accounting() = inner.accounting().copy(authorizedReadCount = 1)
+            override fun accounting() = inner.accounting().copy(authorizedReadCount = 1, evidenceBytes = 0)
           }
         },
       ),
@@ -328,6 +328,45 @@ class ParallelCodeReviewEvidenceBoundaryTest {
   }
 
   @Test
+  fun `inline parent evidence allowance equals sum of per-lane derived caps not base times lane count`() {
+    val recorder = ReviewRecorder()
+    val bound = mutableListOf<ReviewEvidenceBrokerBinding>()
+    val defaults = ReviewHarnessConfig(
+      manifests = listOf(
+        reviewPack("kotlin", listOf("architecture", "security"), routingSignals = listOf("*.kt")).copy(
+          laneConditions = mapOf(
+            "architecture" to ReviewLaneCondition(path = listOf("src/core/")),
+            "security" to ReviewLaneCondition(path = listOf("src/secure/")),
+          ),
+        ),
+      ),
+      diff = diffForChanges(
+        "src/core/Repo.kt" to "x".repeat(200_000),
+        "src/secure/Auth.kt" to "ok",
+      ),
+    )
+    reviewHarness(
+      defaults.copy(
+        evidenceBrokerFactory = ReviewEvidenceBrokerFactory { binding ->
+          defaults.evidenceBrokerFactory.brokerFor(binding).also { bound += binding }
+        },
+      ),
+      recorder,
+    ).run(
+      harnessRequest(
+        agent2Id = null,
+        reviewRunId = "rvw-201-parent-derived-budget",
+        codeReviewMode = CodeReviewExecutionMode.INLINE,
+      ),
+    )
+
+    val parentBinding = bound.single()
+    val base = ReviewContextBudgetPolicy.DEFAULT.maxLaneEvidenceBytes
+    assertNotEquals(base * 2, parentBinding.budget.maxLaneEvidenceBytes)
+    assertTrue(parentBinding.budget.maxLaneEvidenceBytes < base * 2)
+  }
+
+  @Test
   fun `a lane reporting no findings after reading no evidence fails instead of passing as clean`() {
     val recorder = ReviewRecorder()
     val result = reviewHarness(
@@ -391,5 +430,30 @@ class ParallelCodeReviewEvidenceBoundaryTest {
     assertFalse(accounting.unreviewedUnits.any { it.endsWith("@src/A.kt") })
     val coverage = assertNotNull(result.coverage)
     assertFalse(coverage.isCleanCoverage)
+  }
+
+  @Test
+  fun `successful governed run with no broker refusal stays complete for lane evidence bytes`() {
+    val recorder = ReviewRecorder()
+    val result = reviewHarness(
+      ReviewHarnessConfig(
+        manifests = listOf(reviewPack("kotlin", listOf("architecture"), routingSignals = listOf("*.kt"))),
+        diff = diffForPaths("src/Repo.kt"),
+      ),
+      recorder,
+    ).run(
+      harnessRequest(
+        agent2Id = null,
+        reviewRunId = "rvw-201-broker-clean",
+        codeReviewMode = CodeReviewExecutionMode.INLINE,
+      ),
+    )
+
+    assertTrue(result.lane1.success)
+    val accounting = assertNotNull(result.lane1.accounting)
+    assertEquals(ReviewLaneReviewDisposition.COMPLETE, accounting.reviewDisposition)
+    assertTrue(accounting.unreviewedUnits.isEmpty())
+    assertEquals(null, accounting.budgetDimension)
+    assertTrue(assertNotNull(result.coverage).isCleanCoverage)
   }
 }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ReviewPreparationServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ReviewPreparationServiceTest.kt
@@ -124,7 +124,7 @@ class ReviewPreparationServiceTest {
   private val hunkA = ReviewChangedHunk("src/A.kt", 1, 1, 1, 2, "+alpha")
   private val hunkB = ReviewChangedHunk("src/B.kt", 4, 1, 4, 1, "+beta")
 
-  private fun includedDecision(lane: String, reason: String, path: String) = ReviewLaneDecision(
+  internal fun includedDecision(lane: String, reason: String, path: String) = ReviewLaneDecision(
     lane = lane,
     included = true,
     reason = reason,
@@ -503,12 +503,12 @@ class ReviewPreparationServiceTest {
     assertEquals(observedBytes, failure.outcome.observedValue)
   }
 
-  private fun oversizedPatch(path: String = "src/Huge.kt"): String {
+  internal fun oversizedPatch(path: String = "src/Huge.kt"): String {
     val body = "+" + "x".repeat(700 * 1024)
     return "diff --git a/$path b/$path\n--- a/$path\n+++ b/$path\n@@ -1,1 +1,2 @@\n$body\n"
   }
 
-  private fun storePrepare(
+  internal fun storePrepare(
     hunks: List<ReviewChangedHunk>,
     payload: String,
     storePath: String = ".skill-bill/run-evidence/code-review/fp-store",
@@ -522,117 +522,6 @@ class ReviewPreparationServiceTest {
     return ReviewPreparationService(factPorts, RecordingValidator(), hunkLocatorReader = reader).prepare(
       request().copy(evidenceStorePath = storePath, repoRoot = Path.of(".")),
     )
-  }
-
-  @Test fun `oversized stored patch composes an index-only parent under the default budget`() {
-    val patch = oversizedPatch()
-    val hunk = ReviewDiffEvidence.parse(patch).hunks.single()
-    val storePath = ".skill-bill/run-evidence/code-review/fp-oversize"
-    var workerLaunches = 0
-    val result = storePrepare(listOf(hunk), patch, storePath)
-    val parentBytes = result.packet.canonicalBytes
-    val wireHunks = result.packetEnvelope.asWireMap()["changed_hunks"] as List<*>
-    val first = wireHunks.single() as Map<*, *>
-    assertTrue(parentBytes < 524_288, "parent canonicalBytes $parentBytes")
-    assertTrue(parentBytes < patch.toByteArray().size)
-    assertEquals(hunk.hunkId, first["hunk_id"])
-    assertEquals(ReviewChangedHunk.digestOfBody(hunk.content), first["content_digest"])
-    assertFalse(first.containsKey("content"))
-    val locator = first["evidence_locator"] as Map<*, *>
-    assertEquals(storePath, locator["store_path"])
-    assertEquals("diff.patch", locator["payload_file"])
-    assertEquals(1, result.assignments.size)
-    assertEquals(result.packet.ownedHunkIds, result.assignments.single().assignedHunks.toSet())
-    assertTrue(result.assignments.single().assignedHunks.all { it in result.packet.ownedHunkIds })
-    val assignmentWire = result.assignmentEnvelopes.single().asWireMap()
-    assertFalse(assignmentWire.containsKey("changed_hunks"))
-    assertTrue((assignmentWire["assigned_hunks"] as List<*>).all { it is String })
-    val assignmentBytes = assignmentWire.toString().toByteArray().size
-    assertTrue(assignmentBytes < patch.toByteArray().size / 10, "assignment envelope $assignmentBytes")
-    assertEquals(0, workerLaunches)
-    result.packet.changedHunks.forEach { assertEquals("", it.content) }
-    val launch = GovernedReviewLaunch(
-      result.assignments.single(),
-      result.packet,
-      "contract",
-      "rubric",
-      "broker",
-      ReviewContextBudgetPolicy.DEFAULT,
-    )
-    assertEquals(ReviewLaneReviewDisposition.COMPLETE, launch.completionState.disposition)
-    assertEquals(null, launch.completionState.budgetDimension)
-    assertTrue(launch.completionState.unreviewedUnits.isEmpty())
-  }
-
-  @Test fun `evidence overflow on one assignment leaves the sibling selected and complete`() {
-    val hugePatch = oversizedPatch("src/A.kt")
-    val smallPatch = "diff --git a/src/B.kt b/src/B.kt\n--- a/src/B.kt\n+++ b/src/B.kt\n@@ -1,1 +1,2 @@\n+beta\n"
-    val stored = hugePatch + smallPatch
-    val parsed = ReviewDiffEvidence.parse(stored).hunks
-    val huge = parsed.single { it.path == "src/A.kt" }
-    val small = parsed.single { it.path == "src/B.kt" }
-    val storePath = ".skill-bill/run-evidence/code-review/fp-sibling"
-    val result = storePrepare(
-      listOf(huge, small),
-      stored,
-      storePath,
-      decisions = listOf(
-        includedDecision("testing", "test sources changed", "src/A.kt").copy(required = true),
-        includedDecision("security", "auth surface changed", "src/B.kt"),
-      ),
-    )
-    assertEquals(listOf("security", "testing"), result.packet.selectedLanes)
-    assertTrue(result.packet.canonicalBytes < 524_288)
-    val testing = GovernedReviewLaunch(
-      result.assignments.single { it.lane == "testing" },
-      result.packet,
-      "contract",
-      "rubric",
-      "broker",
-      ReviewContextBudgetPolicy.DEFAULT,
-    )
-    val security = GovernedReviewLaunch(
-      result.assignments.single { it.lane == "security" },
-      result.packet,
-      "contract",
-      "rubric",
-      "broker",
-      ReviewContextBudgetPolicy.DEFAULT,
-    )
-    assertEquals(ReviewLaneReviewDisposition.COMPLETE, testing.completionState.disposition)
-    assertEquals(null, testing.completionState.budgetDimension)
-    assertTrue(testing.completionState.unreviewedUnits.isEmpty())
-    assertEquals(ReviewLaneReviewDisposition.COMPLETE, security.completionState.disposition)
-    assertTrue(result.packet.laneDecisions.single { it.lane == "testing" }.required)
-  }
-
-  @Test fun `assignment-scaled specialist budgets differ when lane assignments differ in breadth`() {
-    val hugePatch = oversizedPatch("src/A.kt")
-    val smallPatch = "diff --git a/src/B.kt b/src/B.kt\n--- a/src/B.kt\n+++ b/src/B.kt\n@@ -1,1 +1,2 @@\n+beta\n"
-    val stored = hugePatch + smallPatch
-    val parsed = ReviewDiffEvidence.parse(stored).hunks
-    val result = storePrepare(
-      parsed,
-      stored,
-      ".skill-bill/run-evidence/code-review/fp-budget-scale",
-      decisions = listOf(
-        includedDecision("testing", "test sources changed", "src/A.kt").copy(required = true),
-        includedDecision("security", "auth surface changed", "src/B.kt"),
-      ),
-    )
-    val base = ReviewContextBudgetPolicy.DEFAULT
-    val testingBudget = deriveSpecialistBudget(
-      base,
-      result.assignments.single { it.lane == "testing" },
-      result.packet,
-    ).maxLaneEvidenceBytes
-    val securityBudget = deriveSpecialistBudget(
-      base,
-      result.assignments.single { it.lane == "security" },
-      result.packet,
-    ).maxLaneEvidenceBytes
-    assertNotEquals(testingBudget, securityBudget)
-    assertTrue(testingBudget > securityBudget)
   }
 
   @Test fun `blank store path with a live locator reader fails compose without launching workers`() {
@@ -793,5 +682,118 @@ class ReviewPreparationServiceTest {
     assertNotEquals(ReviewChangedHunk.digestOfBody(aggregateHunk.content), first["content_digest"])
     assertFalse(first.containsKey("content"))
     assertEquals("", result.packet.changedHunks.single().content)
+  }
+}
+
+class ReviewPreparationServiceBudgetTest {
+  private val fixture = ReviewPreparationServiceTest()
+
+  @Test fun `oversized stored patch composes an index-only parent under the default budget`() {
+    val patch = fixture.oversizedPatch()
+    val hunk = ReviewDiffEvidence.parse(patch).hunks.single()
+    val storePath = ".skill-bill/run-evidence/code-review/fp-oversize"
+    val result = fixture.storePrepare(listOf(hunk), patch, storePath)
+    val parentBytes = result.packet.canonicalBytes
+    val wireHunks = result.packetEnvelope.asWireMap()["changed_hunks"] as List<*>
+    val first = wireHunks.single() as Map<*, *>
+    assertTrue(parentBytes < 524_288, "parent canonicalBytes $parentBytes")
+    assertTrue(parentBytes < patch.toByteArray().size)
+    assertEquals(hunk.hunkId, first["hunk_id"])
+    assertEquals(ReviewChangedHunk.digestOfBody(hunk.content), first["content_digest"])
+    assertFalse(first.containsKey("content"))
+    val locator = first["evidence_locator"] as Map<*, *>
+    assertEquals(storePath, locator["store_path"])
+    assertEquals("diff.patch", locator["payload_file"])
+    assertEquals(1, result.assignments.size)
+    assertEquals(result.packet.ownedHunkIds, result.assignments.single().assignedHunks.toSet())
+    assertTrue(result.assignments.single().assignedHunks.all { it in result.packet.ownedHunkIds })
+    val assignmentWire = result.assignmentEnvelopes.single().asWireMap()
+    assertFalse(assignmentWire.containsKey("changed_hunks"))
+    assertTrue((assignmentWire["assigned_hunks"] as List<*>).all { it is String })
+    val assignmentBytes = assignmentWire.toString().toByteArray().size
+    assertTrue(assignmentBytes < patch.toByteArray().size / 10, "assignment envelope $assignmentBytes")
+    result.packet.changedHunks.forEach { assertEquals("", it.content) }
+    val launch = GovernedReviewLaunch(
+      result.assignments.single(),
+      result.packet,
+      "contract",
+      "rubric",
+      "broker",
+      ReviewContextBudgetPolicy.DEFAULT,
+    )
+    assertEquals(ReviewLaneReviewDisposition.COMPLETE, launch.completionState.disposition)
+    assertEquals(null, launch.completionState.budgetDimension)
+    assertTrue(launch.completionState.unreviewedUnits.isEmpty())
+  }
+
+  @Test fun `evidence overflow on one assignment leaves the sibling selected and complete`() {
+    val hugePatch = fixture.oversizedPatch("src/A.kt")
+    val smallPatch = "diff --git a/src/B.kt b/src/B.kt\n--- a/src/B.kt\n+++ b/src/B.kt\n@@ -1,1 +1,2 @@\n+beta\n"
+    val stored = hugePatch + smallPatch
+    val parsed = ReviewDiffEvidence.parse(stored).hunks
+    val huge = parsed.single { it.path == "src/A.kt" }
+    val small = parsed.single { it.path == "src/B.kt" }
+    val storePath = ".skill-bill/run-evidence/code-review/fp-sibling"
+    val result = fixture.storePrepare(
+      listOf(huge, small),
+      stored,
+      storePath,
+      decisions = listOf(
+        fixture.includedDecision("testing", "test sources changed", "src/A.kt").copy(required = true),
+        fixture.includedDecision("security", "auth surface changed", "src/B.kt"),
+      ),
+    )
+    assertEquals(listOf("security", "testing"), result.packet.selectedLanes)
+    assertTrue(result.packet.canonicalBytes < 524_288)
+    val testing = GovernedReviewLaunch(
+      result.assignments.single { it.lane == "testing" },
+      result.packet,
+      "contract",
+      "rubric",
+      "broker",
+      ReviewContextBudgetPolicy.DEFAULT,
+    )
+    val security = GovernedReviewLaunch(
+      result.assignments.single { it.lane == "security" },
+      result.packet,
+      "contract",
+      "rubric",
+      "broker",
+      ReviewContextBudgetPolicy.DEFAULT,
+    )
+    assertEquals(ReviewLaneReviewDisposition.COMPLETE, testing.completionState.disposition)
+    assertEquals(null, testing.completionState.budgetDimension)
+    assertTrue(testing.completionState.unreviewedUnits.isEmpty())
+    assertEquals(ReviewLaneReviewDisposition.COMPLETE, security.completionState.disposition)
+    assertTrue(result.packet.laneDecisions.single { it.lane == "testing" }.required)
+  }
+
+  @Test fun `assignment-scaled specialist budgets differ when lane assignments differ in breadth`() {
+    val hugePatch = fixture.oversizedPatch("src/A.kt")
+    val smallPatch = "diff --git a/src/B.kt b/src/B.kt\n--- a/src/B.kt\n+++ b/src/B.kt\n@@ -1,1 +1,2 @@\n+beta\n"
+    val stored = hugePatch + smallPatch
+    val parsed = ReviewDiffEvidence.parse(stored).hunks
+    val result = fixture.storePrepare(
+      parsed,
+      stored,
+      ".skill-bill/run-evidence/code-review/fp-budget-scale",
+      decisions = listOf(
+        fixture.includedDecision("testing", "test sources changed", "src/A.kt").copy(required = true),
+        fixture.includedDecision("security", "auth surface changed", "src/B.kt"),
+      ),
+    )
+    val base = ReviewContextBudgetPolicy.DEFAULT
+    val testingBudget = deriveSpecialistBudget(
+      base,
+      result.assignments.single { it.lane == "testing" },
+      result.packet,
+    ).maxLaneEvidenceBytes
+    val securityBudget = deriveSpecialistBudget(
+      base,
+      result.assignments.single { it.lane == "security" },
+      result.packet,
+    ).maxLaneEvidenceBytes
+    assertNotEquals(testingBudget, securityBudget)
+    assertTrue(testingBudget > securityBudget)
   }
 }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ReviewPreparationServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/review/ReviewPreparationServiceTest.kt
@@ -606,6 +606,35 @@ class ReviewPreparationServiceTest {
     assertTrue(result.packet.laneDecisions.single { it.lane == "testing" }.required)
   }
 
+  @Test fun `assignment-scaled specialist budgets differ when lane assignments differ in breadth`() {
+    val hugePatch = oversizedPatch("src/A.kt")
+    val smallPatch = "diff --git a/src/B.kt b/src/B.kt\n--- a/src/B.kt\n+++ b/src/B.kt\n@@ -1,1 +1,2 @@\n+beta\n"
+    val stored = hugePatch + smallPatch
+    val parsed = ReviewDiffEvidence.parse(stored).hunks
+    val result = storePrepare(
+      parsed,
+      stored,
+      ".skill-bill/run-evidence/code-review/fp-budget-scale",
+      decisions = listOf(
+        includedDecision("testing", "test sources changed", "src/A.kt").copy(required = true),
+        includedDecision("security", "auth surface changed", "src/B.kt"),
+      ),
+    )
+    val base = ReviewContextBudgetPolicy.DEFAULT
+    val testingBudget = deriveSpecialistBudget(
+      base,
+      result.assignments.single { it.lane == "testing" },
+      result.packet,
+    ).maxLaneEvidenceBytes
+    val securityBudget = deriveSpecialistBudget(
+      base,
+      result.assignments.single { it.lane == "security" },
+      result.packet,
+    ).maxLaneEvidenceBytes
+    assertNotEquals(testingBudget, securityBudget)
+    assertTrue(testingBudget > securityBudget)
+  }
+
   @Test fun `blank store path with a live locator reader fails compose without launching workers`() {
     val hunk = hunkA
     var workerLaunches = 0

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/review/ReviewAccountingDurableRedactionTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/review/ReviewAccountingDurableRedactionTest.kt
@@ -95,6 +95,38 @@ class ReviewAccountingDurableRedactionTest {
     }
   }
 
+  @Test fun `a legacy evidence-unreviewable segment quarantines and regenerates in band`() {
+    withConnection { connection ->
+      val summary = recordedReview().second
+      val current = summary.toBoundedPayload()
+      val legacy = legacyEvidenceUnreviewablePayload(current)
+      connection.prepareStatement(
+        """
+        INSERT INTO review_accounting (review_id, packet_digest, bounded_payload_json, updated_at)
+        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+        """.trimIndent(),
+      ).use { statement ->
+        statement.setString(1, REVIEW_RUN_ID)
+        statement.setString(2, summary.packetDigest)
+        statement.setString(3, JsonSupport.mapToJsonString(legacy))
+        statement.executeUpdate()
+      }
+
+      assertNull(loadReviewAccounting(connection, REVIEW_RUN_ID))
+      val quarantined = skillbill.db.telemetry.TelemetryOutboxStore(connection).listPending(null)
+      assertTrue(
+        quarantined.any { record ->
+          record.eventName == skillbill.review.model.REVIEW_STAGE_DEGRADATION_EVENT_NAME &&
+            record.payloadJson.contains("accounting_contract_quarantined")
+        },
+      )
+
+      upsertReviewAccounting(connection, ReviewAccountingRecord(REVIEW_RUN_ID, summary.packetDigest, current))
+      val regenerated = assertNotNull(loadReviewAccounting(connection, REVIEW_RUN_ID))
+      assertEquals(REVIEW_CONTEXT_CONTRACT_VERSION, regenerated.boundedPayload["contract_version"])
+    }
+  }
+
   @Test fun `a pre-bump accounting record quarantines and regenerates in band`() {
     withConnection { connection ->
       val summary = recordedReview().second
@@ -125,45 +157,6 @@ class ReviewAccountingDurableRedactionTest {
       val regenerated = assertNotNull(loadReviewAccounting(connection, REVIEW_RUN_ID))
       assertEquals(REVIEW_CONTEXT_CONTRACT_VERSION, regenerated.boundedPayload["contract_version"])
       assertEquals("2.1", regenerated.boundedPayload["contract_version"])
-    }
-  }
-
-  @Test fun `a legacy evidence-unreviewable segment quarantines and regenerates in band`() {
-    withConnection { connection ->
-      val summary = recordedReview().second
-      val current = summary.toBoundedPayload()
-
-      @Suppress("UNCHECKED_CAST")
-      val lanes = (current["lanes"] as List<Map<String, Any?>>).map { lane ->
-        LinkedHashMap(lane).apply {
-          this["unreviewed_segment_ids"] = listOf("evidence-unreviewable")
-          this["terminal_outcome"] = "incomplete"
-        }
-      }
-      val legacy = LinkedHashMap(current).apply { this["lanes"] = lanes }
-      connection.prepareStatement(
-        """
-        INSERT INTO review_accounting (review_id, packet_digest, bounded_payload_json, updated_at)
-        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
-        """.trimIndent(),
-      ).use { statement ->
-        statement.setString(1, REVIEW_RUN_ID)
-        statement.setString(2, summary.packetDigest)
-        statement.setString(3, JsonSupport.mapToJsonString(legacy))
-        statement.executeUpdate()
-      }
-
-      assertNull(loadReviewAccounting(connection, REVIEW_RUN_ID))
-      val quarantined = skillbill.db.telemetry.TelemetryOutboxStore(connection).listPending(null)
-      assertTrue(
-        quarantined.any { record ->
-          record.eventName == skillbill.review.model.REVIEW_STAGE_DEGRADATION_EVENT_NAME &&
-            record.payloadJson.contains("accounting_contract_quarantined")
-        },
-      )
-
-      upsertReviewAccounting(connection, ReviewAccountingRecord(REVIEW_RUN_ID, summary.packetDigest, current))
-      assertNotNull(loadReviewAccounting(connection, REVIEW_RUN_ID))
     }
   }
 
@@ -246,6 +239,33 @@ class ReviewAccountingDurableRedactionTest {
     )
 
     return recorder to assertNotNull(result.accountingSummary, "The recorded review produced no accounting.")
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun legacyEvidenceUnreviewablePayload(current: Map<String, Any?>): Map<String, Any?> {
+    val digest = "a".repeat(64)
+    val lanes = (current["lanes"] as List<Map<String, Any?>>).map { lane ->
+      if (lane["lane"] == "parent") {
+        lane
+      } else {
+        LinkedHashMap(lane).apply {
+          put("bundle_composition_digest", digest)
+          put(
+            "segment_accounting",
+            listOf(
+              mapOf(
+                "segment_id" to "seg-000",
+                "measured_bytes" to 128L,
+                "entry_count" to 2,
+                "composition_digest" to digest,
+              ),
+            ),
+          )
+          put("unreviewed_segment_ids", listOf("evidence-unreviewable"))
+        }
+      }
+    }
+    return LinkedHashMap(current).apply { put("lanes", lanes) }
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/runtime-kotlin/runtime-domain/agent/history.md
+++ b/runtime-kotlin/runtime-domain/agent/history.md
@@ -1,5 +1,15 @@
 # Boundary History — runtime-domain
 
+## [2026-08-20] SKILL-201 subtask 4 — Reporting schema and projections
+Areas: runtime-infra-sqlite/sqlite/review, runtime-core/review (test)
+- `loadReviewAccounting` quarantines persisted accounting rows whose lanes still list `evidence-unreviewable` in `unreviewed_segment_ids`; read returns null and emits `ACCOUNTING_CONTRACT_QUARANTINED` degradation telemetry instead of serving stale projection semantics or crashing
+- `quarantineReviewAccounting` now takes an expected/actual pair shared by contract-version drift and legacy segment-id detection (reusable)
+- `ReviewAccountingDurableRedactionTest` pins in-band quarantine and regeneration when a pre-subtask-1 row carries the retired segment id
+- Pattern: legacy review accounting contracts fail loud at the SQLite load seam; regeneration belongs to the writer, matching runtime contract quarantine rules
+- Known limits: end-to-end delegated review reproduction remains subtask 5
+Feature flag: N/A
+Acceptance criteria: 10/10 implemented
+
 ## [2026-08-20] SKILL-201 subtask 3 — Per-lane budget derivation from assignment breadth
 Areas: runtime-domain/review/context/model, runtime-application/review
 - `ReviewContextBudgetPolicy.deriveLaneEvidenceBytes` scales each lane's cumulative broker `read_evidence` cap from the repo base policy by that lane's share of packet hunk content bytes, floored at `maxEvidenceResultBytes`; lanes owning more diff surface receive a larger allowance than narrow lanes

--- a/runtime-kotlin/runtime-domain/agent/history.md
+++ b/runtime-kotlin/runtime-domain/agent/history.md
@@ -1,5 +1,14 @@
 # Boundary History — runtime-domain
 
+## [2026-08-20] SKILL-201 subtask 1 — Sever coverage verdict from projected evidence budget
+Areas: runtime-domain/review/context/model
+- Removed `withLaneEvidenceBudget` from `GovernedReviewLaunch.completionState`; a lane whose worker run succeeded and whose segmentation stayed clean no longer flips to `incomplete` from a pre-flight sum of `entry.hunk.contentBytes` against `maxLaneEvidenceBytes`
+- Retired `EVIDENCE_UNREVIEWABLE_SEGMENT_ID` and the projection-only evidence-budget rewrite; `unreviewedUnits` may now come only from withheld or refused reads or a failed run, not from an allowance the broker never attempted to spend
+- Segmentation's `unreviewable` path for entries exceeding `maxLaneLaunchBytes` and `asFailedLaneRun` are unchanged; subtask 2 owns wiring broker refusal into completion
+- Pattern: keep enforcement (broker reads) and projection (pre-flight size sums) separate at the completion seam so coverage verdicts name only code the worker did not receive. reusable
+Feature flag: N/A
+Acceptance criteria: 7/7 implemented
+
 ## [2026-08-19] Amend-aware checkpoint-identity contract
 Areas: runtime-domain/workflow/taskruntime, orchestration/contracts
 - `FeatureTaskRuntimeCheckpointIdentity` now requires `checkpointRef` to equal `featureTaskRuntimeCheckpointRefName(issueKey, subtaskId, sequenceNumber)`. The pattern alone only proved shape, so an inline-formatted or stale-subtask ref used to validate and then dedupe under an authority boundary its own record does not own; because the ref is the identity, that drift was invisible on every later read.

--- a/runtime-kotlin/runtime-domain/agent/history.md
+++ b/runtime-kotlin/runtime-domain/agent/history.md
@@ -1,5 +1,15 @@
 # Boundary History — runtime-domain
 
+## [2026-08-20] SKILL-201 subtask 3 — Per-lane budget derivation from assignment breadth
+Areas: runtime-domain/review/context/model, runtime-application/review
+- `ReviewContextBudgetPolicy.deriveLaneEvidenceBytes` scales each lane's cumulative broker `read_evidence` cap from the repo base policy by that lane's share of packet hunk content bytes, floored at `maxEvidenceResultBytes`; lanes owning more diff surface receive a larger allowance than narrow lanes
+- `ReviewPreparationService.deriveSpecialistBudget` applies assignment-scaled derivation when composing specialist launches; `ParallelCodeReviewRunner.mergedBudget` sums each specialist's derived cap for the parent broker instead of `base * laneCount`
+- `maxLaneEvidenceBytes` now names one thing everywhere: the cumulative broker read_evidence allowance for the bound assignment surface, not a flat per-lane constant independent of ownership breadth
+- Pattern: derive enforcement budgets from assignment breadth at preparation; parent fan-out sums specialist-derived caps so parent and lane seams stay aligned. reusable
+- Known limits: coverage report and integration-pass prompt changes remain subtask 4
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-08-20] SKILL-201 subtask 2 — Broker refusal drives lane_evidence_bytes incomplete verdict
 Areas: runtime-domain/review/context/model, runtime-infra-fs/infrastructure/fs, runtime-application/review
 - `FileSystemReviewEvidenceBroker` records each `lane_evidence_bytes` refusal at the read that triggers it, appending a `commitSha@path` unit to `deniedUnits`; accounting exposes `budgetDimension` and `unreviewedUnits` only when the terminal outcome names that budget kind.

--- a/runtime-kotlin/runtime-domain/agent/history.md
+++ b/runtime-kotlin/runtime-domain/agent/history.md
@@ -1,5 +1,15 @@
 # Boundary History — runtime-domain
 
+## [2026-08-20] SKILL-201 subtask 2 — Broker refusal drives lane_evidence_bytes incomplete verdict
+Areas: runtime-domain/review/context/model, runtime-infra-fs/infrastructure/fs, runtime-application/review
+- `FileSystemReviewEvidenceBroker` records each `lane_evidence_bytes` refusal at the read that triggers it, appending a `commitSha@path` unit to `deniedUnits`; accounting exposes `budgetDimension` and `unreviewedUnits` only when the terminal outcome names that budget kind.
+- `ReviewLaneCompletionState.withBrokerEvidenceRefusal` is the completion seam: incomplete disposition, `lane_evidence_bytes` dimension, and the broker's denied-unit list — not a path-sorted greedy tail over the assembled bundle.
+- `ParallelCodeReviewRunner` applies broker accounting to bundle completion after a worker run; a successful lane with no evidence refusal stays complete (builds on subtask 1's severed projection).
+- Pattern: name unreviewed units only from enforcement (broker reads), never from pre-flight projection or alphabetical bundle order. reusable
+- Known limits: per-lane budget derivation remains subtask 3; coverage report and integration-pass prompt changes are subtask 4.
+Feature flag: N/A
+Acceptance criteria: 6/6 implemented
+
 ## [2026-08-20] SKILL-201 subtask 1 — Sever coverage verdict from projected evidence budget
 Areas: runtime-domain/review/context/model
 - Removed `withLaneEvidenceBudget` from `GovernedReviewLaunch.completionState`; a lane whose worker run succeeded and whose segmentation stayed clean no longer flips to `incomplete` from a pre-flight sum of `entry.hunk.contentBytes` against `maxLaneEvidenceBytes`

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/context/model/ReviewContextModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/context/model/ReviewContextModels.kt
@@ -372,6 +372,24 @@ data class ReviewContextBudgetPolicy(
 
   companion object {
     val DEFAULT: ReviewContextBudgetPolicy = ReviewContextBudgetPolicy()
+
+    /**
+     * [maxLaneEvidenceBytes] is the cumulative broker `read_evidence` allowance for this lane's
+     * assigned surface, scaled from [basePolicy] by the lane's share of packet hunk content bytes,
+     * not a flat cap independent of assignment breadth.
+     */
+    fun deriveLaneEvidenceBytes(
+      basePolicy: ReviewContextBudgetPolicy,
+      assignment: ReviewAssignment,
+      packet: ReviewContextPacket,
+    ): Long {
+      val packetBytes = packet.changedHunks.sumOf { it.contentBytes }
+      if (packetBytes == 0L) return basePolicy.maxLaneEvidenceBytes
+      val bytesByHunkId = packet.changedHunks.associate { it.hunkId to it.contentBytes }
+      val assignmentBytes = assignment.assignedHunks.sumOf { bytesByHunkId.getValue(it) }
+      val scaled = basePolicy.maxLaneEvidenceBytes * assignmentBytes / packetBytes
+      return maxOf(scaled, basePolicy.maxEvidenceResultBytes)
+    }
   }
 }
 

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewContextModelsTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewContextModelsTest.kt
@@ -333,6 +333,91 @@ class ReviewContextModelsTest {
     }
   }
 
+  @Test fun `assignment-scaled lane evidence budgets differ when bundle content bytes differ`() {
+    val small = ReviewChangedHunk("src/A.kt", 1, 1, 1, 2, "+a")
+    val large = ReviewChangedHunk("src/B.kt", 1, 1, 1, 2, "+" + "x".repeat(100_000))
+    val packet = ReviewContextPacket(
+      "review", "repo", "base", "head", "clean", "kotlin", "kotlin", emptyList(),
+      listOf("security", "testing"),
+      listOf(small, large),
+      commitUnits = listOf(syntheticUnit(listOf(small, large))),
+      coverageFact = fact(),
+      routingMatrix = focusedMatrix(listOf(syntheticUnit(listOf(small, large))), listOf("security", "testing")),
+      reviewRevision = revision(),
+      laneDecisions = listOf(lane("security", listOf("src/A.kt")), lane("testing", listOf("src/B.kt"))),
+    )
+    val narrow = launchAssignment(packet, listOf(small.hunkId)).copy(
+      lane = "security",
+      assignedPaths = listOf("src/A.kt"),
+      laneDecision = lane("security", listOf("src/A.kt")),
+      laneRouting = packet.routingMatrix.decisionsFor("security"),
+    )
+    val broad = launchAssignment(packet, listOf(large.hunkId)).copy(
+      lane = "testing",
+      assignedPaths = listOf("src/B.kt"),
+      laneDecision = lane("testing", listOf("src/B.kt")),
+      laneRouting = packet.routingMatrix.decisionsFor("testing"),
+    )
+    val base = ReviewContextBudgetPolicy.DEFAULT
+    val narrowBudget = ReviewContextBudgetPolicy.deriveLaneEvidenceBytes(base, narrow, packet)
+    val broadBudget = ReviewContextBudgetPolicy.deriveLaneEvidenceBytes(base, broad, packet)
+    assertNotEquals(narrowBudget, broadBudget)
+    assertTrue(broadBudget > narrowBudget)
+  }
+
+  @Test fun `derived lane evidence budget satisfies policy init`() {
+    val small = ReviewChangedHunk("src/A.kt", 1, 1, 1, 2, "+a")
+    val large = ReviewChangedHunk("src/B.kt", 1, 1, 1, 2, "+" + "x".repeat(100_000))
+    val packet = ReviewContextPacket(
+      "review", "repo", "base", "head", "clean", "kotlin", "kotlin", emptyList(),
+      listOf("security"),
+      listOf(small, large),
+      commitUnits = listOf(syntheticUnit(listOf(small, large))),
+      coverageFact = fact(),
+      routingMatrix = focusedMatrix(listOf(syntheticUnit(listOf(small, large))), listOf("security")),
+      reviewRevision = revision(),
+      laneDecisions = listOf(lane("security", listOf("src/A.kt"))),
+    )
+    val assignment = launchAssignment(packet, listOf(small.hunkId))
+    val base = ReviewContextBudgetPolicy.DEFAULT
+    val derived = ReviewContextBudgetPolicy.deriveLaneEvidenceBytes(base, assignment, packet)
+    ReviewContextBudgetPolicy(
+      maxLaneEvidenceBytes = derived,
+      maxEvidenceResultBytes = base.maxEvidenceResultBytes,
+    )
+  }
+
+  @Test fun `parent merged evidence allowance matches sum of per-lane derived caps`() {
+    val small = ReviewChangedHunk("src/A.kt", 1, 1, 1, 2, "+a")
+    val large = ReviewChangedHunk("src/B.kt", 1, 1, 1, 2, "+" + "x".repeat(100_000))
+    val packet = ReviewContextPacket(
+      "review", "repo", "base", "head", "clean", "kotlin", "kotlin", emptyList(),
+      listOf("security", "testing"),
+      listOf(small, large),
+      commitUnits = listOf(syntheticUnit(listOf(small, large))),
+      coverageFact = fact(),
+      routingMatrix = focusedMatrix(listOf(syntheticUnit(listOf(small, large))), listOf("security", "testing")),
+      reviewRevision = revision(),
+      laneDecisions = listOf(lane("security", listOf("src/A.kt")), lane("testing", listOf("src/B.kt"))),
+    )
+    val base = ReviewContextBudgetPolicy.DEFAULT
+    val narrow = launchAssignment(packet, listOf(small.hunkId)).copy(
+      lane = "security",
+      assignedPaths = listOf("src/A.kt"),
+      laneDecision = lane("security", listOf("src/A.kt")),
+      laneRouting = packet.routingMatrix.decisionsFor("security"),
+    )
+    val broad = launchAssignment(packet, listOf(large.hunkId)).copy(
+      lane = "testing",
+      assignedPaths = listOf("src/B.kt"),
+      laneDecision = lane("testing", listOf("src/B.kt")),
+      laneRouting = packet.routingMatrix.decisionsFor("testing"),
+    )
+    val mergedSum = ReviewContextBudgetPolicy.deriveLaneEvidenceBytes(base, narrow, packet) +
+      ReviewContextBudgetPolicy.deriveLaneEvidenceBytes(base, broad, packet)
+    assertNotEquals(base.maxLaneEvidenceBytes * 2, mergedSum)
+  }
+
   @Test fun `oversized compact launch segments instead of failing the whole payload`() {
     val packet = launchPacket()
     val assignment = launchAssignment(packet)

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewLaneBundleAssemblyTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewLaneBundleAssemblyTest.kt
@@ -300,7 +300,6 @@ class ReviewLaneBundleAssemblyTest {
     assertEquals(null, governed.completionState.budgetDimension)
   }
 
-  // AC-009: a bundle that fit the budget still is not clean coverage when the lane's run failed.
   @Test fun `a failed lane run downgrades a complete state to incomplete naming its whole bundle`() {
     val built = packet(listOf(unit("c1", "base", 0, listOf(hunkA))))
     val assembled = ReviewLaneAssembledBundle.assemble(

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewLaneBundleAssemblyTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/review/context/model/ReviewLaneBundleAssemblyTest.kt
@@ -6,6 +6,7 @@ import skillbill.review.context.model.ReviewLaneBundleSegmentation.Companion.UNR
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -298,6 +299,45 @@ class ReviewLaneBundleAssemblyTest {
     assertEquals(emptyList(), governed.completionState.unreviewedSegmentIds)
     assertEquals(emptyList(), governed.completionState.unreviewedUnits)
     assertEquals(null, governed.completionState.budgetDimension)
+  }
+
+  @Test fun `broker evidence refusal names supplied units not bundle alphabetical tail`() {
+    val firstPath = ReviewChangedHunk("src/A.kt", 1, 1, 1, 2, "+a")
+    val middlePath = ReviewChangedHunk("src/M.kt", 4, 1, 4, 1, "+m")
+    val latePath = ReviewChangedHunk("src/Z.kt", 7, 1, 7, 1, "+z")
+    val built = packet(listOf(unit("c1", "base", 0, listOf(firstPath, middlePath, latePath))))
+    val bundle = ReviewLaneBundle(
+      listOf(ReviewLaneBundleEntry("c1", 0, listOf(firstPath.hunkId, middlePath.hunkId, latePath.hunkId))),
+    )
+    val assembled = ReviewLaneAssembledBundle.assemble(assignment(built, bundle), built)
+    val complete = segmentAssembledBundle(assembled, maxLaneLaunchBytes = 10_000) { _ -> 10L }
+      .toCompletionState(assembled.compositionDigest)
+    val brokerDenied = "c1@src/M.kt"
+    val result = complete.withBrokerEvidenceRefusal(listOf(brokerDenied))
+
+    assertEquals(ReviewLaneReviewDisposition.INCOMPLETE, result.disposition)
+    assertEquals(LANE_EVIDENCE_BYTES_DIMENSION, result.budgetDimension)
+    assertEquals(listOf(brokerDenied), result.unreviewedUnits)
+    assertFalse(result.unreviewedUnits.contains("c1@src/Z.kt"))
+    assertFalse(result.unreviewedSegmentIds.contains(UNREVIEWABLE_SEGMENT_ID))
+  }
+
+  @Test fun `withBrokerEvidenceRefusal on a complete state yields incomplete with broker denied units`() {
+    val built = packet(listOf(unit("c1", "base", 0, listOf(hunkA))))
+    val assembled = ReviewLaneAssembledBundle.assemble(
+      assignment(built, ReviewLaneBundle(listOf(ReviewLaneBundleEntry("c1", 0, listOf(hunkA.hunkId))))),
+      built,
+    )
+    val complete = segmentAssembledBundle(assembled, maxLaneLaunchBytes = 10_000) { _ -> 10L }
+      .toCompletionState(assembled.compositionDigest)
+    val denied = listOf("c1@${hunkA.path}")
+
+    val result = complete.withBrokerEvidenceRefusal(denied)
+
+    assertEquals(ReviewLaneReviewDisposition.INCOMPLETE, result.disposition)
+    assertEquals(LANE_EVIDENCE_BYTES_DIMENSION, result.budgetDimension)
+    assertEquals(denied, result.unreviewedUnits)
+    assertFalse(result.unreviewedSegmentIds.contains(UNREVIEWABLE_SEGMENT_ID))
   }
 
   @Test fun `a failed lane run downgrades a complete state to incomplete naming its whole bundle`() {

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemReviewEvidenceBrokerBudgetTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemReviewEvidenceBrokerBudgetTest.kt
@@ -1,0 +1,260 @@
+package skillbill.infrastructure.fs
+
+import skillbill.error.ReviewHunkEvidenceIntegrityError
+import skillbill.ports.review.BrokerBackedNativeReviewOperationProtocol
+import skillbill.ports.review.ReviewStoredHunkBodyExtractor
+import skillbill.ports.review.model.ReviewEvidenceBatchRequest
+import skillbill.ports.review.model.ReviewEvidenceBrokerBinding
+import skillbill.ports.review.model.ReviewEvidenceRequest
+import skillbill.ports.review.model.ReviewToolCall
+import skillbill.ports.taskruntime.FeatureTaskRuntimeSharedEvidenceLocatorReadPort
+import skillbill.review.context.model.ProviderTokenUsage
+import skillbill.review.context.model.REVIEW_BUDGET_REGRESSION
+import skillbill.review.context.model.REVIEW_CONTEXT_BUDGET_EXCEEDED
+import skillbill.review.context.model.ReviewAssignment
+import skillbill.review.context.model.ReviewChangedHunk
+import skillbill.review.context.model.ReviewContextBudgetPolicy
+import skillbill.review.context.model.ReviewDependencyAllowlist
+import skillbill.review.context.model.ReviewHunkEvidenceLocator
+import skillbill.review.context.model.ReviewLaneDecision
+import skillbill.review.context.model.ReviewOperationKind
+import skillbill.review.context.model.ReviewRevision
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FileSystemReviewEvidenceBrokerBudgetTest {
+  @Test fun `non-enforceable provider excess reports a regression without terminating`() {
+    val root = repo("A.kt" to "assigned")
+    val broker = projectedBroker(root, assignment(listOf("A.kt")))
+    val outcome = broker.evaluateProviderUsage(ProviderTokenUsage(totalTokens = 500_000), enforceable = false)
+    assertEquals(REVIEW_BUDGET_REGRESSION, outcome?.type)
+    assertEquals(false, outcome?.enforceable)
+    assertNull(broker.accounting().terminalOutcome)
+    assertEquals("assigned", broker.readBatch(batch("A.kt")).results.single().content)
+  }
+
+  @Test fun `enforceable provider excess terminates the lane`() {
+    val root = repo("A.kt" to "assigned")
+    val broker = broker(root, assignment(listOf("A.kt")))
+    val outcome = BrokerBackedNativeReviewOperationProtocol(broker)
+      .providerUsage(ProviderTokenUsage(totalTokens = 500_000))
+    assertEquals(REVIEW_CONTEXT_BUDGET_EXCEEDED, outcome?.type)
+    assertNotNull(broker.accounting().terminalOutcome)
+    assertEquals("total_tokens", outcome?.budgetKind)
+  }
+
+  @Test fun `paths escaping the repository are rejected`() {
+    val root = repo("A.kt" to "assigned")
+    val broker = broker(root, assignment(listOf("A.kt")))
+    assertFailsWith<IllegalArgumentException> { broker.readBatch(batch("../outside.kt")) }
+  }
+
+  @Test fun `assigned locator read returns the stored hunk body`() {
+    val root = repo("A.kt" to "working-tree")
+    val hunk = ReviewChangedHunk("A.kt", 2, 1, 2, 1, "@@ -2 +2 @@\n-owned\n+changed")
+    val storePath = ".skill-bill/run-evidence/code-review/fp-assigned"
+    val broker = locatorBroker(LocatorBrokerSpec(root, listOf(hunk), storePath, mapOf(storePath to hunk.content)))
+
+    val first = broker.readBatch(batch("A.kt")).results.single()
+    assertEquals(hunk.content, first.content)
+    assertEquals(hunk.content.toByteArray(Charsets.UTF_8).size.toLong(), first.bytes)
+  }
+
+  @Test fun `overwriting stored body without updating content digest throws integrity error`() {
+    val root = repo("A.kt" to "working-tree")
+    val original = "@@ -2 +2 @@\n-owned\n+changed"
+    val overwritten = "@@ -2 +2 @@\n-owned\n+tampered"
+    val hunk = ReviewChangedHunk("A.kt", 2, 1, 2, 1, original)
+    val storePath = ".skill-bill/run-evidence/code-review/fp-integrity"
+    val payloads = mutableMapOf(storePath to original)
+    val broker = locatorBroker(LocatorBrokerSpec(root, listOf(hunk), storePath, payloads))
+    payloads[storePath] = overwritten
+
+    val failure = assertFailsWith<ReviewHunkEvidenceIntegrityError> {
+      broker.readBatch(batch("A.kt"))
+    }
+    assertEquals(storePath, failure.storePath)
+    assertEquals(ReviewChangedHunk.digestOfBody(original), failure.expectedDigest)
+    assertEquals(ReviewChangedHunk.digestOfBody(overwritten), failure.observedDigest)
+    assertEquals(0, broker.accounting().evidenceBytes)
+  }
+
+  @Test fun `a hunk larger than remaining evidence budget is omitted entirely`() {
+    val root = repo("A.kt" to "aa", "B.kt" to "bbbb")
+    val small = ReviewChangedHunk("A.kt", 1, 1, 1, 1, "aa")
+    val large = ReviewChangedHunk("B.kt", 1, 1, 1, 1, "bbbb")
+    val storePath = ".skill-bill/run-evidence/code-review/fp-budget"
+    val broker = locatorBroker(
+      LocatorBrokerSpec(root, listOf(small, large), storePath, mapOf(storePath to "aa")),
+      policy(result = 3, cumulative = 3),
+      ReviewStoredHunkBodyExtractor { _, hunk -> if (hunk.path == "A.kt") "aa" else "bbbb" },
+    )
+    val first = broker.readBatch(batch("A.kt")).results.single()
+    val second = broker.readBatch(batch("B.kt")).results.single()
+
+    assertEquals("aa", first.content)
+    assertEquals(null, second.content)
+    assertEquals("lane_evidence_bytes", second.budgetExceeded?.budgetKind)
+    assertTrue(second.bytes == 0L)
+    assertEquals("lane_evidence_bytes", broker.accounting().terminalOutcome?.budgetKind)
+    assertEquals(listOf("head@B.kt"), broker.accounting().unreviewedUnits)
+    assertEquals(1, broker.accounting().refusedOperationCount)
+  }
+
+  @Test fun `mid batch lane evidence refusal records denied unit for refused target only`() {
+    val root = repo("A.kt" to "12345", "B.kt" to "67890", "C.kt" to "abcde")
+    val hunks = listOf("A.kt", "B.kt", "C.kt").map { path ->
+      ReviewChangedHunk(path, 1, 1, 1, 1, Files.readString(root.resolve(path)))
+    }
+    val assigned = assignment(listOf("A.kt", "B.kt", "C.kt")).copy(
+      assignedHunks = hunks.map { it.hunkId },
+    )
+    val broker = FileSystemReviewEvidenceBroker(
+      ReviewEvidenceBrokerBinding(
+        root,
+        assigned,
+        "security",
+        policy(result = 8, cumulative = 8),
+        projectedHunks = hunks,
+      ),
+    )
+    broker.readBatch(batch("A.kt"))
+    broker.readBatch(batch("B.kt"))
+    val accounting = broker.accounting()
+    assertEquals(listOf("head@B.kt"), accounting.unreviewedUnits)
+    assertEquals("lane_evidence_bytes", accounting.terminalOutcome?.budgetKind)
+    assertTrue(accounting.unreviewedUnits.none { it.endsWith("@C.kt") })
+  }
+
+  @Test fun `an ordinary bounded review completes with full accounting and no termination`() {
+    val root = repo("A.kt" to "assigned")
+    val broker = projectedBroker(root, assignment(listOf("A.kt")))
+    broker.recordModelTurn()
+    broker.recordToolCall(ReviewToolCall("security", ReviewOperationKind.FILE_READ, "A.kt"))
+    broker.readBatch(batch("A.kt"))
+    assertNull(broker.validateLaneResult("- [F-001] Minor | Low | A.kt:1 | bounded finding"))
+    val accounting = broker.accounting()
+    assertEquals(8, accounting.evidenceBytes)
+    assertEquals(1, accounting.toolCalls)
+    assertEquals(1, accounting.modelTurns)
+    assertEquals(48, accounting.resultBytes)
+    assertNull(accounting.terminalOutcome)
+  }
+
+  private fun batch(path: String) = ReviewEvidenceBatchRequest.of(ReviewEvidenceRequest("security", path))
+
+  private fun repo(vararg files: Pair<String, String>): Path {
+    val root = Files.createTempDirectory("review-evidence")
+    files.forEach { (name, content) ->
+      val target = root.resolve(name)
+      target.parent?.let(Files::createDirectories)
+      Files.writeString(target, content)
+    }
+    return root
+  }
+
+  private fun broker(root: Path, assignment: ReviewAssignment, budget: ReviewContextBudgetPolicy = policy()) =
+    FileSystemReviewEvidenceBroker(
+      ReviewEvidenceBrokerBinding(root, assignment, "security", budget),
+    )
+
+  private fun projectedBroker(
+    root: Path,
+    assignment: ReviewAssignment,
+    budget: ReviewContextBudgetPolicy = policy(),
+  ): FileSystemReviewEvidenceBroker {
+    val hunks = assignment.assignedPaths.map { path ->
+      ReviewChangedHunk(path, 1, 1, 1, 1, Files.readString(root.resolve(path)))
+    }
+    val projectedAssignment = assignment.copy(assignedHunks = hunks.map { it.hunkId })
+    return FileSystemReviewEvidenceBroker(
+      ReviewEvidenceBrokerBinding(root, projectedAssignment, "security", budget, projectedHunks = hunks),
+    )
+  }
+
+  private data class LocatorBrokerSpec(
+    val root: Path,
+    val hunks: List<ReviewChangedHunk>,
+    val storePath: String,
+    val payloads: Map<String, String>,
+  )
+
+  private fun locatorBroker(
+    spec: LocatorBrokerSpec,
+    budget: ReviewContextBudgetPolicy = policy(),
+    extractor: ReviewStoredHunkBodyExtractor? = null,
+  ): FileSystemReviewEvidenceBroker {
+    val indexed = spec.hunks.map { hunk ->
+      hunk.asIndex(
+        ReviewHunkEvidenceLocator.atStore(
+          spec.storePath,
+          hunk.oldStart,
+          hunk.oldCount,
+          hunk.newStart,
+          hunk.newCount,
+        ),
+        hunk.content,
+      )
+    }
+    val assigned = assignment(indexed.map { it.path }.distinct()).copy(assignedHunks = indexed.map { it.hunkId })
+    return FileSystemReviewEvidenceBroker(
+      ReviewEvidenceBrokerBinding(
+        spec.root,
+        assigned,
+        "security",
+        budget,
+        projectedHunks = indexed,
+        locatorReader = FeatureTaskRuntimeSharedEvidenceLocatorReadPort { request ->
+          spec.payloads[request.storePath] ?: error("missing locator payload")
+        },
+        bodyExtractor = extractor ?: ReviewStoredHunkBodyExtractor { payload, _ ->
+          payload.replace("\r\n", "\n")
+        },
+      ),
+    )
+  }
+
+  private fun assignment(paths: List<String>, dependencies: List<String> = emptyList()) = ReviewAssignment(
+    "review",
+    "a".repeat(64),
+    "security",
+    "base",
+    "head",
+    paths,
+    emptyList(),
+    reviewRevision = ReviewRevision("rvs-1", 1),
+    laneDecision = ReviewLaneDecision(
+      "security",
+      true,
+      "routed",
+      ownedPaths = paths.ifEmpty { listOf("A.kt") },
+      originLayerChains = listOf(listOf("kotlin")),
+      owningPack = "kotlin",
+      specialistSkillName = "bill-kotlin-code-review-security",
+    ),
+    dependencyAllowlist = ReviewDependencyAllowlist(dependencies),
+  )
+
+  private fun policy(
+    result: Long = 100,
+    cumulative: Long = 200,
+    expansions: Int = 1,
+    toolCalls: Int = 40,
+    modelTurns: Int = 24,
+  ) = ReviewContextBudgetPolicy(
+    maxParentPacketBytes = 1_000,
+    maxLaneLaunchBytes = 500,
+    maxLaneEvidenceBytes = cumulative,
+    maxEvidenceResultBytes = result,
+    maxLaneResultBytes = 100,
+    maxAssignmentExpansions = expansions,
+    maxSpecialistToolCalls = toolCalls,
+    maxSpecialistModelTurns = modelTurns,
+  )
+}

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemReviewEvidenceBrokerTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/infrastructure/fs/FileSystemReviewEvidenceBrokerTest.kt
@@ -1,25 +1,19 @@
 package skillbill.infrastructure.fs
 
 import skillbill.error.InvalidReviewContextSchemaError
-import skillbill.error.ReviewHunkEvidenceIntegrityError
 import skillbill.ports.review.BrokerBackedNativeReviewOperationProtocol
-import skillbill.ports.review.ReviewStoredHunkBodyExtractor
 import skillbill.ports.review.model.ReviewEvidenceBatchRequest
 import skillbill.ports.review.model.ReviewEvidenceBrokerBinding
 import skillbill.ports.review.model.ReviewEvidenceRequest
 import skillbill.ports.review.model.ReviewExpansionAuthorizationRequest
 import skillbill.ports.review.model.ReviewRefusedOperationRecord
 import skillbill.ports.review.model.ReviewToolCall
-import skillbill.ports.taskruntime.FeatureTaskRuntimeSharedEvidenceLocatorReadPort
-import skillbill.review.context.model.ProviderTokenUsage
-import skillbill.review.context.model.REVIEW_BUDGET_REGRESSION
 import skillbill.review.context.model.REVIEW_CONTEXT_BUDGET_EXCEEDED
 import skillbill.review.context.model.ReviewAssignment
 import skillbill.review.context.model.ReviewChangedHunk
 import skillbill.review.context.model.ReviewContextBudgetPolicy
 import skillbill.review.context.model.ReviewDependencyAllowlist
 import skillbill.review.context.model.ReviewExpansionRecord
-import skillbill.review.context.model.ReviewHunkEvidenceLocator
 import skillbill.review.context.model.ReviewLaneDecision
 import skillbill.review.context.model.ReviewOperationKind
 import skillbill.review.context.model.ReviewRevision
@@ -29,7 +23,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -205,6 +198,9 @@ class FileSystemReviewEvidenceBrokerTest {
     assertEquals("lane_evidence_bytes", result.terminalOutcome?.budgetKind)
     assertEquals(10, result.terminalOutcome?.observedValue)
     assertEquals(1, broker.accounting().refusedOperationCount)
+    assertEquals("lane_evidence_bytes", broker.accounting().terminalOutcome?.budgetKind)
+    assertEquals(listOf("head@B.kt"), broker.accounting().unreviewedUnits)
+    assertEquals("lane_evidence_bytes", broker.accounting().budgetDimension)
     val followOn = broker.readBatch(
       ReviewEvidenceBatchRequest(
         "security",
@@ -465,96 +461,6 @@ class FileSystemReviewEvidenceBrokerTest {
     assertEquals(exceeded, broker.terminalOutcome())
   }
 
-  @Test fun `non-enforceable provider excess reports a regression without terminating`() {
-    val root = repo("A.kt" to "assigned")
-    val broker = projectedBroker(root, assignment(listOf("A.kt")))
-    val outcome = broker.evaluateProviderUsage(ProviderTokenUsage(totalTokens = 500_000), enforceable = false)
-    assertEquals(REVIEW_BUDGET_REGRESSION, outcome?.type)
-    assertEquals(false, outcome?.enforceable)
-    assertNull(broker.accounting().terminalOutcome)
-    assertEquals("assigned", broker.readBatch(batch("A.kt")).results.single().content)
-  }
-
-  @Test fun `enforceable provider excess terminates the lane`() {
-    val root = repo("A.kt" to "assigned")
-    val broker = broker(root, assignment(listOf("A.kt")))
-    val outcome = BrokerBackedNativeReviewOperationProtocol(broker)
-      .providerUsage(ProviderTokenUsage(totalTokens = 500_000))
-    assertEquals(REVIEW_CONTEXT_BUDGET_EXCEEDED, outcome?.type)
-    assertNotNull(broker.accounting().terminalOutcome)
-    assertEquals("total_tokens", outcome?.budgetKind)
-  }
-
-  @Test fun `paths escaping the repository are rejected`() {
-    val root = repo("A.kt" to "assigned")
-    val broker = broker(root, assignment(listOf("A.kt")))
-    assertFailsWith<IllegalArgumentException> { broker.readBatch(batch("../outside.kt")) }
-  }
-
-  @Test fun `assigned locator read returns the stored hunk body`() {
-    val root = repo("A.kt" to "working-tree")
-    val hunk = ReviewChangedHunk("A.kt", 2, 1, 2, 1, "@@ -2 +2 @@\n-owned\n+changed")
-    val storePath = ".skill-bill/run-evidence/code-review/fp-assigned"
-    val broker = locatorBroker(LocatorBrokerSpec(root, listOf(hunk), storePath, mapOf(storePath to hunk.content)))
-
-    val first = broker.readBatch(batch("A.kt")).results.single()
-    assertEquals(hunk.content, first.content)
-    assertEquals(hunk.content.toByteArray(Charsets.UTF_8).size.toLong(), first.bytes)
-  }
-
-  @Test fun `overwriting stored body without updating content digest throws integrity error`() {
-    val root = repo("A.kt" to "working-tree")
-    val original = "@@ -2 +2 @@\n-owned\n+changed"
-    val overwritten = "@@ -2 +2 @@\n-owned\n+tampered"
-    val hunk = ReviewChangedHunk("A.kt", 2, 1, 2, 1, original)
-    val storePath = ".skill-bill/run-evidence/code-review/fp-integrity"
-    val payloads = mutableMapOf(storePath to original)
-    val broker = locatorBroker(LocatorBrokerSpec(root, listOf(hunk), storePath, payloads))
-    payloads[storePath] = overwritten
-
-    val failure = assertFailsWith<ReviewHunkEvidenceIntegrityError> {
-      broker.readBatch(batch("A.kt"))
-    }
-    assertEquals(storePath, failure.storePath)
-    assertEquals(ReviewChangedHunk.digestOfBody(original), failure.expectedDigest)
-    assertEquals(ReviewChangedHunk.digestOfBody(overwritten), failure.observedDigest)
-    assertEquals(0, broker.accounting().evidenceBytes)
-  }
-
-  @Test fun `a hunk larger than remaining evidence budget is omitted entirely`() {
-    val root = repo("A.kt" to "aa", "B.kt" to "bbbb")
-    val small = ReviewChangedHunk("A.kt", 1, 1, 1, 1, "aa")
-    val large = ReviewChangedHunk("B.kt", 1, 1, 1, 1, "bbbb")
-    val storePath = ".skill-bill/run-evidence/code-review/fp-budget"
-    val broker = locatorBroker(
-      LocatorBrokerSpec(root, listOf(small, large), storePath, mapOf(storePath to "aa")),
-      policy(result = 3, cumulative = 3),
-      ReviewStoredHunkBodyExtractor { _, hunk -> if (hunk.path == "A.kt") "aa" else "bbbb" },
-    )
-    val first = broker.readBatch(batch("A.kt")).results.single()
-    val second = broker.readBatch(batch("B.kt")).results.single()
-
-    assertEquals("aa", first.content)
-    assertEquals(null, second.content)
-    assertEquals("lane_evidence_bytes", second.budgetExceeded?.budgetKind)
-    assertTrue(second.bytes == 0L)
-  }
-
-  @Test fun `an ordinary bounded review completes with full accounting and no termination`() {
-    val root = repo("A.kt" to "assigned")
-    val broker = projectedBroker(root, assignment(listOf("A.kt")))
-    broker.recordModelTurn()
-    broker.recordToolCall(ReviewToolCall("security", ReviewOperationKind.FILE_READ, "A.kt"))
-    broker.readBatch(batch("A.kt"))
-    assertNull(broker.validateLaneResult("- [F-001] Minor | Low | A.kt:1 | bounded finding"))
-    val accounting = broker.accounting()
-    assertEquals(8, accounting.evidenceBytes)
-    assertEquals(1, accounting.toolCalls)
-    assertEquals(1, accounting.modelTurns)
-    assertEquals(48, accounting.resultBytes)
-    assertNull(accounting.terminalOutcome)
-  }
-
   private fun batch(path: String) = ReviewEvidenceBatchRequest.of(ReviewEvidenceRequest("security", path))
 
   private fun expansionRequest(assignment: ReviewAssignment, path: String, reason: String) = ReviewEvidenceRequest(
@@ -595,48 +501,6 @@ class FileSystemReviewEvidenceBrokerTest {
     val projectedAssignment = assignment.copy(assignedHunks = hunks.map { it.hunkId })
     return FileSystemReviewEvidenceBroker(
       ReviewEvidenceBrokerBinding(root, projectedAssignment, "security", budget, projectedHunks = hunks),
-    )
-  }
-
-  private data class LocatorBrokerSpec(
-    val root: Path,
-    val hunks: List<ReviewChangedHunk>,
-    val storePath: String,
-    val payloads: Map<String, String>,
-  )
-
-  private fun locatorBroker(
-    spec: LocatorBrokerSpec,
-    budget: ReviewContextBudgetPolicy = policy(),
-    extractor: ReviewStoredHunkBodyExtractor? = null,
-  ): FileSystemReviewEvidenceBroker {
-    val indexed = spec.hunks.map { hunk ->
-      hunk.asIndex(
-        ReviewHunkEvidenceLocator.atStore(
-          spec.storePath,
-          hunk.oldStart,
-          hunk.oldCount,
-          hunk.newStart,
-          hunk.newCount,
-        ),
-        hunk.content,
-      )
-    }
-    val assigned = assignment(indexed.map { it.path }.distinct()).copy(assignedHunks = indexed.map { it.hunkId })
-    return FileSystemReviewEvidenceBroker(
-      ReviewEvidenceBrokerBinding(
-        spec.root,
-        assigned,
-        "security",
-        budget,
-        projectedHunks = indexed,
-        locatorReader = FeatureTaskRuntimeSharedEvidenceLocatorReadPort { request ->
-          spec.payloads[request.storePath] ?: error("missing locator payload")
-        },
-        bodyExtractor = extractor ?: ReviewStoredHunkBodyExtractor { payload, _ ->
-          payload.replace("\r\n", "\n")
-        },
-      ),
     )
   }
 

--- a/skills/bill-feature-goal/content.md
+++ b/skills/bill-feature-goal/content.md
@@ -70,6 +70,10 @@ specific path only when there is no match or the matches are ambiguous.
 
 Classify size only to decide whether preparation produces one subtask or multiple dependency-ordered subtasks. Never execute a prepared small goal directly outside the manifest workflow.
 
+Size subtasks by the **Subtask Sizing** rule in `bill-feature-spec`: one subtask by default, no
+cap on a subtask's breadth, and a split only when one pass cannot carry the work, a later part
+needs an earlier contract, or the parts ship separately.
+
 ## Decomposition Proposal
 
 For all prepared goals, first ensure manifest-backed artifacts exist through the
@@ -84,7 +88,8 @@ Then present a concise proposal that includes:
 
 - the issue key and feature name
 - the parent acceptance criteria
-- one or more ordered subtasks with dependency notes
+- one or more ordered subtasks with dependency notes; when there is more than one, a line per
+  subtask saying why it cannot be folded into its neighbor
 - the expected first runnable subtask
 - the agent that will be used for child runs, including any explicit override
 - the parallel review agent when `parallel-review:<agent>` was passed, or `none` otherwise
@@ -221,20 +226,29 @@ into the conversation. There is no in-session transition relay; agent silence
 during the run is deliberate, not a failure, and ends only when a sanctioned
 completion signal or error reaches the session.
 
+After launch, keep the session on the original foreground `skill-bill goal`
+blocking call until it returns, or keep the original process alive across yields
+and await its exit through the harness process-completion primitive. That single
+long wait is the completion signal. It is required, not optional, and it is not
+progress observation — the agent makes no separate tool calls while that call runs.
+
 While a foreground or detached run is in flight:
 
 1. Do not run `skill-bill goal watch` in-session, at any interval or refresh count.
 2. Do not call `skill-bill goal status` on a timer or repeatedly to observe change.
-3. Do not sleep, wait, or otherwise idle in order to re-read progress.
+3. Do not sleep between separate progress checks, schedule wake-ups, or otherwise
+   idle between tool calls whose only purpose is to re-read progress.
 4. Do not tail, poll, or re-read runtime logs, the workflow DB, `git diff`, or
    changed files to infer progress.
 5. Do not re-invoke the runtime or launch an observer process or subagent to
    observe a run that is already executing.
 
 These prohibitions apply to shell loops, scheduled wake-ups, repeated tool
-calls, and delegated observers. The cost rule is request count, not output size:
-one completion signal beats any number of short polls, and trimming a poll's
-output does not make polling acceptable.
+calls, and delegated observers. The cost rule is request count, not wall-clock
+time: one completion signal — one blocking launch call or one background-exit
+re-invocation — beats any number of short polls, and trimming a poll's output
+does not make polling acceptable. A multi-hour blocking wait on the launch
+command is the completion signal, not token waste from observing.
 
 The only permitted in-session surface is one bounded terminal notification,
 errors such as launch failures, loud-fails, or non-zero exits, and one

--- a/skills/bill-feature-spec/content.md
+++ b/skills/bill-feature-spec/content.md
@@ -27,6 +27,26 @@ Classify into one of two modes:
 
 Use `single_spec` by default unless the work clearly needs multiple dependency-ordered subtasks. Mode is sizing and planning metadata only; it never changes the artifact shape or executor.
 
+## Subtask Sizing
+
+A subtask pays the whole ceremony: preplan, plan, implement, review, validate, one commit. That
+cost barely moves between a two-file change and a twenty-file one, so decomposition exists to cut
+work too large for a single pass, not to give each layer, file, or logical unit its own ticket.
+
+Default to one subtask. Split only when one implement pass cannot carry the work to a reviewable
+end, a later part cannot be specified until an earlier contract or schema lands, or the parts ship
+separately. Not reasons to split: layer order, one file or symbol each, "add the field, then read
+the field", tests on their own, or a narrative of steps one agent would finish in a sitting.
+
+Breadth is never a reason. A subtask has no cap on files or diff size, and one coherent twenty-file
+commit is cheaper to run and easier to judge than four five-file commits that only make sense read
+together. Since each subtask is one commit, the only shape that matters is whether that commit
+stands alone: a commit that deletes a path whose replacement lands later, or adds a field nothing
+reads, belongs in the commit that finishes the change.
+
+Floor: a candidate that reads as "change X so it does Y" is below the cost of its own cycle. Two or
+three subtasks is a normal decomposition; name the condition behind each extra split.
+
 ## Service / Spec Source Mode
 
 `bill-feature-spec` accepts an optional `service:default/linear` argument that selects where

--- a/skills/bill-feature-task-runtime/content.md
+++ b/skills/bill-feature-task-runtime/content.md
@@ -102,21 +102,30 @@ into the conversation. There is no in-session transition relay; agent silence
 during the run is deliberate, not a failure, and ends only when a sanctioned
 completion signal or error reaches the session.
 
+After launch, keep the session on the original foreground feature-task runtime
+blocking call until it returns, or keep the original process alive across yields
+and await its exit through the harness process-completion primitive. That single
+long wait is the completion signal. It is required, not optional, and it is not
+progress observation — the agent makes no separate tool calls while that call runs.
+
 While a foreground or detached run is in flight:
 
 1. Do not run `skill-bill goal watch` in-session, at any interval or refresh count.
 2. Do not call `skill-bill feature-task status <workflow_id>` on a timer or
    repeatedly to observe change.
-3. Do not sleep, wait, or otherwise idle in order to re-read progress.
+3. Do not sleep between separate progress checks, schedule wake-ups, or otherwise
+   idle between tool calls whose only purpose is to re-read progress.
 4. Do not tail, poll, or re-read runtime logs, the workflow DB, `git diff`, or
    changed files to infer progress.
 5. Do not re-invoke the runtime or launch an observer process or subagent to
    observe a run that is already executing.
 
 These prohibitions apply to shell loops, scheduled wake-ups, repeated tool
-calls, and delegated observers. The cost rule is request count, not output size:
-one completion signal beats any number of short polls, and trimming a poll's
-output does not make polling acceptable.
+calls, and delegated observers. The cost rule is request count, not wall-clock
+time: one completion signal — one blocking launch call or one background-exit
+re-invocation — beats any number of short polls, and trimming a poll's output
+does not make polling acceptable. A multi-hour blocking wait on the launch
+command is the completion signal, not token waste from observing.
 
 The only permitted in-session surface is exactly one completion line, errors
 such as launch failures, loud-fails, or non-zero exits, and one


### PR DESCRIPTION
# Summary

A delegated review of a 59-file branch reported `Coverage: NOT clean` and named 20 files as unreviewed, including every git and checkpoint file the branch touched. The lanes had reviewed all of them. The verdict was false.

The cause was a pre-flight projection. `withLaneEvidenceBudget` summed the lane's assembled diff bytes, compared that total against `max_lane_evidence_bytes`, and on overflow wrote `evidence-unreviewable` into the field that means "this code was not reviewed". But `max_lane_evidence_bytes` is the broker's cumulative `read_evidence` allowance, and the projection never withheld a single hunk: the payload comes from `deliveredEntries`, which segmentation governs through `max_lane_launch_bytes`. On the observed run the broker made zero tool calls. The reported gap was just the alphabetical tail of a greedy path-sorted prefix, so which files got named depended on how module names spell.

Coverage now follows real enforcement. A lane reports `incomplete` when the broker actually refused a read, when an entry cannot fit a launch segment alone, or when the worker run failed.

- Subtask 1: stop the pre-flight evidence budget from marking successful lanes incomplete.
- Subtask 2: a broker refusal, and only a broker refusal, drives the `lane_evidence_bytes` incomplete verdict, naming only the units the refusal denied.
- Subtask 3: derive per-lane evidence budgets from assignment breadth, so a lane owning 100% of changed paths and one owning 10% no longer share a flat cap.
- Subtask 4: quarantine legacy `evidence-unreviewable` accounting rows at SQLite load and pin in-band regeneration.

`max_lane_launch_bytes`, segmentation, `deliveredEntries`, `asFailedLaneRun`, and the broker's cumulative enforcement are all unchanged. Fewer incomplete verdicts come from removing false ones, not from suppressing true ones, so the broker-refusal, unreviewable-entry, and failed-run paths each keep a test that fails if that path stops reporting.

This branch also carries six `.feature-specs/SKILL-202-*` spec drafts that are unrelated to SKILL-201 and need no review.

## Feature Flags

N/A

# How Has This Been Tested?

New and rewritten suites cover the three surviving incomplete paths and the legacy-record quarantine: `FileSystemReviewEvidenceBrokerBudgetTest`, `ParallelCodeReviewEvidenceBoundaryTest`, `ReviewAccountingDurableRedactionTest`, `ReviewContextModelsTest`, and `ReviewLaneBundleAssemblyTest`. Tests that pinned the removed projection were rewritten against the new rule rather than weakened.

Full validator suite passes:

1. `skill-bill validate` — pass, zero issues.
2. `(cd runtime-kotlin && ./gradlew check)` — pass, 173 tasks.
3. `npx --yes agnix --strict .` — 0 errors (6 pre-existing warnings in files this branch does not touch).
4. `scripts/validate_agent_configs` — pass across 126 skills and 9 packs.

To reproduce the original defect and confirm the fix, run a delegated review over the recorded reproduction range and check the coverage line:

1. `git checkout feat/SKILL-201-review-lane-coverage-verdict-from-real-enforcement`
2. Run `bill-code-review mode:delegated` over `a1afecd5f..feat/SKILL-190-one-commit-per-subtask`.
3. Expect `Coverage: clean`, the same finding set as review `rvw-20260820-052146-53de`, and no lane naming a file its worker received. Before this branch, two `kmp` lanes reported `NOT clean` over 20 files they had read.

Do not raise `max_lane_evidence_bytes` in `.skill-bill/config.yaml` while testing. That masks the defect and removes the reproduction.
