### PR TITLE
SKILL-217: retarget-finalization-off-implement-receipt

### DIFF
--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/agent/history.md
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/agent/history.md
@@ -1,5 +1,14 @@
 # featuretask runtime boundary history
 
+## [2026-08-28] SKILL-217 subtask 1 — Retarget finalization consumers onto phase_prose
+Areas: runtime-domain/workflow/taskruntime, runtime-application/featuretask (tests)
+- Validate, build, write_history, commit_push, and pr take producer words through `phaseProseDeclaration` (`feature_task_runtime.phase_prose`). A value-only implement still launches those consumers; briefings carry `value` and optional `prompt`.
+- `finalizationProjectionContext` no longer reads implement `changed_paths` / `completed_task_ids` / `tests_*` / `deviations` or plan `validation_strategy` / `tasks`. Path inventory is checkpoint `workingTreeOwnedPaths` only. Kotlin does not parse `value`.
+- Dropped `pr_request` fields `completed_task_ids`, `tests_added`, `tests_updated`, `deviations`; dropped `commit_request.required_exclusions` and `validation_request.required_checks` / `validation_strategy`. No new handoff contract id.
+- Pattern: reuse `phase_prose` for agent-facing words; keep measurement (paths, checkpoints) runtime-owned. reusable
+Feature flag: N/A
+Acceptance criteria: 8/8 implemented
+
 ## [2026-08-28] SKILL-216 subtask 1 — Slim verify and fix to an id-enum census
 Areas: runtime-application/featuretask, runtime-domain/workflow/taskruntime, runtime-infra-fs/contracts/workflow, orchestration/contracts, runtime-contracts, runtime-infra-sqlite
 - Slimmed `verify_findings` dispositions to required `finding_id` + `disposition`. Extra keys, including the former fat fields, are ignored. Envelope `verdict` is the sole routing signal. Kotlin no longer derives it from the census or falls back to ADVANCE.

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePlanningProjectionEdgeTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/FeatureTaskRuntimePlanningProjectionEdgeTest.kt
@@ -208,6 +208,71 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
   }
 
   @Test
+  fun `plan to validate delivers only plan prose fields`() {
+    assertProseHandoffAdvances(
+      edge = proseEdge(
+        producer = phasePlan,
+        consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE,
+        prose = "Dense plan prose for downstream validate.",
+      ),
+      expectedInBriefing = listOf("Dense plan prose for downstream validate."),
+      mustNotContain = listOf("complete_plan_envelope_secret"),
+    )
+  }
+
+  @Test
+  fun `plan to build delivers only plan prose fields`() {
+    assertProseHandoffAdvances(
+      edge = proseEdge(
+        producer = phasePlan,
+        consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_BUILD,
+        prose = "Dense plan prose for downstream build.",
+      ),
+      expectedInBriefing = listOf("Dense plan prose for downstream build."),
+      mustNotContain = listOf("complete_plan_envelope_secret"),
+    )
+  }
+
+  @Test
+  fun `implement to write_history delivers only implement prose fields`() {
+    assertProseHandoffAdvances(
+      edge = proseEdge(
+        producer = phaseImplement,
+        consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_WRITE_HISTORY,
+        prose = "Dense implement prose for downstream write_history.",
+      ),
+      expectedInBriefing = listOf("Dense implement prose for downstream write_history."),
+      mustNotContain = listOf("complete_implement_envelope_secret"),
+    )
+  }
+
+  @Test
+  fun `implement to commit_push delivers only implement prose fields`() {
+    assertProseHandoffAdvances(
+      edge = proseEdge(
+        producer = phaseImplement,
+        consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH,
+        prose = "Dense implement prose for downstream commit_push.",
+      ),
+      expectedInBriefing = listOf("Dense implement prose for downstream commit_push."),
+      mustNotContain = listOf("complete_implement_envelope_secret"),
+    )
+  }
+
+  @Test
+  fun `implement to pr delivers only implement prose fields`() {
+    assertProseHandoffAdvances(
+      edge = proseEdge(
+        producer = phaseImplement,
+        consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PR,
+        prose = "Dense implement prose for downstream pr.",
+      ),
+      expectedInBriefing = listOf("Dense implement prose for downstream pr."),
+      mustNotContain = listOf("complete_implement_envelope_secret"),
+    )
+  }
+
+  @Test
   fun `pr keeps the self-read branch-diff instruction on its own derived-context key`() {
     val briefing = assemble(
       consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PR,
@@ -256,6 +321,13 @@ class FeatureTaskRuntimePlanningProjectionEdgeTest {
         else -> FeatureTaskRuntimePhaseWorkflowDefinition.phaseProseDeclaration(phaseImplement, producer)
       }
       phaseAudit -> FeatureTaskRuntimePhaseWorkflowDefinition.phaseProseDeclaration(phaseAudit, phaseImplement)
+      FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE,
+      FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_BUILD,
+      -> FeatureTaskRuntimePhaseWorkflowDefinition.phaseProseDeclaration(consumer, phasePlan)
+      FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_WRITE_HISTORY,
+      FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH,
+      FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PR,
+      -> FeatureTaskRuntimePhaseWorkflowDefinition.phaseProseDeclaration(consumer, phaseImplement)
       else -> FeatureTaskRuntimePhaseWorkflowDefinition.phaseProseDeclaration(consumer, producer)
     }
     return ProseHandoffEdge(

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortTest.kt
@@ -1227,7 +1227,7 @@ class ApplicationPersistencePortTest {
     val service = testWorkflowService(database, FakeWorkflowGitOperations())
     val workflowId = createDecompositionWorkflow(service, parentSpec, subtaskSpec)
 
-    // requiredArtifactsByStep[validate]=[implement,audit]; seed completed phase records so canResume
+    // requiredArtifactsByStep[validate]=[plan,audit]; seed completed phase records so canResume
     // is true. assessment.spec_path remains decomposition metadata only
     // (DecompositionManifestRuntimeState), never a resume-gate satisfier.
     service.update(
@@ -1240,7 +1240,7 @@ class ApplicationPersistencePortTest {
         artifactsPatch =
         mapOf(
           "assessment" to mapOf("spec_path" to subtaskSpec.toString()),
-          FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to completedPhaseRecords("implement", "audit"),
+          FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to completedPhaseRecords("plan", "audit"),
           "blocked_reason" to "Validation paused.",
         ),
       ),
@@ -1625,7 +1625,7 @@ class ApplicationPersistencePortTest {
     val first = service.continueWorkflow(WorkflowFamilyKind.TASK_RUNTIME, "SKILL-51", dbOverride = null)
       as WorkflowContinueResult.DecompositionStandard
     val subtaskWorkflowId = first.view.resume.snapshot.workflowId
-    // requiredArtifactsByStep[validate]=[implement,audit] via FeatureTaskRuntimeRequiredArtifactPresenceResolver.
+    // requiredArtifactsByStep[validate]=[plan,audit] via FeatureTaskRuntimeRequiredArtifactPresenceResolver.
     service.update(
       WorkflowFamilyKind.TASK_RUNTIME,
       WorkflowUpdateRequest(
@@ -1634,7 +1634,7 @@ class ApplicationPersistencePortTest {
         currentStepId = "validate",
         stepUpdates = listOf(mapOf("step_id" to "validate", "status" to "running", "attempt_count" to 1)),
         artifactsPatch = mapOf(
-          FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to completedPhaseRecords("implement", "audit"),
+          FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to completedPhaseRecords("plan", "audit"),
           "validation_result" to mapOf("passed" to false),
         ),
       ),
@@ -2581,7 +2581,7 @@ private fun createDecompositionWorkflow(
 }
 
 private fun markDecompositionSubtaskBlocked(service: WorkflowService, workflowId: String, subtaskSpec: Path) {
-  // requiredArtifactsByStep[validate]=[implement,audit]. assessment.spec_path is decomposition
+  // requiredArtifactsByStep[validate]=[plan,audit]. assessment.spec_path is decomposition
   // metadata (DecompositionManifestRuntimeState), not a resume-gate satisfier.
   service.update(
     WorkflowFamilyKind.TASK_RUNTIME,
@@ -2593,7 +2593,7 @@ private fun markDecompositionSubtaskBlocked(service: WorkflowService, workflowId
       artifactsPatch =
       mapOf(
         "assessment" to mapOf("spec_path" to subtaskSpec.toString()),
-        FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to completedPhaseRecords("implement", "audit"),
+        FEATURE_TASK_RUNTIME_PHASE_RECORDS_ARTIFACT_KEY to completedPhaseRecords("plan", "audit"),
         "validation_result" to mapOf("passed" to false),
         "blocked_reason" to "Validation failed.",
       ),

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidator.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidator.kt
@@ -686,9 +686,7 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
     val context = finalizationProjectionContext(inputs)
     return when (declaration.projectionContractId) {
       FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_REQUEST -> mapOf(
-        "validation_strategy" to (context.plan["validation_strategy"] ?: emptyList<String>()),
         "changed_paths" to context.changedPaths,
-        "required_checks" to context.requiredChecks,
         "repository_checkpoint" to context.checkpoint,
       )
       FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.BOUNDARY_CANDIDATES -> mapOf(
@@ -701,7 +699,6 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
       FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.COMMIT_REQUEST -> mapOf(
         "path_inventory" to context.changedPaths,
         "required_inclusions" to context.changedPaths,
-        "required_exclusions" to context.excludedClaims,
         "branch_identity" to context.branch,
         "gate_attestations" to listOf("audit", "review", "validate", "write_history"),
         "repository_checkpoint" to context.checkpoint,
@@ -716,37 +713,17 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
     inputs: FeatureTaskRuntimeHandoffProjectionInputs,
   ): FinalizationProjectionContext {
     val outputs = inputs.resolvedUpstream.outputsByPhaseId
-    val plan = outputs[FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN]?.let {
-      planningProducedOutputs(it)
-    }.orEmpty()
-    val implementation = outputs[FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT]?.let {
-      planningProducedOutputs(it)
-    }.orEmpty()
     val validation = outputs[FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE]?.let {
       genericProducedOutputs(it)
     }.orEmpty()
     val checkpoint = inputs.resolvedCheckpoint?.let { mapOf("fingerprint" to it.fingerprint) }
-    val claimedChangedPaths = (implementation["changed_paths"] as? List<*>).orEmpty()
-      .filterIsInstance<String>()
-      .distinct()
     val changedPaths = inputs.resolvedCheckpoint?.workingTreeOwnedPaths.orEmpty()
       .distinct()
       .sorted()
-    val excludedClaims = claimedChangedPaths.filterNot { it in changedPaths }.sorted()
-    val requiredChecks = (
-      (plan["validation_strategy"] as? List<*>).orEmpty() +
-        (plan["tasks"] as? List<*>).orEmpty().flatMap { task ->
-          JsonSupport.anyToStringAnyMap(task)?.get("test_obligations") as? List<*> ?: emptyList<Any?>()
-        }
-      ).filterIsInstance<String>().distinct()
     return FinalizationProjectionContext(
-      plan = plan,
-      implementation = implementation,
       validation = validation,
       checkpoint = checkpoint,
       changedPaths = changedPaths,
-      excludedClaims = excludedClaims,
-      requiredChecks = requiredChecks,
       branch = inputs.branchIdentity ?: "unknown",
       base = inputs.baseBranch,
       checkpointFingerprint = inputs.resolvedCheckpoint?.fingerprint,
@@ -754,11 +731,7 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
   }
 
   private fun prRequestProjection(context: FinalizationProjectionContext): Map<String, Any?> = mapOf(
-    "completed_task_ids" to (context.implementation["completed_task_ids"] ?: emptyList<String>()),
     "changed_paths" to context.changedPaths,
-    "tests_added" to (context.implementation["tests_added"] ?: emptyList<String>()),
-    "tests_updated" to (context.implementation["tests_updated"] ?: emptyList<String>()),
-    "deviations" to (context.implementation["deviations"] ?: emptyList<String>()),
     "validation_summary" to (
       context.validation["validation_result"]
         ?: context.validation["validation_summary"]
@@ -770,20 +743,13 @@ object FeatureTaskRuntimeHandoffProjectionValidator {
   )
 
   private data class FinalizationProjectionContext(
-    val plan: Map<String, Any?>,
-    val implementation: Map<String, Any?>,
     val validation: Map<String, Any?>,
     val checkpoint: Map<String, String>?,
     val changedPaths: List<String>,
-    val excludedClaims: List<String>,
-    val requiredChecks: List<String>,
     val branch: String,
     val base: String,
     val checkpointFingerprint: String?,
   )
-
-  private fun planningProducedOutputs(output: FeatureTaskRuntimePhaseOutput): Map<String, Any?> =
-    genericProducedOutputs(output)
 
   private fun genericProducedOutputs(output: FeatureTaskRuntimePhaseOutput): Map<String, Any?> {
     val envelope = output.normalizedOutput?.envelope

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinition.kt
@@ -159,8 +159,8 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
       PHASE_REVIEW to listOf(PHASE_AUDIT),
       PHASE_VERIFY_FINDINGS to listOf(PHASE_REVIEW),
       PHASE_IMPLEMENT_FIX to listOf(PHASE_VERIFY_FINDINGS),
-      PHASE_BUILD to listOf(PHASE_IMPLEMENT, PHASE_AUDIT),
-      PHASE_VALIDATE to listOf(PHASE_IMPLEMENT, PHASE_AUDIT),
+      PHASE_BUILD to listOf(PHASE_PLAN, PHASE_AUDIT),
+      PHASE_VALIDATE to listOf(PHASE_PLAN, PHASE_AUDIT),
       PHASE_WRITE_HISTORY to listOf(PHASE_IMPLEMENT, PHASE_VALIDATE),
       PHASE_COMMIT_PUSH to listOf(PHASE_IMPLEMENT, PHASE_VALIDATE, PHASE_WRITE_HISTORY),
       PHASE_PR to listOf(PHASE_IMPLEMENT, PHASE_COMMIT_PUSH),
@@ -183,8 +183,8 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
       PHASE_VERIFY_FINDINGS to
         "Resume finding verification from the latest review output and in-flight dispositions " +
         "without re-running review.",
-      PHASE_BUILD to "Resume compile/build proof from the latest implement and audit outputs.",
-      PHASE_VALIDATE to "Resume quality validation from the latest implement and audit outputs.",
+      PHASE_BUILD to "Resume compile/build proof from the latest plan and audit outputs.",
+      PHASE_VALIDATE to "Resume quality validation from the latest plan and audit outputs.",
       PHASE_WRITE_HISTORY to
         "Resume boundary history writing from the latest implement and settled build or validate output.",
       PHASE_COMMIT_PUSH to
@@ -398,15 +398,14 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
       sharedReviewEvidenceDeclaration(PHASE_REVIEW),
     ),
     PHASE_VALIDATE to listOf(
+      phaseProseDeclaration(PHASE_VALIDATE, PHASE_PLAN),
       phaseProjection(
         PHASE_VALIDATE,
-        PHASE_IMPLEMENT,
+        PHASE_PLAN,
         "validation_request",
         PhaseProjectionContract.VALIDATION_REQUEST,
         listOf(
-          "validation_strategy",
           "changed_paths",
-          "required_checks",
           "repository_checkpoint",
         ),
         FeatureTaskRuntimeRepositoryCheckpointPolicy.REFRESH_FROM_REPOSITORY,
@@ -421,15 +420,14 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
       ),
     ),
     PHASE_BUILD to listOf(
+      phaseProseDeclaration(PHASE_BUILD, PHASE_PLAN),
       phaseProjection(
         PHASE_BUILD,
-        PHASE_IMPLEMENT,
+        PHASE_PLAN,
         "validation_request",
         PhaseProjectionContract.VALIDATION_REQUEST,
         listOf(
-          "validation_strategy",
           "changed_paths",
-          "required_checks",
           "repository_checkpoint",
         ),
         FeatureTaskRuntimeRepositoryCheckpointPolicy.REFRESH_FROM_REPOSITORY,
@@ -444,6 +442,7 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
       ),
     ),
     PHASE_WRITE_HISTORY to listOf(
+      phaseProseDeclaration(PHASE_WRITE_HISTORY, PHASE_IMPLEMENT),
       phaseProjection(
         PHASE_WRITE_HISTORY,
         PHASE_IMPLEMENT,
@@ -483,6 +482,7 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
       ),
     ),
     PHASE_COMMIT_PUSH to listOf(
+      phaseProseDeclaration(PHASE_COMMIT_PUSH, PHASE_IMPLEMENT),
       phaseProjection(
         PHASE_COMMIT_PUSH,
         PHASE_IMPLEMENT,
@@ -491,7 +491,6 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
         listOf(
           "path_inventory",
           "required_inclusions",
-          "required_exclusions",
           "branch_identity",
           "gate_attestations",
           "repository_checkpoint",
@@ -536,17 +535,14 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
       ),
     ),
     PHASE_PR to listOf(
+      phaseProseDeclaration(PHASE_PR, PHASE_IMPLEMENT),
       phaseProjection(
         PHASE_PR,
         PHASE_IMPLEMENT,
         "pr_request",
         PhaseProjectionContract.PR_REQUEST,
         listOf(
-          "completed_task_ids",
           "changed_paths",
-          "tests_added",
-          "tests_updated",
-          "deviations",
           "validation_summary",
           "base_branch",
           "diff_reference",
@@ -570,8 +566,8 @@ object FeatureTaskRuntimePhaseWorkflowDefinition {
    */
   fun runtimeProjectorProducerPhaseIds(consumerPhaseId: String): Set<String> = when (consumerPhaseId) {
     PHASE_IMPLEMENT_FIX -> setOf(PHASE_REVIEW)
-    PHASE_VALIDATE -> setOf(PHASE_PLAN, PHASE_IMPLEMENT, PHASE_AUDIT)
-    PHASE_BUILD -> setOf(PHASE_PLAN, PHASE_IMPLEMENT, PHASE_AUDIT)
+    PHASE_VALIDATE -> setOf(PHASE_PLAN, PHASE_AUDIT)
+    PHASE_BUILD -> setOf(PHASE_PLAN, PHASE_AUDIT)
     PHASE_WRITE_HISTORY -> setOf(PHASE_IMPLEMENT, PHASE_VALIDATE, PHASE_BUILD)
     PHASE_COMMIT_PUSH -> setOf(PHASE_IMPLEMENT, PHASE_VALIDATE, PHASE_BUILD, PHASE_WRITE_HISTORY)
     PHASE_PR -> setOf(PHASE_IMPLEMENT, PHASE_VALIDATE, PHASE_COMMIT_PUSH)

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidatorTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValidatorTest.kt
@@ -6,7 +6,6 @@ import skillbill.workflow.model.ValidationDepth
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeCompactReferenceKind
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeFeatureSize
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffProjectionBudget
-import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffProjectionField
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffProjectionInputs
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffProjectionValue
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffPromptVisibility
@@ -31,6 +30,14 @@ import kotlin.test.assertTrue
 
 private const val CONSUMER = "implement"
 private const val PRODUCER = "plan"
+private const val VALIDATION_PHASE_PAYLOAD =
+  """{"produced_outputs":{"validation_result":{"validation_status":"passed","checks":[],""" +
+    """"repository_checkpoint":{"fingerprint":"tree-1"},"gate_run_count":1,"gate_runs":[]}}}"""
+private const val HISTORY_PHASE_PAYLOAD =
+  """{"produced_outputs":{"history_result":{"changed_paths":["src/Foo.kt"],"decisions_recorded":[]}}}"""
+private const val COMMIT_PUSH_PHASE_PAYLOAD =
+  """{"produced_outputs":{"commit_push_result":{"commit_sha":"abc","branch":"feat",""" +
+    """"base_branch":"main","pushed":true}}}"""
 
 @Suppress("LargeClass") // single suite over one validator; splitting would scatter projection-contract cases
 class FeatureTaskRuntimeHandoffProjectionValidatorTest {
@@ -220,70 +227,224 @@ class FeatureTaskRuntimeHandoffProjectionValidatorTest {
   }
 
   @Test
-  fun `finalization inventory reconciles receipt claims to runtime owned paths`() {
-    val consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH
-    val declaration = declaration(
-      consumerPhaseId = consumer,
-      sourceRef = FeatureTaskRuntimeHandoffSourceRef.UpstreamPhaseOutput(
-        FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT,
-      ),
-      projectionContractId = FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.COMMIT_REQUEST,
-      declaredFieldNames = listOf(
-        "path_inventory",
-        "required_inclusions",
-        "required_exclusions",
-        "branch_identity",
-        "gate_attestations",
-        "repository_checkpoint",
-      ),
-      checkpointPolicy = FeatureTaskRuntimeRepositoryCheckpointPolicy.REFRESH_FROM_REPOSITORY,
-    )
+  fun `value-only implement and plan launch all five finalization consumers without missing-key failures`() {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
     val checkpoint = FeatureTaskRuntimeRepositoryCheckpoint(
-      fingerprint = "current-tree",
-      baseRef = "base",
-      headRef = "head",
+      fingerprint = "tree-1",
+      workingTreeOwnedPaths = listOf("src/Foo.kt"),
+    )
+    val upstream = valueOnlyFinalizationUpstream()
+    listOf(
+      def.PHASE_VALIDATE,
+      def.PHASE_BUILD,
+      def.PHASE_WRITE_HISTORY,
+      def.PHASE_COMMIT_PUSH,
+      def.PHASE_PR,
+    ).forEach { consumer ->
+      assertValueOnlyConsumerLaunches(consumer, upstream, checkpoint)
+    }
+  }
+
+  @Test
+  fun `validate and build briefings carry plan value verbatim and optional directive`() {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
+    val planProse = """{"projection_kind":"executable_plan","contract_version":"0.2"}"""
+    val plan = FeatureTaskRuntimePhaseOutput(
+      def.PHASE_PLAN,
+      1,
+      """{"produced_outputs":{"value":${planProse.quoteJson()},"prompt":"plan directive"}}""",
+    )
+    val audit = FeatureTaskRuntimePhaseOutput(def.PHASE_AUDIT, 1, """{"verdict":"satisfied","produced_outputs":{}}""")
+    val checkpoint = FeatureTaskRuntimeRepositoryCheckpoint("tree-1", workingTreeOwnedPaths = listOf("src/A.kt"))
+    listOf(def.PHASE_VALIDATE, def.PHASE_BUILD).forEach { consumer ->
+      val declarations = def.phaseDeclaration(consumer, FeatureTaskRuntimeFeatureSize.MEDIUM).projectionDeclarations
+      val envelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
+        inputs(
+          consumerPhaseId = consumer,
+          declarations = declarations,
+          resolvedUpstream = FeatureTaskRuntimeResolvedUpstreamOutputs(
+            mapOf(def.PHASE_PLAN to plan, def.PHASE_AUDIT to audit),
+          ),
+          resolvedCheckpoint = checkpoint,
+        ),
+      )
+      val prose = envelope.projections.single {
+        it.projectionContractId == FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE
+      }
+      val value = assertIs<FeatureTaskRuntimeHandoffProjectionValue.Text>(
+        prose.fields.single { it.name == "value" }.value,
+      )
+      assertEquals(planProse, value.text)
+      val directive = assertIs<FeatureTaskRuntimeHandoffProjectionValue.Text>(
+        prose.fields.single { it.name == "directive" }.value,
+      )
+      assertEquals("plan directive", directive.text)
+    }
+  }
+
+  @Test
+  fun `write_history commit_push and pr briefings carry implement value verbatim`() {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
+    val implementProse = """{"projection_kind":"implementation_receipt","contract_version":"0.2"}"""
+    val implement = FeatureTaskRuntimePhaseOutput(
+      def.PHASE_IMPLEMENT,
+      1,
+      """{"produced_outputs":{"value":${implementProse.quoteJson()},"prompt":"implement directive"}}""",
+    )
+    val validate = FeatureTaskRuntimePhaseOutput(def.PHASE_VALIDATE, 1, VALIDATION_PHASE_PAYLOAD)
+    val writeHistory = FeatureTaskRuntimePhaseOutput(def.PHASE_WRITE_HISTORY, 1, HISTORY_PHASE_PAYLOAD)
+    val commitPush = FeatureTaskRuntimePhaseOutput(def.PHASE_COMMIT_PUSH, 1, COMMIT_PUSH_PHASE_PAYLOAD)
+    val checkpoint = FeatureTaskRuntimeRepositoryCheckpoint("tree-1", workingTreeOwnedPaths = listOf("src/A.kt"))
+    listOf(def.PHASE_WRITE_HISTORY, def.PHASE_COMMIT_PUSH, def.PHASE_PR).forEach { consumer ->
+      val declarations = def.phaseDeclarationForQualityGate(
+        consumer,
+        FeatureTaskRuntimeFeatureSize.MEDIUM,
+        skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQualityGateSelection.VALIDATE,
+      ).projectionDeclarations
+      val upstream = FeatureTaskRuntimeResolvedUpstreamOutputs(
+        buildMap {
+          put(def.PHASE_IMPLEMENT, implement)
+          put(def.PHASE_VALIDATE, validate)
+          if (consumer == def.PHASE_COMMIT_PUSH || consumer == def.PHASE_PR) {
+            put(def.PHASE_WRITE_HISTORY, writeHistory)
+          }
+          if (consumer == def.PHASE_PR) {
+            put(def.PHASE_COMMIT_PUSH, commitPush)
+          }
+        },
+      )
+      val envelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
+        inputs(
+          consumerPhaseId = consumer,
+          declarations = declarations,
+          resolvedUpstream = upstream,
+          resolvedCheckpoint = checkpoint,
+        ),
+      )
+      val prose = envelope.projections.single {
+        it.projectionContractId == FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE
+      }
+      val value = assertIs<FeatureTaskRuntimeHandoffProjectionValue.Text>(
+        prose.fields.single { it.name == "value" }.value,
+      )
+      assertEquals(implementProse, value.text)
+    }
+  }
+
+  @Test
+  fun `changed_paths on finalization consumers come from checkpoint not receipt claims`() {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
+    val plan = FeatureTaskRuntimePhaseOutput(
+      def.PHASE_PLAN,
+      1,
+      """{"produced_outputs":{"value":"plan prose","changed_paths":["src/ClaimOnly.kt"]}}""",
+    )
+    val implement = FeatureTaskRuntimePhaseOutput(
+      def.PHASE_IMPLEMENT,
+      1,
+      """{"produced_outputs":{"value":"implement prose","changed_paths":["src/ClaimOnly.kt"]}}""",
+    )
+    val audit = FeatureTaskRuntimePhaseOutput(def.PHASE_AUDIT, 1, """{"verdict":"satisfied","produced_outputs":{}}""")
+    val validate = FeatureTaskRuntimePhaseOutput(def.PHASE_VALIDATE, 1, VALIDATION_PHASE_PAYLOAD)
+    val writeHistory = FeatureTaskRuntimePhaseOutput(def.PHASE_WRITE_HISTORY, 1, HISTORY_PHASE_PAYLOAD)
+    val checkpoint = FeatureTaskRuntimeRepositoryCheckpoint(
+      fingerprint = "tree-1",
       workingTreeOwnedPaths = listOf("src/Owned.kt", "src/OwnedTest.kt"),
     )
-    val implementation = FeatureTaskRuntimePhaseOutput(
-      phaseId = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT,
-      iteration = 1,
-      payload = """{"produced_outputs":{"changed_paths":["src/Owned.kt","src/ClaimOnly.kt"]}}""",
-    )
+    val expectedPaths = listOf("src/Owned.kt", "src/OwnedTest.kt")
 
-    val envelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
+    fun changedPathsFrom(consumer: String): List<String> {
+      val gateSelection = if (consumer == def.PHASE_BUILD) {
+        skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQualityGateSelection.BUILD
+      } else {
+        skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQualityGateSelection.VALIDATE
+      }
+      val declarations = def.phaseDeclarationForQualityGate(
+        consumer,
+        FeatureTaskRuntimeFeatureSize.MEDIUM,
+        gateSelection,
+      ).projectionDeclarations
+      val upstream = FeatureTaskRuntimeResolvedUpstreamOutputs(
+        buildMap {
+          put(def.PHASE_PLAN, plan)
+          put(def.PHASE_IMPLEMENT, implement)
+          put(def.PHASE_AUDIT, audit)
+          if (consumer != def.PHASE_VALIDATE && consumer != def.PHASE_BUILD) {
+            put(def.PHASE_VALIDATE, validate)
+          }
+          if (consumer == def.PHASE_COMMIT_PUSH) {
+            put(def.PHASE_WRITE_HISTORY, writeHistory)
+          }
+        },
+      )
+      val envelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
+        inputs(
+          consumerPhaseId = consumer,
+          declarations = declarations,
+          resolvedUpstream = upstream,
+          resolvedCheckpoint = checkpoint,
+        ),
+      )
+      val projection = envelope.projections.first {
+        it.projectionName == "validation_request" ||
+          it.projectionName == "boundary_candidates" ||
+          it.projectionName == "commit_request"
+      }
+      val fieldName = when (projection.projectionName) {
+        "commit_request" -> "path_inventory"
+        else -> "changed_paths"
+      }
+      return assertIs<FeatureTaskRuntimeHandoffProjectionValue.TextList>(
+        projection.fields.single { it.name == fieldName }.value,
+      ).items
+    }
+
+    assertEquals(expectedPaths, changedPathsFrom(def.PHASE_VALIDATE))
+    assertEquals(expectedPaths, changedPathsFrom(def.PHASE_BUILD))
+    assertEquals(expectedPaths, changedPathsFrom(def.PHASE_WRITE_HISTORY))
+    assertEquals(expectedPaths, changedPathsFrom(def.PHASE_COMMIT_PUSH))
+  }
+
+  @Test
+  fun `stuffed value JSON in implement and plan does not leak into typed finalization projection fields`() {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
+    val stuffedPlan = """{"validation_strategy":["./gradlew check"],"tasks":[{"test_obligations":["t1"]}]}"""
+    val stuffedImplement =
+      """{"completed_task_ids":["task-x"],"tests_added":["t.kt"],"tests_updated":[],"deviations":["d"]}"""
+    val plan = FeatureTaskRuntimePhaseOutput(
+      def.PHASE_PLAN,
+      1,
+      """{"produced_outputs":{"value":${stuffedPlan.quoteJson()}}}""",
+    )
+    val implement = FeatureTaskRuntimePhaseOutput(
+      def.PHASE_IMPLEMENT,
+      1,
+      """{"produced_outputs":{"value":${stuffedImplement.quoteJson()}}}""",
+    )
+    val audit = FeatureTaskRuntimePhaseOutput(def.PHASE_AUDIT, 1, """{"verdict":"satisfied","produced_outputs":{}}""")
+    val validate = FeatureTaskRuntimePhaseOutput(def.PHASE_VALIDATE, 1, VALIDATION_PHASE_PAYLOAD)
+    val commitPush = FeatureTaskRuntimePhaseOutput(def.PHASE_COMMIT_PUSH, 1, COMMIT_PUSH_PHASE_PAYLOAD)
+    val checkpoint = FeatureTaskRuntimeRepositoryCheckpoint("tree-1", workingTreeOwnedPaths = listOf("src/Real.kt"))
+
+    val validateEnvelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
       inputs(
-        consumerPhaseId = consumer,
-        declarations = listOf(declaration),
+        consumerPhaseId = def.PHASE_VALIDATE,
+        declarations = def.phaseDeclaration(def.PHASE_VALIDATE, FeatureTaskRuntimeFeatureSize.MEDIUM)
+          .projectionDeclarations,
         resolvedUpstream = FeatureTaskRuntimeResolvedUpstreamOutputs(
-          mapOf(FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT to implementation),
+          mapOf(def.PHASE_PLAN to plan, def.PHASE_AUDIT to audit),
         ),
         resolvedCheckpoint = checkpoint,
       ),
     )
+    val validationRequest = validateEnvelope.projections.single { it.projectionName == "validation_request" }
+    assertEquals(
+      listOf("changed_paths", "repository_checkpoint"),
+      validationRequest.fields.map { it.name },
+    )
+    assertTrue(validationRequest.fields.none { it.name == "validation_strategy" || it.name == "required_checks" })
 
-    val fields = envelope.projections.single().fields.associateBy { it.name }
-    assertEquals(
-      listOf("src/Owned.kt", "src/OwnedTest.kt"),
-      assertIs<FeatureTaskRuntimeHandoffProjectionValue.TextList>(fields.getValue("path_inventory").value).items,
-    )
-    assertEquals(
-      listOf("src/Owned.kt", "src/OwnedTest.kt"),
-      assertIs<FeatureTaskRuntimeHandoffProjectionValue.TextList>(fields.getValue("required_inclusions").value).items,
-    )
-    assertEquals(
-      listOf("src/ClaimOnly.kt"),
-      assertIs<FeatureTaskRuntimeHandoffProjectionValue.TextList>(fields.getValue("required_exclusions").value).items,
-    )
-  }
-
-  @Test
-  fun `full and default validation_request required_checks merge strategy and test obligations`() {
-    ValidationDepth.entries.forEach { depth ->
-      val requiredChecks = assertIs<FeatureTaskRuntimeHandoffProjectionValue.TextList>(
-        validationRequestFields(depth).getValue("required_checks").value,
-      ).items
-      assertEquals(emptyList(), requiredChecks)
-    }
+    assertPrRequestOmitsStuffedImplementFields(implement, validate, commitPush, checkpoint)
   }
 
   @Test
@@ -741,6 +902,105 @@ class FeatureTaskRuntimeHandoffProjectionValidatorTest {
     assertEquals(FeatureTaskRuntimeHandoffProjectionFailureKind.UNDECLARED_FIELD, error.failureKind)
   }
 
+  private fun valueOnlyFinalizationUpstream(): FeatureTaskRuntimeResolvedUpstreamOutputs {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
+    val planProse = """{"projection_kind":"executable_plan","tasks":[]}"""
+    val implementProse = """{"projection_kind":"implementation_receipt","completed_task_ids":["task-1"]}"""
+    return FeatureTaskRuntimeResolvedUpstreamOutputs(
+      mapOf(
+        def.PHASE_PLAN to FeatureTaskRuntimePhaseOutput(
+          def.PHASE_PLAN,
+          1,
+          """{"produced_outputs":{"value":${planProse.quoteJson()}}}""",
+        ),
+        def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseOutput(
+          def.PHASE_IMPLEMENT,
+          1,
+          """{"produced_outputs":{"value":${implementProse.quoteJson()}}}""",
+        ),
+        def.PHASE_AUDIT to FeatureTaskRuntimePhaseOutput(
+          def.PHASE_AUDIT,
+          1,
+          """{"verdict":"satisfied","produced_outputs":{}}""",
+        ),
+        def.PHASE_VALIDATE to FeatureTaskRuntimePhaseOutput(
+          def.PHASE_VALIDATE,
+          1,
+          VALIDATION_PHASE_PAYLOAD,
+        ),
+        def.PHASE_WRITE_HISTORY to FeatureTaskRuntimePhaseOutput(
+          def.PHASE_WRITE_HISTORY,
+          1,
+          HISTORY_PHASE_PAYLOAD,
+        ),
+        def.PHASE_COMMIT_PUSH to FeatureTaskRuntimePhaseOutput(
+          def.PHASE_COMMIT_PUSH,
+          1,
+          COMMIT_PUSH_PHASE_PAYLOAD,
+        ),
+      ),
+    )
+  }
+
+  private fun assertValueOnlyConsumerLaunches(
+    consumer: String,
+    upstream: FeatureTaskRuntimeResolvedUpstreamOutputs,
+    checkpoint: FeatureTaskRuntimeRepositoryCheckpoint,
+  ) {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
+    val gateSelection = if (consumer == def.PHASE_BUILD) {
+      skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQualityGateSelection.BUILD
+    } else {
+      skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQualityGateSelection.VALIDATE
+    }
+    val declarations = if (consumer == def.PHASE_VALIDATE || consumer == def.PHASE_BUILD) {
+      def.phaseDeclaration(consumer, FeatureTaskRuntimeFeatureSize.MEDIUM).projectionDeclarations
+    } else {
+      def.phaseDeclarationForQualityGate(
+        consumer,
+        FeatureTaskRuntimeFeatureSize.MEDIUM,
+        gateSelection,
+      ).projectionDeclarations
+    }
+    val envelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
+      inputs(
+        consumerPhaseId = consumer,
+        declarations = declarations,
+        resolvedUpstream = upstream,
+        resolvedCheckpoint = checkpoint,
+      ),
+    )
+    assertTrue(envelope.projections.isNotEmpty(), "$consumer must launch with value-only upstream outputs")
+  }
+
+  private fun assertPrRequestOmitsStuffedImplementFields(
+    implement: FeatureTaskRuntimePhaseOutput,
+    validate: FeatureTaskRuntimePhaseOutput,
+    commitPush: FeatureTaskRuntimePhaseOutput,
+    checkpoint: FeatureTaskRuntimeRepositoryCheckpoint,
+  ) {
+    val def = FeatureTaskRuntimePhaseWorkflowDefinition
+    val prEnvelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
+      inputs(
+        consumerPhaseId = def.PHASE_PR,
+        declarations = def.phaseDeclaration(def.PHASE_PR, FeatureTaskRuntimeFeatureSize.MEDIUM).projectionDeclarations,
+        resolvedUpstream = FeatureTaskRuntimeResolvedUpstreamOutputs(
+          mapOf(
+            def.PHASE_IMPLEMENT to implement,
+            def.PHASE_VALIDATE to validate,
+            def.PHASE_COMMIT_PUSH to commitPush,
+          ),
+        ),
+        resolvedCheckpoint = checkpoint,
+      ),
+    )
+    val prRequest = prEnvelope.projections.single { it.projectionName == "pr_request" }
+    val stuffedFieldNames = setOf("completed_task_ids", "tests_added", "tests_updated", "deviations")
+    assertTrue(prRequest.fields.none { it.name in stuffedFieldNames })
+  }
+
+  private fun String.quoteJson(): String = "\"" + replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
   @Suppress("LongParameterList") // mirrors the declaration record under test; each field is varied by a case
   private fun declaration(
     consumerPhaseId: String = CONSUMER,
@@ -808,54 +1068,4 @@ class FeatureTaskRuntimeHandoffProjectionValidatorTest {
     qualityGateSelection = qualityGateSelection,
     priorGapMemory = priorGapMemory,
   )
-
-  private fun validationRequestFields(
-    validationDepth: ValidationDepth,
-  ): Map<String, FeatureTaskRuntimeHandoffProjectionField> {
-    val consumer = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE
-    val declaration = declaration(
-      consumerPhaseId = consumer,
-      sourceRef = FeatureTaskRuntimeHandoffSourceRef.UpstreamPhaseOutput(
-        FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT,
-      ),
-      projectionName = "validation_request",
-      projectionContractId = FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_REQUEST,
-      declaredFieldNames = listOf(
-        "validation_strategy",
-        "changed_paths",
-        "required_checks",
-        "repository_checkpoint",
-      ),
-      checkpointPolicy = FeatureTaskRuntimeRepositoryCheckpointPolicy.REFRESH_FROM_REPOSITORY,
-    )
-    val plan = FeatureTaskRuntimePhaseOutput(
-      phaseId = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN,
-      iteration = 1,
-      payload = """{"produced_outputs":{"value":"Fixture plan prose for downstream implement and audit."}}""",
-    )
-    val implementation = FeatureTaskRuntimePhaseOutput(
-      phaseId = FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT,
-      iteration = 1,
-      payload = """{"produced_outputs":{"changed_paths":["src/Foo.kt"]}}""",
-    )
-    val checkpoint = FeatureTaskRuntimeRepositoryCheckpoint(
-      fingerprint = "validate-tree",
-      workingTreeOwnedPaths = listOf("src/Foo.kt"),
-    )
-    val envelope = FeatureTaskRuntimeHandoffProjectionValidator.validate(
-      inputs(
-        consumerPhaseId = consumer,
-        declarations = listOf(declaration),
-        resolvedUpstream = FeatureTaskRuntimeResolvedUpstreamOutputs(
-          mapOf(
-            FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN to plan,
-            FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT to implementation,
-          ),
-        ),
-        resolvedCheckpoint = checkpoint,
-        validationDepth = validationDepth,
-      ),
-    )
-    return envelope.projections.single().fields.associateBy { it.name }
-  }
 }

--- a/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinitionTest.kt
+++ b/runtime-kotlin/runtime-domain/src/test/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimePhaseWorkflowDefinitionTest.kt
@@ -113,14 +113,14 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
     )
     assertEquals(
       listOf(
-        FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT,
+        FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN,
         FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_AUDIT,
       ),
       dependenciesOf(FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_BUILD),
     )
     assertEquals(
       listOf(
-        FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT,
+        FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_PLAN,
         FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_AUDIT,
       ),
       dependenciesOf(FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE),
@@ -294,25 +294,30 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
         def.PHASE_AUDIT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.AUDIT_CLEARANCE,
       ),
       def.PHASE_VALIDATE to setOf(
-        def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_REQUEST,
+        def.PHASE_PLAN to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE,
+        def.PHASE_PLAN to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_REQUEST,
         def.PHASE_AUDIT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.AUDIT_CLEARANCE,
       ),
       def.PHASE_BUILD to setOf(
-        def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_REQUEST,
+        def.PHASE_PLAN to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE,
+        def.PHASE_PLAN to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_REQUEST,
         def.PHASE_AUDIT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.AUDIT_CLEARANCE,
       ),
       def.PHASE_WRITE_HISTORY to setOf(
+        def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE,
         def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.BOUNDARY_CANDIDATES,
         def.PHASE_VALIDATE to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_RECEIPT,
         def.PHASE_BUILD to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.BUILD_RECEIPT,
       ),
       def.PHASE_COMMIT_PUSH to setOf(
+        def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE,
         def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.COMMIT_REQUEST,
         def.PHASE_VALIDATE to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.VALIDATION_RECEIPT,
         def.PHASE_BUILD to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.BUILD_RECEIPT,
         def.PHASE_WRITE_HISTORY to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.HISTORY_RECEIPT,
       ),
       def.PHASE_PR to setOf(
+        def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE,
         def.PHASE_IMPLEMENT to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PR_REQUEST,
         def.PHASE_COMMIT_PUSH to FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.COMMIT_RECEIPT,
       ),
@@ -434,14 +439,13 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
       fields(def.PHASE_REVIEW, "audit_clearance"),
     )
     assertEquals(
-      listOf("validation_strategy", "changed_paths", "required_checks", "repository_checkpoint"),
+      listOf("changed_paths", "repository_checkpoint"),
       fields(def.PHASE_VALIDATE, "validation_request"),
     )
     assertEquals(
       listOf(
         "path_inventory",
         "required_inclusions",
-        "required_exclusions",
         "branch_identity",
         "gate_attestations",
         "repository_checkpoint",
@@ -450,25 +454,50 @@ class FeatureTaskRuntimePhaseWorkflowDefinitionTest {
     )
     assertEquals(
       listOf(
-        "completed_task_ids",
         "changed_paths",
-        "tests_added",
-        "tests_updated",
-        "deviations",
         "validation_summary",
         "base_branch",
         "diff_reference",
       ),
       fields(def.PHASE_PR, "pr_request"),
     )
+    val prRequestFields = fields(def.PHASE_PR, "pr_request")
+    assertTrue("completed_task_ids" !in prRequestFields)
+    assertTrue("tests_added" !in prRequestFields)
+    assertTrue("tests_updated" !in prRequestFields)
+    assertTrue("deviations" !in prRequestFields)
+    val commitRequestFields = fields(def.PHASE_COMMIT_PUSH, "commit_request")
+    assertTrue("required_exclusions" !in commitRequestFields)
+    listOf(
+      def.PHASE_VALIDATE,
+      def.PHASE_BUILD,
+      def.PHASE_WRITE_HISTORY,
+      def.PHASE_COMMIT_PUSH,
+      def.PHASE_PR,
+    ).forEach { consumer ->
+      val prose = def.phaseDeclarations.getValue(consumer).projectionDeclarations.filter {
+        it.projectionContractId == FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE
+      }
+      assertTrue(prose.isNotEmpty(), "$consumer must declare phase_prose")
+      prose.forEach { declaration ->
+        assertEquals(
+          FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.PHASE_PROSE,
+          declaration.projectionContractId,
+        )
+      }
+    }
   }
 
   @Test
   fun `runtime projectors privately combine only the producers needed by finalization consumers`() {
     val def = FeatureTaskRuntimePhaseWorkflowDefinition
     assertEquals(
-      setOf(def.PHASE_PLAN, def.PHASE_IMPLEMENT, def.PHASE_AUDIT),
+      setOf(def.PHASE_PLAN, def.PHASE_AUDIT),
       def.runtimeProjectorProducerPhaseIds(def.PHASE_VALIDATE),
+    )
+    assertEquals(
+      setOf(def.PHASE_PLAN, def.PHASE_AUDIT),
+      def.runtimeProjectorProducerPhaseIds(def.PHASE_BUILD),
     )
     assertEquals(
       setOf(def.PHASE_IMPLEMENT, def.PHASE_VALIDATE, def.PHASE_BUILD),


### PR DESCRIPTION
Goal: retarget-finalization-off-implement-receipt

Subtasks:
- 1. Retarget finalization consumers onto phase_prose (485c31e552cfd4322916f31334da10b075a2da0f)
