### PR TITLE
Split prose phase-output recovery so main detekt passes

### DIFF
--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputParse.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputParse.kt
@@ -3,24 +3,14 @@ package skillbill.workflow.taskruntime
 import skillbill.contracts.JsonSupport
 
 internal object ProsePhaseOutputParse {
-  private val LEGACY_VALUE_KEYS: List<String> = listOf(
-    "implementation_receipt",
-    "executable_plan",
-    "preplanning_digest",
-    "gaps",
-  )
-
   private val STATUS_TOKENS: Set<String> = setOf("completed", "blocked", "failed")
   private val STATUS_ALIASES: Map<String, String> = mapOf(
     "complete" to "completed",
     "block" to "blocked",
     "fail" to "failed",
   )
-  private val AUDIT_VERDICTS: Set<String> = setOf("satisfied", "gaps_found")
   private val FENCED_JSON: Regex =
     Regex("```[ \\t]*[A-Za-z0-9_-]*\\r?\\n(.*?)```", RegexOption.DOT_MATCHES_ALL)
-  private const val SUMMARY_MAX_CHARS: Int = 240
-  private const val SUMMARY_ELLIPSIS_PREFIX: Int = 237
 
   fun bestEffortParse(text: String): Map<String, Any?>? {
     parseObject(text.trim())?.let { return it }
@@ -50,76 +40,6 @@ internal object ProsePhaseOutputParse {
 
   private fun canonicalStatus(lowercased: String): String? =
     lowercased.takeIf { it in STATUS_TOKENS } ?: STATUS_ALIASES[lowercased]
-
-  fun directValue(parsed: Map<String, Any?>): String? {
-    val produced = JsonSupport.anyToStringAnyMap(parsed["produced_outputs"]) ?: return null
-    return produced["value"]?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
-  }
-
-  fun recoverLegacyValue(parsed: Map<String, Any?>): String? {
-    val produced = JsonSupport.anyToStringAnyMap(parsed["produced_outputs"])
-    if (produced != null) {
-      for (key in LEGACY_VALUE_KEYS) {
-        val stuffed = stuffSibling(produced[key])
-        if (stuffed != null) return stuffed
-      }
-    }
-    listValue(parsed["produced_outputs"])?.let { return it }
-    return LEGACY_VALUE_KEYS.firstNotNullOfOrNull { key -> stuffSibling(parsed[key]) }
-  }
-
-  private fun listValue(producedOutputs: Any?): String? {
-    val entries = (producedOutputs as? List<*>)?.takeIf { it.isNotEmpty() } ?: return null
-    val singleValue = entries.singleOrNull()
-      ?.let(JsonSupport::anyToStringAnyMap)
-      ?.get("value")
-      ?.toString()
-      ?.takeIf { it.any { ch -> !ch.isWhitespace() } }
-    return singleValue ?: stuffSibling(entries)
-  }
-
-  fun recoverPrompt(parsed: Map<String, Any?>?): String? {
-    val produced = JsonSupport.anyToStringAnyMap(parsed?.get("produced_outputs"))
-    return produced?.get("prompt")?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
-      ?: parsed?.get("prompt")?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
-  }
-
-  fun recoverSummary(parsed: Map<String, Any?>?, value: String): String {
-    val fromField = parsed?.get("summary")?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
-    if (fromField != null) return fromField
-    val compact = value.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty()
-    return when {
-      compact.length <= SUMMARY_MAX_CHARS -> compact.ifBlank { "Prose phase completed." }
-      else -> compact.take(SUMMARY_ELLIPSIS_PREFIX) + "..."
-    }
-  }
-
-  fun recoverAuditVerdict(parsed: Map<String, Any?>?, rawText: String): String? {
-    val fromField = parsed?.get("verdict")?.toString()?.trim()?.lowercase()
-    if (fromField in AUDIT_VERDICTS) return fromField
-    val produced = JsonSupport.anyToStringAnyMap(parsed?.get("produced_outputs"))
-    val fromProduced = produced?.get("verdict")?.toString()?.trim()?.lowercase()
-    if (fromProduced in AUDIT_VERDICTS) return fromProduced
-    val lower = rawText.lowercase()
-    val hasSatisfied = Regex("""\bsatisfied\b""").containsMatchIn(lower)
-    val hasGaps = Regex("""\bgaps_found\b""").containsMatchIn(lower)
-    return when {
-      hasSatisfied && !hasGaps -> "satisfied"
-      hasGaps && !hasSatisfied -> "gaps_found"
-      else -> null
-    }
-  }
-
-  fun recoverFailureDisposition(parsed: Map<String, Any?>?): String? =
-    parsed?.get("failure_disposition")?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
-}
-
-private fun stuffSibling(sibling: Any?): String? = when (sibling) {
-  null -> null
-  is String -> sibling.takeIf { it.any { ch -> !ch.isWhitespace() } }
-  is Map<*, *> -> JsonSupport.anyToStringAnyMap(sibling)?.let(JsonSupport::mapToJsonString)
-  is List<*> -> JsonSupport.mapToJsonString(linkedMapOf("entries" to sibling))
-  else -> sibling.toString().takeIf { it.any { ch -> !ch.isWhitespace() } }
 }
 
 private fun parseObject(raw: String): Map<String, Any?>? {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputRecover.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputRecover.kt
@@ -1,0 +1,85 @@
+package skillbill.workflow.taskruntime
+
+import skillbill.contracts.JsonSupport
+
+internal object ProsePhaseOutputRecover {
+  private val LEGACY_VALUE_KEYS: List<String> = listOf(
+    "implementation_receipt",
+    "executable_plan",
+    "preplanning_digest",
+    "gaps",
+  )
+  private val AUDIT_VERDICTS: Set<String> = setOf("satisfied", "gaps_found")
+  private const val SUMMARY_MAX_CHARS: Int = 240
+  private const val SUMMARY_ELLIPSIS_PREFIX: Int = 237
+
+  fun directValue(parsed: Map<String, Any?>): String? {
+    val produced = JsonSupport.anyToStringAnyMap(parsed["produced_outputs"]) ?: return null
+    return produced["value"]?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+  }
+
+  fun recoverLegacyValue(parsed: Map<String, Any?>): String? {
+    val produced = JsonSupport.anyToStringAnyMap(parsed["produced_outputs"])
+    if (produced != null) {
+      for (key in LEGACY_VALUE_KEYS) {
+        val stuffed = stuffSibling(produced[key])
+        if (stuffed != null) return stuffed
+      }
+    }
+    listValue(parsed["produced_outputs"])?.let { return it }
+    return LEGACY_VALUE_KEYS.firstNotNullOfOrNull { key -> stuffSibling(parsed[key]) }
+  }
+
+  private fun listValue(producedOutputs: Any?): String? {
+    val entries = (producedOutputs as? List<*>)?.takeIf { it.isNotEmpty() } ?: return null
+    val singleValue = entries.singleOrNull()
+      ?.let(JsonSupport::anyToStringAnyMap)
+      ?.get("value")
+      ?.toString()
+      ?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+    return singleValue ?: stuffSibling(entries)
+  }
+
+  fun recoverPrompt(parsed: Map<String, Any?>?): String? {
+    val produced = JsonSupport.anyToStringAnyMap(parsed?.get("produced_outputs"))
+    return produced?.get("prompt")?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+      ?: parsed?.get("prompt")?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+  }
+
+  fun recoverSummary(parsed: Map<String, Any?>?, value: String): String {
+    val fromField = parsed?.get("summary")?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+    if (fromField != null) return fromField
+    val compact = value.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty()
+    return when {
+      compact.length <= SUMMARY_MAX_CHARS -> compact.ifBlank { "Prose phase completed." }
+      else -> compact.take(SUMMARY_ELLIPSIS_PREFIX) + "..."
+    }
+  }
+
+  fun recoverAuditVerdict(parsed: Map<String, Any?>?, rawText: String): String? {
+    val fromField = parsed?.get("verdict")?.toString()?.trim()?.lowercase()
+    if (fromField in AUDIT_VERDICTS) return fromField
+    val produced = JsonSupport.anyToStringAnyMap(parsed?.get("produced_outputs"))
+    val fromProduced = produced?.get("verdict")?.toString()?.trim()?.lowercase()
+    if (fromProduced in AUDIT_VERDICTS) return fromProduced
+    val lower = rawText.lowercase()
+    val hasSatisfied = Regex("""\bsatisfied\b""").containsMatchIn(lower)
+    val hasGaps = Regex("""\bgaps_found\b""").containsMatchIn(lower)
+    return when {
+      hasSatisfied && !hasGaps -> "satisfied"
+      hasGaps && !hasSatisfied -> "gaps_found"
+      else -> null
+    }
+  }
+
+  fun recoverFailureDisposition(parsed: Map<String, Any?>?): String? =
+    parsed?.get("failure_disposition")?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+}
+
+private fun stuffSibling(sibling: Any?): String? = when (sibling) {
+  null -> null
+  is String -> sibling.takeIf { it.any { ch -> !ch.isWhitespace() } }
+  is Map<*, *> -> JsonSupport.anyToStringAnyMap(sibling)?.let(JsonSupport::mapToJsonString)
+  is List<*> -> JsonSupport.mapToJsonString(linkedMapOf("entries" to sibling))
+  else -> sibling.toString().takeIf { it.any { ch -> !ch.isWhitespace() } }
+}

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputSynthesizer.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputSynthesizer.kt
@@ -40,11 +40,11 @@ object ProsePhaseOutputSynthesizer {
       phaseId = phaseId,
       status = status,
       value = valueAndVerdict.first,
-      summary = ProsePhaseOutputParse.recoverSummary(parsed, valueAndVerdict.first),
-      prompt = ProsePhaseOutputParse.recoverPrompt(parsed),
+      summary = ProsePhaseOutputRecover.recoverSummary(parsed, valueAndVerdict.first),
+      prompt = ProsePhaseOutputRecover.recoverPrompt(parsed),
       verdict = valueAndVerdict.second,
       failureDisposition = if (status == "blocked" || status == "failed") {
-        ProsePhaseOutputParse.recoverFailureDisposition(parsed)
+        ProsePhaseOutputRecover.recoverFailureDisposition(parsed)
       } else {
         null
       },
@@ -56,11 +56,11 @@ object ProsePhaseOutputSynthesizer {
     phaseOutputText: String,
     phaseId: String,
   ): Pair<String, String?>? {
-    val existingValue = ProsePhaseOutputParse.directValue(parsed)
-    val value = existingValue ?: ProsePhaseOutputParse.recoverLegacyValue(parsed) ?: return null
+    val existingValue = ProsePhaseOutputRecover.directValue(parsed)
+    val value = existingValue ?: ProsePhaseOutputRecover.recoverLegacyValue(parsed) ?: return null
     if (existingValue != null && phaseId != PHASE_AUDIT) return null
     val verdict = if (phaseId == PHASE_AUDIT) {
-      ProsePhaseOutputParse.recoverAuditVerdict(parsed, phaseOutputText) ?: return null
+      ProsePhaseOutputRecover.recoverAuditVerdict(parsed, phaseOutputText) ?: return null
     } else {
       null
     }


### PR DESCRIPTION
## Summary
- Main CI (`Validate agent configs`) is red because `ProsePhaseOutputParse` has 11 functions, which trips detekt `TooManyFunctions` (object threshold 11).
- Field recovery (`directValue`, legacy stuffing, prompt/summary/verdict/disposition) moves to `ProsePhaseOutputRecover`; parse and status identity stay on `ProsePhaseOutputParse`.
- Behavior is unchanged; synthesizer call sites are the only consumers.

## Test plan
- [x] `:runtime-domain:detekt` and `:runtime-domain:test` pass locally
- [x] `./gradlew check --continue --parallel` passes locally
- [ ] GitHub `Validate agent configs` is green on this PR
- [ ] After merge, `Validate agent configs` is green on `main`


Made with [Cursor](https://cursor.com)