### PR TITLE
Refuse unknown agent ids at the CLI boundary

### DIFF
--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/InvokingAgentResolution.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/core/InvokingAgentResolution.kt
@@ -1,6 +1,7 @@
 package skillbill.cli.core
 
 import com.github.ajalt.clikt.core.UsageError
+import skillbill.install.model.InstallAgent
 import skillbill.install.model.InvokingAgentContextResolver
 import skillbill.install.model.InvokingAgentContextSignal
 
@@ -11,13 +12,45 @@ fun detectInvokingAgentId(explicitAgent: String?, environment: Map<String, Strin
     ?: environment[SKILL_BILL_AGENT_ENV]?.takeIf(String::isNotBlank)
     ?: InvokingAgentContextResolver.detect(environment)?.id
 
-fun requireInvokingAgentId(explicitAgent: String?, environment: Map<String, String>, agentOption: String): String =
-  detectInvokingAgentId(explicitAgent, environment)
+fun requireInvokingAgentId(explicitAgent: String?, environment: Map<String, String>, agentOption: String): String {
+  val resolved = detectInvokingAgentId(explicitAgent, environment)
     ?: throw UsageError(undetectedInvokingAgentMessage(agentOption))
+  return requireSupportedAgentId(resolved, invokingAgentSource(explicitAgent, agentOption))
+}
+
+/**
+ * Refuse an agent id the runtime cannot launch, at the CLI boundary. Detection via execution-context
+ * markers yields an [InstallAgent] id by construction, so only an operator-supplied value can name an
+ * unknown agent — and without this gate that value travels as an opaque string until the runtime
+ * rejects it, by which point a goal record and its planning attempt already exist.
+ */
+fun requireSupportedAgentId(agentId: String, source: String): String {
+  val normalized = agentId.trim().lowercase()
+  if (normalized !in InstallAgent.supportedIds) {
+    throw UsageError(unsupportedAgentMessage(agentId, source))
+  }
+  return normalized
+}
+
+/**
+ * Blank stays the business of the request-level identity validation that already reports it; this
+ * only answers whether a supplied agent id names a supported agent.
+ */
+fun requireSupportedOptionalAgentId(agentId: String?, agentOption: String): String? = when {
+  agentId == null || agentId.isBlank() -> agentId
+  else -> requireSupportedAgentId(agentId, agentOption)
+}
 
 fun invokingAgentResolutionHelp(agentOption: String): String =
-  "Agent invoking this run. Resolution order: $agentOption, then $SKILL_BILL_AGENT_ENV, then the detected " +
-    "invoking-agent execution context. Resolution fails when none of the three names an agent."
+  "Agent invoking this run (${InstallAgent.supportedIds.joinToString("|")}). Resolution order: $agentOption, " +
+    "then $SKILL_BILL_AGENT_ENV, then the detected invoking-agent execution context. Resolution fails when " +
+    "none of the three names an agent."
+
+private fun invokingAgentSource(explicitAgent: String?, agentOption: String): String =
+  if (explicitAgent?.isNotBlank() == true) agentOption else SKILL_BILL_AGENT_ENV
+
+private fun unsupportedAgentMessage(agentId: String, source: String): String =
+  "Unknown agent '$agentId' from $source. Supported agents: ${InstallAgent.supportedIds.joinToString(", ")}."
 
 private fun undetectedInvokingAgentMessage(agentOption: String): String =
   "Cannot determine the invoking agent, and there is no default: $agentOption was not passed, " +

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommandsExtras.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliCommandsExtras.kt
@@ -4,11 +4,13 @@ import com.github.ajalt.clikt.core.UsageError
 import skillbill.agentaddon.model.AgentAddonConsumer
 import skillbill.agentaddon.model.HydratedAgentAddonSelection
 import skillbill.cli.core.refuseUnavailableAgentLaunchers
+import skillbill.cli.core.requireSupportedOptionalAgentId
 import skillbill.cli.featuretask.parseAgentAddonSelection
 import skillbill.ports.agentaddon.model.ExternalAgentAddonSourceConfigRequest
 
 internal fun validateGoalRunInputs(args: GoalRunInputValidationArgs) {
   val invokedAgentId = resolveInvokedAgentId(args.agent, args.state.environment)
+  requireSupportedOptionalAgentId(args.agentOverride, "--agent-override")
   refuseUnavailableAgentLaunchers(listOf(invokedAgentId, args.agentOverride), args.executableLookup)
   val usageError = when {
     args.issueKey == null -> "issue_key is required for goal run."

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliRunCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliRunCommands.kt
@@ -22,6 +22,7 @@ import skillbill.cli.core.CliRunState
 import skillbill.cli.core.DocumentedCliCommand
 import skillbill.cli.core.formatOption
 import skillbill.cli.core.invokingAgentResolutionHelp
+import skillbill.cli.core.requireSupportedOptionalAgentId
 import skillbill.goalrunner.model.UnaddressedFindingsLedger
 import skillbill.workflow.goal.model.CodeReviewExecutionMode
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeFindingVerificationDisposition
@@ -61,12 +62,13 @@ class GoalPreflightCommand(
     val root = repoRoot?.let(Path::of)?.toAbsolutePath()?.normalize()
       ?: Path.of("").toAbsolutePath().normalize()
     val invokedAgentId = resolveInvokedAgentId(agent, state.environment)
+    val agentOverrideId = requireSupportedOptionalAgentId(agentOverride, "--agent-override")
     val result = service.preflight(
       GoalPreflightRequest(
         issueKey = issueKey,
         repoRoot = root,
         invokedAgentId = invokedAgentId,
-        agentOverrideId = agentOverride,
+        agentOverrideId = agentOverrideId,
         requestedReviewMode = parseCodeReviewMode(codeReviewMode),
         requestedAgentAddonSlugs = agentAddonSlugs,
         dbPathOverride = state.dbOverride,

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/InvokingAgentResolutionTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/InvokingAgentResolutionTest.kt
@@ -1,0 +1,67 @@
+package skillbill.cli
+
+import com.github.ajalt.clikt.core.UsageError
+import skillbill.cli.core.SKILL_BILL_AGENT_ENV
+import skillbill.cli.core.requireInvokingAgentId
+import skillbill.cli.core.requireSupportedOptionalAgentId
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/**
+ * Bug this catches: an operator-supplied agent id that names no supported agent travels past the CLI
+ * as an opaque string, so `goal preflight` renders a confirmation gate for an agent that cannot run
+ * and the launch only fails once a goal record and its planning attempt already exist.
+ */
+class InvokingAgentResolutionTest {
+  @Test
+  fun `unknown explicit agent is refused with the supported list`() {
+    val error = assertFailsWith<UsageError> {
+      requireInvokingAgentId("claude-code", emptyMap(), "--agent")
+    }
+
+    assertContains(error.message.orEmpty(), "Unknown agent 'claude-code'")
+    assertContains(error.message.orEmpty(), "claude, codex, junie, cursor")
+    assertContains(error.message.orEmpty(), "--agent")
+  }
+
+  @Test
+  fun `unknown agent from the environment names the environment variable`() {
+    val error = assertFailsWith<UsageError> {
+      requireInvokingAgentId(null, mapOf(SKILL_BILL_AGENT_ENV to "claude-code"), "--agent")
+    }
+
+    assertContains(error.message.orEmpty(), SKILL_BILL_AGENT_ENV)
+  }
+
+  @Test
+  fun `supported agent resolves`() {
+    assertEquals("claude", requireInvokingAgentId("claude", emptyMap(), "--agent"))
+  }
+
+  @Test
+  fun `supported agent resolves regardless of casing or padding`() {
+    assertEquals("codex", requireInvokingAgentId("  Codex ", emptyMap(), "--agent"))
+  }
+
+  @Test
+  fun `detected execution context still resolves`() {
+    assertEquals("claude", requireInvokingAgentId(null, mapOf("CLAUDECODE" to "1"), "--agent"))
+  }
+
+  @Test
+  fun `unknown agent override is refused`() {
+    val error = assertFailsWith<UsageError> {
+      requireSupportedOptionalAgentId("claude-code", "--agent-override")
+    }
+
+    assertContains(error.message.orEmpty(), "--agent-override")
+  }
+
+  @Test
+  fun `absent agent override is allowed`() {
+    assertNull(requireSupportedOptionalAgentId(null, "--agent-override"))
+  }
+}


### PR DESCRIPTION
## Problem

`--agent` resolution returned whatever string it was handed without checking that it names a supported agent. `InstallAgent.fromId` has always rejected an unknown id, but nothing on the CLI path called it, so a typo travelled as an opaque string until the runtime refused it.

`goal preflight` was the worst case. Passing `--agent claude-code` (a plausible-looking typo for `claude`) produced a normal-looking confirmation gate:

```json
"gate_block": { "child_agent": "claude-code", ... }
```

The operator confirmed against that gate, and the failure surfaced only after launch:

```
goal WE-XXXX: blocked at subtask 0 — Goal planning 'preplan' failed before its
output could be checkpointed: IllegalArgumentException: Unknown agent 'claude-code'.
Supported agents: claude, codex, junie, cursor.
```

By then a goal record and a failed planning attempt already existed, and recovery meant a `goal_continuation` rather than a clean start.

`refuseUnavailableAgentLaunchers` looks like the gate for this — it is documented as "the first point that can tell an operator the launch will fail — before a goal record, branch, or child process exists" — but it delegates to `unavailableAgentLauncherReason`, which returns `null` when the agent is unknown. It only catches *known* agents whose headless CLI is missing, so unknown ids fall straight through the gate meant to stop exactly this.

## Change

- Validate in `requireInvokingAgentId`, the single chokepoint for `--agent` across `goal run`, `goal preflight`, feature-task runtime, and the code-review driver's `--agent1`. The message names the source so an operator who exported `SKILL_BILL_AGENT` knows where to look:
  `Unknown agent 'claude-code' from --agent. Supported agents: claude, codex, junie, cursor.`
- `requireSupportedOptionalAgentId` closes the same hole on `--agent-override`, which preflight passed through with only a blank-check. Blank stays the business of the existing request-level identity validation.
- Ids are trimmed and lowercased, so `--agent Codex` resolves instead of failing opaquely later.
- `--help` for `--agent` now lists the accepted values: `Agent invoking this run (claude|codex|junie|cursor)`. That absence is what made the typo easy to make.

## Verification

`InvokingAgentResolutionTest` covers unknown-from-option, unknown-from-env (asserting the env var is named), `--agent-override`, casing/padding, and that execution-context detection still resolves.

`(cd runtime-kotlin && ./gradlew check)` passes — full suite plus detekt and `validateAgentConfigs`.

Installed from source and confirmed against the reproducer:

```
$ skill-bill goal preflight WE-XXXX --agent claude-code
Error: Unknown agent 'claude-code' from --agent. Supported agents: claude, codex, junie, cursor.
```

No goal record is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)