### PR TITLE
SKILL-211: prose-centric-preplan-phase-io

### DIFF
--- a/.feature-specs/done/SKILL-211-prose-centric-preplan-phase-io/decomposition-manifest.yaml
+++ b/.feature-specs/done/SKILL-211-prose-centric-preplan-phase-io/decomposition-manifest.yaml
@@ -1,0 +1,27 @@
+---
+contract_version: "0.5"
+issue_key: "SKILL-211"
+feature_name: "prose-centric-preplan-phase-io"
+parent_spec_path: ".feature-specs/SKILL-211-prose-centric-preplan-phase-io/spec.md"
+status: "complete"
+execution_model: "same_branch_commit_per_subtask"
+base_branch: "main"
+feature_branch: "feat/SKILL-211-prose-centric-preplan-phase-io"
+stack_branches: []
+current_subtask_intent:
+  subtask_id: 0
+  action: "complete"
+subtasks:
+- id: 1
+  name: "Replace preplanning digest with prose PhaseOutput"
+  spec_path: ".feature-specs/SKILL-211-prose-centric-preplan-phase-io/spec_subtask_1_replace-preplanning-digest-with-prose-phase-output.md"
+  status: "complete"
+  branch: null
+  commit_sha: null
+  workflow_id: "wftr-20260826-205014-jrbt"
+  blocked_reason: null
+  last_resumable_step: "commit_push"
+  linear_issue_id: null
+  finalizing_agent_id: null
+  participating_agent_ids: []
+  dependencies: []

--- a/.feature-specs/done/SKILL-211-prose-centric-preplan-phase-io/spec.md
+++ b/.feature-specs/done/SKILL-211-prose-centric-preplan-phase-io/spec.md
@@ -1,0 +1,110 @@
+# SKILL-211 — Prose-centric preplan phase I/O
+
+## Context
+
+Preplan is the first agent-launched phase of a goal run. It must emit a
+`preplanning_digest`: a closed JSON object with `projection_kind`, non-empty
+`affected_boundaries` / `risks` / `validation_strategy`, and a `rollout` object
+that is never a string. The producer gate and the plan launch seam both parse
+that digest with `additionalProperties: false`. A near-miss (nested wrapper,
+prose `rollout`, missing discriminator, payload that is not a JSON object) is
+rejected. The phase retries until a schema-valid digest appears, or the run
+blocks.
+
+That design fights how agents write. They reason in prose. They can *read*
+shapes; they do not emit them reliably. In this install, fifteen recent preplan
+attempts failed with `Goal planning 'preplan' payload is not a JSON object`
+(SKILL-208 and SKILL-13). Those were digest-generation failures, not missing
+planning thought.
+
+SKILL-207 already made this call for review: the authoritative result is a
+string; shape in the prompt is guidance, not a filter that deletes meaning.
+This skill does the same for the preplan → plan edge only.
+
+## Intended Outcome
+
+Preplan’s `produced_outputs` is a two-field prose payload:
+
+```kotlin
+data class PhaseOutput(
+  val value: String,
+  val prompt: String? = null,
+)
+```
+
+The outer phase envelope stays (`contract_version`, `phase_id`, `status`,
+`summary`, …). Plan reads `value`, then `prompt` if present, as prose. It does
+not schema-check digest fields. Recommended digest headings remain in the
+preplan prompt as guidance only.
+
+`PhaseOutput` lives next to SKILL-207’s `AgentPhaseOutput` in
+`skillbill.agent.model`. It is not `FeatureTaskRuntimePhaseOutput` (that name
+already means the persisted `{phaseId, attempt, payload}` record). `value` is
+this phase’s prose (same role as `AgentPhaseOutput.output`). `prompt` is
+optional instructions for the *next* phase, not SKILL-207’s inbound
+`requestedAction`.
+
+Later phases may reuse `PhaseOutput`. This skill wires preplan → plan only.
+Plan still emits a gated `executable_plan`.
+
+## Acceptance Criteria
+
+1. A `PhaseOutput` type exists with `value: String` and `prompt: String?` and
+   is the agent-authored shape of preplan `produced_outputs`.
+2. A completed preplan whose `produced_outputs` is only a non-blank `value`
+   advances to plan; the plan briefing contains that string.
+3. Extra keys on preplan `produced_outputs` (legacy digest fields, runtime
+   sidecar) are ignored, not rejected; the producer gate does not re-enter
+   preplan for missing `projection_kind` or a malformed `rollout`.
+4. Blank or missing `value` on `status: completed` is missing content: preplan
+   retries or blocks; plan does not launch on an empty handoff.
+5. When `prompt` is present, the plan briefing includes it; when absent, plan
+   still launches from `value` alone.
+6. `producedProjectionKindFor("preplan")` is null. Plan no longer consumes
+   `feature_task_runtime.preplanning_digest`. The `regenerate_preplan` consumer
+   edge from plan is gone. Preplan still retries its own envelope and
+   blank-`value` failures.
+7. Goal-planning `_goal_planning_shared_context` remains a runtime-owned extra
+   key the agent never emits, and still round-trips after a prose `value`.
+8. Stale shared-preplan refresh no longer keys off `selected_boundary_headings`.
+   It compares `value` (and `prompt`) hashes. Plan still receives the boundary
+   catalog from the planning packet and does not get auto-resolved bodies from
+   a gated heading list.
+9. Preplan and plan phase prompts describe recommended prose, not a gated
+   digest JSON example. Plan is told to treat upstream as prose.
+10. In-flight `preplanning_digest` checkpoints loud-fail and regenerate in-band
+    after the planning-projections contract bump.
+11. Automated tests cover criteria 2–5 and 7. Preplan producer-gate tests that
+    only asserted digest-schema rejection are deleted or rewritten.
+
+## Constraints
+
+- Keep the outer envelope. Do not treat the agent’s entire stdout as
+  `PhaseOutput`.
+- Do not name the new type `FeatureTaskRuntimePhaseOutput`.
+- Do not schema-check recommended digest fields (`affected_boundaries`,
+  `rollout` object shape, `selected_boundary_headings`, `projection_kind`).
+- Preserve loud-fail for envelope failures, blank `value`, agent process
+  failure, and missing manifests or contract-version drift.
+- Do not require a second LLM format-repair pass.
+- Plan’s `executable_plan` producer gate stays.
+
+## Non-Goals
+
+- Moving plan, implement, audit, validate, or commit onto `PhaseOutput`.
+- Unifying `PhaseOutput.value` and `AgentPhaseOutput.output` field names.
+- Changing review (already on `AgentPhaseOutput`).
+- Remote telemetry breakdowns for digest failures.
+- Restoring structured heading-body injection from preplan into plan.
+
+## Decomposition Rationale
+
+One subtask. Schema, producer gate, plan briefing, goal-sweep sidecar/refresh,
+and prompts are one handoff change. Splitting “add the type” from “read the
+type” would leave a commit that nothing consumes.
+
+## Next Path
+
+Adopt `PhaseOutput` on the next feature-task edge that still loses meaning to
+a shape gate, likely plan → implement, without weakening `executable_plan`
+until that skill lands.

--- a/.feature-specs/done/SKILL-211-prose-centric-preplan-phase-io/spec_subtask_1_replace-preplanning-digest-with-prose-phase-output.md
+++ b/.feature-specs/done/SKILL-211-prose-centric-preplan-phase-io/spec_subtask_1_replace-preplanning-digest-with-prose-phase-output.md
@@ -1,0 +1,69 @@
+# SKILL-211 subtask 1 — Replace preplanning digest with prose PhaseOutput
+
+## Scope
+
+Wire preplan → plan to `PhaseOutput` (`value`, optional `prompt`) on
+`produced_outputs`. Keep the outer envelope. Drop the digest schema gate on
+this edge. Adjust goal-sweep sidecar, heading refresh, and phase prompts so
+they match the new handoff.
+
+In scope:
+
+- `skillbill.agent.model.PhaseOutput`
+- Preplan `allOf` on the phase-output schema: required `value`, optional
+  `prompt`, extra keys allowed
+- Remove `preplanning_digest` from the planning-projections `oneOf` and bump
+  that contract version
+- `producedProjectionKindFor(preplan)` returns null; plan projection matrix
+  delivers prose instead of `preplanningDigestDeclaration`
+- Remove the plan → preplan `regenerate_preplan` consumer edge
+- Keep `_goal_planning_shared_context` as a runtime-owned extra key
+- Replace heading-set refresh with `value`/`prompt` hash comparison; stop
+  resolving plan bodies from `selected_boundary_headings`
+- Preplan/plan prompt directives and shape examples
+- The five boundary tests in the parent spec; delete digest-rejection
+  siblings that no longer name a real bug
+
+## Acceptance Criteria
+
+1. `PhaseOutput` exists with `value: String` and `prompt: String?` and is the
+   agent-authored shape of preplan `produced_outputs`.
+2. A completed preplan whose `produced_outputs` is only `{ "value": "…" }`
+   advances to plan; the plan briefing contains that string.
+3. Leftover digest keys plus `value` still complete; the producer gate does
+   not re-enter preplan for digest-schema violations.
+4. Blank or missing `value` on `status: completed` retries or blocks preplan.
+5. Optional `prompt` appears in the plan briefing when present and is omitted
+   cleanly when absent.
+6. Goal sweep still round-trips `_goal_planning_shared_context` after a prose
+   `value`.
+7. `producedProjectionKindFor("preplan")` is null; plan does not parse
+   `feature_task_runtime.preplanning_digest`; the `regenerate_preplan` consumer
+   edge from plan is gone.
+8. Stale shared-preplan refresh compares `value`/`prompt` hashes, not
+   `selected_boundary_headings`.
+9. Preplan and plan prompts recommend prose and do not require a gated digest
+   JSON example.
+
+## Non-Goals
+
+- Rewiring plan’s `executable_plan` or any later phase onto `PhaseOutput`.
+- Renaming `AgentPhaseOutput.output`.
+- Auto-resolving boundary heading bodies from preplan prose.
+- Telemetry proxy stats for this edge.
+
+## Dependency Notes
+
+- Depends on: none (only subtask).
+- Unblocks: later skills that reuse `PhaseOutput` on other edges.
+
+## Validation Strategy
+
+- The five parent-spec boundary tests (criteria 2–5 and 7 / sidecar round-trip).
+- Compile the affected runtime modules. Do not use a full repo-root `check` as
+  the acceptance bar for this subtask.
+
+## Next Path
+
+Parent next path: the next shape-gated feature-task edge, starting with plan
+→ implement when that skill is filed.

--- a/orchestration/contracts/feature-task-runtime-phase-output-schema.yaml
+++ b/orchestration/contracts/feature-task-runtime-phase-output-schema.yaml
@@ -528,3 +528,22 @@ allOf:
           required: [repair_receipt]
           properties:
             repair_receipt: { $ref: "#/$defs/repairReceipt" }
+  - if:
+      properties:
+        phase_id: { const: preplan }
+        status: { const: completed }
+      required: [phase_id, status]
+    then:
+      properties:
+        produced_outputs:
+          type: object
+          required: [value]
+          properties:
+            value:
+              type: string
+              minLength: 1
+              pattern: ".*\\S.*"
+            prompt:
+              type: string
+              minLength: 1
+              pattern: ".*\\S.*"

--- a/orchestration/contracts/feature-task-runtime-planning-projections-schema.yaml
+++ b/orchestration/contracts/feature-task-runtime-planning-projections-schema.yaml
@@ -1,9 +1,8 @@
 # Feature-task-runtime planning-projections schema (canonical source of truth).
 #
-# This file describes the four concrete, bounded projections that replace the coarse whole-receipt
-# projection for the preplan->plan, plan->implement, and plan+implement->audit handoff edges:
+# This file describes the three concrete, bounded projections that replace the coarse whole-receipt
+# projection for the plan->implement and plan+implement->audit handoff edges:
 #
-# - preplanning_digest   : what `plan` receives from `preplan` (AC-003)
 # - executable_plan      : what `implement` receives from `plan` (AC-005)
 # - plan_commitment      : the bounded task/criterion obligation `audit` receives from `plan` (AC-011)
 # - implementation_receipt: the bounded producer claim `audit` receives from `implement` (AC-008/009)
@@ -39,10 +38,9 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 $id: "https://skill-bill.dev/contracts/feature-task-runtime-planning-projections-schema.yaml"
 title: "Feature-task-runtime planning projections"
-description: "Strict oneOf over the four concrete bounded projections for the planning/implementation/audit edges."
+description: "Strict oneOf over the three concrete bounded projections for the plan/implement/audit edges."
 type: object
 oneOf:
-  - $ref: "#/$defs/preplanning_digest"
   - $ref: "#/$defs/executable_plan"
   - $ref: "#/$defs/plan_commitment"
   - $ref: "#/$defs/implementation_receipt"
@@ -51,7 +49,7 @@ x-coherence-checks:
   - id: discriminator-uniqueness
     description: >-
       Each variant carries a unique projection_kind. The Kotlin ProjectionKind enum mirrors these
-      four values; an unknown or missing kind is a malformed-projection rejection.
+      three values; an unknown or missing kind is a malformed-projection rejection.
   - id: decomposition-data-only-under-decompose
     description: >-
       decomposition_* fields are accepted only when executable_plan.mode is "decompose". A DIRECT
@@ -68,8 +66,7 @@ x-coherence-checks:
     description: >-
       Every `maxItems` here equals the matching Kotlin cap
       (FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT, FEATURE_TASK_RUNTIME_CHANGED_PATH_MAX_COUNT
-      for changed_paths and working_tree_owned_paths, or
-      FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT for selected_boundary_headings), and
+      for changed_paths and working_tree_owned_paths), and
       FeatureTaskRuntimeHandoffProjectionBudget.PLANNING_PROJECTION sums the widest variant's caps.
       A schema-valid projection therefore cannot overflow the item budget it is delivered under.
   - id: tests-executed-distinct
@@ -158,50 +155,6 @@ $defs:
         type: array
         maxItems: 512
         items: { $ref: "#/$defs/repoPath" }
-
-  preplanning_digest:
-    type: object
-    additionalProperties: false
-    required:
-      - projection_kind
-      - contract_version
-      - affected_boundaries
-      - risks
-      - rollout
-      - validation_strategy
-    properties:
-      projection_kind: { const: "preplanning_digest" }
-      contract_version: { $ref: "#/$defs/contractVersion" }
-      affected_boundaries: { $ref: "#/$defs/nonEmptyStrings" }
-      patterns_and_decisions: { $ref: "#/$defs/strings" }
-      risks: { $ref: "#/$defs/nonEmptyStrings" }
-      rollout:
-        type: object
-        additionalProperties: false
-        required: [flag_required, notes]
-        properties:
-          flag_required: { type: boolean }
-          flag_pattern:
-            type: string
-            enum: [none, simple_conditional, di_switch, legacy]
-          notes: { $ref: "#/$defs/nonBlank" }
-      validation_strategy: { $ref: "#/$defs/nonEmptyStrings" }
-      unresolved_questions: { $ref: "#/$defs/strings" }
-      evidence_refs: { $ref: "#/$defs/strings" }
-      # SKILL-174 heading-selection channel: the boundary-memory heading ids the preplan agent judged
-      # relevant, resolved to bodies for the plan phase only. contract_version stays "0.1" because the
-      # field is additive and optional. The accepted cost: preplanning_digest is
-      # additionalProperties:false, so rolling the runtime back across this change quarantines
-      # in-flight digests as carrying an unknown key. Downgrade is not supported here.
-      # maxItems equals FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT (list-cap-budget-agreement).
-      selected_boundary_headings:
-        type: array
-        maxItems: 64
-        items: { $ref: "#/$defs/nonBlank" }
-      # Governed co-resident of the goal-planning sweep's preplan produced_outputs, owned by
-      # goal-planning-preparation-schema.yaml. Named here only so additionalProperties:false does not
-      # reject an output that seam requires; it is not part of the digest this variant delivers.
-      _goal_planning_shared_context: { type: object }
 
   executable_plan:
     type: object

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseProjectionShapes.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseProjectionShapes.kt
@@ -35,25 +35,19 @@ internal object FeatureTaskRuntimePhaseProjectionShapes {
     else -> ""
   }
 
-  private val PREPLAN: String =
-    "\n    - Required produced_outputs shape: emit these fields DIRECTLY on produced_outputs — do NOT\n" +
-      "      nest them under a \"preplanning_digest\" key — and \"rollout\" is an OBJECT, never a string:\n" +
+  private const val PREPLAN: String =
+    "\n    - Required produced_outputs shape: emit a non-blank value string carrying your planning prose.\n" +
+      "      Optional prompt may add a short directive when non-blank. Extra keys are allowed.\n" +
       "      ```json\n" +
-      "      { \"projection_kind\": \"preplanning_digest\",\n" +
-      "        \"contract_version\": \"$FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION\",\n" +
-      "        \"affected_boundaries\": [\"<module or boundary touched>\"], \"patterns_and_decisions\": [],\n" +
-      "        \"risks\": [\"<concrete risk>\"],\n" +
-      "        \"rollout\": { \"flag_required\": false, \"flag_pattern\": \"none\",\n" +
-      "          \"notes\": \"<rollout note, or N/A>\" },\n" +
-      "        \"validation_strategy\": [\"<how the change is validated>\"],\n" +
-      "        \"unresolved_questions\": [], \"evidence_refs\": [],\n" +
-      "        \"selected_boundary_headings\": [\"<heading_id copied verbatim from the boundary catalog>\"] }\n" +
+      "      { \"value\": \"<dense planning prose for the plan phase>\",\n" +
+      "        \"prompt\": \"<optional short directive>\" }\n" +
       "      ```\n" +
-      "      flag_pattern is one of none, simple_conditional, di_switch, legacy. Optional arrays may be\n" +
-      "      omitted or []; every listed string must be non-empty."
+      "      Walk boundary_memory headings for relevance; weave context into value rather than listing " +
+      "selected_boundary_headings."
 
   private val PLAN: String =
-    "\n    - Required produced_outputs shape: emit these fields DIRECTLY on produced_outputs. Every\n" +
+    "\n    - Upstream preplan is prose (value, optional prompt), not a bounded digest. Required " +
+      "produced_outputs shape: emit these fields DIRECTLY on produced_outputs. Every\n" +
       "      task_id MUST match ^[a-z][a-z0-9-]*\$ (lowercase kebab; \"T1\" is REJECTED — use \"task-1\") and\n" +
       "      criterion_refs use the AC-### form:\n" +
       "      ```json\n" +

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptDirectives.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhasePromptDirectives.kt
@@ -344,16 +344,14 @@ internal fun goalContinuationDirective(phaseId: String, suppressDecomposition: B
 // Validate Task-line specialization lives in FeatureTaskRuntimePhasePromptValidateDirectives.
 internal val phaseDirectives: Map<String, String> = mapOf(
   FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN to
-    "Produce the scaled pre-planning digest for the resolved feature size. Do not modify " +
-    "repository files during this phase. Emit a schema-valid produced_outputs object carrying the " +
-    "bounded digest for the downstream plan phase: projection_kind \"preplanning_digest\", " +
-    "contract_version \"$FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION\", and the " +
-    "declared digest fields (affected_boundaries, patterns_and_decisions, risks, rollout, " +
-    "validation_strategy, unresolved_questions, evidence_refs). Do not forward the complete " +
-    "preplan envelope, a generic summary, or progress diagnostics.",
+    "Produce the scaled pre-planning prose for the resolved feature size. Do not modify " +
+    "repository files during this phase. Emit produced_outputs with a non-blank value string " +
+    "carrying your planning prose for the downstream plan phase; optional prompt may add a short " +
+    "directive when non-blank. Do not forward the complete preplan envelope, a generic summary, " +
+    "or progress diagnostics.",
   FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN to
     "Produce an ordered implementation plan that satisfies every acceptance criterion, using " +
-    "the upstream preplan digest as planning context. Do not modify repository files during " +
+    "the upstream preplan prose as planning context. Do not modify repository files during " +
     "this phase. Emit a schema-valid produced_outputs object carrying the bounded executable plan: " +
     "projection_kind \"executable_plan\", contract_version " +
     "\"$FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION\", mode (direct or decompose), " +

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/GoalPlanningPreparationValidator.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/GoalPlanningPreparationValidator.kt
@@ -30,7 +30,6 @@ class GoalPlanningPreparationValidator(
     failure?.let { throw InvalidGoalPlanningPreparationSchemaError(sourceLabel = label, fieldPath = "", reason = it) }
     requireCompleted(preplan, PREPLAN_PHASE_ID, label)
     requireCompleted(plan, PLAN_PHASE_ID, label)
-    requireValidProjection(preplan, PREPLAN_PHASE_ID, label)
     requireValidProjection(plan, PLAN_PHASE_ID, label)
     return record.copy(
       preplanPayload = skillbill.contracts.JsonSupport.mapToJsonString(preplan),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/agent/history.md
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/agent/history.md
@@ -1,5 +1,14 @@
 # featuretask runtime boundary history
 
+## [2026-08-27] SKILL-211 — Prose-centric preplan phase I/O
+Areas: runtime-application/{featuretask,goalrunner,workflow}, runtime-domain/{agent/model,workflow/taskruntime}, runtime-infra-fs/contracts/workflow, orchestration/contracts
+- Preplan `produced_outputs` is now prose `PhaseOutput` (`value`, optional `prompt`); the planning-projections digest schema gate and `regenerate_preplan` consumer edge are gone.
+- Plan briefings carry `value`/`prompt` text; goal-sweep `_goal_planning_shared_context` still round-trips; stale shared-preplan refresh hashes prose fields instead of selected headings.
+- Pattern: first planning edge uses an ungated prose handoff while later phases keep bounded projection contracts. reusable
+- Limitation: plan `executable_plan` and later edges are unchanged; heading bodies are not auto-resolved from preplan prose.
+Feature flag: N/A
+Acceptance criteria: 9/9 implemented
+
 ## [2026-08-27] Validate repair uses project-wide spotlessApply
 Areas: runtime-application/featuretask
 - Validate Task and findings preamble tell the agent to run `./gradlew spotlessApply` once at the Gradle root for format findings, never `:module:spotlessApply`.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningContextPromptFormatter.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningContextPromptFormatter.kt
@@ -61,9 +61,9 @@ internal object GoalPlanningContextPromptFormatter {
     } else {
       append(
         "\nboundary_memory is a heading catalog: heading text and stable heading_id only, no entry bodies. " +
-          "Walk the headings, stop once they are no longer relevant to this goal's scope, and return the " +
-          "heading_id values you judge relevant in produced_outputs.selected_boundary_headings. Only those " +
-          "entries' bodies will be delivered to the plan phase.",
+          "Walk the headings, stop once they are no longer relevant to this goal's scope, and weave the " +
+          "relevant context into produced_outputs.value as prose for the plan phase. Recommended headings " +
+          "may guide your prose; selected_boundary_headings is not required.",
       )
     }
   }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningSweep.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/GoalPlanningSweep.kt
@@ -32,7 +32,6 @@ import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
 import skillbill.ports.agentrun.model.AgentRunOutputStream
 import skillbill.ports.agentrun.model.SkillRunRequest
 import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch
-import skillbill.ports.goalrunner.GoalPlanningBoundaryBodyResolver
 import skillbill.ports.goalrunner.GoalPlanningContextDiscovery
 import skillbill.ports.goalrunner.GoalRunnerManifestStore
 import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
@@ -112,7 +111,6 @@ class DefaultGoalPlanningSweep(
   private val planningRejectionRecorder: GoalPlanningRejectionRecorder = GoalPlanningRejectionRecorder.NONE,
   private val timingPort: RuntimeTimingPort = NoopRuntimeTimingPort,
   private val burstSchedule: GoalPlanningBurstSchedule = GoalPlanningBurstSchedule(),
-  private val boundaryBodyResolver: GoalPlanningBoundaryBodyResolver,
   private val refreshLiveness: GoalPlanningRefreshLiveness = GoalPlanningRefreshLiveness.IDLE,
 ) : GoalPlanningSweep {
   @Suppress("ReturnCount")
@@ -193,12 +191,7 @@ class DefaultGoalPlanningSweep(
         )
       }
     val subtasksById = activeSubtasks.associateBy(DecompositionSubtask::id)
-    // The preplan payload is immutable for this prepare(), so every subtask's plan prompt resolves
-    // the same bodies. Resolving inside producePlan re-read and re-parsed every referenced boundary
-    // file once per subtask for a provably identical result.
-    val resolvedBodies = resolvedBoundaryBodies(shared, sharedCheckpoint.preplanPayload)
-    // Pace only between consecutive plan launches in this prepare() call — never before the first
-    // (including the first plan after resume) and never after the last.
+    val resolvedBodies = GoalPlanningResolvedBoundaryBodies()
     var plansLaunchedThisPrepare = 0
     while (true) {
       val recovery = runCatching {
@@ -415,9 +408,11 @@ class DefaultGoalPlanningSweep(
     val refreshShared = shared.copy(planningPacket = freshPlanningPacket(shared, state))
     val produced = produceSharedPreplanCheckpoint(refreshShared, request, currentProvenance)
       .getOrElse { throw it }
-    val savedHeadings = selectedBoundaryHeadingIds(existing.preplanPayload).toSet()
-    val newHeadings = selectedBoundaryHeadingIds(produced.preplanPayload).toSet()
-    if (savedHeadings == newHeadings) {
+    val savedValueHash = preplanProseValueHash(existing.preplanPayload)
+    val newValueHash = preplanProseValueHash(produced.preplanPayload)
+    val savedPromptHash = preplanProsePromptHash(existing.preplanPayload)
+    val newPromptHash = preplanProsePromptHash(produced.preplanPayload)
+    if (savedValueHash == newValueHash && savedPromptHash == newPromptHash) {
       checkpoint.sharedPreplanRefresh.advanceSharedPreplanProvenance(
         identity = existing.identity,
         expectedPayloadSha256 = existing.payloadSha256,
@@ -1127,26 +1122,6 @@ class DefaultGoalPlanningSweep(
     )
   }
 
-  /**
-   * Reads the heading ids the settled preplan selected and resolves exactly those bodies. A missing,
-   * legacy, or malformed selection degrades to catalog-only rather than falling back to a full-file
-   * dump. Resolution failures are not caught here: the resolver already reports unreadable files as
-   * unresolved ids, so anything that escapes it is a contract or wiring fault that must surface
-   * instead of being laundered into a silently body-less plan phase on every resume.
-   */
-  private fun resolvedBoundaryBodies(
-    shared: GoalPlanningSharedContext,
-    preplanPayload: String,
-  ): GoalPlanningResolvedBoundaryBodies {
-    val selected = selectedBoundaryHeadingIds(preplanPayload)
-    if (selected.isEmpty()) return GoalPlanningResolvedBoundaryBodies()
-    return boundaryBodyResolver.resolve(
-      shared.repoRoot,
-      selected,
-      GoalPlanningSharedContextPacket.catalogHeadingIds(shared.planningPacket),
-    )
-  }
-
   private fun gatherSharedContext(
     state: GoalRunnerManifestState,
     request: GoalRunnerRunRequest,
@@ -1470,17 +1445,32 @@ internal fun classifyGoalPlanningProvenanceRecoverability(
   }
 }
 
-internal fun selectedBoundaryHeadingIds(preplanPayload: String): List<String> = runCatching {
+internal fun preplanProseValue(preplanPayload: String): String = runCatching {
   JsonSupport.parseObjectOrNull(preplanPayload)
     ?.let(JsonSupport::jsonElementToValue)
     ?.let(JsonSupport::anyToStringAnyMap)
     ?.get("produced_outputs")
     ?.let(JsonSupport::anyToStringAnyMap)
-    ?.get(SELECTED_BOUNDARY_HEADINGS_FIELD)
-    ?.let { value -> (value as? List<*>)?.mapNotNull { id -> (id as? String)?.takeIf(String::isNotBlank) } }
-}.getOrNull().orEmpty()
+    ?.get("value")
+    ?.toString()
+    .orEmpty()
+}.getOrDefault("")
 
-private const val SELECTED_BOUNDARY_HEADINGS_FIELD: String = "selected_boundary_headings"
+internal fun preplanProsePrompt(preplanPayload: String): String? = runCatching {
+  JsonSupport.parseObjectOrNull(preplanPayload)
+    ?.let(JsonSupport::jsonElementToValue)
+    ?.let(JsonSupport::anyToStringAnyMap)
+    ?.get("produced_outputs")
+    ?.let(JsonSupport::anyToStringAnyMap)
+    ?.get("prompt")
+    ?.toString()
+    ?.takeIf(String::isNotBlank)
+}.getOrNull()
+
+internal fun preplanProseValueHash(preplanPayload: String): String = sha256HexUtf8(preplanProseValue(preplanPayload))
+
+internal fun preplanProsePromptHash(preplanPayload: String): String =
+  sha256HexUtf8(preplanProsePrompt(preplanPayload).orEmpty())
 
 /**
  * Durable evidence seam for a planning attempt the run rejected without any output to gate. Kept

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/GoalPlanningPreparationCheckpoint.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/GoalPlanningPreparationCheckpoint.kt
@@ -297,7 +297,6 @@ internal class GoalPlanningPreparationProjectionGate(
   fun validateSharedPreplan(checkpoint: SharedGoalPreplanCheckpoint) {
     val (label, envelope) = sharedPreplanEnvelope(checkpoint)
     envelope.requirePrepared(label)
-    requireValidPlanningProjection(envelope, "preplan", label, planningProjectionValidator)
   }
 
   fun validateSubtaskPlan(checkpoint: GoalSubtaskPlanCheckpoint) {
@@ -315,8 +314,8 @@ internal class GoalPlanningPreparationProjectionGate(
    * block every existing goal on the first contract bump with no path that can repair the record.
    */
   fun sharedPreplanRejection(checkpoint: SharedGoalPreplanCheckpoint): String? = planningRecordRejection {
-    val (_, envelope) = sharedPreplanEnvelope(checkpoint)
-    producerProjectionGateReason("preplan", envelope, planningProjectionValidator)
+    sharedPreplanEnvelope(checkpoint)
+    null
   }
 
   /** Null when the stored subtask plan satisfies the projection gate; the bounded reason otherwise. */

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeHandoffProjectionTestSupport.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeHandoffProjectionTestSupport.kt
@@ -38,11 +38,7 @@ internal val FINALIZATION_PHASE_IDS: Set<String> = setOf("write_history", "commi
  */
 internal object PlanningProjectionFixtures {
   const val PREPLAN_DIGEST: String =
-    """{"projection_kind":"preplanning_digest","contract_version":"0.1",""" +
-      """"affected_boundaries":["runtime-application"],""" +
-      """"risks":["Fixture risk."],""" +
-      """"rollout":{"flag_required":false,"flag_pattern":"none","notes":"No flag needed."},""" +
-      """"validation_strategy":["Focused runtime tests."]}"""
+    """{"value":"Fixture preplan prose for downstream plan."}"""
 
   const val EXECUTABLE_PLAN: String =
     """{"projection_kind":"executable_plan","contract_version":"0.1","mode":"direct","tasks":[{"task_id":"task-1",""" +

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeLeastContextEndToEndTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeLeastContextEndToEndTest.kt
@@ -107,10 +107,20 @@ class FeatureTaskRuntimeLeastContextEndToEndTest {
         actual.projectionContractId to actual.projectionContractVersion,
         "${actual.projectionName} changed contract identity",
       )
-      assertEquals(
-        declaredProjection.declaredFieldNames,
-        actual.fields.map { it.name },
-        "${actual.projectionName} changed its required-field shape",
+      val deliveredNames = actual.fields.map { it.name }
+      assertTrue(
+        deliveredNames.all { it in declaredProjection.declaredFieldNames },
+        "${actual.projectionName} delivered undeclared fields: " +
+          "${deliveredNames - declaredProjection.declaredFieldNames.toSet()}",
+      )
+      val requiredNames = declaredProjection.declaredFieldNames.filterNot { name ->
+        declaredProjection.projectionContractId ==
+          FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PREPLAN_PROSE &&
+          name == "directive"
+      }
+      assertTrue(
+        requiredNames.all { it in deliveredNames },
+        "${actual.projectionName} missing required fields: ${requiredNames - deliveredNames.toSet()}",
       )
     }
     assertEquals(declaration.derivedContextKeys, briefing.derivedContextKeys)

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhaseOutputFixtures.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhaseOutputFixtures.kt
@@ -167,16 +167,10 @@ internal fun validProducedOutputs(phaseId: String, commitPushChangedPaths: List<
       commitSha = null,
       changedPaths = commitPushChangedPaths ?: listOf("src/Foo.kt"),
     )
-    // preplan and plan feed the bounded planning projections on the preplan->plan and plan->implement
-    // (and plan->audit commitment) edges, so their fixture payloads carry the declared projection shape.
+    // preplan owns PhaseOutput prose; plan and implement feed bounded planning projections.
     "preplan" ->
       """{
-      "projection_kind":"preplanning_digest",
-      "contract_version":"0.1",
-      "affected_boundaries":["runtime-application"],
-      "risks":["Fixture risk."],
-      "rollout":{"flag_required":false,"flag_pattern":"none","notes":"No flag needed."},
-      "validation_strategy":["Focused runtime tests."]
+      "value":"Fixture preplan prose for downstream plan."
     }
       """.trimIndent()
     "plan" ->
@@ -245,11 +239,12 @@ internal data class PhaseOutputFixture(
   val producedOutputs: String,
 )
 
-// The producing phases own a bounded planning projection, so their produced_outputs must validate
+// plan and implement own a bounded planning projection, so their produced_outputs must validate
 // against the canonical planning-projections schema. `implement_fix` re-enters the implement phase and
-// reuses the same implementation_receipt projection, so it is validated too.
+// reuses the same implementation_receipt projection, so it is validated too. preplan owns PhaseOutput
+// prose (`value` / optional `prompt`) and no longer feeds a planning-projection edge.
 internal val PLANNING_PROJECTION_FIXTURES: List<PhaseOutputFixture> =
-  listOf("preplan", "plan", "implement").map { phaseId ->
+  listOf("plan", "implement").map { phaseId ->
     PhaseOutputFixture(
       id = "validProducedOutputs:$phaseId",
       phaseId = phaseId,
@@ -259,10 +254,11 @@ internal val PLANNING_PROJECTION_FIXTURES: List<PhaseOutputFixture> =
 
 // Explicit, named exemptions (AC-002): these phases carry no planning-projection obligation, so their
 // produced_outputs are not validated against the planning-projections schema.
+// - preplan: agent-authored PhaseOutput prose; producedProjectionKindFor("preplan") is null.
 // - review / audit: emit verification signals (findings / gaps), not a bounded projection.
 // - commit_push: emits a commit_push_result, owned by the phase-output contract, not this schema.
 internal val PLANNING_PROJECTION_EXEMPT_PHASES: Set<String> =
-  setOf("review", "audit", "verify_findings", "implement_fix", "commit_push")
+  setOf("preplan", "review", "audit", "verify_findings", "implement_fix", "commit_push")
 
 /**
  * SKILL-187 subtask 3: synthetic audit envelopes for repair-context conformance. Sentinels only —

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhasePromptComposerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePhasePromptComposerTest.kt
@@ -59,9 +59,9 @@ class FeatureTaskRuntimePhasePromptComposerTest {
       briefingFor(FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN),
     )
 
-    assertContains(prompt, "projection_kind \"preplanning_digest\"")
-    assertContains(prompt, "emit these fields DIRECTLY on produced_outputs", false, "preplan warns against nesting")
-    assertContains(prompt, "\"rollout\": { \"flag_required\": false", false, "preplan shows rollout as an object")
+    assertContains(prompt, "non-blank value")
+    assertContains(prompt, "produced_outputs", false, "preplan warns about produced_outputs shape")
+    assertFalse(prompt.contains("projection_kind \"preplanning_digest\""))
     assertFalse(prompt.contains("bill-code-review mode:"), "review execution mode must not reach preplan")
     assertFalse(prompt.contains("Review execution mode"), "review execution directive must not reach preplan")
     assertFalse(
@@ -73,21 +73,16 @@ class FeatureTaskRuntimePhasePromptComposerTest {
   }
 
   @Test
-  fun `preplan shape example itself declares selected_boundary_headings`() {
+  fun `preplan shape example declares value prose`() {
     val prompt = FeatureTaskRuntimePhasePromptComposer.compose(
       ISSUE_KEY,
       briefingFor(FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN),
     )
 
-    val shapeExample = prompt.substringAfter("emit these fields DIRECTLY on produced_outputs")
+    val shapeExample = prompt.substringAfter("Required produced_outputs shape")
       .substringAfter("```json")
       .substringBefore("```")
-    assertContains(
-      shapeExample,
-      "\"selected_boundary_headings\": [",
-      false,
-      "the copyable shape example must name selected_boundary_headings, not only trailing prose",
-    )
+    assertContains(shapeExample, "\"value\":", false, "the copyable shape example must name value prose")
   }
 
   @Test
@@ -546,12 +541,12 @@ class FeatureTaskRuntimePhasePromptComposerTest {
     val commitPrompt = FeatureTaskRuntimePhasePromptComposer.compose(ISSUE_KEY, briefingFor("commit_push"))
     val prPrompt = FeatureTaskRuntimePhasePromptComposer.compose(ISSUE_KEY, briefingFor("pr"))
 
-    assertContains(preplanPrompt, "scaled pre-planning digest")
+    assertContains(preplanPrompt, "scaled pre-planning prose")
     assertContains(preplanPrompt, "full preplan covering boundaries")
     assertContains(preplanPrompt, "Do not modify repository files during this phase.")
-    assertContains(preplanPrompt, "schema-valid produced_outputs")
+    assertContains(preplanPrompt, "non-blank value")
     assertContains(planPrompt, "Do not modify repository files during this phase.")
-    assertContains(planPrompt, "upstream preplan digest")
+    assertContains(planPrompt, "upstream preplan prose")
     assertContains(implementPrompt, "Reconcile the repository to the intended state")
     assertTrue(
       !implementPrompt.contains("Do not modify repository files during this phase."),
@@ -1263,13 +1258,6 @@ class FeatureTaskRuntimePhasePromptComposerTest {
       "implementation_receipt.unresolved_items" to
         "Must be [] on a 'completed' receipt: the completion gate refuses a receipt that claims completion " +
         "while carrying open work, so a populated example would teach output the gate rejects.",
-      "preplanning_digest.patterns_and_decisions" to
-        "Optional narrative list with no element shape to pin: items are plain strings like the populated " +
-        "`risks` and `validation_strategy` siblings in the same example.",
-      "preplanning_digest.unresolved_questions" to
-        "Optional plain-string list, shape already pinned by the populated `risks` sibling.",
-      "preplanning_digest.evidence_refs" to
-        "Optional plain-string list, shape already pinned by the populated `risks` sibling.",
       "implementation_receipt.deferred_repair_item_ids" to
         "Deferring a carried repair item is the exception, so [] is the correct default to show; the id " +
         "strings are pinned by the populated repair_item_results[].repair_item_id in the same example.",
@@ -1622,7 +1610,6 @@ private fun isArrayNode(defs: JsonNode, node: JsonNode): Boolean {
 }
 
 private fun projectionExampleCases() = listOf(
-  Triple(preplanPhase, FeatureTaskRuntimeProjectionKind.PREPLANNING_DIGEST, briefingFor(preplanPhase)),
   Triple(planPhase, FeatureTaskRuntimeProjectionKind.EXECUTABLE_PLAN, briefingFor(planPhase)),
   Triple(implementPhase, receiptKind, briefingFor(implementPhase)),
   Triple(
@@ -1632,7 +1619,6 @@ private fun projectionExampleCases() = listOf(
   ),
 )
 
-private val preplanPhase = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN
 private val planPhase = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN
 private val implementPhase = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT
 private val receiptKind = FeatureTaskRuntimeProjectionKind.IMPLEMENTATION_RECEIPT

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePlanningProjectionEdgeTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePlanningProjectionEdgeTest.kt
@@ -28,17 +28,16 @@ import kotlin.test.assertTrue
 @Suppress("LargeClass") // one suite per producer/consumer projection edge; they share the payload fixtures
 class FeatureTaskRuntimePlanningProjectionEdgeTest {
   @Test
-  fun `plan receives only the bounded preplanning digest fields, never the complete preplan envelope`() {
+  fun `plan receives only preplan prose fields, never the complete preplan envelope`() {
     val briefing = assemble(
       consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN,
-      declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan)),
-      recordedOutputs = listOf(phaseOutput(phasePreplan, preplanDigestPayload(undeclaredFields = true))),
+      declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanProseDeclaration(phasePlan)),
+      recordedOutputs = listOf(phaseOutput(phasePreplan, preplanProsePayload(undeclaredFields = true))),
       runInvariants = runInvariants(),
     )
 
-    assertContains(briefing.briefingText, "affected_boundaries:")
-    assertContains(briefing.briefingText, "risks:")
-    assertContains(briefing.briefingText, "validation_strategy:")
+    assertContains(briefing.briefingText, "Dense preplan prose for downstream plan.")
+    assertContains(briefing.briefingText, "optional directive")
     assertFalse(
       briefing.briefingText.contains("complete_envelope_secret"),
       "complete preplan envelope must not survive projection",
@@ -47,6 +46,19 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
       briefing.briefingText.contains("progress_diagnostics"),
       "progress diagnostics must not survive projection",
     )
+  }
+
+  @Test
+  fun `value-only completed preplan reaches plan and omits absent prompt cleanly`() {
+    val briefing = assemble(
+      consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN,
+      declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanProseDeclaration(phasePlan)),
+      recordedOutputs = listOf(phaseOutput(phasePreplan, preplanProsePayload(includePrompt = false))),
+      runInvariants = runInvariants(),
+    )
+
+    assertContains(briefing.briefingText, "Dense preplan prose for downstream plan.")
+    assertFalse(briefing.briefingText.contains("optional directive"))
   }
 
   @Test
@@ -143,19 +155,15 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
 
   @Test
   fun `a free-form producer payload loud-fails rather than being forwarded as a coarse receipt`() {
-    var threw = false
-    try {
+    val error = assertFailsWith<skillbill.error.InvalidFeatureTaskRuntimeHandoffProjectionError> {
       assemble(
         consumer = phasePlan,
-        declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan)),
+        declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanProseDeclaration(phasePlan)),
         recordedOutputs = listOf(phaseOutput(phasePreplan, """{"free":"form","narration":"whole envelope"}""")),
         runInvariants = runInvariants(),
       )
-    } catch (error: skillbill.error.InvalidFeatureTaskRuntimePlanningProjectionSchemaError) {
-      threw = true
-      assertTrue(error.message!!.contains("planning projection"))
     }
-    assertTrue(threw, "a free-form payload under a planning contract must loud-fail")
+    assertContains(error.message.orEmpty(), "produced_outputs.value is required")
   }
 
   @Test
@@ -289,8 +297,8 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
   fun `a phase whose declarations require no checkpoint renders no checkpoint section`() {
     val briefing = assemble(
       consumer = phasePlan,
-      declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan)),
-      recordedOutputs = listOf(phaseOutput(phasePreplan, preplanDigestPayload())),
+      declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanProseDeclaration(phasePlan)),
+      recordedOutputs = listOf(phaseOutput(phasePreplan, preplanProsePayload())),
       runInvariants = runInvariants(),
     )
 
@@ -302,16 +310,16 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
     val validator = RecordingPlanningProjectionValidator()
 
     assemble(
-      consumer = phasePlan,
-      declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan)),
-      recordedOutputs = listOf(phaseOutput(phasePreplan, preplanDigestPayload())),
+      consumer = phaseImplement,
+      declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.executablePlanDeclaration(phaseImplement)),
+      recordedOutputs = listOf(phaseOutput(phasePlan, executablePlanPayload())),
       runInvariants = runInvariants(),
       planningProjectionValidator = validator,
     )
 
-    assertEquals(listOf("preplan#produced_outputs"), validator.sourceLabels)
+    assertEquals(listOf("plan#produced_outputs"), validator.sourceLabels)
     assertEquals(
-      "preplanning_digest",
+      "executable_plan",
       validator.payloads.single()["projection_kind"],
       "the gate must see the producer payload, not a re-serialized projection",
     )
@@ -321,9 +329,9 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
   fun `a schema rejection surfaces as the typed planning-projection error, not an opaque failure`() {
     val error = assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
       assemble(
-        consumer = phasePlan,
-        declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan)),
-        recordedOutputs = listOf(phaseOutput(phasePreplan, preplanDigestPayload())),
+        consumer = phaseImplement,
+        declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.executablePlanDeclaration(phaseImplement)),
+        recordedOutputs = listOf(phaseOutput(phasePlan, executablePlanPayload())),
         runInvariants = runInvariants(),
         planningProjectionValidator = RejectingPlanningProjectionValidator,
       )
@@ -331,7 +339,7 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
 
     assertContains(error.reason, "additionalProperties")
     assertEquals(
-      FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan).projectionName,
+      FeatureTaskRuntimePhaseWorkflowDefinition.executablePlanDeclaration(phaseImplement).projectionName,
       error.projectionName,
     )
   }
@@ -355,13 +363,13 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
 
   @Test
   fun `a projection payload on a different contract version is rejected rather than reinterpreted`() {
-    val legacy = preplanDigestPayload().replace(""""contract_version":"0.1"""", """"contract_version":"0.0"""")
+    val legacy = executablePlanPayload().replace(""""contract_version":"0.1"""", """"contract_version":"0.0"""")
 
     val error = assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
       assemble(
-        consumer = phasePlan,
-        declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan)),
-        recordedOutputs = listOf(phaseOutput(phasePreplan, legacy)),
+        consumer = phaseImplement,
+        declarations = listOf(FeatureTaskRuntimePhaseWorkflowDefinition.executablePlanDeclaration(phaseImplement)),
+        recordedOutputs = listOf(phaseOutput(phasePlan, legacy)),
         runInvariants = runInvariants(),
       )
     }
@@ -842,12 +850,6 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
   private val parityEdges: List<ParityEdge>
     get() = listOf(
       ParityEdge(
-        phasePreplan,
-        phasePlan,
-        FeatureTaskRuntimePhaseWorkflowDefinition.preplanningDigestDeclaration(phasePlan),
-        preplanDigestPayload(),
-      ),
-      ParityEdge(
         phasePlan,
         phaseImplement,
         FeatureTaskRuntimePhaseWorkflowDefinition.executablePlanDeclaration(phaseImplement),
@@ -916,23 +918,16 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
     mandatesAndOverrides = emptyList(),
   )
 
-  // The undeclared fields the projection must strip are the point of the leak tests, but the real
-  // preplanning_digest schema sets additionalProperties:false, so a payload carrying them cannot also
-  // stand in for an envelope the gate accepts. Parity fixtures take the clean form.
-  private fun preplanDigestPayload(undeclaredFields: Boolean = false): String {
+  private fun preplanProsePayload(undeclaredFields: Boolean = false, includePrompt: Boolean = true): String {
     val undeclared = if (undeclaredFields) {
       ""","complete_envelope_secret":"MUST NOT SURVIVE","progress_diagnostics":"MUST NOT SURVIVE""""
     } else {
       ""
     }
+    val prompt = if (includePrompt) ""","prompt":"optional directive"""" else ""
     return """
       {"produced_outputs":{
-        "projection_kind":"preplanning_digest",
-        "contract_version":"0.1",
-        "affected_boundaries":["runtime-domain/model"],
-        "risks":["producer may omit fields"],
-        "rollout":{"flag_required":false,"notes":"no flag needed"},
-        "validation_strategy":["snapshot projection tests"]$undeclared
+        "value":"Dense preplan prose for downstream plan."$prompt$undeclared
       }}
     """.trimIndent()
   }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeProducerProjectionGateTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeProducerProjectionGateTest.kt
@@ -2,13 +2,16 @@
 
 package skillbill.application
 
+import skillbill.application.featuretask.producerProjectionGateReason
 import skillbill.application.model.FeatureTaskRuntimeRunReport
+import skillbill.contracts.JsonSupport
 import skillbill.error.InvalidFeatureTaskRuntimePlanningProjectionSchemaError
 import skillbill.workflow.FeatureTaskRuntimePlanningProjectionValidator
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -54,13 +57,39 @@ class FeatureTaskRuntimeProducerProjectionGateTest {
   }
 
   @Test
-  fun `a preplan digest whose rollout is an array instead of an object blocks preplan (RDN-29)`() {
-    val outcome = runRejectedProducer("preplan", PREPLAN_ROLLOUT_AS_ARRAY)
+  fun `a preplan output missing value blocks preplan and never reaches plan`() {
+    val harness = runnerHarness(
+      launcher = RuntimeRecordingLauncher { request ->
+        val phaseId = phaseIdFromPrompt(requireNotNull(request.skillRunRequest.promptOverride))
+        facts(if (phaseId == "preplan") PREPLAN_MISSING_VALUE else validJsonOutput(phaseId))
+      },
+      validator = realFeatureTaskRuntimePhaseOutputValidator,
+      agentAssignment = phasePerAgentAssignment(),
+    )
 
-    assertEquals(1, outcome.launchCount("preplan"))
-    assertGateBlockNamesRule(outcome.blocked.blockedReason, "producer-projection")
-    assertDiagnosticNamesConstraint(outcome.diagnosticReason, "preplanning_digest", "rollout")
-    assertTrue(!outcome.launched("plan"))
+    val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(harness.runner.run(harness.request()))
+    assertEquals("preplan", blocked.lastIncompletePhase)
+    assertTrue(
+      blocked.blockedReason.contains("value", ignoreCase = true) ||
+        harness.io.database.rejectedDiagnostics().any {
+          it.metadata.phaseId == "preplan" && it.metadata.reason.contains("value", ignoreCase = true)
+        },
+    )
+    assertTrue(harness.launchedPromptPhaseOrder().none { it == "plan" })
+  }
+
+  @Test
+  fun `leftover digest keys plus value complete preplan without producer-projection re-entry`() {
+    val envelope = JsonSupport.anyToStringAnyMap(
+      JsonSupport.jsonElementToValue(JsonSupport.parseObjectOrNull(PREPLAN_LEFTOVER_DIGEST_KEYS)!!),
+    )!!
+    assertNull(
+      producerProjectionGateReason(
+        phaseId = "preplan",
+        outputMap = envelope,
+        planningProjectionValidator = realPlanningProjectionValidator,
+      ),
+    )
   }
 
   @Test
@@ -117,16 +146,6 @@ class FeatureTaskRuntimeProducerProjectionGateTest {
       "implementation_receipt",
       "deviations",
     )
-  }
-
-  @Test
-  fun `a decompose-shaped preplan output faces the gate because preplan owns no decompose backstop`() {
-    val outcome = runRejectedProducer("preplan", PREPLAN_DECOMPOSE_SHAPED)
-
-    assertEquals(1, outcome.launchCount("preplan"))
-    assertGateBlockNamesRule(outcome.blocked.blockedReason, "producer-projection")
-    assertDiagnosticNamesConstraint(outcome.diagnosticReason, "preplanning_digest", "is not a valid")
-    assertEquals(0, outcome.launchCount("plan"), "a decompose-shaped preplan must not bypass the gate and wedge plan")
   }
 
   @Test
@@ -407,26 +426,22 @@ private val PLAN_UNDECLARED_DEPENDENCY: String = envelope(
     """"criterion_refs":["AC-001"],"test_obligations":["parity"]}],"validation_strategy":["v"]}""",
 )
 
-// A completed producing-phase output shaped like a decomposition package (mode=decompose, no
-// projection_kind). Only `plan` has a decompose stopper backstop, so for any other producer this must
-// still face the projection gate rather than the exemption. The implement variant carries
-// reconciled_state so it clears the separate mutating-phase reconciliation gate and actually reaches
-// the projection gate under test.
-private val PREPLAN_DECOMPOSE_SHAPED: String = envelope(
+private val PREPLAN_MISSING_VALUE: String = envelope(
   "preplan",
-  """{"mode":"decompose","reason":"looks like a decompose but preplan owns no stopper"}""",
+  """{"prompt":"optional only"}""",
+)
+
+private val PREPLAN_LEFTOVER_DIGEST_KEYS: String = envelope(
+  "preplan",
+  """{"value":"prose preplan with leftover digest keys","affected_boundaries":["runtime-domain"],""" +
+    """"risks":["Fixture risk."],"rollout":{"flag_required":false,"flag_pattern":"none","notes":"n"},""" +
+    """"validation_strategy":["Focused runtime tests."]}""",
 )
 
 private val IMPLEMENT_DECOMPOSE_SHAPED: String = envelope(
   "implement",
   """{"mode":"decompose","reason":"looks like a decompose but implement owns no stopper",""" +
     """"reconciled_state":{"reconciled":true}}""",
-)
-
-private val PREPLAN_ROLLOUT_AS_ARRAY: String = envelope(
-  "preplan",
-  """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":["b"],""" +
-    """"risks":["r"],"rollout":[{"flag_required":false,"notes":"n"}],"validation_strategy":["v"]}""",
 )
 
 private val IMPLEMENT_INVENTED_CHECKPOINT: String = envelope(

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeProjectionRejectionTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeProjectionRejectionTest.kt
@@ -4,7 +4,6 @@ import skillbill.application.featuretask.RejectedOutputDiagnosticService
 import skillbill.application.model.FeatureTaskRuntimePhaseLedgerRequest
 import skillbill.application.model.FeatureTaskRuntimeRunReport
 import skillbill.ports.persistence.ProducerOutputEvidence
-import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeFailureDisposition
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseLedgerAction
 import java.time.Instant
@@ -20,12 +19,13 @@ import kotlin.test.assertTrue
  */
 class FeatureTaskRuntimeProjectionRejectionTest {
   @Test
-  fun `a preplan digest at the largest deliverable size is delivered to plan, not rejected`() {
+  fun `preplan prose value is delivered to plan`() {
+    val prose = "Dense fixture preplan prose for plan."
     val harness = runnerHarness(
       launcher = RuntimeRecordingLauncher { request ->
         val phaseId = phaseIdFromPrompt(requireNotNull(request.skillRunRequest.promptOverride))
         facts(
-          if (phaseId == "preplan") preplanOutput(LARGEST_DELIVERABLE_DIGEST_ITEMS) else validJsonOutput(phaseId),
+          if (phaseId == "preplan") preplanEnvelope(prose) else validJsonOutput(phaseId),
         )
       },
       agentAssignment = phasePerAgentAssignment(),
@@ -39,25 +39,17 @@ class FeatureTaskRuntimeProjectionRejectionTest {
         .map { requireNotNull(it.skillRunRequest.promptOverride) }
         .firstOrNull { phaseIdFromPrompt(it) == "plan" },
     )
-    // Delivered whole, not truncated: every bounded digest entry reaches the consumer verbatim.
-    assertContains(planPrompt, RISK_ENTRY)
-    assertEquals(
-      LARGEST_DELIVERABLE_DIGEST_ITEMS,
-      planPrompt.split(RISK_ENTRY).size - 1,
-      "every digest entry must be delivered, none dropped by truncation",
-    )
+    assertContains(planPrompt, prose)
   }
 
   @Test
   fun `a projection that overflows its budget blocks the phase durably instead of aborting the run`() {
-    // Item count is bounded by the model caps the budget sums, so the byte dimension is the one an
-    // overflowing payload actually trips: far fewer entries than the item cap, each far longer.
     val harness = runnerHarness(
       launcher = RuntimeRecordingLauncher { request ->
         val phaseId = phaseIdFromPrompt(requireNotNull(request.skillRunRequest.promptOverride))
         facts(
-          if (phaseId == "preplan") {
-            preplanOutput(OVERSIZED_DIGEST_ITEMS, entry = OVERSIZED_ENTRY)
+          if (phaseId == "plan") {
+            planOutput(OVERSIZED_PLAN_ITEMS, entry = OVERSIZED_ENTRY)
           } else {
             validJsonOutput(phaseId)
           },
@@ -69,14 +61,12 @@ class FeatureTaskRuntimeProjectionRejectionTest {
     val report = harness.runner.run(harness.request())
 
     val blocked = assertIs<FeatureTaskRuntimeRunReport.Blocked>(report)
-    assertEquals("plan", blocked.lastIncompletePhase)
+    assertEquals("implement", blocked.lastIncompletePhase)
     assertContains(blocked.blockedReason, "handoff projection")
     assertContains(blocked.blockedReason, "budget")
-    assertTrue(harness.launchedPromptPhaseOrder().none { it == "plan" })
+    assertTrue(harness.launchedPromptPhaseOrder().none { it == "implement" })
 
-    // The rejection is ledgered: a resume sees a blocked row with an operator-facing disposition
-    // rather than a row left running by a driver that died mid-phase.
-    val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID).orEmpty()["plan"])
+    val record = requireNotNull(harness.recorder.loadPhaseRecords(WORKFLOW_ID).orEmpty()["implement"])
     assertEquals("blocked", record.status)
     assertEquals("needs_user_action", record.failureDisposition?.wireValue)
     assertTrue(requireNotNull(record.blockedReason).isNotBlank())
@@ -408,33 +398,26 @@ class FeatureTaskRuntimeProjectionRejectionTest {
     """.trimIndent()
   }
 
-  private fun preplanEnvelope(): String =
-    """{"contract_version":"0.2","phase_id":"preplan","status":"completed","summary":"Digest.",""" +
-      """"produced_outputs":${PlanningProjectionFixtures.PREPLAN_DIGEST}}"""
+  private fun preplanEnvelope(value: String = "Fixture preplan prose."): String =
+    """{"contract_version":"0.2","phase_id":"preplan","status":"completed","summary":"Prose.",""" +
+      """"produced_outputs":{"value":"$value"}}"""
 
-  // The digest carries the declared preplanning_digest projection shape. Size is driven by repeating
-  // bounded `risks` entries rather than one giant string, because each projection field is itself
-  // length-capped — the budget is what a whole digest may weigh, not what one field may.
-  // Builds a digest carrying exactly [totalItems] length-capped entries, spread across the digest's
-  // list fields so no single field is unrealistically deep.
-  private fun preplanOutput(totalItems: Int, entry: String = RISK_ENTRY): String {
-    val fields = DIGEST_LIST_FIELDS.mapIndexed { index, name ->
-      val count = totalItems / DIGEST_LIST_FIELDS.size +
-        if (index < totalItems % DIGEST_LIST_FIELDS.size) 1 else 0
-      val entries = List(count) { "\"$entry\"" }.joinToString(",")
-      "\"$name\": [$entries]"
-    }.joinToString(",\n          ")
+  private fun planOutput(totalItems: Int, entry: String): String {
+    val tasks = (1..totalItems).joinToString(",") { index ->
+      """{"task_id":"task-$index","description":"$entry","criterion_refs":["AC-001"],"test_obligations":["parity"]}"""
+    }
     return """
       {
         "contract_version": "0.2",
-        "phase_id": "preplan",
+        "phase_id": "plan",
         "status": "completed",
-        "summary": "Preplanning digest.",
+        "summary": "Executable plan.",
         "produced_outputs": {
-          "projection_kind": "preplanning_digest",
+          "projection_kind": "executable_plan",
           "contract_version": "0.1",
-          $fields,
-          "rollout": {"flag_required": false, "flag_pattern": "none", "notes": "No flag needed."}
+          "mode": "direct",
+          "tasks": [$tasks],
+          "validation_strategy": ["focused gradle"]
         }
       }
     """.trimIndent()
@@ -458,28 +441,8 @@ private fun RunnerHarness.retainExactProducerEvidence(phaseId: String, output: S
   )
 }
 
-private val DIGEST_LIST_FIELDS = listOf(
-  "affected_boundaries",
-  "risks",
-  "validation_strategy",
-  "patterns_and_decisions",
-  "unresolved_questions",
-  "evidence_refs",
-)
-
-// The widest digest the model itself admits: every list field filled to its own entry cap. The item
-// budget sums those caps, so this is deliverable by construction — a schema-valid projection can never
-// be rejected for item count, and only a genuinely oversized payload trips the byte dimension.
-private val LARGEST_DELIVERABLE_DIGEST_ITEMS =
-  DIGEST_LIST_FIELDS.size * FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT
-
-// One bounded digest entry. Short enough that a digest filled to every list cap still fits the byte
-// budget, which is what makes the item dimension provably unreachable for a schema-valid digest.
-private val RISK_ENTRY = "d".repeat(200)
-
-// Well under the item caps, but heavy enough that the digest exceeds its byte budget.
-private val OVERSIZED_ENTRY = "d".repeat(1_000)
-private const val OVERSIZED_DIGEST_ITEMS: Int = 240
+private const val OVERSIZED_PLAN_ITEMS: Int = 64
+private val OVERSIZED_ENTRY = "d".repeat(3_500)
 
 // Comfortably past the 64-item cap that used to reject this receipt, and within every current cap.
 private const val WIDE_RECEIPT_CHANGED_PATHS: Int = 120

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimeRunnerTest.kt
@@ -451,7 +451,7 @@ class FeatureTaskRuntimeRunnerTest {
       assertContains(briefing.briefingText, "mandate-X", message = "mandates missing for $phaseId")
     }
     // plan and implement receive bounded planning projections rather than coarse upstream receipts.
-    assertContains(briefings.getValue("plan").briefingText, "affected_boundaries")
+    assertContains(briefings.getValue("plan").briefingText, "Fixture preplan prose for downstream plan.")
     assertContains(briefings.getValue("implement").briefingText, "Fixture task.")
     assertEquals(listOf("current_unit_of_work"), briefings.getValue("review").derivedContextKeys)
     assertContains(briefings.getValue("review").briefingText, "current_unit_of_work")
@@ -710,7 +710,7 @@ class FeatureTaskRuntimeRunnerTest {
   }
 
   @Test
-  fun `resume skips completed preplan and restores its digest into plan briefing`() {
+  fun `resume skips completed preplan and restores its prose into plan briefing`() {
     val harness = runnerHarness(agentAssignment = phasePerAgentAssignment())
     harness.seedPhase("preplan", "completed", 1, phaseAgent("preplan"), PREPLAN_OUTPUT)
 
@@ -723,10 +723,8 @@ class FeatureTaskRuntimeRunnerTest {
     )
     assertTrue(harness.launchedPhaseOrder().none { it == "preplan" })
     val planBriefing = requireNotNull(harness.recorder.loadPhaseBriefings(WORKFLOW_ID).orEmpty()["plan"])
-    // plan receives the bounded preplanning digest, not preplan's complete envelope.
     assertContains(planBriefing.briefingText, "### from: preplan")
-    assertContains(planBriefing.briefingText, "affected_boundaries")
-    assertContains(planBriefing.briefingText, "Fixture risk.")
+    assertContains(planBriefing.briefingText, "Fixture preplan prose for downstream plan.")
     assertFalse(planBriefing.briefingText.contains("Phase produced a validated output."))
   }
 
@@ -741,7 +739,7 @@ class FeatureTaskRuntimeRunnerTest {
     assertEquals(AGENT_LAUNCHED_PHASES, harness.launchedPhaseOrder())
     val planBriefing = requireNotNull(harness.recorder.loadPhaseBriefings(WORKFLOW_ID).orEmpty()["plan"])
     assertContains(planBriefing.briefingText, "### from: preplan")
-    assertContains(planBriefing.briefingText, "affected_boundaries")
+    assertContains(planBriefing.briefingText, "Fixture preplan prose for downstream plan.")
   }
 
   @Test
@@ -1624,7 +1622,7 @@ class FeatureTaskRuntimeRunnerPersistenceTest {
       }
     }
     // plan and implement receive bounded planning projections rather than coarse upstream receipts.
-    assertContains(briefings.getValue("plan").briefingText, "affected_boundaries")
+    assertContains(briefings.getValue("plan").briefingText, "Fixture preplan prose for downstream plan.")
     assertContains(briefings.getValue("implement").briefingText, "Fixture task.")
     assertContains(briefings.getValue("review").briefingText, "clearance_status: satisfied")
     assertFalse(briefings.getValue("review").briefingText.contains(validJsonOutput("implement")))

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalPlanningContextPromptFormatterTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalPlanningContextPromptFormatterTest.kt
@@ -44,8 +44,8 @@ class GoalPlanningContextPromptFormatterTest {
     val composed = GoalPlanningContextPromptFormatter.append("base", packet, null, "preplan")
 
     assertContains(composed, "first-entry")
-    assertContains(composed, "second-entry")
-    assertContains(composed, "selected_boundary_headings")
+    assertContains(composed, "produced_outputs.value")
+    assertContains(composed, "Recommended headings")
     assertFalse(FIRST_BODY in composed)
     assertFalse(SECOND_BODY in composed)
   }

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalPlanningSweepTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/GoalPlanningSweepTest.kt
@@ -21,7 +21,6 @@ import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.contracts.workflow.FeatureTaskRuntimePhaseOutputSchemaPaths
 import skillbill.contracts.workflow.GoalPlanningPreparationSchemaPaths
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
-import skillbill.error.InvalidFeatureTaskRuntimePlanningProjectionSchemaError
 import skillbill.goalrunner.model.ExecutionLiveness
 import skillbill.goalrunner.model.GoalRunnerControlState
 import skillbill.goalrunner.model.GoalRunnerExecutionLease
@@ -33,14 +32,11 @@ import skillbill.ports.agentrun.model.AgentRunLaunchOutcome
 import skillbill.ports.agentrun.model.AgentRunOutputSink
 import skillbill.ports.agentrun.model.AgentRunOutputStream
 import skillbill.ports.agentrun.model.AgentRunSpawnAuthorization
-import skillbill.ports.goalrunner.GoalPlanningBoundaryBodyResolver
 import skillbill.ports.goalrunner.GoalPlanningContextDiscovery
 import skillbill.ports.goalrunner.GoalRunnerManifestStore
 import skillbill.ports.goalrunner.GoalRunnerSubtaskLauncher
-import skillbill.ports.goalrunner.model.GoalPlanningBoundaryBody
 import skillbill.ports.goalrunner.model.GoalPlanningBoundaryHeading
 import skillbill.ports.goalrunner.model.GoalPlanningContext
-import skillbill.ports.goalrunner.model.GoalPlanningResolvedBoundaryBodies
 import skillbill.ports.goalrunner.model.GoalRunnerManifestState
 import skillbill.ports.goalrunner.model.GoalRunnerSubtaskLaunchRequest
 import skillbill.ports.persistence.DatabaseSessionFactory
@@ -268,15 +264,16 @@ class GoalPlanningSweepTest {
 
     val preplanPrompt = harness.launcher.requests.first().skillRunRequest.promptOverride.orEmpty()
     assertContains(preplanPrompt, FIXTURE_HEADING_ID)
-    assertContains(preplanPrompt, "selected_boundary_headings")
+    assertContains(preplanPrompt, "produced_outputs.value")
     assertFalse(preplanPrompt.contains(FIXTURE_BODY), "the catalog never carries entry bodies")
   }
 
   @Test
-  fun `a selected heading id delivers only that body to the plan prompt`() {
+  fun `preplan prose reaches the plan prompt`() {
+    val prose = "Distinctive preplan prose for plan."
     val harness = sweepHarness { phase, _, _ ->
       if (phase == "preplan") {
-        launchFacts(stdout = preplanPayloadSelecting(FIXTURE_HEADING_ID))
+        launchFacts(stdout = preplanProsePayload(value = prose))
       } else {
         validPhaseOutcome(phase)
       }
@@ -285,12 +282,11 @@ class GoalPlanningSweepTest {
     harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
 
     val planPrompt = harness.launcher.requests[1].skillRunRequest.promptOverride.orEmpty()
-    assertContains(planPrompt, "## Selected boundary memory")
-    assertContains(planPrompt, FIXTURE_BODY)
+    assertContains(planPrompt, prose)
   }
 
   @Test
-  fun `a preplan without a selection field yields a catalog only plan prompt`() {
+  fun `a preplan without optional prompt yields a plan prompt without a prompt field`() {
     val harness = sweepHarness { phase, _, _ -> validPhaseOutcome(phase) }
 
     val outcome = harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
@@ -609,7 +605,7 @@ class GoalPlanningSweepTest {
   }
 
   @Test
-  fun `resume refreshes stale shared preplan in-run when parent spec body changes with identical headings`() {
+  fun `resume refreshes stale shared preplan in-run when parent spec body changes with identical prose`() {
     val harness = sweepHarness { phase, _, _ -> validPhaseOutcome(phase) }
     val state = harness.stateFor(manifest(subtaskCount = 1))
     harness.sweep.prepare(state, harness.request())
@@ -650,17 +646,17 @@ class GoalPlanningSweepTest {
   }
 
   @Test
-  fun `resume refreshes and cascades via shared helper when heading set changes`() {
+  fun `resume refreshes and cascades via shared helper when prose content changes`() {
     var preplanLaunches = 0
     val harness = sweepHarness { phase, _, _ ->
       if (phase == "preplan") {
         preplanLaunches += 1
-        val headings = if (preplanLaunches == 1) {
-          arrayOf(FIXTURE_HEADING_ID)
+        val value = if (preplanLaunches == 1) {
+          "First preplan prose payload."
         } else {
-          emptyArray()
+          "Refreshed preplan prose payload."
         }
-        launchFacts(stdout = preplanPayloadSelecting(*headings))
+        launchFacts(stdout = preplanProsePayload(value = value))
       } else {
         validPhaseOutcome(phase)
       }
@@ -676,7 +672,7 @@ class GoalPlanningSweepTest {
         ".feature-specs/SKILL-56-goal/spec_subtask_1.md",
       ),
     )
-    val refreshedParentSpec = "# Initial feature contract edited for heading drift"
+    val refreshedParentSpec = "# Initial feature contract edited for prose drift"
     harness.manifestFileStore.replaceSpec("spec.md", refreshedParentSpec)
 
     val outcome = harness.sweep.prepare(state, harness.request())
@@ -711,7 +707,7 @@ class GoalPlanningSweepTest {
   }
 
   @Test
-  fun `changed heading set refresh preserves complete-with-commit sibling plan`() {
+  fun `changed prose refresh preserves complete-with-commit sibling plan`() {
     val fixture = changedHeadingSetRefreshFixture()
     val outcome = fixture.harness.sweep.prepare(
       fixture.harness.stateFor(fixture.resumeManifest),
@@ -775,12 +771,12 @@ class GoalPlanningSweepTest {
     val harness = sweepHarness(manifestStore = store) { phase, _, _ ->
       if (phase == "preplan") {
         preplanLaunches += 1
-        val headings = if (preplanLaunches == 1) {
-          arrayOf(FIXTURE_HEADING_ID)
+        val value = if (preplanLaunches == 1) {
+          "First preplan prose for cascade test."
         } else {
-          emptyArray()
+          "Refreshed preplan prose for cascade test."
         }
-        launchFacts(stdout = preplanPayloadSelecting(*headings))
+        launchFacts(stdout = preplanProsePayload(value = value))
       } else {
         validPhaseOutcome(phase)
       }
@@ -801,7 +797,7 @@ class GoalPlanningSweepTest {
       ),
     )
     val launchCount = harness.launcher.requests.size
-    harness.manifestFileStore.replaceSpec("spec.md", "# Initial feature contract edited for heading drift")
+    harness.manifestFileStore.replaceSpec("spec.md", "# Initial feature contract edited for prose drift")
     return ChangedHeadingSetRefreshFixture(harness, store, resumeManifest, plan1Before, launchCount)
   }
 
@@ -907,11 +903,11 @@ class GoalPlanningSweepTest {
   }
 
   @Test
-  fun `resume reuses saved planning when a selected boundary heading is absent from the fresh catalog`() {
+  fun `resume reuses saved planning when the fresh catalog no longer lists a referenced heading`() {
     val discovery = MutableContextDiscovery()
     val harness = sweepHarness(contextDiscovery = discovery) { phase, _, _ ->
       if (phase == "preplan") {
-        launchFacts(stdout = preplanPayloadSelecting(FIXTURE_HEADING_ID))
+        launchFacts(stdout = preplanProsePayload(value = "Preplan prose with catalog context."))
       } else {
         validPhaseOutcome(phase)
       }
@@ -928,7 +924,7 @@ class GoalPlanningSweepTest {
     assertEquals(
       sharedBefore.preplanPayload,
       sharedAfter.preplanPayload,
-      "An unresolvable heading must not discard the accepted preplan.",
+      "An absent catalog heading must not discard the accepted preplan.",
     )
   }
 
@@ -1135,7 +1131,6 @@ class GoalPlanningSweepTest {
       discovery,
       NoopFeatureTaskRuntimePlanningProjectionValidator,
       manifestStore = NoopGoalPlanningManifestStore,
-      boundaryBodyResolver = fakeBoundaryBodyResolver,
     )
 
     val initial = manifest(subtaskCount = 2).copy(specSource = SpecSource.LINEAR)
@@ -1154,7 +1149,6 @@ class GoalPlanningSweepTest {
       discovery,
       NoopFeatureTaskRuntimePlanningProjectionValidator,
       manifestStore = NoopGoalPlanningManifestStore,
-      boundaryBodyResolver = fakeBoundaryBodyResolver,
     )
 
     val resumed = initial.copy(
@@ -1570,11 +1564,7 @@ class GoalPlanningSweepTest {
   }
 
   @Test
-  fun `a rejected planning projection stops the sweep durably instead of crashing the goal driver`() {
-    // The launch seam owns rejection only for a preplan that was already settled under a laxer contract:
-    // run one checkpoints it, run two resumes under a validator that refuses it. The producer gate cannot
-    // pre-empt that — nothing is produced in run two — so an unhandled throw here would crash the goal
-    // driver with no Stopped outcome and crash identically on every resume.
+  fun `a settled preplan with blank prose stops the sweep durably at plan launch`() {
     val fixtures = sharedSweepFixtures()
     val settledPreplan = DefaultGoalPlanningSweep(
       fixtures.checkpoint,
@@ -1591,12 +1581,18 @@ class GoalPlanningSweepTest {
       fakeContextDiscovery,
       NoopFeatureTaskRuntimePlanningProjectionValidator,
       manifestStore = NoopGoalPlanningManifestStore,
-      boundaryBodyResolver = fakeBoundaryBodyResolver,
     )
     assertIs<GoalPlanningSweepOutcome.Stopped>(
       settledPreplan.prepare(fixtures.stateFor(manifest(subtaskCount = 1)), fixtures.request()),
     )
     assertEquals(0, fixtures.preparedCount(), "run one must settle the shared preplan and no plan")
+    fixtures.database.repository.blankSettledPreplanValue(
+      GoalPlanningIdentity(
+        "wfl-parent",
+        "SKILL-56",
+        "repo-root-realpath-v1:${fixtures.repoRoot.toRealPath()}",
+      ),
+    )
 
     val launcher = SweepPlanningLauncher { phase, _, _ -> validPhaseOutcome(phase) }
     val sweep = DefaultGoalPlanningSweep(
@@ -1606,13 +1602,10 @@ class GoalPlanningSweepTest {
       fixtures.invariantsSource,
       fixtures.manifestFileStore,
       fakeContextDiscovery,
-      RejectingSweepPlanningProjectionValidator,
+      NoopFeatureTaskRuntimePlanningProjectionValidator,
       manifestStore = NoopGoalPlanningManifestStore,
-      boundaryBodyResolver = fakeBoundaryBodyResolver,
     )
-
     val outcome = sweep.prepare(fixtures.stateFor(manifest(subtaskCount = 1)), fixtures.request())
-
     val stopped = assertIs<GoalPlanningSweepOutcome.Stopped>(outcome)
     assertEquals("plan", stopped.lastResumableStep)
     assertEquals(1, stopped.currentSubtaskId)
@@ -1621,6 +1614,7 @@ class GoalPlanningSweepTest {
       stopped.blockedReason.contains("Migrate or delete"),
       "the block must name the operator remedy for a non-conforming durable record",
     )
+    assertTrue(stopped.blockedReason.contains("produced_outputs.value must contain non-blank prose"))
     assertEquals(
       0,
       launcher.requests.size,
@@ -1659,7 +1653,6 @@ class GoalPlanningSweepTest {
       fakeContextDiscovery,
       NoopFeatureTaskRuntimePlanningProjectionValidator,
       manifestStore = NoopGoalPlanningManifestStore,
-      boundaryBodyResolver = fakeBoundaryBodyResolver,
     )
     val store = InMemoryGoalManifestStore(manifest = manifest(subtaskCount = 2))
     val runner = GoalRunner(
@@ -1729,7 +1722,6 @@ class GoalPlanningSweepTest {
       fakeContextDiscovery,
       NoopFeatureTaskRuntimePlanningProjectionValidator,
       manifestStore = NoopGoalPlanningManifestStore,
-      boundaryBodyResolver = fakeBoundaryBodyResolver,
     )
     val state = GoalRunnerManifestState(
       parentWorkflowId = "wfl-parent",
@@ -1937,19 +1929,29 @@ class GoalPlanningSweepTest {
   }
 
   @Test
-  fun `the preplan gate observes the enriched payload that is actually checkpointed`() {
-    // Enrichment, not raw child stdout, produces the checkpointed bytes. A rejecting validator must
-    // therefore be reached through the enriched payload, before checkpointSharedPreplan runs.
-    val validator = RejectOnceSweepPlanningProjectionValidator()
+  fun `preplan settles without consulting the planning projection producer gate`() {
+    val labels = mutableListOf<String>()
+    val validator = object : FeatureTaskRuntimePlanningProjectionValidator {
+      override fun validatePlanningProjection(producedOutputs: Map<String, Any?>, sourceLabel: String) {
+        labels += sourceLabel
+      }
+    }
     val harness = sweepHarness(planningProjectionValidator = validator) { phase, _, _ ->
-      validPhaseOutcome(phase)
+      if (phase == "plan") {
+        launchFacts(stdout = phasePayload(phase).replace("\"completed\"", "\"blocked\""))
+      } else {
+        validPhaseOutcome(phase)
+      }
     }
 
     val outcome = harness.sweep.prepare(harness.stateFor(manifest(subtaskCount = 1)), harness.request())
 
-    assertIs<GoalPlanningSweepOutcome.PreparedAll>(outcome)
-    assertEquals(2, harness.launcher.phases.count { it == "preplan" })
-    assertTrue(validator.calls >= 1, "the gate must observe the enriched payload before checkpointing")
+    assertIs<GoalPlanningSweepOutcome.Stopped>(outcome)
+    assertEquals(1, harness.launcher.phases.count { it == "preplan" })
+    assertTrue(
+      labels.none { it.startsWith("preplan#") },
+      "producedProjectionKindFor(preplan) is null, so the producer gate must not validate preplan prose",
+    )
   }
 
   @Test
@@ -2072,10 +2074,7 @@ private const val RAW_REPAIRED_PREPLAN = "raw preplan repaired before enrichment
 
 private const val REPAIRED_PREPLAN_PAYLOAD =
   """{"contract_version":"$FEATURE_TASK_RUNTIME_CONTRACT_VERSION","phase_id":"preplan",""" +
-    """"status":"completed","summary":"s","produced_outputs":{"projection_kind":"preplanning_digest",""" +
-    """"contract_version":"0.1","affected_boundaries":["runtime-application/workflow"],""" +
-    """"risks":["fixture risk"],"rollout":{"flag_required":false,"notes":"fixture"},""" +
-    """"validation_strategy":["Focused runtime tests"]}}"""
+    """"status":"completed","summary":"s","produced_outputs":{"value":"fixture preplan prose"}}"""
 
 private class RepairingPreplanOutputValidator(
   private val evidence: FeatureTaskRuntimePhaseOutputRepairEvidence,
@@ -2232,12 +2231,11 @@ private fun blockedPhasePayload(phaseId: String, summary: String, disposition: S
     """"status":"blocked","failure_disposition":"$disposition","summary":"$summary",""" +
     """"produced_outputs":{"result":"$phaseId"}}"""
 
-private fun preplanPayloadSelecting(vararg headingIds: String): String {
-  val ids = headingIds.joinToString(",") { id -> "\"" + id + "\"" }
-  val digest = PlanningProjectionFixtures.PREPLAN_DIGEST.dropLast(1) +
-    ""","selected_boundary_headings":[""" + ids + "]}"
+private fun preplanProsePayload(value: String = "Fixture preplan prose.", prompt: String? = null): String {
+  val promptPart = prompt?.let { ""","prompt":"$it"""" } ?: ""
+  val produced = """{"value":"$value"$promptPart}"""
   return """{"contract_version":"$FEATURE_TASK_RUNTIME_CONTRACT_VERSION","phase_id":"preplan",""" +
-    """"status":"completed","summary":"s","produced_outputs":""" + digest + "}"
+    """"status":"completed","summary":"s","produced_outputs":$produced}"""
 }
 
 private fun fencedPhasePayload(phaseId: String): String =
@@ -2556,6 +2554,27 @@ private class InMemoryPreparationRepository(
     plans[subtaskId] = plan.copy(provenance = plan.provenance.copy(parentSpecHash = "stale-parent-spec-hash"))
   }
 
+  fun overwriteSharedPreplanPayload(preplanPayload: String) {
+    val shared = requireNotNull(sharedPreplan)
+    sharedPreplan = shared.copy(
+      payloadSha256 = sha256HexUtf8(preplanPayload),
+      preplanPayload = preplanPayload,
+    )
+  }
+
+  fun blankSettledPreplanValue(identity: GoalPlanningIdentity) {
+    val settled = requireNotNull(findSharedPreplan(identity))
+    val root = requireNotNull(
+      JsonSupport.parseObjectOrNull(settled.preplanPayload)
+        ?.let(JsonSupport::jsonElementToValue)
+        ?.let(JsonSupport::anyToStringAnyMap),
+    )
+    val produced = requireNotNull(JsonSupport.anyToStringAnyMap(root["produced_outputs"]))
+    overwriteSharedPreplanPayload(
+      JsonSupport.mapToJsonString(root + ("produced_outputs" to (produced + ("value" to "   ")))),
+    )
+  }
+
   override fun findSharedPreplan(expectedIdentity: skillbill.ports.persistence.model.GoalPlanningIdentity) =
     sharedPreplan?.takeIf { it.identity == expectedIdentity }
 
@@ -2775,7 +2794,6 @@ private fun sweepHarness(
   planningRejectionRecorder: GoalPlanningRejectionRecorder = GoalPlanningRejectionRecorder.NONE,
   timingPort: RuntimeTimingPort = NoopRuntimeTimingPort,
   burstSchedule: GoalPlanningBurstSchedule = GoalPlanningBurstSchedule(),
-  boundaryBodyResolver: GoalPlanningBoundaryBodyResolver = fakeBoundaryBodyResolver,
   refreshLiveness: GoalPlanningRefreshLiveness = GoalPlanningRefreshLiveness.IDLE,
   behavior: (phase: String, subtaskId: Int, request: GoalRunnerSubtaskLaunchRequest) -> AgentRunLaunchOutcome,
 ): SweepHarness {
@@ -2798,7 +2816,6 @@ private fun sweepHarness(
     planningRejectionRecorder = planningRejectionRecorder,
     timingPort = timingPort,
     burstSchedule = burstSchedule,
-    boundaryBodyResolver = boundaryBodyResolver,
     refreshLiveness = refreshLiveness,
   )
   return SweepHarness(fixtures, launcher, sweep)
@@ -2849,28 +2866,6 @@ private class MutablePauseGoalPlanningManifestStore : GoalRunnerManifestStore {
   ): Boolean = true
 }
 
-private class RejectOnceSweepPlanningProjectionValidator : FeatureTaskRuntimePlanningProjectionValidator {
-  var calls: Int = 0
-
-  override fun validatePlanningProjection(producedOutputs: Map<String, Any?>, sourceLabel: String) {
-    calls += 1
-    if (calls == 1) {
-      throw InvalidFeatureTaskRuntimePlanningProjectionSchemaError(
-        sourceLabel = sourceLabel,
-        reason = "additionalProperties: legacy shared preplan carries an undeclared field",
-      )
-    }
-  }
-}
-
-private object RejectingSweepPlanningProjectionValidator : FeatureTaskRuntimePlanningProjectionValidator {
-  override fun validatePlanningProjection(producedOutputs: Map<String, Any?>, sourceLabel: String): Unit =
-    throw InvalidFeatureTaskRuntimePlanningProjectionSchemaError(
-      sourceLabel = sourceLabel,
-      reason = "additionalProperties: legacy shared preplan carries an undeclared field",
-    )
-}
-
 internal const val FIXTURE_HEADING_ID = "runtime-kotlin/agent/history.md#0-000000000000"
 internal const val FIXTURE_HEADING = "## [2026-08-01] fixture-entry"
 internal const val FIXTURE_BODY = "distinctive fixture body sentence"
@@ -2895,21 +2890,6 @@ private val fakeContextDiscovery = object : GoalPlanningContextDiscovery {
       boundaryCatalogTruncated = false,
       boundaryContextUnavailable = findingPaths.isEmpty(),
     )
-}
-
-private val fakeBoundaryBodyResolver = object : GoalPlanningBoundaryBodyResolver {
-  override fun resolve(
-    repoRoot: Path,
-    headingIds: List<String>,
-    catalogHeadingIds: Set<String>,
-    caps: skillbill.ports.goalrunner.model.GoalPlanningBoundaryBodyResolutionCaps,
-    loudFailOnCapExceeded: Boolean,
-  ) = GoalPlanningResolvedBoundaryBodies(
-    bodies = headingIds.filter { id -> id == FIXTURE_HEADING_ID }.map { id ->
-      GoalPlanningBoundaryBody(id, "runtime-kotlin/agent/history.md", FIXTURE_HEADING, FIXTURE_BODY)
-    },
-    unresolvedHeadingIds = headingIds.filterNot { id -> id == FIXTURE_HEADING_ID },
-  )
 }
 
 private object NoopGoalPlanningManifestStore : GoalRunnerManifestStore {

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/PhaseOutputFixtureParityTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/PhaseOutputFixtureParityTest.kt
@@ -9,16 +9,15 @@ import kotlin.test.assertFailsWith
 import kotlin.test.fail
 
 /**
- * SKILL-140 Subtask 3 (AC-002): every canned producing-phase fixture is validated against the
+ * SKILL-140 Subtask 3 (AC-002): every canned planning-projection fixture is validated against the
  * canonical planning-projections schema with the real infra-fs validator, so fixture drift fails the
  * build instead of hiding behind the Noop stand-in used by most runner suites. The two mutation-check
  * tests below permanently encode the manual mutation check the plan describes: an undeclared key and a
  * task_id pattern violation each fail with a message naming the fixture and the violation.
  *
- * Scope: the planning-projections schema governs the preplan/plan/implement produced_outputs bodies.
- * The review, audit, and commit_push fixtures own no planning projection (see
- * [PLANNING_PROJECTION_EXEMPT_PHASES]) and are enumerated as explicit, justified exemptions rather
- * than silently skipped.
+ * Scope: the planning-projections schema governs the plan/implement produced_outputs bodies.
+ * preplan owns PhaseOutput prose and is named in [PLANNING_PROJECTION_EXEMPT_PHASES] with review,
+ * audit, and commit_push rather than silently skipped.
  */
 class PhaseOutputFixtureParityTest {
 
@@ -38,12 +37,12 @@ class PhaseOutputFixtureParityTest {
     // No fixture is silently skipped: the union of validated and exempt phases is the closed corpus.
     val validated = PLANNING_PROJECTION_FIXTURES.map { it.phaseId }.toSet()
     assertEquals(
-      setOf("preplan", "plan", "implement"),
+      setOf("plan", "implement"),
       validated,
       "the producing-phase corpus drifted from the fixtures the planning-projections schema governs",
     )
     assertEquals(
-      setOf("review", "audit", "verify_findings", "implement_fix", "commit_push"),
+      setOf("preplan", "review", "audit", "verify_findings", "implement_fix", "commit_push"),
       PLANNING_PROJECTION_EXEMPT_PHASES,
       "the exemption list drifted; every non-producing phase must be named and justified, never skipped",
     )

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
@@ -2961,7 +2961,7 @@ class GoalChildPlanningHydrationTransactionIntegrationTest {
 
     assertEquals(first, resumed, "duplicate resume must be a byte-identical no-op")
     assertEquals("implement", resumed.currentStepId)
-    assertContains(resumed.artifactsJson, "shared-preplan")
+    assertContains(resumed.artifactsJson, "shared preplan prose for hydration")
     assertContains(resumed.artifactsJson, "owned-plan-one")
     assertEquals(2, Regex("goal-planning-import").findAll(resumed.artifactsJson).count())
     assertEquals(2, Regex("\\\"action\\\":\\\"complete\\\"").findAll(resumed.artifactsJson).count())
@@ -3009,8 +3009,8 @@ class GoalChildPlanningHydrationTransactionIntegrationTest {
 
     val first = requireNotNull(harness.workflows.getFeatureTaskRuntimeWorkflow(CHILD_ID)).artifactsJson
     val second = requireNotNull(harness.workflows.getFeatureTaskRuntimeWorkflow("wfl-child-2")).artifactsJson
-    assertContains(first, "shared-preplan")
-    assertContains(second, "shared-preplan")
+    assertContains(first, "shared preplan prose for hydration")
+    assertContains(second, "shared preplan prose for hydration")
     assertContains(first, "owned-plan-one")
     assertFalse(first.contains("owned-plan-two"))
     assertContains(second, "owned-plan-two")
@@ -3485,10 +3485,7 @@ class GoalChildPlanningHydrationTransactionIntegrationTest {
     val PREPLAN_PAYLOAD = """
       {
         "contract_version":"0.2","phase_id":"preplan","status":"completed","summary":"shared",
-        "produced_outputs":{"projection_kind":"preplanning_digest","contract_version":"0.1",
-        "affected_boundaries":["runtime-application/goalrunner"],"risks":["hydration drift"],
-        "rollout":{"flag_required":false,"notes":"no flag needed"},
-        "validation_strategy":["focused gradle"],"evidence_refs":["shared-preplan"]}
+        "produced_outputs":{"value":"shared preplan prose for hydration"}
       }
     """.trimIndent()
 

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeRuntimeTest.kt
@@ -2052,10 +2052,7 @@ private class RecordingPhaseLauncher(
 
     // Flow-style so each stays a single YAML line the phase-output template can substitute directly.
     private const val PREPLAN_DIGEST_OUTPUTS: String =
-      """{projection_kind: "preplanning_digest", contract_version: "0.1", affected_boundaries: ["runtime-cli"], """ +
-        """risks: ["Fixture risk."], """ +
-        """rollout: {flag_required: false, flag_pattern: "none", notes: "No flag needed."}, """ +
-        """validation_strategy: ["Focused runtime tests."]}"""
+      """{value: "Fixture preplan prose for downstream plan."}"""
 
     private const val EXECUTABLE_PLAN_OUTPUTS: String =
       """{projection_kind: "executable_plan", contract_version: "0.1", mode: "direct", tasks: [{task_id: "task-1", """ +

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliGoalRuntimeTest.kt
@@ -2062,10 +2062,7 @@ private fun phasePlanningPayload(phaseId: String): String =
 // preplan and plan feed the bounded planning projections, so their payloads carry the declared shape.
 private fun planningProjectionOutputs(phaseId: String): String? = when (phaseId) {
   "preplan" ->
-    """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":["runtime-cli"],""" +
-      """"risks":["Fixture risk."],""" +
-      """"rollout":{"flag_required":false,"flag_pattern":"none","notes":"No flag needed."},""" +
-      """"validation_strategy":["Focused runtime tests."]}"""
+    """{"value":"Fixture preplan prose for downstream plan."}"""
   "plan" ->
     """{"projection_kind":"executable_plan","contract_version":"0.1","mode":"direct","tasks":[{"task_id":"task-1",""" +
       """"description":"Fixture task.","criterion_refs":["AC-001"],""" +

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/GoalPlanningPreparationCheckpointTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/GoalPlanningPreparationCheckpointTest.kt
@@ -212,12 +212,8 @@ class GoalPlanningPreparationCheckpointTest {
   fun `re-checkpointing a gate-satisfying record with different bytes still loud-fails as immutable`() {
     val harness = checkpointHarness()
     harness.checkpoint.checkpointSharedPreplan(validShared(), harness.dbOverride)
-    val otherProjection = """
-      {"projection_kind":"preplanning_digest","contract_version":"0.1",
-      "affected_boundaries":["runtime-application/workflow"],"risks":["a different risk"],
-      "rollout":{"flag_required":false,"notes":"no flag needed"},
-      "validation_strategy":["focused gradle"]}
-    """.trimIndent().replace("\n", "")
+    val otherProjection =
+      """{"value":"A different preplan prose payload for refresh testing."}"""
     val different = validShared(payload = payloadJson("preplan", producedOutputsJson = otherProjection))
 
     assertFailsWith<IncompatibleGoalPlanningPreparationRecoveryError> {
@@ -389,12 +385,7 @@ class GoalPlanningPreparationCheckpointTest {
     """.trimIndent().replace("\n", "")
 
     fun projectionJson(phaseId: String): String = if (phaseId == "preplan") {
-      """
-      {"projection_kind":"preplanning_digest","contract_version":"0.1",
-      "affected_boundaries":["runtime-application/workflow"],"risks":["producer may omit obligations"],
-      "rollout":{"flag_required":false,"notes":"no flag needed"},
-      "validation_strategy":["focused gradle"]}
-      """.trimIndent().replace("\n", "")
+      """{"value":"Producer may omit obligations in prose."}"""
     } else {
       """
       {"projection_kind":"executable_plan","contract_version":"0.1","mode":"direct",

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/GoalPlanningPreparationValidatorTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/GoalPlanningPreparationValidatorTest.kt
@@ -53,12 +53,12 @@ class GoalPlanningPreparationValidatorTest {
   }
 
   @Test
-  fun `a preplan payload that is not a valid preplanning digest is rejected at write time`() {
+  fun `a preplan payload missing value is rejected at write time`() {
     val record = validRecord(parentGoalWorkflowId = "goal-1", subtaskId = 1).copy(
-      preplanPayload = payloadJson(phaseId = "preplan", producedOutputsJson = """{"mode":"implement"}"""),
+      preplanPayload = payloadJson(phaseId = "preplan", producedOutputsJson = """{"prompt":"optional only"}"""),
     )
 
-    assertFailsWith<InvalidGoalPlanningPreparationSchemaError> { validator.validate(record) }
+    assertFailsWith<InvalidFeatureTaskRuntimePhaseOutputSchemaError> { validator.validate(record) }
   }
 
   @Test
@@ -165,15 +165,10 @@ class GoalPlanningPreparationValidatorTest {
   """.trimIndent().replace("\n", "")
 
   private fun defaultProjectionJson(phaseId: String): String =
-    if (phaseId == "preplan") preplanProjectionJson() else planProjectionJson()
+    if (phaseId == "preplan") preplanProjectionJson else planProjectionJson()
 
-  private fun preplanProjectionJson(): String = """
-    {"projection_kind":"preplanning_digest","contract_version":"0.1",
-    "affected_boundaries":["runtime-application/goalrunner"],
-    "risks":["producer may omit test obligations"],
-    "rollout":{"flag_required":false,"notes":"no flag needed"},
-    "validation_strategy":["focused gradle"]}
-  """.trimIndent().replace("\n", "")
+  private val preplanProjectionJson =
+    """{"value":"Producer may omit test obligations in prose."}"""
 
   private fun planProjectionJson(testObligations: String = """["parity"]"""): String = """
     {"projection_kind":"executable_plan","contract_version":"0.1","mode":"direct",

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/agent/model/PhaseOutput.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/agent/model/PhaseOutput.kt
@@ -1,0 +1,6 @@
+package skillbill.agent.model
+
+data class PhaseOutput(
+  val value: String,
+  val prompt: String? = null,
+)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidator.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidator.kt
@@ -415,7 +415,7 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
       }
     }
     declaration.declaredFieldNames.forEach { declaredName ->
-      if (declaredName !in seen && declaration.required) {
+      if (declaredName !in seen && declaration.required && !optionalDeclaredField(declaration, declaredName)) {
         reject(
           inputs,
           declaration,
@@ -425,6 +425,11 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
       }
     }
   }
+
+  private fun optionalDeclaredField(declaration: PhaseHandoffProjectionDeclaration, fieldName: String): Boolean =
+    declaration.projectionContractId ==
+      FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PREPLAN_PROSE &&
+      fieldName == "directive"
 
   private fun enforceCompactReferences(
     inputs: FeatureTaskRuntimeHandoffProjectionInputs,
@@ -518,7 +523,6 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
   private val SUPPORTED_PROJECTION_CONTRACT_VERSIONS: Set<String> = setOf("0.1")
 
   private val PLANNING_PROJECTION_CONTRACT_IDS: Set<String> = setOf(
-    FeatureTaskRuntimePlanningProjectionContract.PREPLANNING_DIGEST_ID,
     FeatureTaskRuntimePlanningProjectionContract.EXECUTABLE_PLAN_ID,
     FeatureTaskRuntimePlanningProjectionContract.PLAN_COMMITMENT_ID,
     FeatureTaskRuntimePlanningProjectionContract.IMPLEMENTATION_RECEIPT_ID,
@@ -541,6 +545,7 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.COMMIT_REQUEST,
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.COMMIT_RECEIPT,
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PR_REQUEST,
+    FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PREPLAN_PROSE,
   )
 
   /**
@@ -588,36 +593,68 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
         .ceremonyScaling(inputs.runInvariants.featureSize)
         .reviewScope
         .wireValue,
-      "repository_checkpoint" to inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) },
+      "repository_checkpoint" to checkpointFingerprint(inputs),
       "verdict" to auditClearanceStatus(produced),
     )
-    // The whole audit-remediation handoff: which acceptance criteria are unmet, and the checkpoint the
-    // round starts from. The implement round plans the work itself, so there is nothing else to carry.
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.AUDIT_REPAIR_REQUEST -> mapOf(
       "unmet_criteria" to inputs.unmetCriterionRefs,
-      "repository_checkpoint" to inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) },
+      "repository_checkpoint" to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.REVIEW_REPAIR_REQUEST -> mapOf(
       "unresolved_blocker_findings" to verifiedFindingsProjection(produced),
-      "repository_checkpoint" to inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) },
+      "repository_checkpoint" to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.FINDINGS_VERIFICATION_INPUT -> mapOf(
       "findings" to reviewFindingsForVerificationProjection(produced),
-      "repository_checkpoint" to inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) },
+      "repository_checkpoint" to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.FINDINGS_VERIFICATION_DISPOSITIONS -> mapOf(
       "finding_dispositions" to produced["finding_dispositions"],
-      "repository_checkpoint" to inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) },
+      "repository_checkpoint" to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.CHANGE_RECEIPT -> mapOf(
       "changed_paths" to inputs.resolvedCheckpoint?.workingTreeOwnedPaths.orEmpty(),
       "tests_added" to (produced["tests_added"] as? List<*>).orEmpty().filterIsInstance<String>(),
       "tests_updated" to (produced["tests_updated"] as? List<*>).orEmpty().filterIsInstance<String>(),
       "deviations" to (produced["deviations"] as? List<*>).orEmpty().filterIsInstance<String>(),
-      "repository_checkpoint" to inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) },
+      "repository_checkpoint" to checkpointFingerprint(inputs),
     )
+    FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PREPLAN_PROSE ->
+      preplanProseProjectionValues(inputs, declaration, produced)
     else -> finalizationProjectionValues(inputs, declaration)
   }.filterValues { it != null }
+
+  private fun checkpointFingerprint(inputs: FeatureTaskRuntimeHandoffProjectionInputs): Map<String, String>? =
+    inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) }
+
+  private fun preplanProseProjectionValues(
+    inputs: FeatureTaskRuntimeHandoffProjectionInputs,
+    declaration: PhaseHandoffProjectionDeclaration,
+    produced: Map<String, Any?>,
+  ): Map<String, Any?> {
+    val value = resolveDeclaredPhaseField(produced, "value")
+      ?: reject(
+        inputs,
+        declaration,
+        FeatureTaskRuntimeHandoffProjectionFailureKind.MALFORMED_FIELD,
+        "produced_outputs.value is required for preplan prose handoff.",
+      )
+    val valueText = value.toString()
+    if (valueText.isBlank()) {
+      reject(
+        inputs,
+        declaration,
+        FeatureTaskRuntimeHandoffProjectionFailureKind.MALFORMED_FIELD,
+        "produced_outputs.value must contain non-blank prose for preplan handoff.",
+      )
+    }
+    val fields = linkedMapOf<String, Any?>("value" to valueText)
+    resolveDeclaredPhaseField(produced, "prompt")
+      ?.toString()
+      ?.takeIf(String::isNotBlank)
+      ?.let { fields["directive"] = it }
+    return fields
+  }
 
   private fun auditClearanceStatus(produced: Map<String, Any?>): String? {
     val gaps = produced["gaps"] as? List<*>
@@ -867,8 +904,6 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
     // A plan_commitment is derived from the plan's executable_plan output, so the kind the PRODUCER
     // must emit is not always the kind this edge delivers.
     val expectedKind = when (contractId) {
-      FeatureTaskRuntimePlanningProjectionContract.PREPLANNING_DIGEST_ID ->
-        FeatureTaskRuntimeProjectionKind.PREPLANNING_DIGEST
       FeatureTaskRuntimePlanningProjectionContract.EXECUTABLE_PLAN_ID,
       FeatureTaskRuntimePlanningProjectionContract.PLAN_COMMITMENT_ID,
       -> FeatureTaskRuntimeProjectionKind.EXECUTABLE_PLAN

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinition.kt
@@ -18,7 +18,6 @@ import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseDeclaration
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseEntryGate
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePlanCommitment
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePlanningProjectionContract
-import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePrePlanningDigest
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePreplanCeremony
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePriorGapMemory
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQualityGateSelection
@@ -91,14 +90,11 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
   // producer maps to that producer's regeneration edge. A consumer absent from this map has no
   // attributable producer, so its rejection blocks durably rather than re-entering an impossible edge.
   val REGENERATION_LOOP_ID_BY_PRODUCER: Map<String, String> = mapOf(
-    PHASE_PREPLAN to PREPLAN_REGENERATION_LOOP_ID,
     PHASE_PLAN to PLAN_REGENERATION_LOOP_ID,
     PHASE_IMPLEMENT to IMPLEMENT_REGENERATION_LOOP_ID,
   )
 
-  // Consumer phase -> the producer whose bounded planning projection it parses at its launch seam.
   val REGENERATION_PRODUCER_BY_CONSUMER: Map<String, String> = mapOf(
-    PHASE_PLAN to PHASE_PREPLAN,
     PHASE_IMPLEMENT to PHASE_PLAN,
     PHASE_AUDIT to PHASE_IMPLEMENT,
   )
@@ -243,6 +239,7 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
    */
   object PhaseProjectionContract {
     const val VERSION: String = "0.1"
+    const val PREPLAN_PROSE: String = "feature_task_runtime.preplan_prose"
     const val AUDIT_CLEARANCE: String = "feature_task_runtime.audit_clearance"
     const val AUDIT_REPAIR_REQUEST: String = "feature_task_runtime.audit_repair_request"
     const val REVIEW_CLEARANCE: String = "feature_task_runtime.review_clearance"
@@ -302,18 +299,18 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
     priorGapMemoryDeclaration(PHASE_IMPLEMENT),
   )
 
-  fun preplanningDigestDeclaration(
+  fun preplanProseDeclaration(
     consumerPhaseId: String,
     producingPhaseId: String = PHASE_PREPLAN,
   ): PhaseHandoffProjectionDeclaration = PhaseHandoffProjectionDeclaration(
     consumerPhaseId = consumerPhaseId,
     sourceRef = FeatureTaskRuntimeHandoffSourceRef.UpstreamPhaseOutput(producingPhaseId),
-    projectionName = "${producingPhaseId}_preplanning_digest",
-    projectionContractId = FeatureTaskRuntimePlanningProjectionContract.PREPLANNING_DIGEST_ID,
-    projectionContractVersion = FeatureTaskRuntimePlanningProjectionContract.VERSION,
+    projectionName = "${producingPhaseId}_prose",
+    projectionContractId = PhaseProjectionContract.PREPLAN_PROSE,
+    projectionContractVersion = PhaseProjectionContract.VERSION,
     promptVisibility = FeatureTaskRuntimeHandoffPromptVisibility.PROMPT_VISIBLE,
     budget = FeatureTaskRuntimeHandoffProjectionBudget.PLANNING_PROJECTION,
-    declaredFieldNames = FeatureTaskRuntimePrePlanningDigest.DECLARED_FIELD_NAMES,
+    declaredFieldNames = listOf("value", "directive"),
     checkpointPolicy = FeatureTaskRuntimeRepositoryCheckpointPolicy.NOT_REQUIRED,
     required = true,
   )
@@ -439,7 +436,7 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
    */
   private val PHASE_PROJECTION_MATRIX: Map<String, List<PhaseHandoffProjectionDeclaration>> = mapOf(
     PHASE_PREPLAN to emptyList(),
-    PHASE_PLAN to listOf(preplanningDigestDeclaration(PHASE_PLAN)),
+    PHASE_PLAN to listOf(preplanProseDeclaration(PHASE_PLAN)),
     PHASE_IMPLEMENT to listOf(executablePlanDeclaration(PHASE_IMPLEMENT)),
     // The shared evidence is a floor for audit, never a replacement for its scoped repository read: it is
     // appended to the existing declarations, which stay exactly as they were.
@@ -732,14 +729,6 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
         // SKILL-140: quarantine-and-regenerate edges. A consumer that rejects an upstream producer's
         // durable record at its launch seam re-enters that producer under a bounded cap; cap
         // exhaustion blocks durably (BLOCK, the default), naming the quarantined record.
-        FeatureTaskRuntimeBackwardEdge(
-          fromPhaseId = PHASE_PLAN,
-          triggeringVerdict = FeatureTaskRuntimeVerdict.RECORD_REJECTED,
-          destinationPhaseId = PHASE_PREPLAN,
-          loopId = PREPLAN_REGENERATION_LOOP_ID,
-          perEdgeCap = MAX_RECORD_REGENERATION_ATTEMPTS,
-          capScope = FeatureTaskRuntimeBackwardEdgeCapScope.PER_SUBTASK,
-        ),
         FeatureTaskRuntimeBackwardEdge(
           fromPhaseId = PHASE_IMPLEMENT,
           triggeringVerdict = FeatureTaskRuntimeVerdict.RECORD_REJECTED,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanningProjectionModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanningProjectionModels.kt
@@ -9,8 +9,8 @@ import skillbill.workflow.FeatureTaskRuntimePlanningProjectionValidator
 import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
 
 /**
- * Typed models for the four concrete bounded planning projections (preplanning digest, executable plan,
- * plan commitment, implementation receipt). Each is closed and immutable, parses the producing phase's
+ * Typed models for the three concrete bounded planning projections (executable plan, plan commitment,
+ * implementation receipt). Each is closed and immutable, parses the producing phase's
  * schema-validated `produced_outputs`, and renders the exact field set a consumer projection delivers —
  * never the producing phase's complete envelope, narration, presentation summary, progress diagnostics,
  * or raw source.
@@ -20,7 +20,7 @@ import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition
  */
 
 /**
- * Closed family of the four bounded planning projections. Parsing returns this type rather than `Any`,
+ * Closed family of the three bounded planning projections.
  * so a consumer narrows with an exhaustive `when` and a producer/declaration kind mismatch surfaces as
  * a typed rejection instead of a raw `ClassCastException` at the launch seam.
  */
@@ -31,7 +31,6 @@ sealed interface FeatureTaskRuntimePlanningProjection {
 }
 
 enum class FeatureTaskRuntimeProjectionKind(val wireValue: String) {
-  PREPLANNING_DIGEST("preplanning_digest"),
   EXECUTABLE_PLAN("executable_plan"),
   PLAN_COMMITMENT("plan_commitment"),
   IMPLEMENTATION_RECEIPT("implementation_receipt"),
@@ -47,7 +46,6 @@ enum class FeatureTaskRuntimeProjectionKind(val wireValue: String) {
 }
 
 object FeatureTaskRuntimePlanningProjectionContract {
-  const val PREPLANNING_DIGEST_ID: String = "feature_task_runtime.preplanning_digest"
   const val EXECUTABLE_PLAN_ID: String = "feature_task_runtime.executable_plan"
   const val PLAN_COMMITMENT_ID: String = "feature_task_runtime.plan_commitment"
   const val IMPLEMENTATION_RECEIPT_ID: String = "feature_task_runtime.implementation_receipt"
@@ -65,7 +63,6 @@ object FeatureTaskRuntimePlanningProjectionContract {
    * produced by a phase, so gating a phase against it would demand a shape no producer emits.
    */
   fun producedProjectionKindFor(phaseId: String): FeatureTaskRuntimeProjectionKind? = when (phaseId) {
-    FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN -> FeatureTaskRuntimeProjectionKind.PREPLANNING_DIGEST
     FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN -> FeatureTaskRuntimeProjectionKind.EXECUTABLE_PLAN
     FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT ->
       FeatureTaskRuntimeProjectionKind.IMPLEMENTATION_RECEIPT
@@ -89,110 +86,6 @@ const val FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT: Int = 128
 
 /** changed_paths is the one list sized for a large feature's file inventory rather than a summary. */
 const val FEATURE_TASK_RUNTIME_CHANGED_PATH_MAX_COUNT: Int = 512
-
-/**
- * SKILL-174: the boundary-memory heading ids a preplan may select for body resolution. The schema
- * repeats this number as `maxItems` on preplanning_digest.selected_boundary_headings.
- */
-const val FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT: Int = 64
-
-/**
- * The bounded digest `plan` receives from `preplan` (AC-003). Excludes the complete preplan envelope,
- * its summary, derived notes, and any progress diagnostics.
- */
-data class FeatureTaskRuntimePrePlanningDigest(
-  val affectedBoundaries: List<String>,
-  val patternsAndDecisions: List<String> = emptyList(),
-  val risks: List<String>,
-  val rollout: FeatureTaskRuntimeRolloutDecision,
-  val validationStrategy: List<String>,
-  val unresolvedQuestions: List<String> = emptyList(),
-  val evidenceRefs: List<String> = emptyList(),
-  val selectedBoundaryHeadings: List<String> = emptyList(),
-) : FeatureTaskRuntimePlanningProjection {
-  override val projectionKind: FeatureTaskRuntimeProjectionKind =
-    FeatureTaskRuntimeProjectionKind.PREPLANNING_DIGEST
-
-  init {
-    requireNonBlankStrings(affectedBoundaries, "affected_boundaries")
-    requireNonBlankStrings(risks, "risks")
-    requireNonBlankStrings(validationStrategy, "validation_strategy")
-    requireNonBlankStrings(patternsAndDecisions, "patterns_and_decisions")
-    requireNonBlankStrings(unresolvedQuestions, "unresolved_questions")
-    requireNonBlankStrings(evidenceRefs, "evidence_refs")
-    requireNonBlankStrings(selectedBoundaryHeadings, "selected_boundary_headings")
-    require(selectedBoundaryHeadings.size <= FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT) {
-      "selected_boundary_headings exceeds $FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT entries."
-    }
-  }
-
-  override fun toProjectionFields(): List<FeatureTaskRuntimeHandoffProjectionField> = listOf(
-    field(FIELD_AFFECTED_BOUNDARIES, FeatureTaskRuntimeHandoffProjectionValue.TextList(affectedBoundaries)),
-    field(FIELD_PATTERNS_AND_DECISIONS, FeatureTaskRuntimeHandoffProjectionValue.TextList(patternsAndDecisions)),
-    field(FIELD_RISKS, FeatureTaskRuntimeHandoffProjectionValue.TextList(risks)),
-    field(FIELD_ROLLOUT, FeatureTaskRuntimeHandoffProjectionValue.Text(rollout.toBriefingLine())),
-    field(FIELD_VALIDATION_STRATEGY, FeatureTaskRuntimeHandoffProjectionValue.TextList(validationStrategy)),
-    field(FIELD_UNRESOLVED_QUESTIONS, FeatureTaskRuntimeHandoffProjectionValue.TextList(unresolvedQuestions)),
-    field(FIELD_EVIDENCE_REFS, FeatureTaskRuntimeHandoffProjectionValue.TextList(evidenceRefs)),
-    field(
-      FIELD_SELECTED_BOUNDARY_HEADINGS,
-      FeatureTaskRuntimeHandoffProjectionValue.TextList(selectedBoundaryHeadings),
-    ),
-  )
-
-  companion object {
-    val DECLARED_FIELD_NAMES: List<String> = listOf(
-      FIELD_AFFECTED_BOUNDARIES,
-      FIELD_PATTERNS_AND_DECISIONS,
-      FIELD_RISKS,
-      FIELD_ROLLOUT,
-      FIELD_VALIDATION_STRATEGY,
-      FIELD_UNRESOLVED_QUESTIONS,
-      FIELD_EVIDENCE_REFS,
-      FIELD_SELECTED_BOUNDARY_HEADINGS,
-    )
-
-    const val FIELD_AFFECTED_BOUNDARIES: String = "affected_boundaries"
-    const val FIELD_PATTERNS_AND_DECISIONS: String = "patterns_and_decisions"
-    const val FIELD_RISKS: String = "risks"
-    const val FIELD_ROLLOUT: String = "rollout"
-    const val FIELD_VALIDATION_STRATEGY: String = "validation_strategy"
-    const val FIELD_UNRESOLVED_QUESTIONS: String = "unresolved_questions"
-    const val FIELD_EVIDENCE_REFS: String = "evidence_refs"
-    const val FIELD_SELECTED_BOUNDARY_HEADINGS: String = "selected_boundary_headings"
-  }
-}
-
-data class FeatureTaskRuntimeRolloutDecision(
-  val flagRequired: Boolean,
-  val flagPattern: FeatureTaskRuntimeFlagPattern = FeatureTaskRuntimeFlagPattern.NONE,
-  val notes: String,
-) {
-  init {
-    require(notes.isNotBlank()) { "FeatureTaskRuntimeRolloutDecision.notes must be non-blank." }
-    require(
-      notes.length <= TEXT_MAX_LENGTH,
-    ) { "FeatureTaskRuntimeRolloutDecision.notes exceeds $TEXT_MAX_LENGTH chars." }
-  }
-
-  fun toBriefingLine(): String = "flag_required=$flagRequired; flag_pattern=${flagPattern.wireValue}; notes=$notes"
-}
-
-enum class FeatureTaskRuntimeFlagPattern(val wireValue: String) {
-  NONE("none"),
-  SIMPLE_CONDITIONAL("simple_conditional"),
-  DI_SWITCH("di_switch"),
-  LEGACY("legacy"),
-  ;
-
-  companion object {
-    fun fromWire(value: String): FeatureTaskRuntimeFlagPattern = entries.firstOrNull { it.wireValue == value }
-      ?: throw InvalidFeatureTaskRuntimePlanningProjectionSchemaError(
-        sourceLabel = "<rollout.flag_pattern>",
-        reason = "unknown flag_pattern '$value'.",
-      )
-  }
-}
 
 enum class FeatureTaskRuntimePlanMode(val wireValue: String) {
   DIRECT("direct"),
@@ -693,7 +586,6 @@ internal fun featureTaskRuntimePlanningProjectionParseFromEnvelope(
   schemaValidator.validatePlanningProjection(canonical, sourceLabel)
   return try {
     val projection = when (expectedKind) {
-      FeatureTaskRuntimeProjectionKind.PREPLANNING_DIGEST -> FeatureTaskRuntimePrePlanningDigest.fromMap(canonical)
       FeatureTaskRuntimeProjectionKind.EXECUTABLE_PLAN -> FeatureTaskRuntimeExecutablePlan.fromMap(canonical)
       FeatureTaskRuntimeProjectionKind.PLAN_COMMITMENT -> FeatureTaskRuntimePlanCommitment.fromMap(canonical)
       FeatureTaskRuntimeProjectionKind.IMPLEMENTATION_RECEIPT ->
@@ -720,30 +612,6 @@ private fun requirePinnedContractVersion(produced: Map<String, Any?>, sourceLabe
         "'$FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION', was ${version?.let { "'$it'" } ?: "absent"}.",
     )
   }
-}
-
-@Suppress("ThrowsCount") // one malformed-field rejection per required field; collapsing would blur the diagnosis
-private fun FeatureTaskRuntimePrePlanningDigest.Companion.fromMap(
-  map: Map<String, Any?>,
-): FeatureTaskRuntimePrePlanningDigest {
-  val rolloutMap = map.stringAnyMap("rollout")
-    ?: throw malformed("rollout", "must be an object")
-  return FeatureTaskRuntimePrePlanningDigest(
-    affectedBoundaries = map.requireStringList("affected_boundaries"),
-    patternsAndDecisions = map.optionalStringList("patterns_and_decisions"),
-    risks = map.requireStringList("risks"),
-    rollout = FeatureTaskRuntimeRolloutDecision(
-      flagRequired = (rolloutMap["flag_required"] as? Boolean)
-        ?: throw malformed("rollout.flag_required", "must be a boolean"),
-      flagPattern = rolloutMap["flag_pattern"]?.toString()?.let(FeatureTaskRuntimeFlagPattern::fromWire)
-        ?: FeatureTaskRuntimeFlagPattern.NONE,
-      notes = rolloutMap.firstString("notes"),
-    ),
-    validationStrategy = map.requireStringList("validation_strategy"),
-    unresolvedQuestions = map.optionalStringList("unresolved_questions"),
-    evidenceRefs = map.optionalStringList("evidence_refs"),
-    selectedBoundaryHeadings = map.optionalStringList("selected_boundary_headings"),
-  )
 }
 
 @Suppress("ThrowsCount") // one malformed-field rejection per required field; collapsing would blur the diagnosis

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeProjectionCanonicalization.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeProjectionCanonicalization.kt
@@ -94,14 +94,6 @@ internal object FeatureTaskRuntimeProjectionCanonicalizer {
     "deviations" -> mapEntries(value) { index, entry -> canonicalizeDeviationEntry(entry, records, index) }
     "completed_task_ids" -> canonicalizeReferenceIds(value, declaredIds, records, key)
     "tests_executed" -> discardUnknownKeysInEntries(value, TEST_EXECUTION_KEYS, key, records)
-    "rollout" -> mapObject(value) {
-      trimNonBlank(
-        discardUnknownKeys(it, ROLLOUT_KEYS, key, records),
-        "notes",
-        records,
-        "rollout.notes",
-      )
-    }
     "reconciliation_evidence" -> mapObject(promotedReconciliationEvidence(value, records)) {
       trimNonBlank(
         // Adoption runs BEFORE the discard: afterwards the misnamed key is already gone, and all the
@@ -446,7 +438,6 @@ internal object FeatureTaskRuntimeProjectionCanonicalizer {
   )
 
   private val RECONCILIATION_EVIDENCE_KEYS = governedKeysOf("reconciliation_evidence")
-  private val ROLLOUT_KEYS = governedKeysOf("preplanning_digest.rollout")
   private val REPOSITORY_CHECKPOINT_KEYS = governedKeysOf("repositoryCheckpoint")
   private val PLAN_TASK_KEYS = governedKeysOf("plan_task")
   private val TASK_COMMITMENT_KEYS = governedKeysOf("task_commitment")
@@ -504,7 +495,7 @@ enum class FeatureTaskRuntimeProjectionCanonicalizationTransform(val wireValue: 
 }
 
 /**
- * Governed key sets of the fully-enumerated closed projection objects — the four top-level variants and
+ * Governed key sets of the fully-enumerated closed projection objects — the three top-level variants and
  * every nested one — keyed by their location in
  * `orchestration/contracts/feature-task-runtime-planning-projections-schema.yaml`: a `$defs` name, or a
  * `<variant>.<property>` path for an inline object. A top-level variant's entry is keyed by its
@@ -516,19 +507,6 @@ enum class FeatureTaskRuntimeProjectionCanonicalizationTransform(val wireValue: 
  * appear here and the prune retains them.
  */
 internal val FEATURE_TASK_RUNTIME_CLOSED_PROJECTION_OBJECT_KEYS: Map<String, Set<String>> = mapOf(
-  "preplanning_digest" to setOf(
-    "projection_kind",
-    "contract_version",
-    "affected_boundaries",
-    "patterns_and_decisions",
-    "risks",
-    "rollout",
-    "validation_strategy",
-    "unresolved_questions",
-    "evidence_refs",
-    "selected_boundary_headings",
-    "_goal_planning_shared_context",
-  ),
   "executable_plan" to setOf(
     "projection_kind",
     "contract_version",
@@ -558,7 +536,6 @@ internal val FEATURE_TASK_RUNTIME_CLOSED_PROJECTION_OBJECT_KEYS: Map<String, Set
     "repair_receipt",
   ),
   "reconciliation_evidence" to setOf("reconciled", "evidence"),
-  "preplanning_digest.rollout" to setOf("flag_required", "flag_pattern", "notes"),
   "repositoryCheckpoint" to setOf("fingerprint", "base_ref", "head_ref", "working_tree_owned_paths"),
   "plan_task" to setOf(
     "task_id",

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/agent/model/AgentPhaseModelsTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/agent/model/AgentPhaseModelsTest.kt
@@ -12,15 +12,23 @@ class AgentPhaseModelsTest {
       requestedAction = "verify claims",
     )
     val output = AgentPhaseOutput(output = "verified prose")
+    val phaseOutput = PhaseOutput(value = "preplan prose", prompt = "optional directive")
 
     assertEquals("review prose", input.input)
     assertEquals("verify claims", input.requestedAction)
     assertEquals("verified prose", output.output)
+    assertEquals("preplan prose", phaseOutput.value)
+    assertEquals("optional directive", phaseOutput.prompt)
     assertEquals(String::class.java, AgentPhaseInput::class.java.getDeclaredField("input").type)
     assertEquals(String::class.java, AgentPhaseInput::class.java.getDeclaredField("requestedAction").type)
     assertEquals(String::class.java, AgentPhaseOutput::class.java.getDeclaredField("output").type)
+    assertEquals(String::class.java, PhaseOutput::class.java.getDeclaredField("value").type)
     assertFalse(
-      (AgentPhaseInput::class.java.declaredFields + AgentPhaseOutput::class.java.declaredFields)
+      (
+        AgentPhaseInput::class.java.declaredFields +
+          AgentPhaseOutput::class.java.declaredFields +
+          PhaseOutput::class.java.declaredFields
+        )
         .any { it.name in setOf("repoRoot", "agentId", "evidenceBroker", "budget", "budgets") },
     )
   }

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidatorTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidatorTest.kt
@@ -678,6 +678,31 @@ class FeatureTaskRuntimeHandoffProjectionValidatorTest {
   }
 
   @Test
+  fun `preplan prose handoff rejects whitespace-only value`() {
+    val consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN
+    val declaration = FeatureTaskRuntimePhaseWorkflowDefinition.preplanProseDeclaration(consumer)
+    val error = assertFailsWith<InvalidFeatureTaskRuntimeHandoffProjectionError> {
+      FeatureTaskRuntimeHandoffProjectionValidator.validate(
+        inputs(
+          consumerPhaseId = consumer,
+          declarations = listOf(declaration),
+          resolvedUpstream = FeatureTaskRuntimeResolvedUpstreamOutputs(
+            mapOf(
+              FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN to FeatureTaskRuntimePhaseOutput(
+                phaseId = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PREPLAN,
+                iteration = 1,
+                payload = """{"produced_outputs":{"value":"   "}}""",
+              ),
+            ),
+          ),
+        ),
+      )
+    }
+    assertEquals(FeatureTaskRuntimeHandoffProjectionFailureKind.MALFORMED_FIELD, error.failureKind)
+    assertContains(error.message.orEmpty(), "non-blank prose")
+  }
+
+  @Test
   fun `null prior gap memory omits the optional projection while present memory enforces the declared shape`() {
     val consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT
     val memoryDeclaration = FeatureTaskRuntimePhaseWorkflowDefinition.priorGapMemoryDeclaration(consumer)

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinitionTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinitionTest.kt
@@ -189,15 +189,14 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
   }
 
   @Test
-  fun `the three record-regeneration edges keep their caps and cap-exhaustion behavior`() {
+  fun `the two record-regeneration edges keep their caps and cap-exhaustion behavior`() {
     val def = FeatureTaskRuntimePhaseWorkflowDefinition
     val expected = mapOf(
-      def.PREPLAN_REGENERATION_LOOP_ID to (def.PHASE_PLAN to def.PHASE_PREPLAN),
       def.PLAN_REGENERATION_LOOP_ID to (def.PHASE_IMPLEMENT to def.PHASE_PLAN),
       def.IMPLEMENT_REGENERATION_LOOP_ID to (def.PHASE_AUDIT to def.PHASE_IMPLEMENT),
     )
 
-    assertEquals(setOf("regenerate_preplan", "regenerate_plan", "regenerate_implement"), def.REGENERATION_LOOP_IDS)
+    assertEquals(setOf("regenerate_plan", "regenerate_implement"), def.REGENERATION_LOOP_IDS)
     assertEquals(2, def.MAX_RECORD_REGENERATION_ATTEMPTS)
     expected.forEach { (loopId, endpoints) ->
       val edge = def.transitions.backwardEdges.single { it.loopId == loopId }
@@ -214,7 +213,7 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
   fun `the audit_gap backward edge reopens implement-through-audit without planning and without a cap`() {
     val def = FeatureTaskRuntimePhaseWorkflowDefinition
     val transitions = def.transitions
-    assertEquals(5, transitions.backwardEdges.size)
+    assertEquals(4, transitions.backwardEdges.size)
     val edge = transitions.backwardEdges.single { it.loopId == def.AUDIT_GAP_LOOP_ID }
     assertEquals(def.PHASE_AUDIT, edge.fromPhaseId)
     assertEquals(def.PHASE_IMPLEMENT, edge.destinationPhaseId)
@@ -290,7 +289,7 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
   fun `consumer projection matrix is exact and downstream edges never receive whole phase receipts`() {
     val def = FeatureTaskRuntimePhaseWorkflowDefinition
     val expected = mapOf(
-      def.PHASE_PLAN to setOf(def.PHASE_PREPLAN to "feature_task_runtime.preplanning_digest"),
+      def.PHASE_PLAN to setOf(def.PHASE_PREPLAN to "feature_task_runtime.preplan_prose"),
       def.PHASE_IMPLEMENT to setOf(def.PHASE_PLAN to "feature_task_runtime.executable_plan"),
       def.PHASE_AUDIT to setOf(
         def.PHASE_PLAN to "feature_task_runtime.plan_commitment",
@@ -553,7 +552,7 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
   @Test
   fun `all backward edges declare PER_SUBTASK capScope explicitly`() {
     val edges = FeatureTaskRuntimePhaseWorkflowDefinition.transitions.backwardEdges
-    assertEquals(5, edges.size, "expected exactly five declared backward edges: ${edges.map { it.loopId }}")
+    assertEquals(4, edges.size, "expected exactly four declared backward edges: ${edges.map { it.loopId }}")
     edges.forEach { edge ->
       assertEquals(
         FeatureTaskRuntimeBackwardEdgeCapScope.PER_SUBTASK,

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeTransitionFunctionTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeTransitionFunctionTest.kt
@@ -648,7 +648,6 @@ class FeatureTaskRuntimeTransitionFunctionTest {
   fun `RECORD_REJECTED below cap re-enters the producer on its regeneration loop`() {
     val def = FeatureTaskRuntimePhaseWorkflowDefinition
     val cases = listOf(
-      Triple(def.PHASE_PLAN, def.PHASE_PREPLAN, def.PREPLAN_REGENERATION_LOOP_ID),
       Triple(def.PHASE_IMPLEMENT, def.PHASE_PLAN, def.PLAN_REGENERATION_LOOP_ID),
       Triple(def.PHASE_AUDIT, def.PHASE_IMPLEMENT, def.IMPLEMENT_REGENERATION_LOOP_ID),
     )
@@ -678,28 +677,16 @@ class FeatureTaskRuntimeTransitionFunctionTest {
   }
 
   @Test
-  fun `a producer absent from the resolved pipeline yields no regeneration edge`() {
+  fun `RECORD_REJECTED at plan advances forward when no regeneration edge targets preplan`() {
     val def = FeatureTaskRuntimePhaseWorkflowDefinition
-    // A truncated pipeline that dropped preplan cannot legally carry the plan->preplan edge, so the
-    // transition function computes no re-entry: RECORD_REJECTED at plan simply advances forward.
-    val truncated = FeatureTaskRuntimeTransitionDeclaration(
-      forwardPhaseIds = listOf(def.PHASE_PLAN, def.PHASE_IMPLEMENT, def.PHASE_AUDIT),
-      backwardEdges = shipped.backwardEdges.filter {
-        it.fromPhaseId != def.PHASE_PLAN || it.destinationPhaseId != def.PHASE_PREPLAN
-      }.filter {
-        it.fromPhaseId in listOf(def.PHASE_PLAN, def.PHASE_IMPLEMENT, def.PHASE_AUDIT) &&
-          it.destinationPhaseId in listOf(def.PHASE_PLAN, def.PHASE_IMPLEMENT, def.PHASE_AUDIT)
-      },
-    )
     val next = assertIs<FeatureTaskRuntimeNextPhase.Next>(
-      FeatureTaskRuntimeTransitionFunction.nextTransition(
-        declaration = truncated,
-        currentPhaseId = def.PHASE_PLAN,
-        verdict = FeatureTaskRuntimeVerdict.RECORD_REJECTED,
+      shippedTransition(
+        def.PHASE_PLAN,
+        FeatureTaskRuntimeVerdict.RECORD_REJECTED,
         edgeIterationCount = 0,
       ),
     )
-    assertEquals(def.PHASE_IMPLEMENT, next.phaseId, "no edge to a dropped producer; plain forward advance")
+    assertEquals(def.PHASE_IMPLEMENT, next.phaseId)
     assertEquals(null, next.loopId)
   }
 }

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/UnboundedRemediationLoopRegressionTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/UnboundedRemediationLoopRegressionTest.kt
@@ -69,7 +69,7 @@ class UnboundedRemediationLoopRegressionTest {
   @Test
   fun `every record-regeneration edge keeps its finite cap and blocking exhaustion`() {
     val regenerationEdges = transitions.backwardEdges.filter { def.isRegenerationLoopId(it.loopId) }
-    assertEquals(3, regenerationEdges.size)
+    assertEquals(2, regenerationEdges.size)
     assertEquals(2, def.MAX_RECORD_REGENERATION_ATTEMPTS)
     regenerationEdges.forEach { edge ->
       assertEquals(
@@ -101,11 +101,11 @@ class UnboundedRemediationLoopRegressionTest {
   @Test
   fun `an exhausted regeneration edge still blocks durably`() {
     val transition = transition(
-      def.PHASE_PLAN,
+      def.PHASE_IMPLEMENT,
       FeatureTaskRuntimeVerdict.RECORD_REJECTED,
       def.MAX_RECORD_REGENERATION_ATTEMPTS,
     )
     val blocked = assertIs<FeatureTaskRuntimeNextPhase.TerminalBlock>(transition)
-    assertEquals(def.PREPLAN_REGENERATION_LOOP_ID, blocked.loopId)
+    assertEquals(def.PLAN_REGENERATION_LOOP_ID, blocked.loopId)
   }
 }

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanningProjectionModelsTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanningProjectionModelsTest.kt
@@ -249,10 +249,10 @@ class FeatureTaskRuntimePlanningProjectionModelsTest {
   }
 
   @Test
-  fun `the producing-phase mapping names the three producer kinds and nothing else`() {
-    assertEquals(
-      FeatureTaskRuntimeProjectionKind.PREPLANNING_DIGEST,
+  fun `the producing-phase mapping names the two producer kinds and nothing else`() {
+    assertNull(
       FeatureTaskRuntimePlanningProjectionContract.producedProjectionKindFor("preplan"),
+      "preplan delivers prose on the phase-output envelope, not a bounded planning projection",
     )
     assertEquals(
       FeatureTaskRuntimeProjectionKind.EXECUTABLE_PLAN,

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeProjectionCanonicalizationFixtures.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeProjectionCanonicalizationFixtures.kt
@@ -30,15 +30,6 @@ internal object FeatureTaskRuntimeProjectionCanonicalizationFixtures {
     "validation_strategy" to listOf("  focused gradle  "),
   )
 
-  private val CANONICAL_PREPLAN_DIGEST: Map<String, Any?> = mapOf(
-    "projection_kind" to "preplanning_digest",
-    "contract_version" to "0.1",
-    "affected_boundaries" to listOf("  runtime-domain  "),
-    "risks" to listOf("producer may omit fields"),
-    "rollout" to mapOf("flag_required" to false, "notes" to "  no flag needed  "),
-    "validation_strategy" to listOf("snapshot tests"),
-  )
-
   private val PLAN_COMMITMENT: Map<String, Any?> = mapOf(
     "projection_kind" to "plan_commitment",
     "contract_version" to "0.1",
@@ -65,7 +56,6 @@ internal object FeatureTaskRuntimeProjectionCanonicalizationFixtures {
 
   val ALL: List<Map<String, Any?>> = listOf(
     UPPERCASE_EXECUTABLE_PLAN,
-    CANONICAL_PREPLAN_DIGEST,
     PLAN_COMMITMENT,
     IMPLEMENTATION_RECEIPT,
   )

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeProjectionCanonicalizationTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeProjectionCanonicalizationTest.kt
@@ -94,7 +94,6 @@ class FeatureTaskRuntimeProjectionCanonicalizationTest {
   fun `nonBlank scalar and array string fields are trimmed without touching interior content`() {
     val produced = mapOf(
       "affected_boundaries" to listOf("  runtime-domain  ", "runtime-application"),
-      "rollout" to mapOf("flag_required" to false, "notes" to "  no flag  "),
       "reconciliation_evidence" to mapOf("reconciled" to true, "evidence" to "  at target  "),
       "repository_checkpoint" to mapOf("fingerprint" to "  abc  ", "base_ref" to " main "),
     )
@@ -102,7 +101,6 @@ class FeatureTaskRuntimeProjectionCanonicalizationTest {
     val result = FeatureTaskRuntimeProjectionCanonicalizer.canonicalize(produced)
 
     assertEquals(listOf("runtime-domain", "runtime-application"), result.canonical["affected_boundaries"])
-    assertEquals("no flag", (result.canonical["rollout"] as Map<*, *>)["notes"])
     assertEquals("at target", (result.canonical["reconciliation_evidence"] as Map<*, *>)["evidence"])
     val checkpoint = result.canonical["repository_checkpoint"] as Map<*, *>
     assertEquals("abc", checkpoint["fingerprint"])
@@ -362,7 +360,7 @@ class FeatureTaskRuntimeProjectionCanonicalizationTest {
       ),
       "tests_executed" to listOf(mapOf("name" to "FooTest", "outcome" to "passed", "duration_ms" to 12)),
       "deviations" to listOf(mapOf("ref" to "AC-001", "note" to "n", "severity" to "minor")),
-      "rollout" to mapOf("flag_required" to false, "notes" to "n", "owner" to "me"),
+      "reconciliation_evidence" to mapOf("reconciled" to true, "evidence" to "n", "owner" to "me"),
       "repository_checkpoint" to mapOf("fingerprint" to "abc", "dirty" to true),
     )
 
@@ -377,12 +375,11 @@ class FeatureTaskRuntimeProjectionCanonicalizationTest {
         "task_commitments[0].owner",
         "tests_executed[0].duration_ms",
         "deviations[0].severity",
-        "rollout.owner",
+        "reconciliation_evidence.owner",
         "repository_checkpoint.dirty",
       ).sorted(),
       discarded.sorted(),
     )
-    // Every governed field survives the prune.
     val task = (result.canonical["tasks"] as List<*>).single() as Map<*, *>
     assertEquals(setOf("task_id", "description", "criterion_refs", "test_obligations"), task.keys)
     val checkpoint = result.canonical["repository_checkpoint"] as Map<*, *>
@@ -392,18 +389,18 @@ class FeatureTaskRuntimeProjectionCanonicalizationTest {
   @Test
   fun `the discard never synthesizes a missing field nor coerces a type`() {
     val produced = mapOf(
-      // A required governed field is absent and an unknown key is present: only the unknown key goes.
       "reconciliation_evidence" to mapOf("reconciled" to true, "extra" to 1),
-      // A wrong-typed governed field keeps its wrong type for the schema to reject.
-      "rollout" to mapOf("flag_required" to "yes", "notes" to "n", "extra" to 1),
+      "repository_checkpoint" to mapOf("fingerprint" to 42, "base_ref" to "main", "extra" to 1),
     )
 
     val result = FeatureTaskRuntimeProjectionCanonicalizer.canonicalize(produced)
 
     val evidence = result.canonical["reconciliation_evidence"] as Map<*, *>
     assertEquals(mapOf("reconciled" to true), evidence, "no field may be synthesized to satisfy the schema")
-    val rollout = result.canonical["rollout"] as Map<*, *>
-    assertEquals("yes", rollout["flag_required"], "a wrong-typed governed field must not be coerced")
+    val checkpoint = result.canonical["repository_checkpoint"] as Map<*, *>
+    assertEquals(42, checkpoint["fingerprint"], "a wrong-typed governed field must not be coerced")
+    assertEquals("main", checkpoint["base_ref"])
+    assertEquals(setOf("fingerprint", "base_ref"), checkpoint.keys)
   }
 
   @Test
@@ -429,24 +426,6 @@ class FeatureTaskRuntimeProjectionCanonicalizationTest {
         .filter { it.transforms == listOf(Transform.UNKNOWN_KEY_DISCARDED) }
         .map { it.fieldPath },
     )
-  }
-
-  @Test
-  fun `the goal-planning shared context survives the preplanning digest prune`() {
-    val sharedContext = mapOf("goal_id" to "SKILL-152")
-    val produced = mapOf(
-      "projection_kind" to "preplanning_digest",
-      "contract_version" to "0.1",
-      "_goal_planning_shared_context" to sharedContext,
-      "presentation_summary" to "prose the consumer never asked for",
-    )
-
-    val result = FeatureTaskRuntimeProjectionCanonicalizer.canonicalize(produced)
-
-    assertEquals(sharedContext, result.canonical["_goal_planning_shared_context"])
-    assertEquals("preplanning_digest", result.canonical["projection_kind"])
-    assertEquals("0.1", result.canonical["contract_version"])
-    assertTrue("presentation_summary" !in result.canonical.keys)
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionSchemaValidator.kt
@@ -16,8 +16,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 /**
- * Draft 2020-12 validator for the four concrete planning projections (preplanning digest, executable
- * plan, plan commitment, implementation receipt). Validates the structured payload a projection parses
+ * Draft 2020-12 validator for the three concrete planning projections (executable plan, plan
+ * commitment, implementation receipt).
  * and forwards; any violation fails with [InvalidFeatureTaskRuntimePlanningProjectionSchemaError], the
  * message carrying schema locations, never projection bodies.
  */
@@ -56,7 +56,6 @@ object FeatureTaskRuntimePlanningProjectionSchemaValidator {
     .getSchema(ObjectMapper().writeValueAsString(document), LOCALE_STABLE_SCHEMA_CONFIG)
 
   private val PROJECTION_VARIANT_DEFS: Set<String> = setOf(
-    "preplanning_digest",
     "executable_plan",
     "plan_commitment",
     "implementation_receipt",

--- a/runtime-kotlin/runtime-infra-fs/src/repoTest/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeProjectionCanonicalizationSchemaRepoTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/repoTest/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeProjectionCanonicalizationSchemaRepoTest.kt
@@ -2,23 +2,23 @@ package skillbill.contracts.workflow
 
 import org.yaml.snakeyaml.Yaml
 import skillbill.testing.repoRootFromTest
-import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT
+import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class FeatureTaskRuntimeProjectionCanonicalizationSchemaRepoTest {
-  // The schema's list-cap-budget-agreement check names the constant in prose; only this binds it.
   @Test
-  fun `the schema literal cap equals the Kotlin selected boundary heading cap`() {
+  fun `the schema literal task cap equals the Kotlin projection list cap`() {
     val schema = Yaml().load<Map<String, Any?>>(
       Files.readString(
         repoRootFromTest().resolve("orchestration/contracts/feature-task-runtime-planning-projections-schema.yaml"),
       ),
     )
-    val digest = (schema["\$defs"] as Map<*, *>)["preplanning_digest"] as Map<*, *>
-    val headings = (digest["properties"] as Map<*, *>)["selected_boundary_headings"] as Map<*, *>
+    val plan = (schema["\$defs"] as Map<*, *>)["executable_plan"] as Map<*, *>
+    val tasks = (plan["properties"] as Map<*, *>)["tasks"] as Map<*, *>
+    val maxItems = (tasks["maxItems"] as? Number)?.toInt()
 
-    assertEquals(FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT, headings["maxItems"])
+    assertEquals(FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT, maxItems)
   }
 }

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidatorTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidatorTest.kt
@@ -654,6 +654,68 @@ class FeatureTaskRuntimePhaseOutputSchemaValidatorEnvelopeTest {
     }
   }
 
+  @Test
+  fun `completed preplan with non-blank value passes validation`() {
+    val preplan =
+      """
+      contract_version: "0.4"
+      phase_id: "preplan"
+      status: "completed"
+      summary: "Preplan prose ready for plan."
+      produced_outputs:
+        value: "Dense planning prose for the plan phase."
+      """.trimIndent()
+    FeatureTaskRuntimePhaseOutputSchemaValidator.validatePhaseOutputText(preplan, "preplan")
+  }
+
+  @Test
+  fun `completed preplan with blank value fails validation`() {
+    val preplan =
+      """
+      contract_version: "0.4"
+      phase_id: "preplan"
+      status: "completed"
+      summary: "Preplan missing prose."
+      produced_outputs:
+        value: ""
+      """.trimIndent()
+    assertFailsWith<InvalidFeatureTaskRuntimePhaseOutputSchemaError> {
+      FeatureTaskRuntimePhaseOutputSchemaValidator.validatePhaseOutputText(preplan, "preplan")
+    }
+  }
+
+  @Test
+  fun `completed preplan with whitespace-only value fails validation`() {
+    val preplan =
+      """
+      contract_version: "0.4"
+      phase_id: "preplan"
+      status: "completed"
+      summary: "Preplan whitespace-only prose."
+      produced_outputs:
+        value: "   "
+      """.trimIndent()
+    assertFailsWith<InvalidFeatureTaskRuntimePhaseOutputSchemaError> {
+      FeatureTaskRuntimePhaseOutputSchemaValidator.validatePhaseOutputText(preplan, "preplan")
+    }
+  }
+
+  @Test
+  fun `completed preplan missing value fails validation`() {
+    val preplan =
+      """
+      contract_version: "0.4"
+      phase_id: "preplan"
+      status: "completed"
+      summary: "Preplan missing value."
+      produced_outputs:
+        prompt: "optional only"
+      """.trimIndent()
+    assertFailsWith<InvalidFeatureTaskRuntimePhaseOutputSchemaError> {
+      FeatureTaskRuntimePhaseOutputSchemaValidator.validatePhaseOutputText(preplan, "preplan")
+    }
+  }
+
   private fun buildPhaseEnvelope(buildReceipt: String): String =
     """{"contract_version":"0.4","phase_id":"build","status":"completed",""" +
       """"summary":"Build satisfied by runtime-owned gate execution.",""" +

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionSchemaValidatorTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionSchemaValidatorTest.kt
@@ -10,21 +10,6 @@ import kotlin.test.assertTrue
 
 class FeatureTaskRuntimePlanningProjectionSchemaValidatorTest {
   @Test
-  fun `a valid preplanning digest validates`() {
-    FeatureTaskRuntimePlanningProjectionSchemaValidator.validate(
-      payload = linkedMapOf<String, Any?>(
-        "projection_kind" to "preplanning_digest",
-        "contract_version" to FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION,
-        "affected_boundaries" to listOf("runtime-domain/model"),
-        "risks" to listOf("producer may omit digest fields"),
-        "rollout" to linkedMapOf("flag_required" to false, "notes" to "no flag needed"),
-        "validation_strategy" to listOf("snapshot projection tests"),
-      ),
-      sourceLabel = "preplan#1",
-    )
-  }
-
-  @Test
   fun `a valid executable plan validates`() {
     FeatureTaskRuntimePlanningProjectionSchemaValidator.validate(
       payload = linkedMapOf<String, Any?>(
@@ -132,18 +117,24 @@ class FeatureTaskRuntimePlanningProjectionSchemaValidatorTest {
     val error = assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
       FeatureTaskRuntimePlanningProjectionValidatorAdapter().validatePlanningProjection(
         producedOutputs = linkedMapOf<String, Any?>(
-          "projection_kind" to "preplanning_digest",
+          "projection_kind" to "executable_plan",
           "contract_version" to FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION,
-          "affected_boundaries" to listOf("runtime-domain/model"),
-          "risks" to listOf("producer may omit digest fields"),
-          "rollout" to linkedMapOf("flag_required" to false, "notes" to "no flag needed"),
-          "validation_strategy" to listOf("snapshot projection tests"),
+          "mode" to "direct",
+          "tasks" to listOf(
+            linkedMapOf(
+              "task_id" to "task-01",
+              "description" to "add contract",
+              "criterion_refs" to listOf("AC-005"),
+              "test_obligations" to listOf("parity"),
+            ),
+          ),
+          "validation_strategy" to listOf("focused gradle"),
           "progress_diagnostics" to "smuggled whole-envelope field",
         ),
-        sourceLabel = "preplan#produced_outputs",
+        sourceLabel = "plan#produced_outputs",
       )
     }
-    assertEquals("preplan#produced_outputs", error.sourceLabel)
+    assertEquals("plan#produced_outputs", error.sourceLabel)
     assertTrue(
       error.reason.contains("progress_diagnostics"),
       "the adapter must surface the canonical schema's additionalProperties violation: ${error.reason}",
@@ -209,26 +200,31 @@ class FeatureTaskRuntimePlanningProjectionSchemaValidatorTest {
 
   @Test
   fun `empty required string lists the model rejects are rejected by the schema`() {
-    // F-002: affected_boundaries / risks / validation_strategy (requireStringList) and criterion_refs /
-    // test_obligations (.ifEmpty{throw}) are all schema-required-non-empty now, matching the model, so a
-    // schema-valid projection can never pass this gate and then throw in fromMap.
-    fun rejectsEmpty(mutate: (LinkedHashMap<String, Any?>) -> Unit): Boolean {
-      val digest = linkedMapOf<String, Any?>(
-        "projection_kind" to "preplanning_digest",
-        "contract_version" to FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION,
-        "affected_boundaries" to listOf("runtime-domain/model"),
-        "risks" to listOf("producer may omit digest fields"),
-        "rollout" to linkedMapOf("flag_required" to false, "notes" to "no flag needed"),
-        "validation_strategy" to listOf("snapshot projection tests"),
+    fun task(mutate: (LinkedHashMap<String, Any?>) -> Unit = {}): LinkedHashMap<String, Any?> {
+      val t = linkedMapOf<String, Any?>(
+        "task_id" to "task-01",
+        "description" to "add contract",
+        "criterion_refs" to listOf("AC-005"),
+        "test_obligations" to listOf("parity"),
       )
-      mutate(digest)
-      return runCatching {
-        FeatureTaskRuntimePlanningProjectionSchemaValidator.validate(payload = digest, sourceLabel = "preplan#1")
-      }.exceptionOrNull() is InvalidFeatureTaskRuntimePlanningProjectionSchemaError
+      mutate(t)
+      return t
     }
-    assertTrue(rejectsEmpty { it["affected_boundaries"] = emptyList<String>() }, "empty affected_boundaries")
-    assertTrue(rejectsEmpty { it["risks"] = emptyList<String>() }, "empty risks")
-    assertTrue(rejectsEmpty { it["validation_strategy"] = emptyList<String>() }, "empty validation_strategy")
+    fun rejects(tasks: List<Any>): Boolean = runCatching {
+      FeatureTaskRuntimePlanningProjectionSchemaValidator.validate(
+        payload = linkedMapOf<String, Any?>(
+          "projection_kind" to "executable_plan",
+          "contract_version" to FEATURE_TASK_RUNTIME_PLANNING_PROJECTIONS_CONTRACT_VERSION,
+          "mode" to "direct",
+          "tasks" to tasks,
+          "validation_strategy" to listOf("focused gradle"),
+        ),
+        sourceLabel = "plan#1",
+      )
+    }.exceptionOrNull() is InvalidFeatureTaskRuntimePlanningProjectionSchemaError
+    assertTrue(rejects(emptyList()), "empty tasks")
+    assertTrue(rejects(listOf(task { it["criterion_refs"] = emptyList<String>() })), "empty criterion_refs")
+    assertTrue(rejects(listOf(task { it["test_obligations"] = emptyList<String>() })), "empty test_obligations")
   }
 
   @Test

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionsSchemaContractVersionTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimePlanningProjectionsSchemaContractVersionTest.kt
@@ -37,20 +37,19 @@ class FeatureTaskRuntimePlanningProjectionsSchemaContractVersionTest {
   }
 
   @Test
-  fun `schema declares oneOf over the four concrete projection kinds`() {
+  fun `schema declares oneOf over the three concrete projection kinds`() {
     val oneOf = classpathSchema().path("oneOf")
 
-    assertTrue(oneOf.isArray && oneOf.size() == 4, "Schema must declare exactly four oneOf variants; found: $oneOf")
+    assertTrue(oneOf.isArray && oneOf.size() == 3, "Schema must declare exactly three oneOf variants; found: $oneOf")
     val refs = oneOf.map { it.path("\$ref").asText() }
     assertEquals(
       listOf(
-        "#/\$defs/preplanning_digest",
         "#/\$defs/executable_plan",
         "#/\$defs/plan_commitment",
         "#/\$defs/implementation_receipt",
       ),
       refs,
-      "Schema oneOf variants must reference the four concrete projection kinds in order.",
+      "Schema oneOf variants must reference the three concrete projection kinds in order.",
     )
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeProjectionCanonicalizationSchemaTest.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/test/kotlin/skillbill/contracts/workflow/FeatureTaskRuntimeProjectionCanonicalizationSchemaTest.kt
@@ -4,9 +4,8 @@ package skillbill.contracts.workflow
 
 import skillbill.error.InvalidFeatureTaskRuntimePlanningProjectionSchemaError
 import skillbill.infrastructure.fs.FeatureTaskRuntimePlanningProjectionValidatorAdapter
-import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT
+import skillbill.workflow.taskruntime.model.FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeExecutablePlan
-import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePrePlanningDigest
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProjectionKind
 import skillbill.workflow.taskruntime.model.featureTaskRuntimePlanningProjectionFromEnvelope
 import kotlin.test.Test
@@ -107,70 +106,35 @@ class FeatureTaskRuntimeProjectionCanonicalizationSchemaTest {
   @Test
   fun `a missing required field rejects`() {
     assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
-      parseDigest(
-        """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":["b"],""" +
-          """"rollout":{"flag_required":false,"notes":"n"},"validation_strategy":["v"]}""",
+      parsePlan(
+        """{"projection_kind":"executable_plan","contract_version":"0.1","mode":"direct","tasks":[""" +
+          """{"task_id":"task-1","description":"a","criterion_refs":["AC-001"]}],"validation_strategy":["v"]}""",
       )
     }
   }
 
-  // AC-005: an undeclared key on a fully-enumerated closed object — including a top-level variant — is
-  // discarded during canonicalization, so it never reaches the strict schema and never costs an attempt.
   @Test
   fun `an unknown key on a closed object is absorbed and the projection advances`() {
-    val digest = assertIs<FeatureTaskRuntimePrePlanningDigest>(
-      parseDigest(
-        """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":["b"],""" +
-          """"risks":["r"],"rollout":{"flag_required":false,"notes":"n","bogus_nested":1},""" +
-          """"validation_strategy":["v"],"bogus":1}""",
+    val plan = assertIs<FeatureTaskRuntimeExecutablePlan>(
+      parsePlan(
+        """{"projection_kind":"executable_plan","contract_version":"0.1","mode":"direct","tasks":[""" +
+          """{"task_id":"task-1","description":"a","criterion_refs":["AC-001"],"test_obligations":["parity"],""" +
+          """"bogus_nested":1}],"validation_strategy":["v"],"bogus":1}""",
       ),
     )
 
-    assertEquals(listOf("b"), digest.affectedBoundaries)
-    assertEquals(listOf("r"), digest.risks)
-    assertEquals("n", digest.rollout.notes)
-  }
-
-  // SKILL-174: selected_boundary_headings is additive and optional, so the contract version stays 0.1.
-  @Test
-  fun `a digest with selected boundary headings round-trips and one without still validates`() {
-    val withSelection = assertIs<FeatureTaskRuntimePrePlanningDigest>(
-      parseDigest(
-        """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":["b"],""" +
-          """"risks":["r"],"rollout":{"flag_required":false,"notes":"n"},"validation_strategy":["v"],""" +
-          """"selected_boundary_headings":["modules/a/agent/history.md#0-abc123abc123"]}""",
-      ),
-    )
-    assertEquals(listOf("modules/a/agent/history.md#0-abc123abc123"), withSelection.selectedBoundaryHeadings)
-
-    val without = assertIs<FeatureTaskRuntimePrePlanningDigest>(
-      parseDigest(
-        """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":["b"],""" +
-          """"risks":["r"],"rollout":{"flag_required":false,"notes":"n"},"validation_strategy":["v"]}""",
-      ),
-    )
-    assertEquals(emptyList(), without.selectedBoundaryHeadings)
-  }
-
-  @Test
-  fun `a selected boundary heading list beyond its declared cap rejects`() {
-    val ids = (0..FEATURE_TASK_RUNTIME_SELECTED_BOUNDARY_HEADING_MAX_COUNT).joinToString(",") { "\"h$it\"" }
-    assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
-      parseDigest(
-        """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":["b"],""" +
-          """"risks":["r"],"rollout":{"flag_required":false,"notes":"n"},"validation_strategy":["v"],""" +
-          """"selected_boundary_headings":[$ids]}""",
-      )
-    }
+    assertEquals("task-1", plan.tasks.single().taskId)
   }
 
   @Test
   fun `a budget overflow rejects`() {
-    val boundaries = (1..129).joinToString(",") { "\"b$it\"" }
+    val tasks = (1..FEATURE_TASK_RUNTIME_PROJECTION_LIST_MAX_COUNT + 1).joinToString(",") {
+      """{"task_id":"task-$it","description":"a","criterion_refs":["AC-001"],"test_obligations":["parity"]}"""
+    }
     assertFailsWith<InvalidFeatureTaskRuntimePlanningProjectionSchemaError> {
-      parseDigest(
-        """{"projection_kind":"preplanning_digest","contract_version":"0.1","affected_boundaries":[$boundaries],""" +
-          """"risks":["r"],"rollout":{"flag_required":false,"notes":"n"},"validation_strategy":["v"]}""",
+      parsePlan(
+        """{"projection_kind":"executable_plan","contract_version":"0.1","mode":"direct","tasks":[$tasks],""" +
+          """"validation_strategy":["v"]}""",
       )
     }
   }
@@ -205,13 +169,6 @@ class FeatureTaskRuntimeProjectionCanonicalizationSchemaTest {
     envelope = envelope(producedOutputs),
     producingPhaseId = "plan",
     expectedKind = FeatureTaskRuntimeProjectionKind.EXECUTABLE_PLAN,
-    schemaValidator = validator,
-  )
-
-  private fun parseDigest(producedOutputs: String) = featureTaskRuntimePlanningProjectionFromEnvelope(
-    envelope = envelope(producedOutputs),
-    producingPhaseId = "preplan",
-    expectedKind = FeatureTaskRuntimeProjectionKind.PREPLANNING_DIGEST,
     schemaValidator = validator,
   )
 


### PR DESCRIPTION
Goal: prose-centric-preplan-phase-io

Subtasks:
- 1. Replace preplanning digest with prose PhaseOutput (a87522ebd51055198481b013892cce6eb526517e)
