### PR TITLE
Keep validate retries cheap: prune delivered projections + sparse progress

### DIFF
--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/decomposition/DecompositionManifestRuntimeState.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/decomposition/DecompositionManifestRuntimeState.kt
@@ -18,6 +18,17 @@ internal fun decodeArtifacts(existingArtifactsJson: String): Map<String, Any?> =
     ?.let(JsonSupport::anyToStringAnyMap)
     .orEmpty()
 
+internal fun decodeArtifactKeys(existingArtifactsJson: String, keys: Set<String>): Map<String, Any?> {
+  if (keys.isEmpty()) return emptyMap()
+  val root = JsonSupport.parseObjectOrNull(existingArtifactsJson) ?: return emptyMap()
+  return buildMap {
+    keys.forEach { key ->
+      val element = root[key] ?: return@forEach
+      put(key, JsonSupport.jsonElementToValue(element))
+    }
+  }
+}
+
 internal fun loadManifestOrNull(
   path: Path,
   validator: DecompositionManifestValidator,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseBriefingRecorder.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimePhaseBriefingRecorder.kt
@@ -56,7 +56,10 @@ internal class FeatureTaskRuntimePhaseBriefingRecorder(
     recordProjectionMeasurements(unitOfWork, workflowId, briefing, delivered, artifacts)
     recordSharedEvidenceMeasurement(unitOfWork, sharedEvidenceMeasurement)
     val updatedDelivered = LinkedHashMap(deliveredHistory)
-      .apply { put(deliveredProjectionKey(delivered), delivered) }
+      .apply {
+        entries.removeIf { (_, value) -> value.consumerPhaseId == briefing.phaseId }
+        put(deliveredProjectionKey(delivered), delivered)
+      }
     val patch = mapOf(
       FEATURE_TASK_RUNTIME_PHASE_BRIEFINGS_ARTIFACT_KEY to
         updatedBriefings.mapValues { (_, value) -> value.toArtifactMap() },

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationExtras.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationExtras.kt
@@ -1,9 +1,7 @@
 package skillbill.application.featuretask
 
-import skillbill.ports.workflow.gitops.WorkflowGitRemoteOperations
 import skillbill.ports.workflow.gitops.captureIndexState
 import skillbill.ports.workflow.gitops.headCommitMessage
-import skillbill.ports.workflow.gitops.model.WorkflowGitOperationResult
 import skillbill.ports.workflow.gitops.restoreIndexState
 import skillbill.ports.workflow.gitops.stagePaths
 
@@ -130,9 +128,7 @@ internal fun FeatureTaskRuntimeSubtaskFinalisation.decide(
 internal fun FeatureTaskRuntimeSubtaskFinalisation.headMessage(): String? =
   gitOperations.headCommitMessage(repoRoot).takeIf { it.ok }?.value
 
-internal fun FeatureTaskRuntimeSubtaskFinalisation.ownedHeadAlreadyFinalised(
-  durableCommitSha: String?,
-): Boolean {
+internal fun FeatureTaskRuntimeSubtaskFinalisation.ownedHeadAlreadyFinalised(durableCommitSha: String?): Boolean {
   val durable = durableCommitSha?.trim()?.takeIf(String::isNotBlank) ?: return false
   val headSha = gitOperations.headCommitSha(repoRoot).takeIf { it.ok }?.value?.trim()?.takeIf(String::isNotBlank)
     ?: return false
@@ -145,51 +141,6 @@ internal fun FeatureTaskRuntimeSubtaskFinalisation.remoteDiverged(branch: String
     .takeIf { it.ok }?.value?.trim()?.takeIf(String::isNotBlank) ?: return false
   val ancestor = gitOperations.isCommitAncestor(repoRoot, remoteTip, commitSha)
   return ancestor.ok && ancestor.value.orEmpty().trim().equals("false", ignoreCase = true)
-}
-
-internal fun FeatureTaskRuntimeSubtaskFinalisation.push(
-  branch: String,
-  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
-  commitSha: String,
-  withLease: Boolean,
-): String? {
-  if (!withLease) {
-    val pushed = gitOperations.pushBranch(repoRoot, branch)
-    return if (pushed.ok) null else "the finalised subtask commit '$commitSha' could not be pushed (${pushed.error})"
-  }
-  record(forceWithLeaseRecord(identity, branch, commitSha))
-  val refreshed = refreshRemote(identity, branch)
-  if (refreshed.namesAbsentRemote()) return pushAmended(branch, commitSha)
-  val first = gitOperations.pushBranchWithLease(repoRoot, branch)
-  if (first.ok) return null
-  record(leaseRetryRecord(identity, branch, first.error))
-  val retried = refreshRemote(identity, branch)
-  if (retried.namesAbsentRemote()) return pushAmended(branch, commitSha)
-  val second = gitOperations.pushBranchWithLease(repoRoot, branch)
-  if (second.ok) return null
-  record(leaseAbortRecord(identity, branch, second.error))
-  return "the reopened subtask's amended commit '$commitSha' could not be pushed (${second.error})"
-}
-
-private fun FeatureTaskRuntimeSubtaskFinalisation.pushAmended(branch: String, commitSha: String): String? {
-  val pushed = gitOperations.pushBranch(repoRoot, branch)
-  return if (pushed.ok) null else "the reopened subtask's amended commit '$commitSha' could not be pushed (${pushed.error})"
-}
-
-private fun WorkflowGitOperationResult.namesAbsentRemote(): Boolean =
-  ok && value.trim() == WorkflowGitRemoteOperations.ABSENT_REMOTE_BRANCH
-
-private fun FeatureTaskRuntimeSubtaskFinalisation.refreshRemote(
-  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
-  branch: String,
-): WorkflowGitOperationResult {
-  val refreshed = gitOperations.refreshRemoteBranch(repoRoot, branch)
-  when {
-    refreshed.namesAbsentRemote() -> record(leaseAbsentRecord(identity, branch))
-    refreshed.ok -> record(leaseRefreshRecord(identity, branch))
-    else -> record(leaseRefreshFailedRecord(identity, branch, refreshed.error))
-  }
-  return refreshed
 }
 
 internal fun FeatureTaskRuntimeSubtaskFinalisation.restoring(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationGitPaths.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationGitPaths.kt
@@ -54,46 +54,6 @@ internal fun specExclusionRecord(identity: FeatureTaskRuntimeSubtaskCommitIdenti
     "'${identity.issueKey}/${identity.subtaskId}' cause=governed feature specs are workflow input, " +
     "never subtask deliverable output, so they are dropped from the staged set and left dirty locally"
 
-internal fun forceWithLeaseRecord(
-  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
-  branch: String,
-  commitSha: String,
-) = "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='git push --force-with-lease origin " +
-  "$branch' value_expected=a non-forcing push of '$commitSha' cause=subtask " +
-  "'${identity.issueKey}/${identity.subtaskId}' was reopened after its commit had already been " +
-  "published, so finalisation rewrote a commit the remote already carries"
-
-internal fun leaseRefreshRecord(identity: FeatureTaskRuntimeSubtaskCommitIdentity, branch: String) =
-  "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='git fetch origin +refs/heads/$branch:" +
-    "refs/remotes/origin/$branch' value_expected=the remote-tracking tip for 'origin/$branch' for subtask " +
-    "'${identity.issueKey}/${identity.subtaskId}' cause=a leased push is only as current as the last fetch"
-
-internal fun leaseAbsentRecord(identity: FeatureTaskRuntimeSubtaskCommitIdentity, branch: String) =
-  "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='git push -u origin $branch' " +
-    "value_expected=a leased push of 'origin/$branch' for subtask '${identity.issueKey}/${identity.subtaskId}' " +
-    "cause=the remote no longer has '$branch', so finalisation publishes the local tip as a new remote branch"
-
-internal fun leaseRefreshFailedRecord(
-  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
-  branch: String,
-  error: String,
-) = "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='the last observed origin/$branch' " +
-  "value_expected=a refreshed 'origin/$branch' for subtask '${identity.issueKey}/${identity.subtaskId}' " +
-  "cause=git fetch origin $branch failed, so the leased push will use the last observed tip ($error)"
-
-internal fun leaseRetryRecord(
-  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
-  branch: String,
-  error: String,
-) = "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='a second leased push after fetch' " +
-  "value_expected=the first leased push of subtask '${identity.issueKey}/${identity.subtaskId}' " +
-  "cause=the first leased push was rejected ($error), so finalisation refreshes origin/$branch and retries"
-
-internal fun leaseAbortRecord(identity: FeatureTaskRuntimeSubtaskCommitIdentity, branch: String, error: String) =
-  "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='an unpushed local tip' " +
-    "value_expected='origin/$branch' for subtask '${identity.issueKey}/${identity.subtaskId}' " +
-    "cause=the leased push was rejected after refresh and retry ($error)"
-
 internal fun isGovernedSpecPath(path: String): Boolean = normalizeRepoPath(path).startsWith(GOVERNED_SPEC_ROOT)
 
 internal fun normalizeRepoPath(path: String): String = path.trim().removeSurrounding("\"").removePrefix("./")

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationLeaseRecords.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationLeaseRecords.kt
@@ -1,0 +1,38 @@
+package skillbill.application.featuretask
+
+internal fun forceWithLeaseRecord(
+  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
+  branch: String,
+  commitSha: String,
+) = "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='git push --force-with-lease origin " +
+  "$branch' value_expected=a non-forcing push of '$commitSha' cause=subtask " +
+  "'${identity.issueKey}/${identity.subtaskId}' was reopened after its commit had already been " +
+  "published, so finalisation rewrote a commit the remote already carries"
+
+internal fun leaseRefreshRecord(identity: FeatureTaskRuntimeSubtaskCommitIdentity, branch: String) =
+  "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='git fetch origin +refs/heads/$branch:" +
+    "refs/remotes/origin/$branch' value_expected=the remote-tracking tip for 'origin/$branch' for subtask " +
+    "'${identity.issueKey}/${identity.subtaskId}' cause=a leased push is only as current as the last fetch"
+
+internal fun leaseAbsentRecord(identity: FeatureTaskRuntimeSubtaskCommitIdentity, branch: String) =
+  "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='git push -u origin $branch' " +
+    "value_expected=a leased push of 'origin/$branch' for subtask '${identity.issueKey}/${identity.subtaskId}' " +
+    "cause=the remote no longer has '$branch', so finalisation publishes the local tip as a new remote branch"
+
+internal fun leaseRefreshFailedRecord(
+  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
+  branch: String,
+  error: String,
+) = "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='the last observed origin/$branch' " +
+  "value_expected=a refreshed 'origin/$branch' for subtask '${identity.issueKey}/${identity.subtaskId}' " +
+  "cause=git fetch origin $branch failed, so the leased push will use the last observed tip ($error)"
+
+internal fun leaseRetryRecord(identity: FeatureTaskRuntimeSubtaskCommitIdentity, branch: String, error: String) =
+  "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='a second leased push after fetch' " +
+    "value_expected=the first leased push of subtask '${identity.issueKey}/${identity.subtaskId}' " +
+    "cause=the first leased push was rejected ($error), so finalisation refreshes origin/$branch and retries"
+
+internal fun leaseAbortRecord(identity: FeatureTaskRuntimeSubtaskCommitIdentity, branch: String, error: String) =
+  "seam=FeatureTaskRuntimeSubtaskFinalisation.push value_used='an unpushed local tip' " +
+    "value_expected='origin/$branch' for subtask '${identity.issueKey}/${identity.subtaskId}' " +
+    "cause=the leased push was rejected after refresh and retry ($error)"

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationPush.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/featuretask/FeatureTaskRuntimeSubtaskFinalisationPush.kt
@@ -1,0 +1,68 @@
+package skillbill.application.featuretask
+
+import skillbill.ports.workflow.gitops.WorkflowGitRemoteOperations
+import skillbill.ports.workflow.gitops.model.WorkflowGitOperationResult
+
+internal fun FeatureTaskRuntimeSubtaskFinalisation.push(
+  branch: String,
+  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
+  commitSha: String,
+  withLease: Boolean,
+): String? {
+  if (!withLease) return pushDirect(branch, commitSha)
+  record(forceWithLeaseRecord(identity, branch, commitSha))
+  return pushWithLease(branch, identity, commitSha)
+}
+
+private fun FeatureTaskRuntimeSubtaskFinalisation.pushDirect(branch: String, commitSha: String): String? {
+  val pushed = gitOperations.pushBranch(repoRoot, branch)
+  if (pushed.ok) return null
+  return "the finalised subtask commit '$commitSha' could not be pushed (${pushed.error})"
+}
+
+private fun FeatureTaskRuntimeSubtaskFinalisation.pushWithLease(
+  branch: String,
+  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
+  commitSha: String,
+): String? {
+  val firstError = attemptLeasedPush(branch, identity, commitSha) ?: return null
+  record(leaseRetryRecord(identity, branch, firstError))
+  val secondError = attemptLeasedPush(branch, identity, commitSha) ?: return null
+  record(leaseAbortRecord(identity, branch, secondError))
+  return "the reopened subtask's amended commit '$commitSha' could not be pushed ($secondError)"
+}
+
+private fun FeatureTaskRuntimeSubtaskFinalisation.attemptLeasedPush(
+  branch: String,
+  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
+  commitSha: String,
+): String? {
+  if (refreshRemote(identity, branch).namesAbsentRemote()) {
+    return pushAmended(branch, commitSha)
+  }
+  val pushed = gitOperations.pushBranchWithLease(repoRoot, branch)
+  if (pushed.ok) return null
+  return pushed.error
+}
+
+private fun FeatureTaskRuntimeSubtaskFinalisation.pushAmended(branch: String, commitSha: String): String? {
+  val pushed = gitOperations.pushBranch(repoRoot, branch)
+  if (pushed.ok) return null
+  return "the reopened subtask's amended commit '$commitSha' could not be pushed (${pushed.error})"
+}
+
+private fun WorkflowGitOperationResult.namesAbsentRemote(): Boolean =
+  ok && value.trim() == WorkflowGitRemoteOperations.ABSENT_REMOTE_BRANCH
+
+private fun FeatureTaskRuntimeSubtaskFinalisation.refreshRemote(
+  identity: FeatureTaskRuntimeSubtaskCommitIdentity,
+  branch: String,
+): WorkflowGitOperationResult {
+  val refreshed = gitOperations.refreshRemoteBranch(repoRoot, branch)
+  when {
+    refreshed.namesAbsentRemote() -> record(leaseAbsentRecord(identity, branch))
+    refreshed.ok -> record(leaseRefreshRecord(identity, branch))
+    else -> record(leaseRefreshFailedRecord(identity, branch, refreshed.error))
+  }
+  return refreshed
+}

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/AttemptLedgerWorkflowDecoding.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/AttemptLedgerWorkflowDecoding.kt
@@ -18,8 +18,7 @@ internal fun WorkflowStateSnapshot.progressToken(): String = listOf(
   finishedAt.orEmpty(),
 ).joinToString("\n")
 
-internal fun artifactsFingerprint(artifactsJson: String): String =
-  "${artifactsJson.length}:${artifactsJson.hashCode()}"
+internal fun artifactsFingerprint(artifactsJson: String): String = "${artifactsJson.length}:${artifactsJson.hashCode()}"
 
 internal fun decodeWorkflowSteps(stepsJson: String): List<WorkflowStepState> =
   parseWorkflowStepsArray(stepsJson).mapIndexed(::decodeWorkflowStepAt)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/AttemptLedgerWorkflowDecoding.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/AttemptLedgerWorkflowDecoding.kt
@@ -13,10 +13,13 @@ internal fun WorkflowStateSnapshot.progressToken(): String = listOf(
   workflowStatus,
   currentStepId,
   stepsJson,
-  artifactsJson,
+  artifactsFingerprint(artifactsJson),
   updatedAt.orEmpty(),
   finishedAt.orEmpty(),
 ).joinToString("\n")
+
+internal fun artifactsFingerprint(artifactsJson: String): String =
+  "${artifactsJson.length}:${artifactsJson.hashCode()}"
 
 internal fun decodeWorkflowSteps(stepsJson: String): List<WorkflowStepState> =
   parseWorkflowStepsArray(stepsJson).mapIndexed(::decodeWorkflowStepAt)

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/WorkflowGoalRunnerProgressRecording.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/goalrunner/WorkflowGoalRunnerProgressRecording.kt
@@ -1,5 +1,6 @@
 package skillbill.application.goalrunner
 
+import skillbill.application.decomposition.decodeArtifactKeys
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.featuretask.phaseRecordsFrom
 import skillbill.application.workflow.WorkflowFamily
@@ -18,11 +19,18 @@ import skillbill.workflow.engine.WorkflowEngine
 import skillbill.workflow.engine.model.WorkflowUpdateInput
 import skillbill.workflow.goal.GoalObservabilityEventValidator
 import skillbill.workflow.goal.GoalProgressEventValidator
+import skillbill.workflow.goal.model.GOAL_OBSERVABILITY_LATEST_EVENT_ARTIFACT_KEY
 import skillbill.workflow.goal.model.GOAL_PROGRESS_HISTORY_LIMIT
 import skillbill.workflow.goal.model.GOAL_PROGRESS_LATEST_EVENT_ARTIFACT_KEY
 import skillbill.workflow.goal.model.GOAL_PROGRESS_RUN_HISTORY_ARTIFACT_KEY
 import skillbill.workflow.goal.model.appendBoundedHistoryBySequence
 import skillbill.workflow.goal.model.goalObservabilityLatestEventFromArtifacts
+
+private val PROGRESS_POLL_ARTIFACT_KEYS = setOf(
+  "progress_event",
+  GOAL_PROGRESS_LATEST_EVENT_ARTIFACT_KEY,
+  GOAL_OBSERVABILITY_LATEST_EVENT_ARTIFACT_KEY,
+)
 
 internal class WorkflowGoalRunnerProgressRecording(
   private val database: DatabaseSessionFactory,
@@ -36,7 +44,7 @@ internal class WorkflowGoalRunnerProgressRecording(
       val record = family.get(unitOfWork.workflowStates, workflowId) ?: return@read null
       engine.snapshotView(family.definition, record)
       val steps = decodeWorkflowSteps(record.stepsJson)
-      val artifacts = decodeArtifacts(record.artifactsJson)
+      val artifacts = decodeArtifactKeys(record.artifactsJson, PROGRESS_POLL_ARTIFACT_KEYS)
       val finishCompleted = steps.any { step -> step.stepId == "pr" && step.status == "completed" }
       val currentStep = if (record.workflowStatus == "completed" || finishCompleted) "pr" else record.currentStepId
       val progressEvent = progressEventFrom(artifacts)

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/WorkflowServiceTest.kt
@@ -2555,6 +2555,46 @@ class WorkflowGoalRunnerProgressStoreTest {
   }
 
   @Test
+  fun `goal runner progress returns declared progress when unrelated artifact keys are oversized`() {
+    val workflows = InMemoryWorkflowStates()
+    workflows.saveFeatureImplementWorkflow(
+      workflowRecord(
+        workflowId = "wfl-child",
+        artifactsPatch = mapOf(
+          "feature_task_runtime_delivered_projections" to mapOf(
+            "validate|1" to "z".repeat(1_500_000),
+          ),
+          GoalProgressEvent(
+            eventKind = GoalProgressEventKind.OPERATION_HEARTBEAT,
+            workflowId = "wfl-child",
+            workflowPhase = "validate",
+            processAlive = true,
+            sequenceNumber = 9,
+            timestamp = "2026-06-02T11:00:00Z",
+            operationName = "pack validation gate",
+            operationKind = "validate",
+            expectedLong = true,
+          ).let { event -> "goal_progress_latest_event" to event.toArtifactMap() },
+        ),
+      ),
+    )
+    val store = testWorkflowGoalRunnerOutcomeStore(
+      outcomeStoreDeps(
+        database = FakeDatabaseSessionFactory(workflows),
+        workflowSnapshotValidator = testWorkflowSnapshotValidator,
+      ),
+    )
+
+    val progress = requireNotNull(store.progress("wfl-child"))
+
+    assertTrue(progress.progressToken.length < 4_000)
+    assertFalse(progress.progressToken.contains("zzzz"))
+    val declared = requireNotNull(progress.latestDeclaredProgressEvent)
+    assertEquals("pack validation gate", declared.operationName)
+    assertEquals(9, declared.sequenceNumber)
+  }
+
+  @Test
   fun `goal runner outcome store appends worker subtask request outcomes`() {
     val workflows = InMemoryWorkflowStates()
     workflows.saveFeatureImplementWorkflow(workflowRecord("wfl-child", emptyMap()))

--- a/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/goalrunner/AttemptLedgerWorkflowDecodingTest.kt
+++ b/runtime-kotlin/runtime-application/src/test/kotlin/skillbill/application/goalrunner/AttemptLedgerWorkflowDecodingTest.kt
@@ -1,0 +1,74 @@
+package skillbill.application.goalrunner
+
+import skillbill.application.decomposition.decodeArtifactKeys
+import skillbill.contracts.JsonSupport
+import skillbill.workflow.engine.model.WorkflowStateSnapshot
+import skillbill.workflow.goal.model.GOAL_PROGRESS_LATEST_EVENT_ARTIFACT_KEY
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AttemptLedgerWorkflowDecodingTest {
+  @Test
+  fun `progress token fingerprints artifacts without embedding the body`() {
+    val bloatedArtifacts = JsonSupport.mapToJsonString(
+      mapOf("feature_task_runtime_delivered_projections" to "x".repeat(50_000)),
+    )
+    val snapshot = progressSnapshot(artifactsJson = bloatedArtifacts)
+
+    val token = snapshot.progressToken()
+
+    assertFalse(token.contains("xxxx"))
+    assertTrue(token.length < 2_000)
+    assertTrue(artifactsFingerprint(bloatedArtifacts) in token)
+  }
+
+  @Test
+  fun `progress token changes when only artifacts mutate`() {
+    val before = progressSnapshot(artifactsJson = """{"progress_event":{"summary":"a"}}""")
+    val after = progressSnapshot(artifactsJson = """{"progress_event":{"summary":"b"}}""")
+
+    assertNotEquals(before.progressToken(), after.progressToken())
+  }
+
+  @Test
+  fun `decodeArtifactKeys materializes only requested top-level keys`() {
+    val artifactsJson = JsonSupport.mapToJsonString(
+      mapOf(
+        GOAL_PROGRESS_LATEST_EVENT_ARTIFACT_KEY to mapOf(
+          "event_kind" to "operation_heartbeat",
+          "workflow_id" to "wfl-child",
+        ),
+        "feature_task_runtime_delivered_projections" to mapOf(
+          "bloat" to "y".repeat(20_000),
+        ),
+        "progress_event" to mapOf("summary" to "alive"),
+      ),
+    )
+
+    val sparse = decodeArtifactKeys(
+      artifactsJson,
+      setOf(GOAL_PROGRESS_LATEST_EVENT_ARTIFACT_KEY, "progress_event"),
+    )
+
+    assertEquals(setOf(GOAL_PROGRESS_LATEST_EVENT_ARTIFACT_KEY, "progress_event"), sparse.keys)
+    assertEquals("alive", (sparse["progress_event"] as Map<*, *>)["summary"])
+    assertFalse(sparse.containsKey("feature_task_runtime_delivered_projections"))
+  }
+
+  private fun progressSnapshot(artifactsJson: String): WorkflowStateSnapshot = WorkflowStateSnapshot(
+    workflowId = "wfl-child",
+    sessionId = "session-1",
+    workflowName = "bill-feature-task",
+    contractVersion = "1.0",
+    workflowStatus = "running",
+    currentStepId = "validate",
+    stepsJson = """[{"step_id":"validate","status":"running","attempt_count":1}]""",
+    artifactsJson = artifactsJson,
+    startedAt = "2026-06-02T10:00:00Z",
+    updatedAt = "2026-06-02T10:00:01Z",
+    finishedAt = null,
+  )
+}

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortWorkflowTest.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/application/ApplicationPersistencePortWorkflowTest.kt
@@ -157,7 +157,6 @@ class ApplicationPersistencePortWorkflowTest {
     assertEquals(handoffBriefing().handoffEnvelope, requireNotNull(delivered).envelope)
     assertEquals(1, delivered.iteration)
 
-    // A second delivery to the same consumer is a new iteration, not a silent overwrite of history.
     assertTrue(recorder.recordPhaseBriefing(workflowId, handoffBriefing()))
     assertEquals(2, requireNotNull(recorder.loadDeliveredProjections(workflowId))["implement"]?.iteration)
     val afterSecondDelivery = decodeArtifactsForTest(
@@ -166,10 +165,10 @@ class ApplicationPersistencePortWorkflowTest {
     val deliveredHistory = requireNotNull(
       JsonSupport.anyToStringAnyMap(afterSecondDelivery[FEATURE_TASK_RUNTIME_DELIVERED_PROJECTIONS_ARTIFACT_KEY]),
     )
-    assertEquals(2, deliveredHistory.size, "distinct producer iterations must remain independently durable")
+    assertEquals(1, deliveredHistory.size, "only the latest delivered projection per consumer phase is retained")
     assertTrue(
-      deliveredHistory.keys.all { "|plan#1|" in it },
-      "durable selection keys must carry the normalized source producer identity",
+      deliveredHistory.keys.single().let { key -> "|2|" in key && "|plan#1|" in key },
+      "retained key must be the bumped iteration with normalized source producer identity",
     )
   }
 


### PR DESCRIPTION
## Summary
- Retain only the latest delivered projection per consumer phase so validate retries no longer accumulate multi-MB `feature_task_runtime_delivered_projections` history.
- Fingerprint `artifactsJson` in `progressToken` instead of embedding the full blob.
- Sparse-read only the progress/declared-progress/observability keys on the goal-runner progress poll hot path.

## Test plan
- [x] `AttemptLedgerWorkflowDecodingTest` (token fingerprint + `decodeArtifactKeys`)
- [x] `WorkflowGoalRunnerProgressStoreTest` (oversized unrelated artifacts still return declared progress)
- [x] `ApplicationPersistencePortWorkflowTest` (delivered history stays size 1 with bumped iteration)
- [ ] Manual: relaunch validate and confirm delivered-projections artifact stays bounded while iteration increments


Made with [Cursor](https://cursor.com)