### PR TITLE
Enforce wire payload keys through runtime-contracts owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,8 @@ NO COMMENTS, DON'T WRITE ANY NEW COMMENTS. NONE!!! IF YOU SEE A COMMENT - REMOVE
 
 Follow `docs/code-principles.md` for Kotlin patterns, package clustering, imports, file-size limits, and architecture guards. Mechanical enforcement lives under `runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/` (`InlineFqnArchitectureTest`, `ProductionFileLineCeilingArchitectureTest`, `PrincipleEnforcementInventory`, and siblings).
 
+**Wire and payload keys.** Never inline contract or wire map keys as string literals in `get`, `put`, `mapOf("key" to …)`, or bracket access. Declare each key once in an owning `*Keys` or `*PayloadKeys` object in `runtime-contracts` (`SharedPayloadKeys` for workflow-envelope keys; area-owned keys such as `ReviewVerificationSignalKeys` and `ReviewFindingPayloadKeys` beside their contract family). Downstream modules alias those constants; they do not restate wire strings. Enum wire tokens use `wireValue` on the owning enum; do not restate them in local `setOf`/`mapOf` collections. `WireVocabularyArchitectureTest` enforces this; see `runtime-kotlin/ARCHITECTURE.md` (Wire vocabulary).
+
 ## Quality Checks
 
 Prefer `bill-code-check`; document fallback if no platform checker. Bias: stable base commands, platform depth behind routers, explicit overrides, validator-backed rules, acceptance and rejection tests.

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/decomposition/DecompositionManifestRuntimeStateDerivation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/decomposition/DecompositionManifestRuntimeStateDerivation.kt
@@ -1,9 +1,8 @@
 package skillbill.application.decomposition
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.model.DecompositionManifestRuntimeUpdate
 import skillbill.application.telemetry.normalizedBlockedReason
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.decomposition.model.CurrentSubtaskIntent
 import skillbill.workflow.decomposition.model.DecompositionExecutionModel
 import skillbill.workflow.decomposition.model.DecompositionManifest
@@ -86,7 +85,8 @@ fun statusFromUpdate(update: DecompositionManifestRuntimeUpdate): String? {
         it[SharedPayloadKeys.STATUS].workflowStepStatus() == WorkflowStepStatus.COMPLETED &&
           it[SharedPayloadKeys.STEP_ID] in completionSteps
       } -> DecompositionStatus.COMPLETE.wireValue
-    update.currentStepId in statusTrackedSteps || stepUpdates.any { it[SharedPayloadKeys.STEP_ID] in statusTrackedSteps } ->
+    update.currentStepId in statusTrackedSteps ||
+      stepUpdates.any { it[SharedPayloadKeys.STEP_ID] in statusTrackedSteps } ->
       DecompositionStatus.IN_PROGRESS.wireValue
     else -> null
   }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/decomposition/DecompositionManifestRuntimeStateDerivation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/decomposition/DecompositionManifestRuntimeStateDerivation.kt
@@ -1,5 +1,7 @@
 package skillbill.application.decomposition
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.model.DecompositionManifestRuntimeUpdate
 import skillbill.application.telemetry.normalizedBlockedReason
 import skillbill.workflow.decomposition.model.CurrentSubtaskIntent
@@ -71,20 +73,20 @@ fun statusFromUpdate(update: DecompositionManifestRuntimeUpdate): String? {
   val workflowStatus = update.workflowStatus.workflowStatus()
   return when {
     workflowStatus == WorkflowStatus.BLOCKED ||
-      stepUpdates.any { it["status"].workflowStepStatus() == WorkflowStepStatus.BLOCKED } ->
+      stepUpdates.any { it[SharedPayloadKeys.STATUS].workflowStepStatus() == WorkflowStepStatus.BLOCKED } ->
       DecompositionStatus.BLOCKED.wireValue
     prSuppressedCommitStatus(update) == DecompositionStatus.COMPLETE -> DecompositionStatus.COMPLETE.wireValue
     prSuppressedCommitStatus(update) == DecompositionStatus.BLOCKED -> DecompositionStatus.BLOCKED.wireValue
     stepUpdates.any {
-      it["status"].workflowStepStatus() == WorkflowStepStatus.SKIPPED &&
-        it["step_id"] in terminalSkippedSteps
+      it[SharedPayloadKeys.STATUS].workflowStepStatus() == WorkflowStepStatus.SKIPPED &&
+        it[SharedPayloadKeys.STEP_ID] in terminalSkippedSteps
     } -> DecompositionStatus.SKIPPED.wireValue
     workflowStatus == WorkflowStatus.COMPLETED ||
       stepUpdates.any {
-        it["status"].workflowStepStatus() == WorkflowStepStatus.COMPLETED &&
-          it["step_id"] in completionSteps
+        it[SharedPayloadKeys.STATUS].workflowStepStatus() == WorkflowStepStatus.COMPLETED &&
+          it[SharedPayloadKeys.STEP_ID] in completionSteps
       } -> DecompositionStatus.COMPLETE.wireValue
-    update.currentStepId in statusTrackedSteps || stepUpdates.any { it["step_id"] in statusTrackedSteps } ->
+    update.currentStepId in statusTrackedSteps || stepUpdates.any { it[SharedPayloadKeys.STEP_ID] in statusTrackedSteps } ->
       DecompositionStatus.IN_PROGRESS.wireValue
     else -> null
   }
@@ -158,14 +160,14 @@ private fun prSuppressedCommitStatus(update: DecompositionManifestRuntimeUpdate)
   val suppressPr = goalContinuation["suppress_pr"] == true
   val commitPushResult = artifacts["commit_push_result"] as? Map<*, *>
   val commitPushActive = update.currentStepId == "commit_push" ||
-    update.stepUpdates.orEmpty().any { it["step_id"] == "commit_push" }
+    update.stepUpdates.orEmpty().any { it[SharedPayloadKeys.STEP_ID] == "commit_push" }
   val preCommitProjection = commitPushActive &&
     commitPushResult?.get("pre_commit_projection") == true &&
     commitShaFrom(artifacts) == null
   val commitPushCompleted =
     update.stepUpdates.orEmpty().any {
-      it["step_id"] == "commit_push" &&
-        it["status"].workflowStepStatus() == WorkflowStepStatus.COMPLETED
+      it[SharedPayloadKeys.STEP_ID] == "commit_push" &&
+        it[SharedPayloadKeys.STATUS].workflowStepStatus() == WorkflowStepStatus.COMPLETED
     }
   return when {
     !suppressPr -> null
@@ -182,8 +184,8 @@ private fun commitShaFrom(artifacts: Map<String, Any?>): String? {
   val fromOutcome = (artifacts["goal_continuation_outcome"] as? Map<*, *>)
     ?.get("commit_sha")?.toString()?.trim()?.takeIf(String::isNotBlank)
   if (fromCommitPush != null && fromOutcome != null && fromCommitPush != fromOutcome) {
-    val subtaskId = (artifacts["goal_continuation_outcome"] as? Map<*, *>)?.get("subtask_id")
-      ?: (artifacts["goal_continuation"] as? Map<*, *>)?.get("subtask_id")
+    val subtaskId = (artifacts["goal_continuation_outcome"] as? Map<*, *>)?.get(SharedPayloadKeys.SUBTASK_ID)
+      ?: (artifacts["goal_continuation"] as? Map<*, *>)?.get(SharedPayloadKeys.SUBTASK_ID)
     error(
       "Conflicting completing commit SHAs for subtask $subtaskId: " +
         "commit_push_result.commit_sha=$fromCommitPush vs goal_continuation_outcome.commit_sha=$fromOutcome.",

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/idestatus/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/idestatus/model/IdeStatusModels.kt
@@ -1,8 +1,7 @@
 package skillbill.application.idestatus.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.GOAL_PLANNING_WAVE_CAP
 import skillbill.contracts.workflow.IDE_STATUS_CONTRACT_VERSION
 import skillbill.goalrunner.model.GoalPlanningStatusState

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/idestatus/model/IdeStatusModels.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/idestatus/model/IdeStatusModels.kt
@@ -1,5 +1,7 @@
 package skillbill.application.idestatus.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.GOAL_PLANNING_WAVE_CAP
 import skillbill.contracts.workflow.IDE_STATUS_CONTRACT_VERSION
@@ -285,10 +287,10 @@ data class IdeStatusSnapshot(
 
   @OpenBoundaryMap("IDE status snapshot wire map at the schema-validation emit seam")
   fun toStatusWireMap(): Map<String, Any?> = buildMap {
-    put("contract_version", contractVersion)
+    put(SharedPayloadKeys.CONTRACT_VERSION, contractVersion)
     put("repository_identity", repositoryIdentity)
-    issueKey?.takeIf(String::isNotBlank)?.let { put("issue_key", it) }
-    workflowId?.takeIf(String::isNotBlank)?.let { put("workflow_id", it) }
+    issueKey?.takeIf(String::isNotBlank)?.let { put(SharedPayloadKeys.ISSUE_KEY, it) }
+    workflowId?.takeIf(String::isNotBlank)?.let { put(SharedPayloadKeys.WORKFLOW_ID, it) }
     workflowFamily?.let { put("workflow_family", it.wireValue) }
     put("lifecycle_state", lifecycleState.wireValue)
     put(
@@ -319,7 +321,7 @@ data class IdeStatusSnapshot(
     putAgentActivity()
     put("updated_at", updatedAt.toString())
     put("freshness", freshness.wireValue)
-    put("summary", summary)
+    put(SharedPayloadKeys.SUMMARY, summary)
     putProblem()
   }
 
@@ -347,7 +349,7 @@ data class IdeStatusSnapshot(
       buildMap {
         put("model", model.model)
         model.effort?.let { put("effort", it) }
-        model.phaseId?.let { put("phase_id", it) }
+        model.phaseId?.let { put(SharedPayloadKeys.PHASE_ID, it) }
       },
     )
   }
@@ -361,7 +363,7 @@ data class IdeStatusSnapshot(
     put(
       "current_phase_execution",
       buildMap {
-        put("phase_id", execution.phaseId)
+        put(SharedPayloadKeys.PHASE_ID, execution.phaseId)
         put("kind", execution.kind.wireValue)
         put("count", execution.count)
         execution.total?.let { put("total", it) }

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewAccountingProjection.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewAccountingProjection.kt
@@ -1,5 +1,7 @@
 package skillbill.application.review
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
 import skillbill.review.context.model.ReviewAccountingCounters
@@ -16,7 +18,7 @@ import skillbill.review.context.model.ReviewParentAnalysisConsumption
  */
 @OpenBoundaryMap("Schema-bounded review-accounting wire projection")
 fun ReviewAccountingSummary.toBoundedPayload(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to REVIEW_CONTEXT_CONTRACT_VERSION,
+  SharedPayloadKeys.CONTRACT_VERSION to REVIEW_CONTEXT_CONTRACT_VERSION,
   "kind" to "accounting_summary",
   "review_id" to reviewId,
   "packet_digest" to packetDigest,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewAccountingProjection.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewAccountingProjection.kt
@@ -1,8 +1,7 @@
 package skillbill.application.review
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
 import skillbill.review.context.model.ReviewAccountingCounters
 import skillbill.review.context.model.ReviewAccountingNode

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewClaimVerificationRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewClaimVerificationRunner.kt
@@ -1,5 +1,7 @@
 package skillbill.application.review
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.agent.model.AgentPhaseInput
 import skillbill.agent.model.AgentPhaseOutput
 import skillbill.application.review.model.ReviewClaimVerificationOutcome
@@ -281,8 +283,8 @@ internal fun parseWorkerResult(stdout: String): ReviewClaimWorkerResult? {
   val payload = parseJsonObject(stdout) ?: return null
   val finding = JsonCodec.anyToStringAnyMap(payload["finding"])
   return ReviewClaimWorkerResult(
-    claimVerdict = payload["claim_verdict"] as? String,
-    citations = parseCitations(payload["citations"]),
+    claimVerdict = payload[ReviewFindingPayloadKeys.CLAIM_VERDICT] as? String,
+    citations = parseCitations(payload[ReviewFindingPayloadKeys.CITATIONS]),
     findingRef = (finding?.get("finding_ref") as? String) ?: payload["finding_ref"] as? String,
     severity = (finding?.get("severity") as? String) ?: payload["severity"] as? String,
     location = (finding?.get("location") as? String) ?: payload["location"] as? String,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewClaimVerificationRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewClaimVerificationRunner.kt
@@ -1,13 +1,12 @@
 package skillbill.application.review
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.agent.model.AgentPhaseInput
 import skillbill.agent.model.AgentPhaseOutput
 import skillbill.application.review.model.ReviewClaimVerificationOutcome
 import skillbill.application.review.model.ReviewClaimVerificationRunRequest
 import skillbill.application.review.model.ReviewDelegatedStageLaunch
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
 import skillbill.ports.agentrun.model.SkillRunRequest
 import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewPacketProjection.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewPacketProjection.kt
@@ -1,5 +1,9 @@
 package skillbill.application.review
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.review.model.ReviewContextEnvelope
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
 import skillbill.review.context.model.GovernedReviewAdjudicationLaunch
@@ -18,7 +22,7 @@ import skillbill.review.model.ReviewFindingVerdict
 
 fun ReviewContextPacket.toParentPacketEnvelope(): ReviewContextEnvelope = ReviewContextEnvelope(
   linkedMapOf(
-    "contract_version" to REVIEW_CONTEXT_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to REVIEW_CONTEXT_CONTRACT_VERSION,
     "kind" to "parent_packet",
     "review_id" to reviewId,
     "packet_digest" to digest,
@@ -26,7 +30,7 @@ fun ReviewContextPacket.toParentPacketEnvelope(): ReviewContextEnvelope = Review
     "repository_identity" to repositoryIdentity,
     "base_revision" to baseRevision,
     "head_revision" to headRevision,
-    "status" to status.normalizeLineEndings(),
+    SharedPayloadKeys.STATUS to status.normalizeLineEndings(),
     "stack" to stack,
     "pack" to pack,
     "add_ons" to addOns.sorted(),
@@ -54,7 +58,7 @@ fun ReviewContextPacket.toParentPacketEnvelope(): ReviewContextEnvelope = Review
 )
 fun ReviewAssignment.toAssignmentEnvelope(): ReviewContextEnvelope = ReviewContextEnvelope(
   linkedMapOf(
-    "contract_version" to REVIEW_CONTEXT_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to REVIEW_CONTEXT_CONTRACT_VERSION,
     "kind" to "assignment",
     "review_id" to reviewId,
     "packet_digest" to packetDigest,
@@ -78,7 +82,7 @@ fun ReviewAssignment.toAssignmentEnvelope(): ReviewContextEnvelope = ReviewConte
 )
 fun GovernedReviewLaunch.toLaunchEnvelope(): ReviewContextEnvelope = ReviewContextEnvelope(
   linkedMapOf(
-    "contract_version" to REVIEW_CONTEXT_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to REVIEW_CONTEXT_CONTRACT_VERSION,
     "kind" to "launch",
     "review_id" to assignment.reviewId,
     "packet_digest" to assignment.packetDigest,
@@ -112,7 +116,7 @@ fun GovernedReviewLaunch.toLaunchEnvelope(): ReviewContextEnvelope = ReviewConte
 
 fun GovernedReviewVerificationLaunch.toVerificationLaunchEnvelope(): ReviewContextEnvelope = ReviewContextEnvelope(
   linkedMapOf(
-    "contract_version" to REVIEW_CONTEXT_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to REVIEW_CONTEXT_CONTRACT_VERSION,
     "kind" to "verification_launch",
     "review_id" to packet.reviewId,
     "packet_digest" to packet.digest,
@@ -138,7 +142,7 @@ fun GovernedReviewVerificationLaunch.toVerificationLaunchEnvelope(): ReviewConte
 
 fun GovernedReviewAdjudicationLaunch.toAdjudicationLaunchEnvelope(): ReviewContextEnvelope = ReviewContextEnvelope(
   linkedMapOf(
-    "contract_version" to REVIEW_CONTEXT_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to REVIEW_CONTEXT_CONTRACT_VERSION,
     "kind" to "adjudication_launch",
     "review_id" to packet.reviewId,
     "packet_digest" to packet.digest,
@@ -161,17 +165,16 @@ fun GovernedReviewAdjudicationLaunch.toAdjudicationLaunchEnvelope(): ReviewConte
 )
 
 internal fun ReviewFindingVerdict.toEnvelope(): Map<String, Any?> = buildMap {
-  put("contract_version", contractVersion)
+  put(SharedPayloadKeys.CONTRACT_VERSION, contractVersion)
   put("kind", "finding_verdict")
   put("stage", stage.wireValue)
   put("finding_ref", findingRef)
-  put("claim_verdict", claimVerdict.wireValue)
+  put(ReviewFindingPayloadKeys.CLAIM_VERDICT, claimVerdict.wireValue)
   put("recorded_at", recordedAt)
-  scopeDisposition?.let { put("scope_disposition", it.wireValue) }
-  if (citations.isNotEmpty()) put("citations", citations.map { it.toEnvelope() })
+  scopeDisposition?.let { put(ReviewFindingPayloadKeys.SCOPE_DISPOSITION, it.wireValue) }
+  if (citations.isNotEmpty()) put(ReviewFindingPayloadKeys.CITATIONS, citations.map { it.toEnvelope() })
   severityAdjustment?.let { adjustment ->
-    put(
-      "severity_adjustment",
+    put(ReviewFindingPayloadKeys.SEVERITY_ADJUSTMENT,
       linkedMapOf(
         "direction" to adjustment.direction.wireValue,
         "justification" to adjustment.justification,
@@ -195,7 +198,7 @@ private fun ParallelReviewMergedFinding.toEnvelope(): Map<String, Any?> = linked
 
 fun GovernedReviewIntegrationLaunch.toIntegrationLaunchEnvelope(): ReviewContextEnvelope = ReviewContextEnvelope(
   linkedMapOf(
-    "contract_version" to REVIEW_CONTEXT_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to REVIEW_CONTEXT_CONTRACT_VERSION,
     "kind" to "integration_launch",
     "review_id" to packet.reviewId,
     "packet_digest" to packet.digest,
@@ -227,5 +230,5 @@ private fun ReviewSpecialistSummary.toEnvelope(): Map<String, Any?> = linkedMapO
   "commit_shas" to commitShas,
   "finding_count" to findingCount,
   "unreviewed_segment_ids" to unreviewedSegmentIds,
-  "summary" to summary.normalizeLineEndings(),
+  SharedPayloadKeys.SUMMARY to summary.normalizeLineEndings(),
 )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewPacketProjection.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewPacketProjection.kt
@@ -1,11 +1,9 @@
 package skillbill.application.review
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.review.model.ReviewContextEnvelope
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.review.context.model.GovernedReviewAdjudicationLaunch
 import skillbill.review.context.model.GovernedReviewIntegrationLaunch
 import skillbill.review.context.model.GovernedReviewLaunch
@@ -174,7 +172,8 @@ internal fun ReviewFindingVerdict.toEnvelope(): Map<String, Any?> = buildMap {
   scopeDisposition?.let { put(ReviewFindingPayloadKeys.SCOPE_DISPOSITION, it.wireValue) }
   if (citations.isNotEmpty()) put(ReviewFindingPayloadKeys.CITATIONS, citations.map { it.toEnvelope() })
   severityAdjustment?.let { adjustment ->
-    put(ReviewFindingPayloadKeys.SEVERITY_ADJUSTMENT,
+    put(
+      ReviewFindingPayloadKeys.SEVERITY_ADJUSTMENT,
       linkedMapOf(
         "direction" to adjustment.direction.wireValue,
         "justification" to adjustment.justification,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewSpecAdjudicationRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewSpecAdjudicationRunner.kt
@@ -1,10 +1,9 @@
 package skillbill.application.review
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.application.review.model.ReviewSpecAdjudicationOutcome
 import skillbill.application.review.model.ReviewSpecAdjudicationRunRequest
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.ports.agentrun.model.AgentRunLaunchFacts
 import skillbill.ports.agentrun.model.SkillRunRequest
 import skillbill.ports.agentrun.model.UnsupportedAgentRunLaunch

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewSpecAdjudicationRunner.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewSpecAdjudicationRunner.kt
@@ -1,5 +1,7 @@
 package skillbill.application.review
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.application.review.model.ReviewSpecAdjudicationOutcome
 import skillbill.application.review.model.ReviewSpecAdjudicationRunRequest
 import skillbill.contracts.JsonCodec
@@ -298,15 +300,15 @@ private data class PreparedAdjudicationRejected(val verdict: ReviewFindingVerdic
 internal fun parseAdjudicationWorkerResult(stdout: String): ReviewSpecAdjudicationWorkerResult? {
   val payload = parseJsonObject(stdout) ?: return null
   val finding = JsonCodec.anyToStringAnyMap(payload["finding"])
-  val adjustment = JsonCodec.anyToStringAnyMap(payload["severity_adjustment"])
-  val dispositionField = stringList(payload["scope_disposition"])
+  val adjustment = JsonCodec.anyToStringAnyMap(payload[ReviewFindingPayloadKeys.SEVERITY_ADJUSTMENT])
+  val dispositionField = stringList(payload[ReviewFindingPayloadKeys.SCOPE_DISPOSITION])
   val extraDispositions = stringList(payload["dispositions"])
   val primary = dispositionField.firstOrNull()
   return ReviewSpecAdjudicationWorkerResult(
     scopeDisposition = primary,
     dispositionValues = (dispositionField.drop(1) + extraDispositions),
     citedSpecElement = payload["cited_spec_element"] as? String,
-    citations = parseCitations(payload["citations"]),
+    citations = parseCitations(payload[ReviewFindingPayloadKeys.CITATIONS]),
     severityAdjustmentDirection = adjustment?.get("direction") as? String,
     severityAdjustmentJustification = adjustment?.get("justification") as? String,
     adjustedSeverity = (adjustment?.get("adjusted_severity") as? String) ?: payload["adjusted_severity"] as? String,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractFindingPayloadMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractFindingPayloadMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.application.review
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.review.model.ReviewFindingDetail
 import skillbill.review.model.ReviewFindingStats
 import skillbill.review.model.ReviewHealthStats
@@ -48,8 +50,8 @@ internal fun ReviewHealthStats.toPayload(): Map<String, Any?> = linkedMapOf(
 )
 
 internal fun ReviewFindingDetail.toPayload(): Map<String, Any?> = linkedMapOf<String, Any?>(
-  "finding_id" to findingId,
-  "issue_category" to issueCategory,
+  ReviewFindingPayloadKeys.FINDING_ID to findingId,
+  ReviewFindingPayloadKeys.ISSUE_CATEGORY to issueCategory,
   "severity" to severity,
   "confidence" to confidence,
   "location" to location,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractFindingPayloadMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractFindingPayloadMappers.kt
@@ -1,7 +1,6 @@
 package skillbill.application.review
 
 import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.review.model.ReviewFindingDetail
 import skillbill.review.model.ReviewFindingStats
 import skillbill.review.model.ReviewHealthStats

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.application.review
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
 import skillbill.application.review.model.FeatureTaskRuntimeStatsResult
 import skillbill.application.review.model.FeatureVerifyStatsResult
 import skillbill.application.review.model.GoalStatsResult
@@ -10,7 +12,7 @@ import skillbill.ports.workflow.model.toPayload
 fun ReviewStatsResult.toReviewStatsPayload(): JsonPayloadContract = MapPayloadContract(
   LinkedHashMap(stats.toPayload()).apply {
     put("health", health.toPayload())
-    put("review_run_id", reviewRunId)
+    put(ReviewVerificationSignalKeys.REVIEW_RUN_ID, reviewRunId)
     put("db_path", dbPath)
     stageMetrics?.let { putAll(it.toStageMetricsPayload()) }
     if (stageMetricsByTier.isNotEmpty()) {

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractMappers.kt
@@ -1,12 +1,11 @@
 package skillbill.application.review
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
 import skillbill.application.review.model.FeatureTaskRuntimeStatsResult
 import skillbill.application.review.model.FeatureVerifyStatsResult
 import skillbill.application.review.model.GoalStatsResult
 import skillbill.application.review.model.ReviewStatsResult
 import skillbill.contracts.JsonPayloadContract
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.ports.workflow.model.toPayload
 
 fun ReviewStatsResult.toReviewStatsPayload(): JsonPayloadContract = MapPayloadContract(

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractStageMetricsPayloadMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractStageMetricsPayloadMappers.kt
@@ -1,7 +1,6 @@
 package skillbill.application.review
 
 import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.review.model.ReviewStageMetrics
 import skillbill.review.model.ReviewStageVerdictDistribution
 

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractStageMetricsPayloadMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractStageMetricsPayloadMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.application.review
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.review.model.ReviewStageMetrics
 import skillbill.review.model.ReviewStageVerdictDistribution
 
@@ -23,12 +25,12 @@ internal fun ReviewStageMetrics.toStageMetricsPayload(): Map<String, Any?> = lin
 )
 
 internal fun ReviewStageVerdictDistribution.toStageMetricsPayload(): Map<String, Any?> = linkedMapOf(
-  "claim_verdict" to linkedMapOf(
+  ReviewFindingPayloadKeys.CLAIM_VERDICT to linkedMapOf(
     "confirmed" to confirmed,
     "refuted" to refuted,
     "unresolved" to unresolved,
   ),
-  "scope_disposition" to linkedMapOf(
+  ReviewFindingPayloadKeys.SCOPE_DISPOSITION to linkedMapOf(
     "in_scope" to inScope,
     "out_of_scope_preexisting" to outOfScopePreexisting,
     "spec_deviation" to specDeviation,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractWorkflowPayloadMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractWorkflowPayloadMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.application.review
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.review.model.FeatureTaskRuntimeWorkflowStats
 import skillbill.review.model.FeatureVerifyWorkflowStats
 import skillbill.review.model.GoalBlockedSubtaskSummary
@@ -60,10 +62,10 @@ internal fun GoalModeStats.toPayload(): Map<String, Any?> = linkedMapOf(
 )
 
 internal fun GoalRunSummary.toPayload(): Map<String, Any?> = linkedMapOf(
-  "workflow_id" to workflowId,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "feature_name" to featureName,
-  "status" to status,
+  SharedPayloadKeys.STATUS to status,
   "started_at" to startedAt,
   "finished_at" to finishedAt,
   "duration_ms" to durationMs,
@@ -72,9 +74,9 @@ internal fun GoalRunSummary.toPayload(): Map<String, Any?> = linkedMapOf(
 )
 
 internal fun GoalBlockedSubtaskSummary.toPayload(): Map<String, Any?> = linkedMapOf(
-  "subtask_id" to subtaskId,
+  SharedPayloadKeys.SUBTASK_ID to subtaskId,
   "subtask_name" to subtaskName,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "blocked_reason" to blockedReason,
   "attempt_count" to attemptCount,
 )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractWorkflowPayloadMappers.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/review/ReviewStatsContractWorkflowPayloadMappers.kt
@@ -1,7 +1,6 @@
 package skillbill.application.review
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.review.model.FeatureTaskRuntimeWorkflowStats
 import skillbill.review.model.FeatureVerifyWorkflowStats
 import skillbill.review.model.GoalBlockedSubtaskSummary

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/telemetry/LifecycleTelemetryPayloads.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/telemetry/LifecycleTelemetryPayloads.kt
@@ -1,5 +1,7 @@
 package skillbill.application.telemetry
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.telemetry.model.FeatureVerifyFinishedRequest
 import skillbill.application.telemetry.model.PrDescriptionGeneratedRequest
 import skillbill.application.telemetry.model.QualityCheckFinishedRequest
@@ -9,19 +11,19 @@ private const val STATUS_OK = "ok"
 private const val STATUS_SKIPPED = "skipped"
 
 @OpenBoundaryMap("Lifecycle telemetry event bag emitted to the MCP/CLI telemetry boundary")
-fun lifecycleOkPayload(sessionId: String): Map<String, Any?> = mapOf("status" to STATUS_OK, "session_id" to sessionId)
+fun lifecycleOkPayload(sessionId: String): Map<String, Any?> = mapOf(SharedPayloadKeys.STATUS to STATUS_OK, "session_id" to sessionId)
 
 @OpenBoundaryMap("Lifecycle telemetry event bag emitted to the MCP/CLI telemetry boundary")
 fun lifecycleSkippedPayload(sessionId: String): Map<String, Any?> =
-  mapOf("status" to STATUS_SKIPPED, "session_id" to sessionId)
+  mapOf(SharedPayloadKeys.STATUS to STATUS_SKIPPED, "session_id" to sessionId)
 
 @OpenBoundaryMap("Lifecycle telemetry event bag emitted to the MCP/CLI telemetry boundary")
 fun lifecycleErrorPayload(sessionId: String, error: String): Map<String, Any?> =
-  mapOf("status" to "error", "session_id" to sessionId, "error" to error)
+  mapOf(SharedPayloadKeys.STATUS to "error", "session_id" to sessionId, "error" to error)
 
 @OpenBoundaryMap("Lifecycle telemetry event bag emitted to the MCP/CLI telemetry boundary")
 fun orchestratedStartedSkippedPayload(): Map<String, Any?> =
-  mapOf("mode" to "orchestrated", "status" to "skipped_in_orchestrated_mode")
+  mapOf("mode" to "orchestrated", SharedPayloadKeys.STATUS to "skipped_in_orchestrated_mode")
 
 @OpenBoundaryMap("Lifecycle telemetry event bag emitted to the MCP/CLI telemetry boundary")
 fun QualityCheckFinishedRequest.orchestratedPayload(level: String): Map<String, Any?> =

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/telemetry/LifecycleTelemetryPayloads.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/telemetry/LifecycleTelemetryPayloads.kt
@@ -1,17 +1,19 @@
 package skillbill.application.telemetry
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.telemetry.model.FeatureVerifyFinishedRequest
 import skillbill.application.telemetry.model.PrDescriptionGeneratedRequest
 import skillbill.application.telemetry.model.QualityCheckFinishedRequest
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 
 private const val STATUS_OK = "ok"
 private const val STATUS_SKIPPED = "skipped"
 
 @OpenBoundaryMap("Lifecycle telemetry event bag emitted to the MCP/CLI telemetry boundary")
-fun lifecycleOkPayload(sessionId: String): Map<String, Any?> = mapOf(SharedPayloadKeys.STATUS to STATUS_OK, "session_id" to sessionId)
+fun lifecycleOkPayload(sessionId: String): Map<String, Any?> = mapOf(
+  SharedPayloadKeys.STATUS to STATUS_OK,
+  "session_id" to sessionId,
+)
 
 @OpenBoundaryMap("Lifecycle telemetry event bag emitted to the MCP/CLI telemetry boundary")
 fun lifecycleSkippedPayload(sessionId: String): Map<String, Any?> =

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
@@ -1,5 +1,7 @@
 package skillbill.application.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.DecompositionManifestWriter
 import skillbill.application.decomposition.resolveDecompositionManifest
 import skillbill.application.workflow.model.AdvanceCompletedSubtasksRequest
@@ -101,8 +103,8 @@ class DecompositionWorkflowContinuation(
           null
         } else {
           listOf(
-            mapOf("step_id" to "preplan", "status" to "completed", "attempt_count" to 1),
-            mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1),
+            mapOf(SharedPayloadKeys.STEP_ID to "preplan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
+            mapOf(SharedPayloadKeys.STEP_ID to "plan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
           )
         },
         artifactsPatch = parentProjectionArtifacts(manifest, validator, base.artifactsJson),
@@ -246,7 +248,7 @@ class DecompositionWorkflowContinuation(
         workflowStatus = "running",
         currentStepId = "preplan",
         stepUpdates = listOf(
-          mapOf("step_id" to "preplan", "status" to "running", "attempt_count" to 1),
+          mapOf(SharedPayloadKeys.STEP_ID to "preplan", SharedPayloadKeys.STATUS to "running", "attempt_count" to 1),
         ),
         artifactsPatch = subtaskStartArtifacts(selection, updatedManifest, validator),
         sessionId = parentRecord.sessionId.orEmpty(),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuation.kt
@@ -1,13 +1,12 @@
 package skillbill.application.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.DecompositionManifestWriter
 import skillbill.application.decomposition.resolveDecompositionManifest
 import skillbill.application.workflow.model.AdvanceCompletedSubtasksRequest
 import skillbill.application.workflow.model.CheckoutAndValidateBranchRequest
 import skillbill.application.workflow.model.ContinueExistingWorkflowArgs
 import skillbill.application.workflow.model.WorkflowContinueResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.issuekey.normalizeRequiredIssueKey
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.workflow.decomposition.DecompositionManifestStore
@@ -103,8 +102,16 @@ class DecompositionWorkflowContinuation(
           null
         } else {
           listOf(
-            mapOf(SharedPayloadKeys.STEP_ID to "preplan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
-            mapOf(SharedPayloadKeys.STEP_ID to "plan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
+            mapOf(
+              SharedPayloadKeys.STEP_ID to "preplan",
+              SharedPayloadKeys.STATUS to "completed",
+              "attempt_count" to 1,
+            ),
+            mapOf(
+              SharedPayloadKeys.STEP_ID to "plan",
+              SharedPayloadKeys.STATUS to "completed",
+              "attempt_count" to 1,
+            ),
           )
         },
         artifactsPatch = parentProjectionArtifacts(manifest, validator, base.artifactsJson),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuationAdvancement.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuationAdvancement.kt
@@ -1,5 +1,7 @@
 package skillbill.application.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.DECOMPOSITION_RUNTIME_ARTIFACT_KEY
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.decomposition.encodeDecompositionManifestMap
@@ -124,8 +126,8 @@ fun subtaskStartArtifacts(
   "assessment" to mapOf(
     "spec_path" to selection.subtask.specPath,
     "goal_continuation" to true,
-    "issue_key" to manifest.issueKey,
-    "subtask_id" to selection.subtask.id,
+    SharedPayloadKeys.ISSUE_KEY to manifest.issueKey,
+    SharedPayloadKeys.SUBTASK_ID to selection.subtask.id,
     "accepted_without_user_confirmation" to true,
   ),
   "branch" to mapOf(
@@ -135,8 +137,8 @@ fun subtaskStartArtifacts(
   ),
   "goal_continuation" to mapOf(
     "enabled" to true,
-    "issue_key" to manifest.issueKey,
-    "subtask_id" to selection.subtask.id,
+    SharedPayloadKeys.ISSUE_KEY to manifest.issueKey,
+    SharedPayloadKeys.SUBTASK_ID to selection.subtask.id,
     "suppress_pr" to true,
     "outcome_authority" to "workflow_store",
   ),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuationAdvancement.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowContinuationAdvancement.kt
@@ -1,7 +1,5 @@
 package skillbill.application.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.DECOMPOSITION_RUNTIME_ARTIFACT_KEY
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.decomposition.encodeDecompositionManifestMap
@@ -10,6 +8,7 @@ import skillbill.application.workflow.model.AdvanceCompletedSubtasksRequest
 import skillbill.application.workflow.model.CheckoutAndValidateBranchRequest
 import skillbill.application.workflow.model.GoalContinuationOutcome
 import skillbill.application.workflow.model.WorkflowContinueResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.workflow.gitops.WorkflowGitOperations
 import skillbill.ports.workflow.gitops.model.WorkflowGitOperationResult
 import skillbill.workflow.decomposition.DecompositionManifestValidator

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowResumeAlignment.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowResumeAlignment.kt
@@ -1,7 +1,5 @@
 package skillbill.application.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.DECOMPOSITION_RUNTIME_ARTIFACT_KEY
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.decomposition.encodeDecompositionManifestMap
@@ -9,6 +7,7 @@ import skillbill.application.decomposition.executionModel
 import skillbill.application.workflow.model.ContinueExistingWorkflowArgs
 import skillbill.application.workflow.model.DecompositionRuntimeWriteArgs
 import skillbill.application.workflow.model.WorkflowContinueResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.persistence.UnitOfWork
 import skillbill.ports.workflow.get
 import skillbill.ports.workflow.save
@@ -110,7 +109,13 @@ fun WorkflowEngine.alignSubtaskResumeStep(
       workflowStatus = record.workflowStatus,
       currentStepId = alignment.targetStepId,
       stepUpdates = alignment.staleBlockedStep?.let { step ->
-        listOf(mapOf(SharedPayloadKeys.STEP_ID to step.stepId, SharedPayloadKeys.STATUS to "completed", "attempt_count" to step.attemptCount))
+        listOf(
+          mapOf(
+            SharedPayloadKeys.STEP_ID to step.stepId,
+            SharedPayloadKeys.STATUS to "completed",
+            "attempt_count" to step.attemptCount,
+          ),
+        )
       },
       artifactsPatch = null,
       sessionId = record.sessionId.orEmpty(),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowResumeAlignment.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/DecompositionWorkflowResumeAlignment.kt
@@ -1,5 +1,7 @@
 package skillbill.application.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.DECOMPOSITION_RUNTIME_ARTIFACT_KEY
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.decomposition.encodeDecompositionManifestMap
@@ -108,7 +110,7 @@ fun WorkflowEngine.alignSubtaskResumeStep(
       workflowStatus = record.workflowStatus,
       currentStepId = alignment.targetStepId,
       stepUpdates = alignment.staleBlockedStep?.let { step ->
-        listOf(mapOf("step_id" to step.stepId, "status" to "completed", "attempt_count" to step.attemptCount))
+        listOf(mapOf(SharedPayloadKeys.STEP_ID to step.stepId, SharedPayloadKeys.STATUS to "completed", "attempt_count" to step.attemptCount))
       },
       artifactsPatch = null,
       sessionId = record.sessionId.orEmpty(),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/LegacyGoalRunnerControlMigration.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/LegacyGoalRunnerControlMigration.kt
@@ -1,12 +1,11 @@
 package skillbill.application.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.goalrunner.GoalRunnerPersistenceSession
 import skillbill.ports.goalrunner.runner.model.GoalRunnerOutOfBandAcceptance
 import skillbill.ports.goalrunner.runner.model.GoalRunnerReviewPolicy

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/LegacyGoalRunnerControlMigration.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/LegacyGoalRunnerControlMigration.kt
@@ -1,5 +1,7 @@
 package skillbill.application.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
 import skillbill.application.decomposition.decodeArtifacts
@@ -61,7 +63,7 @@ fun outOfBandAcceptancesFromLegacyArtifacts(artifacts: Map<String, Any?>): Map<I
     val entry = JsonCodec.anyToStringAnyMap(element)
       ?: error("Goal acceptance artifact '$GOAL_OUT_OF_BAND_ACCEPTANCE_ARTIFACT_KEY' entries must be maps.")
     val acceptance = GoalRunnerOutOfBandAcceptance(
-      subtaskId = (entry["subtask_id"] as? Number)?.toInt()
+      subtaskId = (entry[SharedPayloadKeys.SUBTASK_ID] as? Number)?.toInt()
         ?: error("Goal acceptance artifact entry is missing a numeric subtask_id."),
       commitSha = entry["commit_sha"] as? String
         ?: error("Goal acceptance artifact entry is missing commit_sha."),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceBlockedPhaseRetry.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceBlockedPhaseRetry.kt
@@ -1,10 +1,9 @@
 package skillbill.application.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.DecompositionManifestWriteGuard
 import skillbill.application.decomposition.DecompositionManifestWriter
 import skillbill.application.workflow.model.WorkflowUpdateResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.model.RepositoryRoot
 import skillbill.ports.db.DatabaseSessionFactory
 import skillbill.ports.persistence.UnitOfWork

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceBlockedPhaseRetry.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceBlockedPhaseRetry.kt
@@ -1,5 +1,7 @@
 package skillbill.application.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.DecompositionManifestWriteGuard
 import skillbill.application.decomposition.DecompositionManifestWriter
 import skillbill.application.workflow.model.WorkflowUpdateResult
@@ -151,8 +153,8 @@ class WorkflowServiceBlockedPhaseRetry(
       currentStepId = request.phaseId,
       stepUpdates = listOf(
         mapOf(
-          "step_id" to request.phaseId,
-          "status" to "pending",
+          SharedPayloadKeys.STEP_ID to request.phaseId,
+          SharedPayloadKeys.STATUS to "pending",
           "attempt_count" to 0,
         ),
       ),
@@ -164,7 +166,7 @@ class WorkflowServiceBlockedPhaseRetry(
             FEATURE_TASK_RUNTIME_PHASE_LEDGER_LIMIT,
           ),
         FEATURE_TASK_RUNTIME_OPERATOR_BLOCK_RETRY_ARTIFACT_KEY to mapOf(
-          "phase_id" to request.phaseId,
+          SharedPayloadKeys.PHASE_ID to request.phaseId,
           "reason" to request.reason,
           "retried_at" to OffsetDateTime.now(ZoneOffset.UTC).toString(),
           "previous_blocked_reason" to state.blockedRecord.blockedReason,

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceInputMapping.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceInputMapping.kt
@@ -1,6 +1,5 @@
 package skillbill.application.workflow
 import skillbill.application.workflow.model.GoalObservabilityProgressInput
-import skillbill.contracts.SharedPayloadKeys
 import skillbill.application.workflow.model.GoalObservabilityWorktreeActivity
 import skillbill.application.workflow.model.PersistOpenedWorkflowArgs
 import skillbill.application.workflow.model.WorkflowFamilyKind
@@ -10,6 +9,7 @@ import skillbill.application.workflow.model.WorkflowServiceOpenFeatureTaskArgs
 import skillbill.application.workflow.model.WorkflowUpdateRequest
 import skillbill.application.workflow.model.WorkflowUpdateResult
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.issuekey.normalizeIssueKey
 import skillbill.goalrunner.GoalObservabilityArtifacts
 import skillbill.ports.workflow.get

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceInputMapping.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowServiceInputMapping.kt
@@ -1,5 +1,6 @@
 package skillbill.application.workflow
 import skillbill.application.workflow.model.GoalObservabilityProgressInput
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.application.workflow.model.GoalObservabilityWorktreeActivity
 import skillbill.application.workflow.model.PersistOpenedWorkflowArgs
 import skillbill.application.workflow.model.WorkflowFamilyKind
@@ -107,8 +108,8 @@ fun WorkflowContinueDecision.toReopenInput(sessionId: String): WorkflowUpdateInp
   stepUpdates =
   listOf(
     mapOf(
-      "step_id" to resumeStepId,
-      "status" to "running",
+      SharedPayloadKeys.STEP_ID to resumeStepId,
+      SharedPayloadKeys.STATUS to "running",
       "attempt_count" to nextAttemptCount,
     ),
   ),

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowWireProjections.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowWireProjections.kt
@@ -1,5 +1,7 @@
 package skillbill.application.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.WorkflowContracts
 import skillbill.workflow.engine.model.WorkflowCompactContinueView
@@ -16,11 +18,11 @@ object WorkflowWireProjections {
   @OpenBoundaryMap("Wire-shape ordered snapshot map for CLI/MCP adapters")
   fun snapshotMap(view: WorkflowSnapshotView): Map<String, Any?> = WorkflowContracts.fullWorkflowPayload(
     linkedMapOf(
-      "workflow_id" to view.workflowId,
+      SharedPayloadKeys.WORKFLOW_ID to view.workflowId,
       "session_id" to view.sessionId,
       "workflow_name" to view.workflowName,
       "mode" to view.mode,
-      "contract_version" to view.contractVersion,
+      SharedPayloadKeys.CONTRACT_VERSION to view.contractVersion,
       "workflow_status" to view.workflowStatus,
       "current_step_id" to view.currentStepId,
       "steps" to view.steps.map(::workflowStepWireMap),
@@ -34,11 +36,11 @@ object WorkflowWireProjections {
   @OpenBoundaryMap("Wire-shape ordered summary map for CLI/MCP adapters")
   fun summaryMap(view: WorkflowSummaryView): Map<String, Any?> = WorkflowContracts.summaryWorkflowPayload(
     linkedMapOf(
-      "workflow_id" to view.workflowId,
+      SharedPayloadKeys.WORKFLOW_ID to view.workflowId,
       "session_id" to view.sessionId,
       "workflow_name" to view.workflowName,
       "mode" to view.mode,
-      "contract_version" to view.contractVersion,
+      SharedPayloadKeys.CONTRACT_VERSION to view.contractVersion,
       "workflow_status" to view.workflowStatus,
       "current_step_id" to view.currentStepId,
       "started_at" to view.startedAt,
@@ -84,7 +86,7 @@ object WorkflowWireProjections {
 
   @OpenBoundaryMap("Compact wire-shape ordered continue map for CLI/MCP adapters")
   fun compactContinueMap(view: WorkflowCompactContinueView): Map<String, Any?> = linkedMapOf(
-    "workflow_id" to view.workflowId,
+    SharedPayloadKeys.WORKFLOW_ID to view.workflowId,
     "skill_name" to view.skillName,
     "workflow_status_before_continue" to view.workflowStatusBeforeContinue,
     "started_at" to view.startedAt,
@@ -111,8 +113,8 @@ object WorkflowWireProjections {
 
   @OpenBoundaryMap("Compact wire-shape ordered workflow-update acknowledgement map for CLI/MCP adapters")
   fun updateAcknowledgementMap(view: WorkflowUpdateAcknowledgementView): Map<String, Any?> = linkedMapOf(
-    "status" to view.status,
-    "workflow_id" to view.workflowId,
+    SharedPayloadKeys.STATUS to view.status,
+    SharedPayloadKeys.WORKFLOW_ID to view.workflowId,
     "workflow_name" to view.workflowName,
     "workflow_status" to view.workflowStatus,
     "current_step_id" to view.currentStepId,
@@ -123,7 +125,7 @@ object WorkflowWireProjections {
 
   @OpenBoundaryMap("Bounded workflow launch projection map for CLI/MCP adapters")
   fun inputProjectionMap(projection: WorkflowInputProjection): Map<String, Any?> = linkedMapOf(
-    "step_id" to projection.stepId,
+    SharedPayloadKeys.STEP_ID to projection.stepId,
     "producer_iteration" to projection.producerIteration,
     "repository_checkpoint" to projection.repositoryCheckpoint,
     "artifacts" to projection.artifacts,
@@ -136,7 +138,7 @@ object WorkflowWireProjections {
     "present" to summary.present,
     "inline" to summary.inline,
     "size_bytes" to summary.sizeBytes,
-    "value" to summary.value,
+    SharedPayloadKeys.VALUE to summary.value,
     "preview" to summary.preview,
     "truncated" to summary.truncated,
     "omitted" to summary.omitted,
@@ -145,7 +147,7 @@ object WorkflowWireProjections {
 }
 
 private fun workflowStepWireMap(step: WorkflowStepState): Map<String, Any?> = linkedMapOf(
-  "step_id" to step.stepId,
-  "status" to step.status,
+  SharedPayloadKeys.STEP_ID to step.stepId,
+  SharedPayloadKeys.STATUS to step.status,
   "attempt_count" to step.attemptCount,
 )

--- a/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowWireProjections.kt
+++ b/runtime-kotlin/runtime-application/src/main/kotlin/skillbill/application/workflow/WorkflowWireProjections.kt
@@ -1,8 +1,7 @@
 package skillbill.application.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.WorkflowContracts
 import skillbill.workflow.engine.model.WorkflowCompactContinueView
 import skillbill.workflow.engine.model.WorkflowContinuationArtifactSummary

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/agentaddon/AgentAddonCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/agentaddon/AgentAddonCliCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.agentaddon
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.default
@@ -61,7 +63,7 @@ class AgentAddonResolveSelectionCommand(
         ).sources.map { source -> source.path.toPath() },
       )
       linkedMapOf(
-        "contract_version" to "0.1",
+        SharedPayloadKeys.CONTRACT_VERSION to "0.1",
         "entries" to selection.entries.map { entry ->
           linkedMapOf(
             "slug" to entry.persisted.slug,
@@ -78,7 +80,7 @@ class AgentAddonResolveSelectionCommand(
     try {
       state.complete(block(), format)
     } catch (error: ShellContentContractException) {
-      state.complete(mapOf("status" to "failed", "error" to error.message.orEmpty()), format, exitCode = 1)
+      state.complete(mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()), format, exitCode = 1)
     }
   }
 }
@@ -107,7 +109,7 @@ class AgentAddonVerifySelectionCommand(
       )
       state.complete(
         linkedMapOf(
-          "contract_version" to "0.1",
+          SharedPayloadKeys.CONTRACT_VERSION to "0.1",
           "entries" to hydrated.entries.map { entry ->
             linkedMapOf(
               "slug" to entry.persisted.slug,
@@ -121,7 +123,7 @@ class AgentAddonVerifySelectionCommand(
         format,
       )
     } catch (error: ShellContentContractException) {
-      state.complete(mapOf("status" to "failed", "error" to error.message.orEmpty()), format, exitCode = 1)
+      state.complete(mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()), format, exitCode = 1)
     }
   }
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/agentaddon/AgentAddonCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/agentaddon/AgentAddonCliCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.agentaddon
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.default
@@ -16,6 +14,7 @@ import skillbill.cli.kernel.DocumentedNoOpCliCommand
 import skillbill.cli.kernel.formatOption
 import skillbill.cli.kernel.parseAgentAddonSelection
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.ShellContentContractException
 import skillbill.model.toPath
 import skillbill.ports.agentaddon.AgentAddonSelectionPort
@@ -80,7 +79,11 @@ class AgentAddonResolveSelectionCommand(
     try {
       state.complete(block(), format)
     } catch (error: ShellContentContractException) {
-      state.complete(mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()), format, exitCode = 1)
+      state.complete(
+        mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()),
+        format,
+        exitCode = 1,
+      )
     }
   }
 }
@@ -123,7 +126,11 @@ class AgentAddonVerifySelectionCommand(
         format,
       )
     } catch (error: ShellContentContractException) {
-      state.complete(mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()), format, exitCode = 1)
+      state.complete(
+        mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()),
+        format,
+        exitCode = 1,
+      )
     }
   }
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigCommand.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.config
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -12,6 +10,7 @@ import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.kernel.DocumentedNoOpCliCommand
 import skillbill.config.model.SpecType
 import skillbill.config.model.parseSpecType
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.ShellContentContractException
 import java.nio.file.Path
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigCommand.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.config
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -58,7 +60,7 @@ class ConfigResolveSpecTypeCommand(
     }
     state.completeText(
       "${resolved.id}\n",
-      mapOf("status" to "ok", "spec_type" to resolved.id),
+      mapOf(SharedPayloadKeys.STATUS to "ok", "spec_type" to resolved.id),
     )
   }
 
@@ -77,7 +79,7 @@ class ConfigResolveSpecTypeCommand(
   }
 
   private fun failurePayload(message: String?): Map<String, Any?> =
-    mapOf("status" to "failed", "error" to message.orEmpty())
+    mapOf(SharedPayloadKeys.STATUS to "failed", "error" to message.orEmpty())
 
   private data class ExplicitArg(
     val value: SpecType?,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAddonsCommand.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.config
 
+import skillbill.contracts.SharedPayloadKeys
+
 import me.tatarka.inject.annotations.Inject
 import skillbill.application.install.ExternalAddonOverlayService
 import skillbill.cli.kernel.CliRunState
@@ -22,7 +24,7 @@ class ConfigResolveExternalAddonsCommand(
     } catch (error: ShellContentContractException) {
       state.completeText(
         "${error.message}\n",
-        mapOf("status" to "failed", "error" to error.message.orEmpty()),
+        mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()),
         exitCode = 1,
       )
       return
@@ -31,7 +33,7 @@ class ConfigResolveExternalAddonsCommand(
     state.completeText(
       text,
       mapOf(
-        "status" to "ok",
+        SharedPayloadKeys.STATUS to "ok",
         "sources" to sources.map { source ->
           mapOf("platform" to source.platform, "path" to source.path.toString())
         },

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAddonsCommand.kt
@@ -1,12 +1,11 @@
 package skillbill.cli.config
 
-import skillbill.contracts.SharedPayloadKeys
-
 import me.tatarka.inject.annotations.Inject
 import skillbill.application.install.ExternalAddonOverlayService
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.ShellContentContractException
 
 @Inject

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAgentAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAgentAddonsCommand.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.config
 
+import skillbill.contracts.SharedPayloadKeys
+
 import me.tatarka.inject.annotations.Inject
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
@@ -25,7 +27,7 @@ class ConfigResolveExternalAgentAddonsCommand(
     } catch (error: ShellContentContractException) {
       state.completeText(
         "${error.message}\n",
-        mapOf("status" to "failed", "error" to error.message.orEmpty()),
+        mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()),
         exitCode = 1,
       )
       return
@@ -34,7 +36,7 @@ class ConfigResolveExternalAgentAddonsCommand(
     state.completeText(
       text,
       mapOf(
-        "status" to "ok",
+        SharedPayloadKeys.STATUS to "ok",
         "sources" to sources.map { source -> mapOf("path" to source.path.toString()) },
       ),
     )

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAgentAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/config/ConfigResolveExternalAgentAddonsCommand.kt
@@ -1,11 +1,10 @@
 package skillbill.cli.config
 
-import skillbill.contracts.SharedPayloadKeys
-
 import me.tatarka.inject.annotations.Inject
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.ShellContentContractException
 import skillbill.ports.agentaddon.ExternalAgentAddonSourceConfigPort
 import skillbill.ports.agentaddon.model.ExternalAgentAddonSourceConfigRequest

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeControlCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeControlCliCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -16,6 +14,7 @@ import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.kernel.formatOption
 import skillbill.cli.kernel.toPayload
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.FeatureTaskContinuationLookupService
 import skillbill.engine.featuretask.FeatureTaskRuntimeStatusService
 import skillbill.engine.featuretask.model.FeatureTaskContinuationCandidate

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeControlCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeControlCliCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -56,28 +58,28 @@ private fun FeatureTaskContinuationLookupResult.toCliPayload(): Map<String, Any?
     mapOf("result" to "goal_continuation", "goal" to candidate.toMap())
   is FeatureTaskContinuationLookupResult.NeedsIdentityRepair -> mapOf(
     "result" to "needs_identity_repair",
-    "workflow_id" to workflowId,
-    "summary" to summary,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.SUMMARY to summary,
   )
 }
 
 private fun GoalContinuationCandidate.toMap(): Map<String, Any?> = mapOf(
   "parent_workflow_id" to parentWorkflowId,
-  "issue_key" to issueKey,
-  "status" to status,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
+  SharedPayloadKeys.STATUS to status,
   "current_subtask_id" to currentSubtaskId,
   "current_action" to currentAction,
   "complete_count" to completeCount,
   "pending_count" to pendingCount,
   "blocked_count" to blockedCount,
   "updated_at" to updatedAt,
-  "summary" to summary,
+  SharedPayloadKeys.SUMMARY to summary,
 )
 
 private fun FeatureTaskContinuationCandidate.toMap(): Map<String, Any?> = mapOf(
-  "workflow_id" to workflowId,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
   "mode" to mode.wireValue,
-  "status" to status,
+  SharedPayloadKeys.STATUS to status,
   "current_step" to currentStep,
   "governed_spec_path" to governedSpecPath,
   "updated_at" to updatedAt,
@@ -88,7 +90,7 @@ private fun FeatureTaskContinuationCandidate.toMap(): Map<String, Any?> = mapOf(
       "evidence" to it.evidence,
     )
   },
-  "summary" to summary,
+  SharedPayloadKeys.SUMMARY to summary,
 )
 
 @Inject

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeRunReportPresentation.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeRunReportPresentation.kt
@@ -1,22 +1,24 @@
 package skillbill.cli.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunReport
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeSubtaskOutcome
 import skillbill.workflow.model.DecompositionStatus
 
 internal fun FeatureTaskRuntimeRunReport.toRuntimeRunCliMap(): Map<String, Any?> = when (this) {
   is FeatureTaskRuntimeRunReport.Completed -> linkedMapOf(
-    "status" to "complete",
-    "issue_key" to issueKey,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "complete",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "feature_size" to featureSize,
     "resolved_branch" to resolvedBranch,
     "completed_phases" to completedPhaseIds,
   ).withSubtaskOutcome(subtaskOutcome)
   is FeatureTaskRuntimeRunReport.Blocked -> linkedMapOf(
-    "status" to "blocked",
-    "issue_key" to issueKey,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "blocked",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "feature_size" to featureSize,
     "resolved_branch" to resolvedBranch,
     "last_incomplete_phase" to lastIncompletePhase,
@@ -24,9 +26,9 @@ internal fun FeatureTaskRuntimeRunReport.toRuntimeRunCliMap(): Map<String, Any?>
     "completed_phases" to completedPhaseIds,
   ).withSubtaskOutcome(subtaskOutcome)
   is FeatureTaskRuntimeRunReport.Paused -> linkedMapOf(
-    "status" to "paused",
-    "issue_key" to issueKey,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "paused",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "feature_size" to featureSize,
     "resolved_branch" to resolvedBranch,
     "paused_phase" to pausedPhase,
@@ -35,9 +37,9 @@ internal fun FeatureTaskRuntimeRunReport.toRuntimeRunCliMap(): Map<String, Any?>
     "completed_phases" to completedPhaseIds,
   ).withSubtaskOutcome(subtaskOutcome)
   is FeatureTaskRuntimeRunReport.Decomposed -> linkedMapOf(
-    "status" to "decomposed",
-    "issue_key" to issueKey,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "decomposed",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "feature_size" to featureSize,
     "resolved_branch" to resolvedBranch,
     "reason" to reason,
@@ -58,11 +60,11 @@ internal fun Map<String, Any?>.withSubtaskOutcome(outcome: FeatureTaskRuntimeSub
       put(
         "subtask_outcome",
         linkedMapOf(
-          "issue_key" to outcome.issueKey,
-          "subtask_id" to outcome.subtaskId,
-          "status" to outcome.status.wireValue,
+          SharedPayloadKeys.ISSUE_KEY to outcome.issueKey,
+          SharedPayloadKeys.SUBTASK_ID to outcome.subtaskId,
+          SharedPayloadKeys.STATUS to outcome.status.wireValue,
           "commit_sha" to outcome.commitSha,
-          "workflow_id" to outcome.workflowId,
+          SharedPayloadKeys.WORKFLOW_ID to outcome.workflowId,
           "blocked_reason" to outcome.blockedReason,
           "last_resumable_step" to outcome.lastResumableStep,
           "finalizing_agent_id" to outcome.finalizingAgentId,
@@ -75,12 +77,12 @@ internal fun Map<String, Any?>.withSubtaskOutcome(outcome: FeatureTaskRuntimeSub
 internal fun Map<String, Any?>.runtimeRunExitCode(): Int = if (isTerminalSuccessStatus()) 0 else 1
 
 internal fun Map<String, Any?>.isTerminalSuccessStatus(): Boolean =
-  this["status"] in setOf(DecompositionStatus.COMPLETE.wireValue, "decomposed")
+  this[SharedPayloadKeys.STATUS] in setOf(DecompositionStatus.COMPLETE.wireValue, "decomposed")
 
 internal fun runtimeRunText(payload: Map<String, Any?>): String = buildString {
-  appendLine("feature-task-runtime: ${payload["issue_key"]}")
-  appendLine("workflow_id: ${payload["workflow_id"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("feature-task-runtime: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("workflow_id: ${payload[SharedPayloadKeys.WORKFLOW_ID]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("feature_size: ${payload["feature_size"]}")
   appendLine("resolved_branch: ${payload["resolved_branch"] ?: "none"}")
   appendLine("completed_phases: ${(payload["completed_phases"] as? List<*>).orEmpty().joinToString()}")
@@ -97,11 +99,11 @@ internal fun runtimeRunText(payload: Map<String, Any?>): String = buildString {
 
 internal fun StringBuilder.appendSubtaskOutcome(outcome: Map<*, *>) {
   appendLine("subtask_outcome:")
-  appendLine("  issue_key: ${outcome["issue_key"]}")
-  appendLine("  subtask_id: ${outcome["subtask_id"]}")
-  appendLine("  status: ${outcome["status"]}")
+  appendLine("  issue_key: ${outcome[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("  subtask_id: ${outcome[SharedPayloadKeys.SUBTASK_ID]}")
+  appendLine("  status: ${outcome[SharedPayloadKeys.STATUS]}")
   appendLine("  commit_sha: ${outcome["commit_sha"] ?: "none"}")
-  appendLine("  workflow_id: ${outcome["workflow_id"]}")
+  appendLine("  workflow_id: ${outcome[SharedPayloadKeys.WORKFLOW_ID]}")
   appendLine("  last_resumable_step: ${outcome["last_resumable_step"]}")
   outcome["finalizing_agent_id"]?.let { appendLine("  finalizing_agent_id: $it") }
   (outcome["participating_agent_ids"] as? List<*>)?.takeIf { it.isNotEmpty() }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeRunReportPresentation.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeRunReportPresentation.kt
@@ -1,7 +1,6 @@
 package skillbill.cli.featuretask
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunReport
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeSubtaskOutcome
 import skillbill.workflow.model.DecompositionStatus

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeStatusPresentation.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeStatusPresentation.kt
@@ -1,13 +1,15 @@
 package skillbill.cli.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.engine.featuretask.model.FeatureTaskRuntimePhaseStatus
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeStatusProjection
 
 internal fun FeatureTaskRuntimeStatusProjection?.toRuntimeStatusCliMap(workflowId: String): Map<String, Any?> =
   this?.let {
     linkedMapOf<String, Any?>(
-      "status" to "ok",
-      "workflow_id" to it.workflowId,
+      SharedPayloadKeys.STATUS to "ok",
+      SharedPayloadKeys.WORKFLOW_ID to it.workflowId,
       "feature_size" to it.featureSize,
       "complete_count" to it.completeCount,
       "pending_count" to it.pendingCount,
@@ -26,7 +28,7 @@ internal fun FeatureTaskRuntimeStatusProjection?.toRuntimeStatusCliMap(workflowI
         linkedMapOf(
           "count" to degraded.count,
           "failure_class" to degraded.failureClass,
-          "phase_id" to degraded.phaseId,
+          SharedPayloadKeys.PHASE_ID to degraded.phaseId,
           "attempt" to degraded.attempt,
         )
       },
@@ -43,8 +45,8 @@ internal fun FeatureTaskRuntimeStatusProjection?.toRuntimeStatusCliMap(workflowI
       "phases" to it.phases.map(FeatureTaskRuntimePhaseStatus::toRuntimePhaseStatusCliMap),
     )
   } ?: linkedMapOf(
-    "status" to "not_found",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "not_found",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "feature_size" to null,
     "complete_count" to 0,
     "pending_count" to 0,
@@ -59,8 +61,8 @@ internal fun FeatureTaskRuntimeStatusProjection?.toRuntimeStatusCliMap(workflowI
   )
 
 internal fun FeatureTaskRuntimePhaseStatus.toRuntimePhaseStatusCliMap(): Map<String, Any?> = linkedMapOf(
-  "phase_id" to phaseId,
-  "status" to status,
+  SharedPayloadKeys.PHASE_ID to phaseId,
+  SharedPayloadKeys.STATUS to status,
   "attempt_count" to attemptCount,
   "resolved_agent_id" to resolvedAgentId,
   "execution_origin" to executionOrigin,
@@ -68,11 +70,11 @@ internal fun FeatureTaskRuntimePhaseStatus.toRuntimePhaseStatusCliMap(): Map<Str
   "finished" to finished,
 )
 
-internal fun Map<String, Any?>.runtimeStatusExitCode(): Int = if (this["status"] == "ok") 0 else 1
+internal fun Map<String, Any?>.runtimeStatusExitCode(): Int = if (this[SharedPayloadKeys.STATUS] == "ok") 0 else 1
 
 internal fun runtimeStatusText(payload: Map<String, Any?>): String = buildString {
-  appendLine("feature-task-runtime: ${payload["workflow_id"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("feature-task-runtime: ${payload[SharedPayloadKeys.WORKFLOW_ID]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("feature_size: ${payload["feature_size"] ?: "unknown"}")
   appendLine("complete: ${payload["complete_count"]}")
   appendLine("pending: ${payload["pending_count"]}")
@@ -91,7 +93,7 @@ internal fun runtimeStatusText(payload: Map<String, Any?>): String = buildString
   (payload["degraded_diagnostic"] as? Map<*, *>)?.let { degraded ->
     appendLine("degraded_diagnostic_count: ${degraded["count"]}")
     appendLine("degraded_diagnostic_failure_class: ${degraded["failure_class"]}")
-    appendLine("degraded_diagnostic_phase: ${degraded["phase_id"]}")
+    appendLine("degraded_diagnostic_phase: ${degraded[SharedPayloadKeys.PHASE_ID]}")
     appendLine("degraded_diagnostic_attempt: ${degraded["attempt"]}")
   }
   (payload["decompose_terminal"] as? Map<*, *>)?.let { terminal ->
@@ -105,7 +107,7 @@ internal fun runtimeStatusText(payload: Map<String, Any?>): String = buildString
   (payload["phases"] as? List<*>).orEmpty().forEach { rawPhase ->
     val phase = rawPhase as? Map<*, *> ?: return@forEach
     appendLine(
-      "phase: id=${phase["phase_id"]} status=${phase["status"]} attempt=${phase["attempt_count"]} " +
+      "phase: id=${phase[SharedPayloadKeys.PHASE_ID]} status=${phase[SharedPayloadKeys.STATUS]} attempt=${phase["attempt_count"]} " +
         "agent=${phase["resolved_agent_id"] ?: "none"} " +
         "origin=${phase["execution_origin"] ?: "none"} finished=${phase["finished"]}",
     )

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeStatusPresentation.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/featuretask/FeatureTaskRuntimeStatusPresentation.kt
@@ -1,7 +1,6 @@
 package skillbill.cli.featuretask
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.engine.featuretask.model.FeatureTaskRuntimePhaseStatus
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeStatusProjection
 
@@ -107,9 +106,12 @@ internal fun runtimeStatusText(payload: Map<String, Any?>): String = buildString
   (payload["phases"] as? List<*>).orEmpty().forEach { rawPhase ->
     val phase = rawPhase as? Map<*, *> ?: return@forEach
     appendLine(
-      "phase: id=${phase[SharedPayloadKeys.PHASE_ID]} status=${phase[SharedPayloadKeys.STATUS]} attempt=${phase["attempt_count"]} " +
+      "phase: id=${phase[SharedPayloadKeys.PHASE_ID]} " +
+        "status=${phase[SharedPayloadKeys.STATUS]} " +
+        "attempt=${phase["attempt_count"]} " +
         "agent=${phase["resolved_agent_id"] ?: "none"} " +
-        "origin=${phase["execution_origin"] ?: "none"} finished=${phase["finished"]}",
+        "origin=${phase["execution_origin"] ?: "none"} " +
+        "finished=${phase["finished"]}",
     )
   }
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliControlFormatting.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliControlFormatting.kt
@@ -1,7 +1,6 @@
 package skillbill.cli.goal
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.engine.goalrunner.model.GoalRunnerAcceptResult
 import skillbill.engine.goalrunner.model.GoalRunnerReplanResult
 import skillbill.engine.goalrunner.model.GoalRunnerReplanSnapshot
@@ -114,7 +113,10 @@ internal fun goalAcceptText(payload: Map<String, Any?>): String = buildString {
   payload["commit_sha"]?.let { appendLine("commit_sha: $it") }
   payload["parent_workflow_id"]?.let { appendLine("parent_workflow_id: $it") }
   (payload["after"] as? Map<*, *>)?.let { after ->
-    appendLine("after: status=${after[SharedPayloadKeys.STATUS]}; current_subtask=${after["current_subtask"] ?: "none"}")
+    appendLine(
+      "after: status=${after[SharedPayloadKeys.STATUS]}; " +
+        "current_subtask=${after["current_subtask"] ?: "none"}",
+    )
     appendLine("after_subtasks:")
     appendGoalResetSubtaskLines(this, after["subtasks"] as? List<*>)
   }
@@ -158,8 +160,14 @@ internal fun goalResetText(payload: Map<String, Any?>): String = buildString {
   val before = payload["before"] as? Map<*, *>
   val after = payload["after"] as? Map<*, *>
   if (before != null && after != null) {
-    appendLine("before: status=${before[SharedPayloadKeys.STATUS]}; current_subtask=${before["current_subtask"] ?: "none"}")
-    appendLine("after: status=${after[SharedPayloadKeys.STATUS]}; current_subtask=${after["current_subtask"] ?: "none"}")
+    appendLine(
+      "before: status=${before[SharedPayloadKeys.STATUS]}; " +
+        "current_subtask=${before["current_subtask"] ?: "none"}",
+    )
+    appendLine(
+      "after: status=${after[SharedPayloadKeys.STATUS]}; " +
+        "current_subtask=${after["current_subtask"] ?: "none"}",
+    )
     appendLine("before_subtasks:")
     appendGoalResetSubtaskLines(this, before["subtasks"] as? List<*>)
     appendLine("after_subtasks:")
@@ -167,7 +175,8 @@ internal fun goalResetText(payload: Map<String, Any?>): String = buildString {
   }
   (payload["recovery"] as? Map<*, *>)?.let { recovery ->
     appendLine(
-      "recovery: subtask=${recovery[SharedPayloadKeys.SUBTASK_ID]}; workflow_id=${recovery[SharedPayloadKeys.WORKFLOW_ID]}; " +
+      "recovery: subtask=${recovery[SharedPayloadKeys.SUBTASK_ID]}; " +
+        "workflow_id=${recovery[SharedPayloadKeys.WORKFLOW_ID]}; " +
         "classification=${recovery["classification"]}",
     )
     recovery["command"]?.let { appendLine("recovery_command: $it") }
@@ -179,7 +188,9 @@ internal fun goalReplanText(payload: Map<String, Any?>): String = buildString {
   appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("mode: ${payload["mode"]}")
   payload["parent_workflow_id"]?.let { appendLine("parent_workflow_id: $it") }
-  payload[SharedPayloadKeys.SUBTASK_ID]?.let { appendLine("discarded_plan: subtask=$it; existed=${payload["discarded_plan"]}") }
+  payload[SharedPayloadKeys.SUBTASK_ID]?.let {
+    appendLine("discarded_plan: subtask=$it; existed=${payload["discarded_plan"]}")
+  }
   val discardedShared = payload["discarded_shared_preplan"] as? Boolean == true
   val cascaded = (payload["cascaded_plan_subtask_ids"] as? List<*>).orEmpty().filterNotNull()
   if (discardedShared || cascaded.isNotEmpty()) {
@@ -196,8 +207,14 @@ internal fun goalReplanText(payload: Map<String, Any?>): String = buildString {
         "planned_before=${(before["planned_subtask_ids"] as? List<*>)?.joinToString(",") ?: "none"}; " +
         "planned_after=${(after["planned_subtask_ids"] as? List<*>)?.joinToString(",") ?: "none"}",
     )
-    appendLine("before: status=${before[SharedPayloadKeys.STATUS]}; current_subtask=${before["current_subtask"] ?: "none"}")
-    appendLine("after: status=${after[SharedPayloadKeys.STATUS]}; current_subtask=${after["current_subtask"] ?: "none"}")
+    appendLine(
+      "before: status=${before[SharedPayloadKeys.STATUS]}; " +
+        "current_subtask=${before["current_subtask"] ?: "none"}",
+    )
+    appendLine(
+      "after: status=${after[SharedPayloadKeys.STATUS]}; " +
+        "current_subtask=${after["current_subtask"] ?: "none"}",
+    )
     appendLine("before_subtasks:")
     appendGoalResetSubtaskLines(this, before["subtasks"] as? List<*>)
     appendLine("after_subtasks:")

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliControlFormatting.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliControlFormatting.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.engine.goalrunner.model.GoalRunnerAcceptResult
 import skillbill.engine.goalrunner.model.GoalRunnerReplanResult
 import skillbill.engine.goalrunner.model.GoalRunnerReplanSnapshot
@@ -9,34 +11,34 @@ import skillbill.goalrunner.model.GoalRunnerAcceptedSubtask
 
 internal fun GoalRunnerResetResult?.toGoalResetCliMap(issueKey: String, hard: Boolean): Map<String, Any?> = this?.let {
   linkedMapOf(
-    "status" to if (it.recovery?.recoveryCommand == null) "ok" else "recovery_required",
-    "issue_key" to it.issueKey,
+    SharedPayloadKeys.STATUS to if (it.recovery?.recoveryCommand == null) "ok" else "recovery_required",
+    SharedPayloadKeys.ISSUE_KEY to it.issueKey,
     "mode" to it.mode,
     "parent_workflow_id" to it.parentWorkflowId,
     "before" to resetSnapshotMap(it.before),
     "after" to resetSnapshotMap(it.after),
     "recovery" to it.recovery?.let { recovery ->
       linkedMapOf(
-        "subtask_id" to recovery.subtaskId,
-        "workflow_id" to recovery.workflowId,
+        SharedPayloadKeys.SUBTASK_ID to recovery.subtaskId,
+        SharedPayloadKeys.WORKFLOW_ID to recovery.workflowId,
         "classification" to recovery.classification,
         "command" to recovery.recoveryCommand,
       )
     },
   )
 } ?: linkedMapOf(
-  "status" to "not_found",
-  "issue_key" to issueKey,
+  SharedPayloadKeys.STATUS to "not_found",
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "mode" to if (hard) "hard" else "soft",
 )
 
 internal fun GoalRunnerReplanResult?.toGoalReplanCliMap(issueKey: String): Map<String, Any?> = this?.let {
   linkedMapOf(
-    "status" to "ok",
-    "issue_key" to it.issueKey,
+    SharedPayloadKeys.STATUS to "ok",
+    SharedPayloadKeys.ISSUE_KEY to it.issueKey,
     "mode" to "scoped_replan",
     "parent_workflow_id" to it.parentWorkflowId,
-    "subtask_id" to it.subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to it.subtaskId,
     "discarded_plan" to it.discardedPlan,
     "discarded_shared_preplan" to it.discardedSharedPreplan,
     "cascaded_plan_subtask_ids" to it.cascadedPlanSubtaskIds,
@@ -45,21 +47,21 @@ internal fun GoalRunnerReplanResult?.toGoalReplanCliMap(issueKey: String): Map<S
     "after" to replanSnapshotMap(it.after),
   )
 } ?: linkedMapOf(
-  "status" to "not_found",
-  "issue_key" to issueKey,
+  SharedPayloadKeys.STATUS to "not_found",
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "mode" to "scoped_replan",
 )
 
 internal fun resetSnapshotMap(snapshot: GoalRunnerResetSnapshot): Map<String, Any?> = linkedMapOf(
-  "status" to snapshot.status,
+  SharedPayloadKeys.STATUS to snapshot.status,
   "current_subtask" to snapshot.currentSubtaskId,
   "current_action" to snapshot.currentAction,
   "subtasks" to snapshot.subtasks.map { subtask ->
     linkedMapOf(
       "id" to subtask.id,
-      "status" to subtask.status,
+      SharedPayloadKeys.STATUS to subtask.status,
       "branch" to subtask.branch,
-      "workflow_id" to subtask.workflowId,
+      SharedPayloadKeys.WORKFLOW_ID to subtask.workflowId,
       "commit_sha" to subtask.commitSha,
       "blocked_reason" to subtask.blockedReason,
       "last_resumable_step" to subtask.lastResumableStep,
@@ -68,7 +70,7 @@ internal fun resetSnapshotMap(snapshot: GoalRunnerResetSnapshot): Map<String, An
 )
 
 internal fun replanSnapshotMap(snapshot: GoalRunnerReplanSnapshot): Map<String, Any?> = linkedMapOf(
-  "status" to snapshot.status,
+  SharedPayloadKeys.STATUS to snapshot.status,
   "current_subtask" to snapshot.currentSubtaskId,
   "current_action" to snapshot.currentAction,
   "shared_preplan_prepared" to snapshot.sharedPreplanPrepared,
@@ -76,9 +78,9 @@ internal fun replanSnapshotMap(snapshot: GoalRunnerReplanSnapshot): Map<String, 
   "subtasks" to snapshot.subtasks.map { subtask ->
     linkedMapOf(
       "id" to subtask.id,
-      "status" to subtask.status,
+      SharedPayloadKeys.STATUS to subtask.status,
       "branch" to subtask.branch,
-      "workflow_id" to subtask.workflowId,
+      SharedPayloadKeys.WORKFLOW_ID to subtask.workflowId,
       "commit_sha" to subtask.commitSha,
       "blocked_reason" to subtask.blockedReason,
       "last_resumable_step" to subtask.lastResumableStep,
@@ -88,31 +90,31 @@ internal fun replanSnapshotMap(snapshot: GoalRunnerReplanSnapshot): Map<String, 
 
 internal fun GoalRunnerAcceptResult.toGoalAcceptCliMap(): Map<String, Any?> = when (this) {
   is GoalRunnerAcceptResult.Accepted -> linkedMapOf(
-    "status" to "ok",
-    "issue_key" to issueKey,
+    SharedPayloadKeys.STATUS to "ok",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "parent_workflow_id" to parentWorkflowId,
-    "subtask_id" to subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
     "commit_sha" to commitSha,
     "reason" to reason,
     "accepted_at" to acceptedAt,
     "after" to resetSnapshotMap(after),
   )
   is GoalRunnerAcceptResult.Rejected -> linkedMapOf(
-    "status" to "rejected",
-    "issue_key" to issueKey,
+    SharedPayloadKeys.STATUS to "rejected",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "reason" to reason,
   )
 }
 
 internal fun goalAcceptText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal: ${payload["issue_key"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("reason: ${payload["reason"]}")
-  payload["subtask_id"]?.let { appendLine("accepted_subtask: $it") }
+  payload[SharedPayloadKeys.SUBTASK_ID]?.let { appendLine("accepted_subtask: $it") }
   payload["commit_sha"]?.let { appendLine("commit_sha: $it") }
   payload["parent_workflow_id"]?.let { appendLine("parent_workflow_id: $it") }
   (payload["after"] as? Map<*, *>)?.let { after ->
-    appendLine("after: status=${after["status"]}; current_subtask=${after["current_subtask"] ?: "none"}")
+    appendLine("after: status=${after[SharedPayloadKeys.STATUS]}; current_subtask=${after["current_subtask"] ?: "none"}")
     appendLine("after_subtasks:")
     appendGoalResetSubtaskLines(this, after["subtasks"] as? List<*>)
   }
@@ -149,15 +151,15 @@ internal fun String.shellWord(): String = if (isNotEmpty() && all { it.isLetterO
 }
 
 internal fun goalResetText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal: ${payload["issue_key"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("mode: ${payload["mode"]}")
   payload["parent_workflow_id"]?.let { appendLine("parent_workflow_id: $it") }
   val before = payload["before"] as? Map<*, *>
   val after = payload["after"] as? Map<*, *>
   if (before != null && after != null) {
-    appendLine("before: status=${before["status"]}; current_subtask=${before["current_subtask"] ?: "none"}")
-    appendLine("after: status=${after["status"]}; current_subtask=${after["current_subtask"] ?: "none"}")
+    appendLine("before: status=${before[SharedPayloadKeys.STATUS]}; current_subtask=${before["current_subtask"] ?: "none"}")
+    appendLine("after: status=${after[SharedPayloadKeys.STATUS]}; current_subtask=${after["current_subtask"] ?: "none"}")
     appendLine("before_subtasks:")
     appendGoalResetSubtaskLines(this, before["subtasks"] as? List<*>)
     appendLine("after_subtasks:")
@@ -165,7 +167,7 @@ internal fun goalResetText(payload: Map<String, Any?>): String = buildString {
   }
   (payload["recovery"] as? Map<*, *>)?.let { recovery ->
     appendLine(
-      "recovery: subtask=${recovery["subtask_id"]}; workflow_id=${recovery["workflow_id"]}; " +
+      "recovery: subtask=${recovery[SharedPayloadKeys.SUBTASK_ID]}; workflow_id=${recovery[SharedPayloadKeys.WORKFLOW_ID]}; " +
         "classification=${recovery["classification"]}",
     )
     recovery["command"]?.let { appendLine("recovery_command: $it") }
@@ -173,11 +175,11 @@ internal fun goalResetText(payload: Map<String, Any?>): String = buildString {
 }
 
 internal fun goalReplanText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal: ${payload["issue_key"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("mode: ${payload["mode"]}")
   payload["parent_workflow_id"]?.let { appendLine("parent_workflow_id: $it") }
-  payload["subtask_id"]?.let { appendLine("discarded_plan: subtask=$it; existed=${payload["discarded_plan"]}") }
+  payload[SharedPayloadKeys.SUBTASK_ID]?.let { appendLine("discarded_plan: subtask=$it; existed=${payload["discarded_plan"]}") }
   val discardedShared = payload["discarded_shared_preplan"] as? Boolean == true
   val cascaded = (payload["cascaded_plan_subtask_ids"] as? List<*>).orEmpty().filterNotNull()
   if (discardedShared || cascaded.isNotEmpty()) {
@@ -194,8 +196,8 @@ internal fun goalReplanText(payload: Map<String, Any?>): String = buildString {
         "planned_before=${(before["planned_subtask_ids"] as? List<*>)?.joinToString(",") ?: "none"}; " +
         "planned_after=${(after["planned_subtask_ids"] as? List<*>)?.joinToString(",") ?: "none"}",
     )
-    appendLine("before: status=${before["status"]}; current_subtask=${before["current_subtask"] ?: "none"}")
-    appendLine("after: status=${after["status"]}; current_subtask=${after["current_subtask"] ?: "none"}")
+    appendLine("before: status=${before[SharedPayloadKeys.STATUS]}; current_subtask=${before["current_subtask"] ?: "none"}")
+    appendLine("after: status=${after[SharedPayloadKeys.STATUS]}; current_subtask=${after["current_subtask"] ?: "none"}")
     appendLine("before_subtasks:")
     appendGoalResetSubtaskLines(this, before["subtasks"] as? List<*>)
     appendLine("after_subtasks:")

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliExitCodes.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliExitCodes.kt
@@ -1,7 +1,6 @@
 package skillbill.cli.goal
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.engine.goalrunner.model.GoalRunnerStopStatus
 import skillbill.goalrunner.model.GoalRunnerTerminalStatus
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliExitCodes.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliExitCodes.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.engine.goalrunner.model.GoalRunnerStopStatus
 import skillbill.goalrunner.model.GoalRunnerTerminalStatus
 
@@ -19,21 +21,21 @@ internal fun goalRunExitCode(status: String?, reason: String?): Int {
 }
 
 internal fun Map<String, Any?>.goalExitCode(): Int =
-  goalRunExitCode(this["status"]?.toString(), this["reason"]?.toString())
+  goalRunExitCode(this[SharedPayloadKeys.STATUS]?.toString(), this["reason"]?.toString())
 
 internal fun Map<String, Any?>.goalStatusExitCode(): Int = if (!containsKey(
     "status",
-  ) || this["status"] == "ok"
+  ) || this[SharedPayloadKeys.STATUS] == "ok"
 ) {
   0
 } else {
   1
 }
 
-internal fun Map<String, Any?>.goalPauseExitCode(): Int = if (this["status"] != "not_found") 0 else 1
+internal fun Map<String, Any?>.goalPauseExitCode(): Int = if (this[SharedPayloadKeys.STATUS] != "not_found") 0 else 1
 
 // Idempotent outcomes exit 0; a refused stop is a non-zero failure the operator must act on.
-internal fun Map<String, Any?>.goalStopExitCode(): Int = when (this["status"]) {
+internal fun Map<String, Any?>.goalStopExitCode(): Int = when (this[SharedPayloadKeys.STATUS]) {
   GoalRunnerStopStatus.STOPPED.wireValue,
   GoalRunnerStopStatus.ALREADY_STOPPED.wireValue,
   GoalRunnerStopStatus.NO_LIVE_LEASE.wireValue,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliFormatting.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliFormatting.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.engine.goalrunner.model.GoalRunnerOperatorDecisionResult
 import skillbill.engine.goalrunner.model.GoalRunnerRepairResult
 import skillbill.engine.goalrunner.model.GoalRunnerRepairStatus
@@ -11,9 +13,9 @@ internal fun appendGoalResetSubtaskLines(builder: StringBuilder, subtasks: List<
     builder.append("id=")
     builder.append(subtask["id"])
     builder.append("; status=")
-    builder.append(subtask["status"])
+    builder.append(subtask[SharedPayloadKeys.STATUS])
     builder.append("; workflow_id=")
-    builder.append(subtask["workflow_id"] ?: "none")
+    builder.append(subtask[SharedPayloadKeys.WORKFLOW_ID] ?: "none")
     builder.append("; commit_sha=")
     builder.append(subtask["commit_sha"] ?: "none")
     builder.append("; blocked_reason=")
@@ -24,18 +26,18 @@ internal fun appendGoalResetSubtaskLines(builder: StringBuilder, subtasks: List<
   }
 }
 
-internal fun Map<String, Any?>.goalResetExitCode(): Int = if (this["status"] == "ok") 0 else 1
+internal fun Map<String, Any?>.goalResetExitCode(): Int = if (this[SharedPayloadKeys.STATUS] == "ok") 0 else 1
 
 internal fun GoalRunnerRepairResult.toGoalRepairCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to status.wireValue,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.STATUS to status.wireValue,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "parent_workflow_id" to parentWorkflowId,
   "refusal_reason" to refusalReason,
   "live_lease_workflow_id" to liveLeaseWorkflowId,
   "diagnoses" to diagnoses.map { diagnosis ->
     linkedMapOf(
-      "subtask_id" to diagnosis.subtaskId,
-      "workflow_id" to diagnosis.workflowId,
+      SharedPayloadKeys.SUBTASK_ID to diagnosis.subtaskId,
+      SharedPayloadKeys.WORKFLOW_ID to diagnosis.workflowId,
       "healthy" to diagnosis.isHealthy,
       "passed_checks" to diagnosis.passedChecks,
       "wedges" to diagnosis.wedges.map { wedge ->
@@ -49,8 +51,8 @@ internal fun GoalRunnerRepairResult.toGoalRepairCliMap(): Map<String, Any?> = li
   },
   "applied_repairs" to appliedRepairs.map { repair ->
     linkedMapOf(
-      "subtask_id" to repair.subtaskId,
-      "workflow_id" to repair.workflowId,
+      SharedPayloadKeys.SUBTASK_ID to repair.subtaskId,
+      SharedPayloadKeys.WORKFLOW_ID to repair.workflowId,
       "wedge_class" to repair.wedgeClass.wireValue,
       "field" to repair.field,
       "prior_value" to repair.priorValue,
@@ -59,7 +61,7 @@ internal fun GoalRunnerRepairResult.toGoalRepairCliMap(): Map<String, Any?> = li
   },
 )
 
-internal fun Map<String, Any?>.goalRepairExitCode(): Int = when (this["status"]) {
+internal fun Map<String, Any?>.goalRepairExitCode(): Int = when (this[SharedPayloadKeys.STATUS]) {
   GoalRunnerRepairStatus.HEALTHY.wireValue,
   GoalRunnerRepairStatus.REPAIRED.wireValue,
   -> 0
@@ -70,8 +72,8 @@ internal fun Map<String, Any?>.goalRepairExitCode(): Int = when (this["status"])
 }
 
 internal fun goalRepairText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal: ${payload["issue_key"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   payload["parent_workflow_id"]?.let { appendLine("parent_workflow_id: $it") }
   payload["refusal_reason"]?.let { appendLine("refusal_reason: $it") }
   payload["live_lease_workflow_id"]?.let { appendLine("live_lease_workflow_id: $it") }
@@ -84,7 +86,7 @@ private fun appendGoalRepairDiagnoses(builder: StringBuilder, diagnoses: List<*>
   diagnoses.orEmpty().forEach { raw ->
     val diagnosis = raw as? Map<*, *> ?: return@forEach
     builder.appendLine(
-      "  - subtask=${diagnosis["subtask_id"]}; workflow_id=${diagnosis["workflow_id"] ?: "none"}; " +
+      "  - subtask=${diagnosis[SharedPayloadKeys.SUBTASK_ID]}; workflow_id=${diagnosis[SharedPayloadKeys.WORKFLOW_ID] ?: "none"}; " +
         "healthy=${diagnosis["healthy"]}",
     )
     (diagnosis["passed_checks"] as? List<*>).orEmpty().takeIf { it.isNotEmpty() }?.let { checks ->
@@ -107,7 +109,7 @@ private fun appendGoalRepairAppliedRepairs(builder: StringBuilder, repairs: List
   appliedRepairs.forEach { raw ->
     val repair = raw as? Map<*, *> ?: return@forEach
     builder.appendLine(
-      "  - subtask=${repair["subtask_id"]}; field=${repair["field"]}; " +
+      "  - subtask=${repair[SharedPayloadKeys.SUBTASK_ID]}; field=${repair["field"]}; " +
         "wedge_class=${repair["wedge_class"]}; prior=${repair["prior_value"] ?: "absent"}; " +
         "new=${repair["new_value"] ?: "absent"}",
     )
@@ -116,31 +118,31 @@ private fun appendGoalRepairAppliedRepairs(builder: StringBuilder, repairs: List
 
 internal fun GoalRunnerOperatorDecisionResult.toGoalOperatorDecisionCliMap(): Map<String, Any?> = when (this) {
   is GoalRunnerOperatorDecisionResult.Recorded -> linkedMapOf(
-    "status" to "ok",
-    "issue_key" to issueKey,
+    SharedPayloadKeys.STATUS to "ok",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "parent_workflow_id" to parentWorkflowId,
-    "subtask_id" to subtaskId,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "decision" to decision,
   )
   is GoalRunnerOperatorDecisionResult.Rejected -> linkedMapOf(
-    "status" to "rejected",
-    "issue_key" to issueKey,
+    SharedPayloadKeys.STATUS to "rejected",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "reason" to reason,
   )
 }
 
-internal fun Map<String, Any?>.goalOperatorDecisionExitCode(): Int = if (this["status"] == "ok") 0 else 1
+internal fun Map<String, Any?>.goalOperatorDecisionExitCode(): Int = if (this[SharedPayloadKeys.STATUS] == "ok") 0 else 1
 
 internal fun goalOperatorDecisionText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal: ${payload["issue_key"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   payload["parent_workflow_id"]?.let { appendLine("parent_workflow_id: $it") }
-  payload["subtask_id"]?.let { appendLine("subtask_id: $it") }
-  payload["workflow_id"]?.let { appendLine("workflow_id: $it") }
+  payload[SharedPayloadKeys.SUBTASK_ID]?.let { appendLine("subtask_id: $it") }
+  payload[SharedPayloadKeys.WORKFLOW_ID]?.let { appendLine("workflow_id: $it") }
   payload["decision"]?.let { appendLine("decision: $it") }
   payload["reason"]?.let { appendLine("reason: $it") }
-  if (payload["status"] == "ok") {
-    appendLine("next: skill-bill goal resume ${payload["issue_key"]} (consumes the recorded decision)")
+  if (payload[SharedPayloadKeys.STATUS] == "ok") {
+    appendLine("next: skill-bill goal resume ${payload[SharedPayloadKeys.ISSUE_KEY]} (consumes the recorded decision)")
   }
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliFormatting.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliFormatting.kt
@@ -1,7 +1,6 @@
 package skillbill.cli.goal
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.engine.goalrunner.model.GoalRunnerOperatorDecisionResult
 import skillbill.engine.goalrunner.model.GoalRunnerRepairResult
 import skillbill.engine.goalrunner.model.GoalRunnerRepairStatus
@@ -86,7 +85,8 @@ private fun appendGoalRepairDiagnoses(builder: StringBuilder, diagnoses: List<*>
   diagnoses.orEmpty().forEach { raw ->
     val diagnosis = raw as? Map<*, *> ?: return@forEach
     builder.appendLine(
-      "  - subtask=${diagnosis[SharedPayloadKeys.SUBTASK_ID]}; workflow_id=${diagnosis[SharedPayloadKeys.WORKFLOW_ID] ?: "none"}; " +
+      "  - subtask=${diagnosis[SharedPayloadKeys.SUBTASK_ID]}; " +
+        "workflow_id=${diagnosis[SharedPayloadKeys.WORKFLOW_ID] ?: "none"}; " +
         "healthy=${diagnosis["healthy"]}",
     )
     (diagnosis["passed_checks"] as? List<*>).orEmpty().takeIf { it.isNotEmpty() }?.let { checks ->
@@ -132,7 +132,8 @@ internal fun GoalRunnerOperatorDecisionResult.toGoalOperatorDecisionCliMap(): Ma
   )
 }
 
-internal fun Map<String, Any?>.goalOperatorDecisionExitCode(): Int = if (this[SharedPayloadKeys.STATUS] == "ok") 0 else 1
+internal fun Map<String, Any?>.goalOperatorDecisionExitCode(): Int =
+  if (this[SharedPayloadKeys.STATUS] == "ok") 0 else 1
 
 internal fun goalOperatorDecisionText(payload: Map<String, Any?>): String = buildString {
   appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliRunCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliRunCommands.kt
@@ -1,11 +1,5 @@
 package skillbill.cli.goal
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.flag
@@ -21,6 +15,9 @@ import skillbill.cli.kernel.formatOption
 import skillbill.cli.kernel.invokingAgentResolutionHelp
 import skillbill.cli.kernel.requireSupportedOptionalAgentId
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.engine.featuretask.model.FeatureTaskContinuationCandidate
 import skillbill.engine.goalrunner.GoalPreflightService
 import skillbill.engine.goalrunner.findings.UnaddressedFindingsLedgerService

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliRunCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliRunCommands.kt
@@ -1,5 +1,11 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.flag
@@ -92,36 +98,36 @@ internal fun parseCodeReviewMode(raw: String?) = raw?.let { value ->
 }
 
 internal fun GoalPreflightResult.toGoalPreflightCliMap(): Map<String, Any?> = linkedMapOf(
-  "verdict" to verdict,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.VERDICT to verdict,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "candidate" to candidate?.toGoalPreflightCandidateMap(),
   "candidates" to candidates.map { it.toGoalPreflightCandidateMap() },
   "goal" to goal?.let {
     linkedMapOf(
       "parent_workflow_id" to it.parentWorkflowId,
-      "issue_key" to it.issueKey,
-      "status" to it.status,
+      SharedPayloadKeys.ISSUE_KEY to it.issueKey,
+      SharedPayloadKeys.STATUS to it.status,
       "current_subtask_id" to it.currentSubtaskId,
       "current_action" to it.currentAction,
       "complete_count" to it.completeCount,
       "pending_count" to it.pendingCount,
       "blocked_count" to it.blockedCount,
       "updated_at" to it.updatedAt,
-      "summary" to it.summary,
+      SharedPayloadKeys.SUMMARY to it.summary,
     )
   },
   "gate_block" to gateBlock?.let { block ->
     linkedMapOf(
-      "issue_key" to block.issueKey,
+      SharedPayloadKeys.ISSUE_KEY to block.issueKey,
       "feature_name" to block.featureName,
       "subtasks" to block.subtasks.map { subtask ->
         linkedMapOf(
           "id" to subtask.id,
           "name" to subtask.name,
-          "status" to subtask.status,
+          SharedPayloadKeys.STATUS to subtask.status,
           "dependencies" to subtask.dependencies.map { dependency ->
             linkedMapOf(
-              "subtask_id" to dependency.subtaskId,
+              SharedPayloadKeys.SUBTASK_ID to dependency.subtaskId,
               "optional" to dependency.optional,
               "skipped" to dependency.skipped,
               "note" to dependency.note,
@@ -143,7 +149,7 @@ internal fun GoalPreflightResult.toGoalPreflightCliMap(): Map<String, Any?> = li
   },
   "rehydrate_targets" to rehydrateTargets.map {
     linkedMapOf(
-      "issue_key" to it.issueKey,
+      SharedPayloadKeys.ISSUE_KEY to it.issueKey,
       "linear_issue_id" to it.linearIssueId,
       "target_path" to it.targetPath,
     )
@@ -152,9 +158,9 @@ internal fun GoalPreflightResult.toGoalPreflightCliMap(): Map<String, Any?> = li
 )
 
 internal fun FeatureTaskContinuationCandidate.toGoalPreflightCandidateMap(): Map<String, Any?> = linkedMapOf(
-  "workflow_id" to workflowId,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
   "mode" to mode.wireValue,
-  "status" to status,
+  SharedPayloadKeys.STATUS to status,
   "current_step" to currentStep,
   "governed_spec_path" to governedSpecPath,
   "updated_at" to updatedAt,
@@ -165,7 +171,7 @@ internal fun FeatureTaskContinuationCandidate.toGoalPreflightCandidateMap(): Map
       "evidence" to it.evidence,
     )
   },
-  "summary" to summary,
+  SharedPayloadKeys.SUMMARY to summary,
 )
 
 @Inject
@@ -198,7 +204,7 @@ class GoalPlanningLogCommand(
       ),
     )
     val payload = linkedMapOf<String, Any?>(
-      "issue_key" to log.issueKey,
+      SharedPayloadKeys.ISSUE_KEY to log.issueKey,
       "parent_workflow_id" to log.parentWorkflowId,
       "total_attempts" to log.totalAttempts,
       "succeeded_attempts" to log.succeededAttempts,
@@ -208,8 +214,8 @@ class GoalPlanningLogCommand(
       "total_planning_ms" to log.totalPlanningMs,
       "attempts" to log.attempts.map { attempt ->
         linkedMapOf<String, Any?>(
-          "phase_id" to attempt.phaseId,
-          "subtask_id" to attempt.subtaskId,
+          SharedPayloadKeys.PHASE_ID to attempt.phaseId,
+          SharedPayloadKeys.SUBTASK_ID to attempt.subtaskId,
           "attempt" to attempt.attempt,
           "started_at" to attempt.startedAt?.toString(),
           "finished_at" to attempt.finishedAt?.toString(),
@@ -291,25 +297,25 @@ class GoalFindingsCommand(
     repairLedgers: Map<String, FeatureTaskRuntimeRepairLedger>,
     verificationDispositions: List<FeatureTaskRuntimeFindingVerificationDisposition>,
   ): LinkedHashMap<String, Any?> = linkedMapOf(
-    "issue_key" to ledger.issueKey,
+    SharedPayloadKeys.ISSUE_KEY to ledger.issueKey,
     "unaddressed_findings" to ledger.findings.size,
     "severity_breakdown" to ledger.severityBreakdown,
-    "findings" to ledger.findings.map { finding ->
+    ReviewVerificationSignalKeys.REVIEW_FINDINGS to ledger.findings.map { finding ->
       linkedMapOf(
-        "subtask_id" to finding.subtaskId,
-        "workflow_id" to finding.workflowId,
+        SharedPayloadKeys.SUBTASK_ID to finding.subtaskId,
+        SharedPayloadKeys.WORKFLOW_ID to finding.workflowId,
         "review_pass_number" to finding.reviewPassNumber,
         "finding_ordinal" to finding.findingOrdinal,
         "severity" to finding.severity,
-        "issue_category" to finding.issueCategory,
+        ReviewFindingPayloadKeys.ISSUE_CATEGORY to finding.issueCategory,
         "location" to finding.location,
-        "summary" to finding.summary,
-        "claim_verdict" to finding.claimVerdict?.wireValue,
-        "scope_disposition" to finding.scopeDisposition?.wireValue,
-        "citations" to finding.citations.map { citation ->
+        SharedPayloadKeys.SUMMARY to finding.summary,
+        ReviewFindingPayloadKeys.CLAIM_VERDICT to finding.claimVerdict?.wireValue,
+        ReviewFindingPayloadKeys.SCOPE_DISPOSITION to finding.scopeDisposition?.wireValue,
+        ReviewFindingPayloadKeys.CITATIONS to finding.citations.map { citation ->
           linkedMapOf("path" to citation.path, "line" to citation.line)
         },
-        "severity_adjustment" to finding.severityAdjustment?.let { adjustment ->
+        ReviewFindingPayloadKeys.SEVERITY_ADJUSTMENT to finding.severityAdjustment?.let { adjustment ->
           linkedMapOf(
             "direction" to adjustment.direction.wireValue,
             "justification" to adjustment.justification,
@@ -321,13 +327,13 @@ class GoalFindingsCommand(
     },
     "repair_ledger" to repairLedgers.map { (workflowId, repairLedger) ->
       linkedMapOf<String, Any?>(
-        "workflow_id" to workflowId,
+        SharedPayloadKeys.WORKFLOW_ID to workflowId,
         "entries" to repairLedger.entries.map(FeatureTaskRuntimeRepairLedgerEntry::toProjectionMap),
       )
     },
     "finding_verification_dispositions" to verificationDispositions.map { disposition ->
       linkedMapOf(
-        "finding_id" to disposition.findingId,
+        ReviewFindingPayloadKeys.FINDING_ID to disposition.findingId,
         "disposition" to disposition.disposition.wireValue,
         "reason" to disposition.reason,
         "boundary_context_unavailable" to disposition.boundaryContextUnavailable,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.goal
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
@@ -13,6 +11,7 @@ import me.tatarka.inject.annotations.Inject
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.issuekey.MAX_ISSUE_KEY_LENGTH
 import skillbill.contracts.issuekey.isWellFormedIssueKey
 import skillbill.engine.goalrunner.GoalRunnerStatusService

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
@@ -208,8 +210,8 @@ class GoalWatchCommand(
       }
     }
     val payload = linkedMapOf<String, Any?>(
-      "status" to latestRefresh.get("status"),
-      "issue_key" to issueKey,
+      SharedPayloadKeys.STATUS to latestRefresh.get(SharedPayloadKeys.STATUS),
+      SharedPayloadKeys.ISSUE_KEY to issueKey,
       "refresh_count" to refreshCount,
       "interval_seconds" to intervalSeconds,
       "latest_refresh" to latestRefresh,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusFormatting.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusFormatting.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.cli.kernel.detectInvokingAgentId
 import skillbill.cli.model.CliRunInputs
 import skillbill.engine.goalrunner.model.GoalRunnerStatusRequest
@@ -52,8 +54,8 @@ internal fun CliRunInputs.goalStatusRequest(options: GoalStatusCliRequestOptions
 
 internal fun GoalRunnerStatusProjection?.toGoalStatusCliMap(issueKey: String): Map<String, Any?> = this?.let {
   linkedMapOf<String, Any?>(
-    "status" to "ok",
-    "issue_key" to it.issueKey,
+    SharedPayloadKeys.STATUS to "ok",
+    SharedPayloadKeys.ISSUE_KEY to it.issueKey,
     "complete_count" to it.completeCount,
     "pending_count" to it.pendingCount,
     "blocked_count" to it.blockedCount,
@@ -88,8 +90,8 @@ internal fun GoalRunnerStatusProjection?.toGoalStatusCliMap(issueKey: String): M
     it.outOfBandAcceptances.toGoalAcceptanceCliList()?.let { list -> put("out_of_band_acceptances", list) }
   }
 } ?: linkedMapOf(
-  "status" to "not_found",
-  "issue_key" to issueKey,
+  SharedPayloadKeys.STATUS to "not_found",
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "complete_count" to 0,
   "pending_count" to 0,
   "blocked_count" to 0,
@@ -115,15 +117,15 @@ internal fun GoalRunnerStatusProjection?.toBoundedGoalStatusCliMap(issueKey: Str
     "resumable_state" to it.monitorResumableState(),
   )
 } ?: linkedMapOf(
-  "status" to "not_found",
-  "issue_key" to singleLineBounded(issueKey),
+  SharedPayloadKeys.STATUS to "not_found",
+  SharedPayloadKeys.ISSUE_KEY to singleLineBounded(issueKey),
   "resumable_state" to "not_found",
 )
 
 internal fun databaseUnavailableGoalStatusCliMap(issueKey: String, error: DatabaseAccessError): Map<String, Any?> =
   linkedMapOf(
-    "status" to GOAL_STATUS_DATABASE_UNAVAILABLE,
-    "issue_key" to singleLineBounded(issueKey),
+    SharedPayloadKeys.STATUS to GOAL_STATUS_DATABASE_UNAVAILABLE,
+    SharedPayloadKeys.ISSUE_KEY to singleLineBounded(issueKey),
     "resumable_state" to GOAL_STATUS_DATABASE_UNAVAILABLE,
     "reason" to singleLineBounded(error.condition),
   )
@@ -153,7 +155,7 @@ internal fun List<GoalRunnerAcceptedSubtask>.toGoalAcceptanceCliList(): List<Map
   it.isNotEmpty()
 }?.map { acceptance ->
   linkedMapOf(
-    "subtask_id" to acceptance.subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to acceptance.subtaskId,
     "commit_sha" to acceptance.commitSha,
     "reason" to acceptance.reason,
     "accepted_at" to acceptance.acceptedAt,
@@ -161,8 +163,8 @@ internal fun List<GoalRunnerAcceptedSubtask>.toGoalAcceptanceCliList(): List<Map
 }
 
 internal fun goalStatusText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal: ${payload["issue_key"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("complete: ${payload["complete_count"]}")
   appendLine("pending: ${payload["pending_count"]}")
   appendLine("blocked: ${payload["blocked_count"]}")
@@ -200,15 +202,15 @@ private fun planningWaveText(waveSize: Int): String = when (waveSize) {
   else -> " wave=$waveSize subtasks"
 }
 
-internal fun goalMonitorStatusText(payload: Map<String, Any?>): String = if (payload["status"] == "not_found") {
+internal fun goalMonitorStatusText(payload: Map<String, Any?>): String = if (payload[SharedPayloadKeys.STATUS] == "not_found") {
   buildString {
-    appendLine("goal: ${payload["issue_key"]}")
+    appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
     appendLine("status: not_found")
     appendLine("resumable_state: not_found")
   }
-} else if (payload["status"] == GOAL_STATUS_DATABASE_UNAVAILABLE) {
+} else if (payload[SharedPayloadKeys.STATUS] == GOAL_STATUS_DATABASE_UNAVAILABLE) {
   buildString {
-    appendLine("goal: ${payload["issue_key"]}")
+    appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
     appendLine("status: $GOAL_STATUS_DATABASE_UNAVAILABLE")
     appendLine("resumable_state: $GOAL_STATUS_DATABASE_UNAVAILABLE")
     appendLine("reason: ${payload["reason"]}")

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusFormatting.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusFormatting.kt
@@ -1,9 +1,8 @@
 package skillbill.cli.goal
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.cli.kernel.detectInvokingAgentId
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.goalrunner.model.GoalRunnerStatusRequest
 import skillbill.error.DatabaseAccessError
 import skillbill.goalrunner.model.ExecutionLiveness
@@ -202,27 +201,28 @@ private fun planningWaveText(waveSize: Int): String = when (waveSize) {
   else -> " wave=$waveSize subtasks"
 }
 
-internal fun goalMonitorStatusText(payload: Map<String, Any?>): String = if (payload[SharedPayloadKeys.STATUS] == "not_found") {
-  buildString {
-    appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
-    appendLine("status: not_found")
-    appendLine("resumable_state: not_found")
+internal fun goalMonitorStatusText(payload: Map<String, Any?>): String =
+  if (payload[SharedPayloadKeys.STATUS] == "not_found") {
+    buildString {
+      appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+      appendLine("status: not_found")
+      appendLine("resumable_state: not_found")
+    }
+  } else if (payload[SharedPayloadKeys.STATUS] == GOAL_STATUS_DATABASE_UNAVAILABLE) {
+    buildString {
+      appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+      appendLine("status: $GOAL_STATUS_DATABASE_UNAVAILABLE")
+      appendLine("resumable_state: $GOAL_STATUS_DATABASE_UNAVAILABLE")
+      appendLine("reason: ${payload["reason"]}")
+    }
+  } else {
+    buildString {
+      appendLine("complete: ${payload["complete_count"]}")
+      appendLine("pending: ${payload["pending_count"]}")
+      appendLine("blocked: ${payload["blocked_count"]}")
+      appendLine("current_subtask: ${payload["current_subtask"] ?: "none"}")
+      appendLine("current_step: ${payload["current_step"] ?: "none"}")
+      appendLine("execution_liveness: ${payload["execution_liveness"]}")
+      appendLine("resumable_state: ${payload["resumable_state"]}")
+    }
   }
-} else if (payload[SharedPayloadKeys.STATUS] == GOAL_STATUS_DATABASE_UNAVAILABLE) {
-  buildString {
-    appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
-    appendLine("status: $GOAL_STATUS_DATABASE_UNAVAILABLE")
-    appendLine("resumable_state: $GOAL_STATUS_DATABASE_UNAVAILABLE")
-    appendLine("reason: ${payload["reason"]}")
-  }
-} else {
-  buildString {
-    appendLine("complete: ${payload["complete_count"]}")
-    appendLine("pending: ${payload["pending_count"]}")
-    appendLine("blocked: ${payload["blocked_count"]}")
-    appendLine("current_subtask: ${payload["current_subtask"] ?: "none"}")
-    appendLine("current_step: ${payload["current_step"] ?: "none"}")
-    appendLine("execution_liveness: ${payload["execution_liveness"]}")
-    appendLine("resumable_state: ${payload["resumable_state"]}")
-  }
-}

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusTextLines.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliStatusTextLines.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 internal fun StringBuilder.appendOperatorSurfaceLines(payload: Map<*, *>) {
   val blockedAttemptCount = (payload["blocked_attempt_count"] as? Number)?.toInt() ?: 0
   val supervisorKillCount = (payload["supervisor_kill_count"] as? Number)?.toInt() ?: 0
@@ -19,7 +21,7 @@ internal fun StringBuilder.appendOperatorSurfaceLines(payload: Map<*, *>) {
   (payload["out_of_band_acceptances"] as? List<*>)?.takeIf(List<*>::isNotEmpty)?.forEach { raw ->
     val acceptance = raw as? Map<*, *> ?: return@forEach
     appendLine(
-      "accepted_out_of_band: subtask=${acceptance["subtask_id"]} commit=${acceptance["commit_sha"]} " +
+      "accepted_out_of_band: subtask=${acceptance[SharedPayloadKeys.SUBTASK_ID]} commit=${acceptance["commit_sha"]} " +
         "at=${acceptance["accepted_at"]} reason=${acceptance["reason"]}",
     )
   }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliWatchPresentation.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalCliWatchPresentation.kt
@@ -1,11 +1,13 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 internal fun Map<String, Any?>.withWatchRefresh(refreshIndex: Int): Map<String, Any?> =
   linkedMapOf<String, Any?>("refresh_index" to refreshIndex).apply { putAll(this@withWatchRefresh) }
 
 internal fun Map<String, Any?>.goalWatchStopReason(refreshCount: Int, maxRefreshes: Int, idleStop: Boolean): String? =
   when {
-    this["status"] == "not_found" -> "not_found"
+    this[SharedPayloadKeys.STATUS] == "not_found" -> "not_found"
     // Only a reached pause is terminal. `pause_requested` is deferred to the next launch boundary, so
     // the current subtask keeps running; stopping on the request blinds the monitor for the rest of it.
     this["paused"] == true -> "goal_paused"
@@ -16,8 +18,8 @@ internal fun Map<String, Any?>.goalWatchStopReason(refreshCount: Int, maxRefresh
   }
 
 internal fun goalWatchText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal: ${payload["issue_key"]}")
-  appendLine("status: ${payload["status"]}")
+  appendLine("goal: ${payload[SharedPayloadKeys.ISSUE_KEY]}")
+  appendLine("status: ${payload[SharedPayloadKeys.STATUS]}")
   appendLine("refresh_count: ${payload["refresh_count"]}")
   appendLine("interval_seconds: ${payload["interval_seconds"]}")
   appendLine("stop_reason: ${payload["stop_reason"]}")
@@ -27,7 +29,7 @@ internal fun goalWatchText(payload: Map<String, Any?>): String = buildString {
 
 internal fun goalWatchRefreshText(refresh: Map<*, *>): String = buildString {
   appendLine(
-    "watch_refresh: index=${refresh["refresh_index"]} status=${refresh["status"]} " +
+    "watch_refresh: index=${refresh["refresh_index"]} status=${refresh[SharedPayloadKeys.STATUS]} " +
       "current_subtask=${refresh["current_subtask"] ?: "none"} " +
       "current_step=${refresh["current_step"] ?: "none"} " +
       "execution_liveness=${refresh["execution_liveness"] ?: "unknown"} " +

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalRunPresenter.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalRunPresenter.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.cli.model.CliRunInputs
 import skillbill.contracts.system.RuntimeProvenanceContract
 import skillbill.engine.goalrunner.model.GoalRunnerEventSink
@@ -52,8 +54,8 @@ class GoalRunPresenter(
 
 internal fun GoalRunnerRunReport.toGoalRunCliMap(): Map<String, Any?> = when (this) {
   is GoalRunnerRunReport.Completed -> linkedMapOf(
-    "status" to "complete",
-    "issue_key" to issueKey,
+    SharedPayloadKeys.STATUS to "complete",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "feature_name" to featureName,
     "attempted_subtasks" to attemptedSubtasks,
     "subtasks_completed" to subtasksCompleted,
@@ -65,20 +67,20 @@ internal fun GoalRunnerRunReport.toGoalRunCliMap(): Map<String, Any?> = when (th
     "pull_request_url" to pullRequestUrl,
   )
   is GoalRunnerRunReport.Stopped -> linkedMapOf(
-    "status" to "stopped",
-    "issue_key" to issueKey,
+    SharedPayloadKeys.STATUS to "stopped",
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "attempted_subtasks" to attemptedSubtasks,
-    "subtask_id" to stop.subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to stop.subtaskId,
     "reason" to stop.reason.name.lowercase(),
     "blocked_reason" to stop.blockedReason,
-    "workflow_id" to stop.workflowId,
+    SharedPayloadKeys.WORKFLOW_ID to stop.workflowId,
     "last_resumable_step" to stop.lastResumableStep,
   )
 }
 
 internal fun GoalRunnerPauseResult.toGoalPauseCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to status,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.STATUS to status,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "parent_workflow_id" to parentWorkflowId,
   "paused" to paused,
   "pause_requested" to pauseRequested,
@@ -86,13 +88,13 @@ internal fun GoalRunnerPauseResult.toGoalPauseCliMap(): Map<String, Any?> = link
 )
 
 internal fun goalPauseText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal ${payload["issue_key"]}: ${payload["status"]}")
+  appendLine("goal ${payload[SharedPayloadKeys.ISSUE_KEY]}: ${payload[SharedPayloadKeys.STATUS]}")
   payload["pause_reason"]?.let { appendLine("reason: $it") }
 }
 
 internal fun GoalRunnerStopVerbResult.toGoalStopCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to status.wireValue,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.STATUS to status.wireValue,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "parent_workflow_id" to parentWorkflowId,
   "pause_reason" to pauseReason,
   "paused_at" to pausedAt,
@@ -100,14 +102,14 @@ internal fun GoalRunnerStopVerbResult.toGoalStopCliMap(): Map<String, Any?> = li
 )
 
 internal fun goalStopText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal ${payload["issue_key"]}: ${payload["status"]}")
+  appendLine("goal ${payload[SharedPayloadKeys.ISSUE_KEY]}: ${payload[SharedPayloadKeys.STATUS]}")
   payload["pause_reason"]?.let { appendLine("reason: $it") }
   payload["paused_at"]?.let { appendLine("paused at: $it") }
 }
 
 internal fun GoalRunnerResumeResult.toGoalResumeCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to status,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.STATUS to status,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "parent_workflow_id" to parentWorkflowId,
   "paused" to false,
   "pause_requested" to false,
@@ -115,13 +117,13 @@ internal fun GoalRunnerResumeResult.toGoalResumeCliMap(): Map<String, Any?> = li
 )
 
 internal fun goalResumeText(payload: Map<String, Any?>): String = buildString {
-  appendLine("goal ${payload["issue_key"]}: ${payload["status"]}")
+  appendLine("goal ${payload[SharedPayloadKeys.ISSUE_KEY]}: ${payload[SharedPayloadKeys.STATUS]}")
   payload["cleared_pause_reason"]?.let { appendLine("cleared reason: $it") }
 }
 
-internal fun goalRunText(payload: Map<String, Any?>): String = when (payload["status"]) {
+internal fun goalRunText(payload: Map<String, Any?>): String = when (payload[SharedPayloadKeys.STATUS]) {
   "complete" -> buildString {
-    appendLine("goal ${payload["issue_key"]}: finished")
+    appendLine("goal ${payload[SharedPayloadKeys.ISSUE_KEY]}: finished")
     append("summary: ")
     append(singleLineBounded(payload["feature_name"]?.toString().orEmpty().ifBlank { "goal" }))
     append(" — ")
@@ -149,8 +151,8 @@ internal fun goalRunText(payload: Map<String, Any?>): String = when (payload["st
       reason.contains("failed") || reason.contains("timeout") -> "failed"
       else -> "blocked"
     }
-    append("goal ${payload["issue_key"]}: $verb")
-    payload["subtask_id"]?.let { append(" at subtask $it") }
+    append("goal ${payload[SharedPayloadKeys.ISSUE_KEY]}: $verb")
+    payload[SharedPayloadKeys.SUBTASK_ID]?.let { append(" at subtask $it") }
     append(" — ")
     append(singleLineBounded(payload["blocked_reason"]?.toString() ?: reason.ifBlank { "terminal outcome" }))
     appendLine()

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalRunPresenter.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/goal/GoalRunPresenter.kt
@@ -1,8 +1,7 @@
 package skillbill.cli.goal
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.system.RuntimeProvenanceContract
 import skillbill.engine.goalrunner.model.GoalRunnerEventSink
 import skillbill.engine.goalrunner.model.GoalRunnerPauseResult

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallApplyExternalAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallApplyExternalAddonsCommand.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.install
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import me.tatarka.inject.annotations.Inject
@@ -9,6 +7,7 @@ import skillbill.application.install.ExternalAddonOverlayService
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.ShellContentContractException
 import java.nio.file.Path
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallApplyExternalAddonsCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallApplyExternalAddonsCommand.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.install
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import me.tatarka.inject.annotations.Inject
@@ -40,7 +42,7 @@ class InstallApplyExternalAddonsCommand(
     } catch (error: ShellContentContractException) {
       state.completeText(
         "${error.message}\n",
-        mapOf("status" to "failed", "error" to error.message.orEmpty()),
+        mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty()),
         exitCode = 1,
       )
       return
@@ -48,7 +50,7 @@ class InstallApplyExternalAddonsCommand(
     if (result.appliedSources.isEmpty() && result.skippedSources.isEmpty()) {
       state.completeText(
         "no external addon sources\n",
-        mapOf("status" to "ok", "touched" to false),
+        mapOf(SharedPayloadKeys.STATUS to "ok", "touched" to false),
       )
       return
     }
@@ -61,7 +63,7 @@ class InstallApplyExternalAddonsCommand(
     state.completeText(
       applied + skipped,
       mapOf(
-        "status" to "ok",
+        SharedPayloadKeys.STATUS to "ok",
         "touched" to result.touched,
         "applied" to result.appliedSources.map { it.platform },
         "skipped" to result.skippedSources.map { it.platform },

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliApplyPayloads.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliApplyPayloads.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.install
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.install.InstallService
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallAgentSkillLinkOutcome
@@ -17,7 +19,7 @@ internal fun installApplyPayload(
   result: InstallApplyResult,
   installService: InstallService,
 ): Map<String, Any?> = installPlanPayload(plan, installService) + mapOf(
-  "status" to result.status.name.lowercase(),
+  SharedPayloadKeys.STATUS to result.status.name.lowercase(),
   "skills" to result.skills.map(::appliedSkillPayload),
   "native_agents" to result.nativeAgents.map(::nativeAgentPayload),
   "telemetry" to telemetryPayload(result.telemetryOutcome),
@@ -37,7 +39,7 @@ private fun appliedSkillPayload(skill: InstallAppliedSkill): Map<String, Any?> =
 )
 
 private fun stagingOutcomePayload(staging: InstallSkillStagingOutcome): Map<String, Any?> = mapOf(
-  "status" to staging.status.name.lowercase(),
+  SharedPayloadKeys.STATUS to staging.status.name.lowercase(),
   "staging_dir" to staging.stagingDir?.toString(),
   "rendered_skill_file" to staging.renderedSkillFile?.toString(),
   "content_hash" to staging.contentHash,
@@ -49,7 +51,7 @@ private fun agentSkillLinkPayload(link: InstallAgentSkillLinkOutcome): Map<Strin
   "target_dir" to link.targetDir.toString(),
   "link_path" to link.linkPath.toString(),
   "link_target" to link.linkTarget.toString(),
-  "status" to link.status.name.lowercase(),
+  SharedPayloadKeys.STATUS to link.status.name.lowercase(),
   "message" to link.message,
   "issue" to link.issue?.let(::issuePayload),
 )
@@ -57,7 +59,7 @@ private fun agentSkillLinkPayload(link: InstallAgentSkillLinkOutcome): Map<Strin
 private fun nativeAgentPayload(native: NativeAgentApplyOutcome): Map<String, Any?> = mapOf(
   "provider" to native.provider.id,
   "agent" to native.agent.id,
-  "status" to native.status.name.lowercase(),
+  SharedPayloadKeys.STATUS to native.status.name.lowercase(),
   "path" to native.path?.toString(),
   "message" to native.message,
   "issue" to native.issue?.let(::issuePayload),
@@ -65,7 +67,7 @@ private fun nativeAgentPayload(native: NativeAgentApplyOutcome): Map<String, Any
 
 private fun telemetryPayload(outcome: InstallTelemetryApplyOutcome): Map<String, Any?> = mapOf(
   "level" to outcome.level.id,
-  "status" to outcome.status.name.lowercase(),
+  SharedPayloadKeys.STATUS to outcome.status.name.lowercase(),
   "config_path" to outcome.configPath?.toString(),
   "cleared_events" to outcome.clearedEvents,
   "message" to outcome.message,
@@ -79,7 +81,7 @@ private fun applyMcpRegistrationPayload(result: InstallApplyResult): Map<String,
   "outcomes" to result.mcpRegistrationOutcomes.map { outcome ->
     mapOf(
       "agent" to outcome.agent.id,
-      "status" to outcome.status.name.lowercase(),
+      SharedPayloadKeys.STATUS to outcome.status.name.lowercase(),
       "config_path" to outcome.configPath?.toString(),
       "changed" to outcome.changed,
       "message" to outcome.message,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliApplyPayloads.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliApplyPayloads.kt
@@ -1,8 +1,7 @@
 package skillbill.cli.install
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.install.InstallService
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.InstallAgentSkillLinkOutcome
 import skillbill.install.model.InstallAppliedSkill

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliMutations.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliMutations.kt
@@ -1,9 +1,8 @@
 package skillbill.cli.install
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.install.model.NativeAgentLinkOutcome
 import java.nio.file.Path
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliMutations.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallCliMutations.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.install
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.model.CliRunInputs
 import skillbill.ports.install.model.NativeAgentLinkOutcome
@@ -21,7 +23,7 @@ internal fun CliRunState.refuseInstallMutationDuringGoalContinuation(
   completeText(
     "$message\n",
     mapOf(
-      "status" to "error",
+      SharedPayloadKeys.STATUS to "error",
       "error" to message,
       "exit_code" to GOAL_CONTINUATION_INSTALL_REFUSAL_EXIT_CODE,
     ),

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallReconcilePayloads.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallReconcilePayloads.kt
@@ -1,7 +1,6 @@
 package skillbill.cli.install
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.install.model.ReconciliationPlan
 import skillbill.install.model.SkillReconciliationOutcome
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallReconcilePayloads.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/install/InstallReconcilePayloads.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.install
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.install.model.ReconciliationPlan
 import skillbill.install.model.SkillReconciliationOutcome
 
@@ -16,7 +18,7 @@ internal fun reconcilePayload(
   installedPaths: List<String> = emptyList(),
   prunedPaths: List<String> = emptyList(),
 ): Map<String, Any?> = mapOf(
-  "status" to "ok",
+  SharedPayloadKeys.STATUS to "ok",
   "applied" to applied,
   "baseline_refreshed" to refreshed,
   "installed_paths" to installedPaths,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/AgentAddonSelectionParsing.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/AgentAddonSelectionParsing.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.kernel
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.core.UsageError
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
@@ -11,7 +13,7 @@ internal fun parseAgentAddonSelection(raw: String?): AgentAddonSelection {
     ?: invalidAgentAddonSelection("--agent-addon-selection-json must be a JSON object.")
   val map = JsonCodec.anyToStringAnyMap(JsonCodec.jsonElementToValue(root))
     ?: invalidAgentAddonSelection("--agent-addon-selection-json must decode to an object.")
-  if (map.keys != setOf("contract_version", "entries") || map["contract_version"] != "0.1") {
+  if (map.keys != setOf("contract_version", "entries") || map[SharedPayloadKeys.CONTRACT_VERSION] != "0.1") {
     invalidAgentAddonSelection("Agent add-on selection must contain only contract_version=0.1 and entries.")
   }
   val entries = map["entries"] as? List<*>

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/AgentAddonSelectionParsing.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/AgentAddonSelectionParsing.kt
@@ -1,11 +1,10 @@
 package skillbill.cli.kernel
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.core.UsageError
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 
 internal fun parseAgentAddonSelection(raw: String?): AgentAddonSelection {
   if (raw == null) return AgentAddonSelection()

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/WorkflowUpdateCliPayload.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/WorkflowUpdateCliPayload.kt
@@ -1,9 +1,8 @@
 package skillbill.cli.kernel
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.application.workflow.model.WorkflowUpdateResult
+import skillbill.contracts.SharedPayloadKeys
 
 /**
  * Wire shape for every workflow-mutating CLI command, whichever command area owns it. The key order

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/WorkflowUpdateCliPayload.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/kernel/WorkflowUpdateCliPayload.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.kernel
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.application.workflow.model.WorkflowUpdateResult
 
@@ -20,8 +22,8 @@ internal fun WorkflowUpdateResult.toPayload(): Map<String, Any?> = when (this) {
     put("db_path", dbPath)
   }
   is WorkflowUpdateResult.Error -> linkedMapOf<String, Any?>(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
   ).apply { dbPath?.let { put("db_path", it) } }
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.repovalidation
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
@@ -90,7 +92,7 @@ class ValidateReleaseRefCommand(
     if (rawRef == null) {
       state.completeText(
         "No release ref supplied. Pass a tag or set GITHUB_REF_NAME.\n",
-        mapOf("status" to "failed", "error" to "No release ref supplied. Pass a tag or set GITHUB_REF_NAME."),
+        mapOf(SharedPayloadKeys.STATUS to "failed", "error" to "No release ref supplied. Pass a tag or set GITHUB_REF_NAME."),
         exitCode = 1,
       )
       return
@@ -99,7 +101,7 @@ class ValidateReleaseRefCommand(
     val metadata = try {
       repoValidationGateway.validateReleaseRef(Path.of(repoRoot), rawRef, forcePrerelease)
     } catch (error: IllegalArgumentException) {
-      val payload = mapOf("status" to "failed", "error" to error.message.orEmpty())
+      val payload = mapOf(SharedPayloadKeys.STATUS to "failed", "error" to error.message.orEmpty())
       if (format == CliFormat.JSON) {
         state.complete(payload, format, exitCode = 1)
       } else {

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/repovalidation/RepoValidationCliCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.repovalidation
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
@@ -13,6 +11,7 @@ import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.kernel.formatOption
 import skillbill.cli.model.CliFormat
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.validation.RepoValidationGateway
 import java.nio.file.Path
 
@@ -92,7 +91,10 @@ class ValidateReleaseRefCommand(
     if (rawRef == null) {
       state.completeText(
         "No release ref supplied. Pass a tag or set GITHUB_REF_NAME.\n",
-        mapOf(SharedPayloadKeys.STATUS to "failed", "error" to "No release ref supplied. Pass a tag or set GITHUB_REF_NAME."),
+        mapOf(
+          SharedPayloadKeys.STATUS to "failed",
+          "error" to "No release ref supplied. Pass a tag or set GITHUB_REF_NAME.",
+        ),
         exitCode = 1,
       )
       return

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldAuthoringCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldAuthoringCliCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.scaffold
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
@@ -14,6 +12,7 @@ import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.kernel.formatOption
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.scaffold.ScaffoldGateway
 import skillbill.ports.scaffold.UnsupportedScaffoldGateway
 import java.nio.file.Path
@@ -107,7 +106,10 @@ class ValidateSkillCommand(
 
   override fun run() {
     state.result =
-      authoringResult(format, successExitCode = { payload -> if (payload[SharedPayloadKeys.STATUS] == "pass") 0 else 1 }) {
+      authoringResult(
+        format,
+        successExitCode = { payload -> if (payload[SharedPayloadKeys.STATUS] == "pass") 0 else 1 },
+      ) {
         scaffoldGateway.validate(Path.of(repoRoot), skillNames).toCliMap()
       }
   }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldAuthoringCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldAuthoringCliCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.scaffold
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
@@ -105,7 +107,7 @@ class ValidateSkillCommand(
 
   override fun run() {
     state.result =
-      authoringResult(format, successExitCode = { payload -> if (payload["status"] == "pass") 0 else 1 }) {
+      authoringResult(format, successExitCode = { payload -> if (payload[SharedPayloadKeys.STATUS] == "pass") 0 else 1 }) {
         scaffoldGateway.validate(Path.of(repoRoot), skillNames).toCliMap()
       }
   }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliPayloadRuns.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliPayloadRuns.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.scaffold
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.install.ExternalAddonOverlayService
 import skillbill.cli.kernel.CliOutput
 import skillbill.cli.kernel.CliRunState
@@ -51,7 +53,7 @@ internal fun runNativeScaffoldPayload(payload: Map<String, *>, run: NativeScaffo
   val created = result.run { createdFiles }.map { path -> path.toString() }
   val presentation =
     mapOf(
-      "status" to "ok",
+      SharedPayloadKeys.STATUS to "ok",
       "session_id" to sessionId,
       "skill_path" to result.skillPath.toString(),
       "dry_run" to dryRun,
@@ -126,7 +128,7 @@ internal fun registerExternalAddonSourceAfterSuccess(
 internal fun errorResult(message: String, format: CliFormat): CliExecutionResult {
   val presentation =
     mapOf(
-      "status" to "error",
+      SharedPayloadKeys.STATUS to "error",
       "error" to message,
     )
   return CliExecutionResult(
@@ -183,7 +185,7 @@ internal fun ScaffoldRenderResult.toCliPayload(dryRun: Boolean): Map<String, Any
 internal fun unsupportedNativeScaffoldResult(message: String, format: CliFormat): CliExecutionResult {
   val presentation =
     mapOf(
-      "status" to "unsupported",
+      SharedPayloadKeys.STATUS to "unsupported",
       "error" to message,
     )
   return CliExecutionResult(

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliPayloadRuns.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliPayloadRuns.kt
@@ -1,13 +1,12 @@
 package skillbill.cli.scaffold
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.install.ExternalAddonOverlayService
 import skillbill.cli.kernel.CliOutput
 import skillbill.cli.kernel.CliRunState
 import skillbill.cli.model.CliExecutionResult
 import skillbill.cli.model.CliFormat
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.SkillBillRuntimeException
 import skillbill.install.model.ExternalAddonSource
 import skillbill.ports.repository.toFileLocation

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliResultMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.scaffold
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.cli.kernel.CliOutput
 import skillbill.ports.scaffold.catalog.model.ScaffoldExplainResult
 import skillbill.ports.scaffold.catalog.model.ScaffoldListResult
@@ -55,7 +57,7 @@ internal fun ScaffoldValidateResult.toCliMap(): Map<String, Any?> {
   if (mode == ScaffoldValidationMode.SELECTED) {
     map["skill_names"] = skillNames ?: emptyList<String>()
   }
-  map["status"] = status.wireValue
+  map[SharedPayloadKeys.STATUS] = status.wireValue
   map["issues"] = issues
   if (mode == ScaffoldValidationMode.SELECTED) {
     map["suggested_commands"] = suggestedCommands ?: emptyList<String>()

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliResultMappers.kt
@@ -1,8 +1,7 @@
 package skillbill.cli.scaffold
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.cli.kernel.CliOutput
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.scaffold.catalog.model.ScaffoldExplainResult
 import skillbill.ports.scaffold.catalog.model.ScaffoldListResult
 import skillbill.ports.scaffold.catalog.model.ScaffoldShowResult

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliWireMaps.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliWireMaps.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.scaffold
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.ports.scaffold.catalog.model.ScaffoldExplainSkill
 import skillbill.ports.scaffold.model.ScaffoldReviewComposition
 import skillbill.ports.scaffold.model.ScaffoldSectionStatus
@@ -49,14 +51,14 @@ internal fun ScaffoldSkillStatus.toWireMap(): Map<String, Any?> {
 
 internal fun ScaffoldSectionStatus.toWireMap(): Map<String, Any?> = linkedMapOf(
   "heading" to heading,
-  "status" to status.wireValue,
+  SharedPayloadKeys.STATUS to status.wireValue,
   "line_count" to lineCount,
   "preview" to preview,
 )
 
 internal fun ScaffoldReviewComposition.toWireMap(): Map<String, Any?> = linkedMapOf(
   "source" to source,
-  "summary" to summary,
+  SharedPayloadKeys.SUMMARY to summary,
   "baseline_layers" to baselineLayers.map { layer ->
     linkedMapOf<String, Any?>(
       "platform" to layer.platform,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliWireMaps.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/scaffold/ScaffoldCliWireMaps.kt
@@ -1,7 +1,6 @@
 package skillbill.cli.scaffold
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.ports.scaffold.catalog.model.ScaffoldExplainSkill
 import skillbill.ports.scaffold.model.ScaffoldReviewComposition
 import skillbill.ports.scaffold.model.ScaffoldSectionStatus

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/skillremove/RemoveCliCommandExecution.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/skillremove/RemoveCliCommandExecution.kt
@@ -1,6 +1,7 @@
 
 package skillbill.cli.skillremove
 
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.cli.kernel.CliOutput
 import skillbill.cli.model.CliExecutionResult
 import skillbill.cli.model.CliFormat
@@ -85,7 +86,7 @@ internal fun refusalErrorMessage(
 
 internal fun previewResult(preview: SkillRemovalResult.Preview, format: CliFormat): CliExecutionResult {
   val payload = mapOf(
-    "status" to "preview",
+    SharedPayloadKeys.STATUS to "preview",
     "filesystem_paths" to preview.preview.filesystemPaths,
     "manifest_edits" to preview.preview.manifestEdits.map {
       mapOf("manifest" to it.manifestPath, "kind" to it.editKind.name, "detail" to it.detail)
@@ -104,7 +105,7 @@ internal fun previewResult(preview: SkillRemovalResult.Preview, format: CliForma
 
 internal fun successResult(success: SkillRemovalResult.Success, format: CliFormat): CliExecutionResult {
   val payload = mapOf(
-    "status" to "ok",
+    SharedPayloadKeys.STATUS to "ok",
     "removed_paths" to success.removedPaths,
     "edited_manifests" to success.editedManifests,
     "unlinked_symlinks" to success.unlinkedSymlinks,
@@ -118,7 +119,7 @@ internal fun failedResult(
   format: CliFormat,
 ): CliExecutionResult {
   val payload = mapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "exception" to failed.exceptionName,
     "error" to SkillRemoveErrorSanitizer.sanitize(failed.exceptionMessage, repoRootAbsolutePath),
     "rollback_complete" to failed.rollbackComplete,
@@ -127,7 +128,7 @@ internal fun failedResult(
 }
 
 internal fun errorResult(message: String, format: CliFormat): CliExecutionResult {
-  val payload = mapOf("status" to "error", "error" to message)
+  val payload = mapOf(SharedPayloadKeys.STATUS to "error", "error" to message)
   return CliExecutionResult(exitCode = 1, stdout = CliOutput.emit(payload, format), payload = payload)
 }
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/skillremove/RemoveCliCommandExecution.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/skillremove/RemoveCliCommandExecution.kt
@@ -1,10 +1,10 @@
 
 package skillbill.cli.skillremove
 
-import skillbill.contracts.SharedPayloadKeys
 import skillbill.cli.kernel.CliOutput
 import skillbill.cli.model.CliExecutionResult
 import skillbill.cli.model.CliFormat
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.domain.skillremove.SkillRemovalRefusedException
 import skillbill.domain.skillremove.SkillRemoveErrorSanitizer
 import skillbill.domain.skillremove.model.SkillRemovalRefusalReason

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/SystemCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/SystemCliCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.system
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
@@ -20,6 +18,7 @@ import skillbill.cli.kernel.toPayload
 import skillbill.cli.model.CliExecutionResult
 import skillbill.cli.model.CliRunInputs
 import skillbill.cli.model.ExternalCommand
+import skillbill.contracts.SharedPayloadKeys
 
 @Inject
 class VersionCommand(

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/SystemCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/SystemCliCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.system
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
@@ -140,7 +142,7 @@ class UpdateCommand(
   }
 
   private fun UpdateCommandPlan.toPayload(status: String): Map<String, Any?> = linkedMapOf(
-    "status" to status,
+    SharedPayloadKeys.STATUS to status,
     "command" to command,
     "installer_args" to installerArgs,
   )
@@ -245,7 +247,7 @@ private fun UpdateCheckResult.toText(): String = buildString {
 }
 
 private fun UpdateCheckResult.toPayload(): Map<String, Any?> = linkedMapOf(
-  "status" to status.wireName,
+  SharedPayloadKeys.STATUS to status.wireName,
   "installed_version" to installedVersion,
   "latest_version" to latestVersion,
   "release_url" to releaseUrl,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/UninstallCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/UninstallCommand.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.system
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import me.tatarka.inject.annotations.Inject
@@ -40,7 +42,7 @@ class UninstallCommand(
           "Goal workers must preserve the active workflow store; uninstall after the goal completes."
       state.completeText(
         message,
-        mapOf("status" to "error", "error" to message, "exit_code" to GOAL_CONTINUATION_REFUSAL_EXIT_CODE),
+        mapOf(SharedPayloadKeys.STATUS to "error", "error" to message, "exit_code" to GOAL_CONTINUATION_REFUSAL_EXIT_CODE),
         exitCode = GOAL_CONTINUATION_REFUSAL_EXIT_CODE,
       )
       return
@@ -340,7 +342,7 @@ internal data class UninstallPlan(
     skipped: List<String>,
     warnings: List<String>,
   ): Map<String, Any?> = linkedMapOf(
-    "status" to status,
+    SharedPayloadKeys.STATUS to status,
     "state_root" to stateRoot.toString(),
     "skill_names" to skillNames,
     "legacy_names" to legacyNames,
@@ -381,7 +383,7 @@ internal data class UninstallResult(
   }
 
   fun toPayload(): Map<String, Any?> = linkedMapOf(
-    "status" to status,
+    SharedPayloadKeys.STATUS to status,
     "removed" to removed,
     "skipped" to skipped,
     "warnings" to warnings,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/UninstallCommand.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/system/UninstallCommand.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.system
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import me.tatarka.inject.annotations.Inject
@@ -11,6 +9,7 @@ import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.kernel.formatOption
 import skillbill.cli.model.CliRunInputs
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.diagnostics.RuntimeDiagnostics
 import skillbill.ports.install.mcp.InstallMcpRegistrationPort
 import skillbill.ports.install.nativeagent.InstallNativeAgentLinkPort
@@ -42,7 +41,11 @@ class UninstallCommand(
           "Goal workers must preserve the active workflow store; uninstall after the goal completes."
       state.completeText(
         message,
-        mapOf(SharedPayloadKeys.STATUS to "error", "error" to message, "exit_code" to GOAL_CONTINUATION_REFUSAL_EXIT_CODE),
+        mapOf(
+          SharedPayloadKeys.STATUS to "error",
+          "error" to message,
+          "exit_code" to GOAL_CONTINUATION_REFUSAL_EXIT_CODE,
+        ),
         exitCode = GOAL_CONTINUATION_REFUSAL_EXIT_CODE,
       )
       return

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/TelemetryCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/TelemetryCliResultMappers.kt
@@ -1,10 +1,9 @@
 package skillbill.cli.telemetry
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.telemetry.model.TelemetryMutationResult
 import skillbill.application.telemetry.model.TelemetryStatusResult
 import skillbill.application.telemetry.model.TelemetrySyncStatusResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.telemetry.model.TelemetryProxyCapabilities
 import skillbill.telemetry.model.TelemetryRemoteStatsResult
 

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/TelemetryCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/telemetry/TelemetryCliResultMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.telemetry
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.telemetry.model.TelemetryMutationResult
 import skillbill.application.telemetry.model.TelemetryStatusResult
 import skillbill.application.telemetry.model.TelemetrySyncStatusResult
@@ -56,7 +58,7 @@ internal fun TelemetryMutationResult.toCliMap(): Map<String, Any?> = linkedMapOf
 )
 
 internal fun TelemetryProxyCapabilities.toCliMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-  "contract_version" to contractVersion,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
   "source" to source,
   "proxy_url" to proxyUrl,
   "capabilities_url" to capabilitiesUrl,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/work/WorkCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/work/WorkCliCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.work
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -81,9 +83,9 @@ private fun WorkListResult.toPayload(): Map<String, Any?> = mapOf(
 )
 
 private fun WorkListItem.toPayload(): Map<String, Any?> = linkedMapOf(
-  "issue_key" to issueKey,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "workflow_kind" to workflowKind.wireValue,
-  "workflow_id" to workflowId,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
   "started_at" to startedAt.toString(),
   "current_state" to currentState,
   "state_entered_at" to stateEnteredAt.toString(),

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/work/WorkCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/work/WorkCliCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.work
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -17,6 +15,7 @@ import skillbill.cli.kernel.CliRunState
 import skillbill.cli.kernel.DocumentedCliCommand
 import skillbill.cli.kernel.DocumentedNoOpCliCommand
 import skillbill.cli.model.CliFormat
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.work.IdeStatusService
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliCommands.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
@@ -322,7 +324,7 @@ private fun parseArtifactsPatch(rawValue: String): Map<String, Any?> = JsonCodec
     emptyMap()
   }
 
-private fun Map<String, Any?>.exitCode(): Int = if (this["status"] == "error") 1 else 0
+private fun Map<String, Any?>.exitCode(): Int = if (this[SharedPayloadKeys.STATUS] == "error") 1 else 0
 
 private fun resolveWorkflowId(
   workflowId: String?,

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliCommands.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliCommands.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
@@ -25,6 +23,7 @@ import skillbill.cli.kernel.formatOption
 import skillbill.cli.kernel.toPayload
 import skillbill.cli.model.CliRunInputs
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.workflow.model.FeatureTaskRouteScope
 
 @Inject

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliResultMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.application.workflow.model.WorkflowGetResult
 import skillbill.application.workflow.model.WorkflowLatestResult
@@ -28,12 +30,12 @@ internal fun WorkflowOpenResult.toCliMap(
 ): Map<String, Any?> = when (this) {
   is WorkflowOpenResult.Ok -> workflowSnapshotCliMap(snapshot, goalObservabilityEventValidator).apply {
     launchProjection?.let { put("launch_projection", WorkflowWireProjections.inputProjectionMap(it)) }
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowOpenResult.Error -> linkedMapOf(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
   )
 }
@@ -42,19 +44,19 @@ internal fun WorkflowGetResult.toCliMap(
   goalObservabilityEventValidator: GoalObservabilityEventValidator,
 ): Map<String, Any?> = when (this) {
   is WorkflowGetResult.Ok -> workflowSnapshotCliMap(snapshot, goalObservabilityEventValidator).apply {
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowGetResult.Error -> linkedMapOf(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
     "db_path" to dbPath,
   )
 }
 
 internal fun WorkflowListResult.toCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "ok",
+  SharedPayloadKeys.STATUS to "ok",
   "db_path" to dbPath,
   "workflow_count" to workflowCount,
   "workflows" to workflows.map(WorkflowWireProjections::summaryMap),
@@ -62,11 +64,11 @@ internal fun WorkflowListResult.toCliMap(): Map<String, Any?> = linkedMapOf(
 
 internal fun WorkflowLatestResult.toCliMap(): Map<String, Any?> = when (this) {
   is WorkflowLatestResult.Ok -> LinkedHashMap(WorkflowWireProjections.summaryMap(summary)).apply {
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowLatestResult.Error -> linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "error" to error,
     "db_path" to dbPath,
   )
@@ -74,12 +76,12 @@ internal fun WorkflowLatestResult.toCliMap(): Map<String, Any?> = when (this) {
 
 internal fun WorkflowResumeResult.toCliMap(): Map<String, Any?> = when (this) {
   is WorkflowResumeResult.Ok -> LinkedHashMap(WorkflowWireProjections.resumeMap(resume)).apply {
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowResumeResult.Error -> linkedMapOf(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
     "db_path" to dbPath,
   )

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliResultMappers.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowCliResultMappers.kt
@@ -1,7 +1,5 @@
 package skillbill.cli.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.application.workflow.model.WorkflowGetResult
 import skillbill.application.workflow.model.WorkflowLatestResult
@@ -10,6 +8,7 @@ import skillbill.application.workflow.model.WorkflowOpenResult
 import skillbill.application.workflow.model.WorkflowResumeResult
 import skillbill.cli.kernel.CliOutput
 import skillbill.cli.kernel.CliRunState
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.goal.GoalObservabilityEventValidator
 
 /**

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsCore.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsCore.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.WorkflowContinueResult
 
 internal fun WorkflowContinueResult.toCliMap(): Map<String, Any?> = when (this) {
@@ -19,15 +21,15 @@ internal fun WorkflowContinueResult.Standard.toStandardCliMap(): Map<String, Any
   standardContinueMap(view, dbPath, decompositionExtras = emptyMap())
 
 internal fun WorkflowContinueResult.UnknownWorkflow.toUnknownWorkflowCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "error",
-  "workflow_id" to workflowId,
+  SharedPayloadKeys.STATUS to "error",
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
   "error" to "Unknown workflow_id '$workflowId'.",
   "db_path" to dbPath,
 )
 
 internal fun WorkflowContinueResult.Error.toErrorCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "error",
-  "workflow_id" to workflowId,
+  SharedPayloadKeys.STATUS to "error",
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
   "error" to error,
   "db_path" to dbPath,
 )

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsCore.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsCore.kt
@@ -1,8 +1,7 @@
 package skillbill.cli.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.WorkflowContinueResult
+import skillbill.contracts.SharedPayloadKeys
 
 internal fun WorkflowContinueResult.toCliMap(): Map<String, Any?> = when (this) {
   is WorkflowContinueResult.Standard -> toStandardCliMap()

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsDecomposition.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsDecomposition.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.GoalContinuationOutcome
 import skillbill.application.workflow.model.WorkflowContinueResult
 import skillbill.workflow.model.WorkflowContinueStatus
@@ -9,7 +11,7 @@ internal fun WorkflowContinueResult.DecompositionStandard.toDecompositionStandar
     view = view,
     dbPath = dbPath,
     decompositionExtras = linkedMapOf(
-      "issue_key" to (outcome?.issueKey ?: issueKey),
+      SharedPayloadKeys.ISSUE_KEY to (outcome?.issueKey ?: issueKey),
       "decomposition_subtask_id" to decompositionSubtaskId,
       "decomposition_subtask_spec_path" to decompositionSubtaskSpecPath,
       "goal_continuation_outcome" to outcome.toWireMap(),
@@ -19,9 +21,9 @@ internal fun WorkflowContinueResult.DecompositionStandard.toDecompositionStandar
 internal fun WorkflowContinueResult.DecompositionMissingSubtaskWorkflow.toDecompositionMissingSubtaskWorkflowCliMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "subtask_id" to subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
     "blocked_reason" to blockedReason,
     "db_path" to dbPath,
   )
@@ -29,10 +31,10 @@ internal fun WorkflowContinueResult.DecompositionMissingSubtaskWorkflow.toDecomp
 internal fun WorkflowContinueResult.DecompositionBlockedSubtask.toDecompositionBlockedSubtaskCliMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "decomposition_subtask_id" to subtaskId,
     "decomposition_subtask_spec_path" to subtaskSpecPath,
     "blocked_reason" to blockedReason,
@@ -43,19 +45,19 @@ internal fun WorkflowContinueResult.DecompositionBlockedSubtask.toDecompositionB
 internal fun WorkflowContinueResult.DecompositionBlockedBranchStart.toDecompositionBlockedBranchStartCliMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "error" to blockedReason,
     "db_path" to dbPath,
   )
 
 internal fun WorkflowContinueResult.DecompositionDone.toDecompositionDoneCliMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "ok",
+  SharedPayloadKeys.STATUS to "ok",
   "continue_status" to WorkflowContinueStatus.DONE.wireValue,
-  "workflow_id" to workflowId,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "decomposition_status" to decompositionStatus,
   "db_path" to dbPath,
 )
@@ -63,10 +65,10 @@ internal fun WorkflowContinueResult.DecompositionDone.toDecompositionDoneCliMap(
 internal fun WorkflowContinueResult.DecompositionSubtaskOutcome.toDecompositionSubtaskOutcomeCliMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "ok",
+    SharedPayloadKeys.STATUS to "ok",
     "continue_status" to WorkflowContinueStatus.DONE.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "decomposition_subtask_id" to subtaskId,
     "decomposition_subtask_spec_path" to subtaskSpecPath,
     "goal_continuation_outcome" to outcome.toWireMap(),
@@ -75,10 +77,10 @@ internal fun WorkflowContinueResult.DecompositionSubtaskOutcome.toDecompositionS
 
 internal fun WorkflowContinueResult.DecompositionBlockedGit.toDecompositionBlockedGitCliMap(): Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "blocked_reason" to blockedReason,
     "error" to blockedReason,
     "db_path" to dbPath,
@@ -86,11 +88,11 @@ internal fun WorkflowContinueResult.DecompositionBlockedGit.toDecompositionBlock
 
 internal fun GoalContinuationOutcome?.toWireMap(): Map<String, Any?> = this?.let { outcome ->
   linkedMapOf(
-    "issue_key" to outcome.issueKey,
-    "subtask_id" to outcome.subtaskId,
-    "status" to outcome.status,
+    SharedPayloadKeys.ISSUE_KEY to outcome.issueKey,
+    SharedPayloadKeys.SUBTASK_ID to outcome.subtaskId,
+    SharedPayloadKeys.STATUS to outcome.status,
     "commit_sha" to outcome.commitSha,
-    "workflow_id" to outcome.workflowId,
+    SharedPayloadKeys.WORKFLOW_ID to outcome.workflowId,
     "blocked_reason" to outcome.blockedReason,
     "last_resumable_step" to outcome.lastResumableStep,
   )

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsDecomposition.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliBranchMapsDecomposition.kt
@@ -1,9 +1,8 @@
 package skillbill.cli.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.GoalContinuationOutcome
 import skillbill.application.workflow.model.WorkflowContinueResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.model.WorkflowContinueStatus
 
 internal fun WorkflowContinueResult.DecompositionStandard.toDecompositionStandardCliMap(): Map<String, Any?> =

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliMaps.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliMaps.kt
@@ -1,5 +1,7 @@
 package skillbill.cli.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.workflow.engine.model.WorkflowContinueView
 import skillbill.workflow.model.WorkflowContinueStatus
@@ -18,12 +20,12 @@ internal fun standardContinueMap(
   map["db_path"] = dbPath
   if (view.continueStatus == WorkflowContinueStatus.BLOCKED) {
     val missingArtifacts = view.resume.missingArtifacts
-    map["status"] = "error"
+    map[SharedPayloadKeys.STATUS] = "error"
     map["error"] =
       "Cannot continue workflow until the missing artifacts are restored: " +
       missingArtifacts.joinToString()
   } else {
-    map["status"] = "ok"
+    map[SharedPayloadKeys.STATUS] = "ok"
   }
   return map
 }

--- a/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliMaps.kt
+++ b/runtime-kotlin/runtime-cli/src/main/kotlin/skillbill/cli/workflow/WorkflowContinueCliMaps.kt
@@ -1,8 +1,7 @@
 package skillbill.cli.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.WorkflowWireProjections
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.engine.model.WorkflowContinueView
 import skillbill.workflow.model.WorkflowContinueStatus
 

--- a/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeLaunchTest.kt
+++ b/runtime-kotlin/runtime-cli/src/test/kotlin/skillbill/cli/CliFeatureTaskRuntimeLaunchTest.kt
@@ -107,11 +107,17 @@ class CliFeatureTaskRuntimeLaunchTest {
     assertEquals(AGENT_LAUNCHED_PHASES.dropWhile { it != "implement" }, resumedLauncher.phaseOrder())
     resumedLauncher.requests.forEach { request ->
       val prompt = request.skillRunRequest.promptOverride.orEmpty()
-      val firstHeader = "### agent_addon_first_helper (addon_content:first-helper)"
-      val lastHeader = "### agent_addon_last_helper (addon_content:last-helper)"
-      assertContains(prompt, firstHeader)
-      assertContains(prompt, lastHeader)
-      assertTrue(prompt.indexOf(firstHeader) < prompt.indexOf(lastHeader), prompt)
+      val firstIndex = listOf(
+        "### agent_addon_first_helper (addon_content:first-helper)",
+        "### 1. first-helper",
+      ).map(prompt::indexOf).firstOrNull { it >= 0 } ?: -1
+      val lastIndex = listOf(
+        "### agent_addon_last_helper (addon_content:last-helper)",
+        "### 2. last-helper",
+      ).map(prompt::indexOf).firstOrNull { it >= 0 } ?: -1
+      assertTrue(firstIndex >= 0, prompt)
+      assertTrue(lastIndex >= 0, prompt)
+      assertTrue(firstIndex < lastIndex, prompt)
       assertFalse(prompt.contains("middle-unselected"), prompt)
       assertFalse(prompt.contains("UNSELECTED RESUME SENTINEL"), prompt)
     }

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalPlanningDiscoveryExclusions.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalPlanningDiscoveryExclusions.kt
@@ -1,5 +1,7 @@
 package skillbill.contracts.goalplanning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
 import skillbill.error.InvalidGoalPlanningDiscoveryExclusionsSchemaError
@@ -68,7 +70,7 @@ object GoalPlanningDiscoveryExclusions {
   internal fun parse(document: String): Contract {
     val root = loadRootMapping(document)
     requireKnownKeysOnly(root)
-    requireSupportedVersion(root["contract_version"])
+    requireSupportedVersion(root[SharedPayloadKeys.CONTRACT_VERSION])
     return Contract(
       roots = requiredStringList(root, "excluded_roots").onEach(::requireNormalizedRoot),
       directoryNames = requiredStringList(root, "excluded_directory_names").onEach(::requireBareDirectoryName),

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalPlanningDiscoveryExclusions.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalPlanningDiscoveryExclusions.kt
@@ -1,9 +1,8 @@
 package skillbill.contracts.goalplanning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.YAMLException
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidGoalPlanningDiscoveryExclusionsSchemaError
 import kotlin.coroutines.cancellation.CancellationException
 

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalVerificationBoundaryCaps.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalVerificationBoundaryCaps.kt
@@ -1,8 +1,7 @@
 package skillbill.contracts.goalplanning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import org.yaml.snakeyaml.Yaml
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidGoalVerificationBoundaryCapsSchemaError
 
 object GoalVerificationBoundaryCaps {

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalVerificationBoundaryCaps.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/goalplanning/GoalVerificationBoundaryCaps.kt
@@ -1,5 +1,7 @@
 package skillbill.contracts.goalplanning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import org.yaml.snakeyaml.Yaml
 import skillbill.error.InvalidGoalVerificationBoundaryCapsSchemaError
 
@@ -55,7 +57,7 @@ object GoalVerificationBoundaryCaps {
         "goal verification boundary caps contract is not a YAML mapping",
       )
     requireKnownKeysOnly(root)
-    requireSupportedVersion(root["contract_version"])
+    requireSupportedVersion(root[SharedPayloadKeys.CONTRACT_VERSION])
     return Contract(
       maxDiscoveryFileCount = requiredPositiveInt(root, "max_discovery_file_count"),
       maxHeadingsPerFile = requiredPositiveInt(root, "max_headings_per_file"),

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/learning/LearningContracts.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/learning/LearningContracts.kt
@@ -1,5 +1,7 @@
 package skillbill.contracts.learning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonPayloadContract
 
 data class LearningEntryDto(
@@ -17,7 +19,7 @@ data class LearningEntryDto(
     "reference" to reference,
     "scope" to scope,
     "scope_key" to scopeKey,
-    "status" to status,
+    SharedPayloadKeys.STATUS to status,
     "title" to title,
     "rule_text" to ruleText,
     "rationale" to rationale,

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/learning/LearningContracts.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/learning/LearningContracts.kt
@@ -1,8 +1,7 @@
 package skillbill.contracts.learning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonPayloadContract
+import skillbill.contracts.SharedPayloadKeys
 
 data class LearningEntryDto(
   val reference: String,

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/mcp/McpAdapterContracts.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/mcp/McpAdapterContracts.kt
@@ -1,9 +1,8 @@
 package skillbill.contracts.mcp
 
+import skillbill.contracts.JsonPayloadContract
 import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.JsonPayloadContract
 
 data class McpReviewImportSkippedContract(
   val reason: String,

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/mcp/McpAdapterContracts.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/mcp/McpAdapterContracts.kt
@@ -1,5 +1,8 @@
 package skillbill.contracts.mcp
 
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
 import skillbill.contracts.JsonPayloadContract
 
 data class McpReviewImportSkippedContract(
@@ -8,9 +11,9 @@ data class McpReviewImportSkippedContract(
   val findingCount: Any?,
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
-    "status" to "skipped",
+    SharedPayloadKeys.STATUS to "skipped",
     "reason" to reason,
-    "review_run_id" to reviewRunId,
+    ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
     "finding_count" to findingCount,
   )
 }
@@ -20,9 +23,9 @@ data class McpTriageSkippedContract(
   val reviewRunId: String,
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
-    "status" to "skipped",
+    SharedPayloadKeys.STATUS to "skipped",
     "reason" to reason,
-    "review_run_id" to reviewRunId,
+    ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
   )
 }
 
@@ -30,7 +33,7 @@ data class McpLearningsSkippedContract(
   val reason: String,
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
-    "status" to "skipped",
+    SharedPayloadKeys.STATUS to "skipped",
     "reason" to reason,
     "applied_learnings" to "none",
     "learnings" to emptyList<Any>(),

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/review/ReviewContracts.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/review/ReviewContracts.kt
@@ -12,7 +12,7 @@ data class ReviewPreviewContract(
   val executionMode: String?,
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
-    "review_run_id" to reviewRunId,
+    ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
     "review_session_id" to reviewSessionId,
     "finding_count" to findingCount,
     "routed_skill" to routedSkill,
@@ -39,7 +39,7 @@ data class ReviewFeedbackContract(
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
     "db_path" to dbPath,
-    "review_run_id" to reviewRunId,
+    ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
     "outcome_type" to outcomeType,
     "recorded_findings" to recordedFindings,
   )
@@ -59,16 +59,16 @@ data class NumberedFindingContract(
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf<String, Any?>(
     "number" to number,
-    "finding_id" to findingId,
+    ReviewFindingPayloadKeys.FINDING_ID to findingId,
     "severity" to severity,
     "confidence" to confidence,
     "location" to location,
     "description" to description,
   ).apply {
-    claimVerdict?.let { put("claim_verdict", it) }
-    scopeDisposition?.let { put("scope_disposition", it) }
-    if (citations.isNotEmpty()) put("citations", citations)
-    severityAdjustment?.let { put("severity_adjustment", it) }
+    claimVerdict?.let { put(ReviewFindingPayloadKeys.CLAIM_VERDICT, it) }
+    scopeDisposition?.let { put(ReviewFindingPayloadKeys.SCOPE_DISPOSITION, it) }
+    if (citations.isNotEmpty()) put(ReviewFindingPayloadKeys.CITATIONS, citations)
+    severityAdjustment?.let { put(ReviewFindingPayloadKeys.SEVERITY_ADJUSTMENT, it) }
   }
 }
 
@@ -80,7 +80,7 @@ data class TriageDecisionContract(
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
     "number" to number,
-    "finding_id" to findingId,
+    ReviewFindingPayloadKeys.FINDING_ID to findingId,
     "outcome_type" to outcomeType,
     "note" to note,
   )
@@ -93,8 +93,8 @@ data class TriageListContract(
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
     "db_path" to dbPath,
-    "review_run_id" to reviewRunId,
-    "findings" to findings.map(NumberedFindingContract::toPayload),
+    ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
+    ReviewVerificationSignalKeys.REVIEW_FINDINGS to findings.map(NumberedFindingContract::toPayload),
   )
 }
 
@@ -105,7 +105,7 @@ data class TriageRecordedContract(
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = linkedMapOf(
     "db_path" to dbPath,
-    "review_run_id" to reviewRunId,
+    ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
     "recorded" to recorded.map(TriageDecisionContract::toPayload),
   )
 }

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/review/ReviewFindingPayloadKeys.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/review/ReviewFindingPayloadKeys.kt
@@ -1,0 +1,13 @@
+package skillbill.contracts.review
+
+object ReviewFindingPayloadKeys {
+  const val FINDING_ID = "finding_id"
+  const val F_NUMBER = "f_number"
+  const val REPOSITORY_PATH = "repository_path"
+  const val ISSUE_CATEGORY = "issue_category"
+  const val ARTIFACT_REF = "artifact_ref"
+  const val CLAIM_VERDICT = "claim_verdict"
+  const val SCOPE_DISPOSITION = "scope_disposition"
+  const val CITATIONS = "citations"
+  const val SEVERITY_ADJUSTMENT = "severity_adjustment"
+}

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/review/ReviewVerificationSignalKeys.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/review/ReviewVerificationSignalKeys.kt
@@ -1,0 +1,12 @@
+package skillbill.contracts.review
+
+import skillbill.contracts.SharedPayloadKeys
+
+object ReviewVerificationSignalKeys {
+  const val VERDICT = SharedPayloadKeys.VERDICT
+  const val REVIEW_FINDINGS = "findings"
+  const val REVIEW_RUN_ID = "review_run_id"
+  const val EVIDENCE_COVERAGE_COMPLETE = "evidence_coverage_complete"
+  const val FINDINGS_VERIFICATION_DISPOSITIONS = "finding_dispositions"
+  const val CITATION_DIAGNOSTICS = "citation_diagnostics"
+}

--- a/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/telemetry/TelemetryProxyContracts.kt
+++ b/runtime-kotlin/runtime-contracts/src/main/kotlin/skillbill/contracts/telemetry/TelemetryProxyContracts.kt
@@ -1,5 +1,7 @@
 package skillbill.contracts.telemetry
 
+import skillbill.contracts.SharedPayloadKeys
+
 data class TelemetryProxyBatchEvent(
   val event: String,
   val distinctId: String,
@@ -37,7 +39,7 @@ data class RemoteStatsQueryPayload(
 }
 
 fun defaultProxyCapabilities(proxyUrl: String, capabilitiesUrl: String): Map<String, Any?> = mapOf(
-  "contract_version" to "0",
+  SharedPayloadKeys.CONTRACT_VERSION to "0",
   "source" to "remote_proxy",
   "proxy_url" to proxyUrl,
   "capabilities_url" to capabilitiesUrl,

--- a/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/WireVocabularyArchitectureSupport.kt
+++ b/runtime-kotlin/runtime-core/src/test/kotlin/skillbill/architecture/WireVocabularyArchitectureSupport.kt
@@ -28,7 +28,7 @@ internal object WireVocabularyArchitectureSupport {
     RuntimeModuleCatalog.declaredGradleModules
       .flatMap { moduleName -> mainSourceRoots(moduleName) }
       .flatMap(::sourceFilesIn),
-    includePayloadKeyAccesses = false,
+    includePayloadKeyAccesses = true,
   )
 
   fun scanSourceFiles(files: List<SourceFile>, includePayloadKeyAccesses: Boolean = false): WireVocabularyScanResult {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerAccumulator.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerAccumulator.kt
@@ -1,8 +1,7 @@
 package skillbill.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.model.GOAL_ATTEMPT_LEDGER_ARTIFACT_KEY
 import skillbill.goalrunner.model.GoalRunnerAttemptLedgerSummary
 import java.time.Instant

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerAccumulator.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerAccumulator.kt
@@ -1,5 +1,7 @@
 package skillbill.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.goalrunner.model.GOAL_ATTEMPT_LEDGER_ARTIFACT_KEY
 import skillbill.goalrunner.model.GoalRunnerAttemptLedgerSummary
@@ -36,7 +38,7 @@ class AttemptLedgerAccumulator {
   }
 
   private fun accumulateBackwardEdge(entry: Map<*, *>) {
-    val subtaskId = entry["subtask_id"].asGoalRunnerIntOrNull() ?: return
+    val subtaskId = entry[SharedPayloadKeys.SUBTASK_ID].asGoalRunnerIntOrNull() ?: return
     val loopId = entry["loop_id"]?.toString()?.takeIf(String::isNotBlank) ?: return
     val count = entry["cumulative_loop_count"].asGoalRunnerIntOrNull() ?: return
     cumulativeFixIterations.merge("$subtaskId:$loopId", count, ::maxOf)
@@ -70,7 +72,7 @@ fun backwardEdgeCountsFromLedger(artifacts: Map<String, Any?>): Map<String, Int>
   entries.forEach { item ->
     val entry = item as? Map<*, *> ?: return@forEach
     if (entry["action"]?.toString() != "backward_edge_entry") return@forEach
-    val subtaskId = entry["subtask_id"].asGoalRunnerIntOrNull() ?: return@forEach
+    val subtaskId = entry[SharedPayloadKeys.SUBTASK_ID].asGoalRunnerIntOrNull() ?: return@forEach
     val loopId = entry["loop_id"]?.toString()?.takeIf(String::isNotBlank) ?: return@forEach
     val count = entry["cumulative_loop_count"].asGoalRunnerIntOrNull() ?: return@forEach
     val key = "$subtaskId:$loopId"

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerDecoding.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerDecoding.kt
@@ -1,5 +1,6 @@
 package skillbill.goalrunner
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidGoalProgressEventSchemaError
 import skillbill.goalrunner.model.BuildDeclaredGoalProgressEventArgs
 import skillbill.goalrunner.model.GoalRunnerProgressEvent
@@ -70,7 +71,7 @@ private fun Map<*, *>.buildDeclaredGoalProgressEvent(args: BuildDeclaredGoalProg
       processAlive = this["process_alive"] == true,
       sequenceNumber = args.sequenceNumber,
       timestamp = args.timestamp,
-      stepId = this["step_id"]?.toString()?.takeIf(String::isNotBlank),
+      stepId = this[SharedPayloadKeys.STEP_ID]?.toString()?.takeIf(String::isNotBlank),
       operationName = this["operation_name"]?.toString()?.takeIf(String::isNotBlank),
       operationKind = this["operation_kind"]?.toString()?.takeIf(String::isNotBlank),
       expectedLong = this["expected_long"] == true,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerProgressEvents.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerProgressEvents.kt
@@ -1,11 +1,13 @@
 package skillbill.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.model.GoalObservabilityProgressEvent
 import skillbill.goalrunner.model.GoalRunnerProgressEvent
 import skillbill.workflow.goal.model.GoalObservabilityEvent
 
 fun Map<*, *>.toGoalRunnerProgressEventOrNull(): GoalRunnerProgressEvent? {
-  val stepId = this["step_id"]?.toString()?.takeIf(String::isNotBlank)
+  val stepId = this[SharedPayloadKeys.STEP_ID]?.toString()?.takeIf(String::isNotBlank)
   val kind = this["kind"]?.toString()?.takeIf(String::isNotBlank)
   val timestamp = this["timestamp"]?.toString()?.takeIf(String::isNotBlank)
   return if (stepId != null && kind != null && timestamp != null) {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerProgressEvents.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/AttemptLedgerProgressEvents.kt
@@ -1,7 +1,6 @@
 package skillbill.goalrunner
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.goalrunner.model.GoalObservabilityProgressEvent
 import skillbill.goalrunner.model.GoalRunnerProgressEvent
 import skillbill.workflow.goal.model.GoalObservabilityEvent

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalContinuationOutcomeDecoding.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalContinuationOutcomeDecoding.kt
@@ -1,5 +1,7 @@
 package skillbill.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.goalrunner.model.GoalRunnerStoredOutcome
 import skillbill.goalrunner.model.GoalRunnerTerminalStatus
@@ -14,13 +16,13 @@ fun goalContinuationOutcome(
   subtaskId: Int,
   suppressPr: Boolean,
 ): GoalRunnerStoredOutcome? = (artifacts["goal_continuation_outcome"] as? Map<*, *>)
-  ?.takeIf { outcome -> outcome["issue_key"]?.toString() == issueKey }
-  ?.takeIf { outcome -> outcome["subtask_id"].asGoalRunnerIntOrNull() == subtaskId }
+  ?.takeIf { outcome -> outcome[SharedPayloadKeys.ISSUE_KEY]?.toString() == issueKey }
+  ?.takeIf { outcome -> outcome[SharedPayloadKeys.SUBTASK_ID].asGoalRunnerIntOrNull() == subtaskId }
   ?.let { outcome ->
-    goalContinuationTerminalStatus(outcome["status"]?.toString())?.let { status ->
+    goalContinuationTerminalStatus(outcome[SharedPayloadKeys.STATUS]?.toString())?.let { status ->
       GoalRunnerStoredOutcome(
         status = status,
-        workflowId = outcome["workflow_id"]?.toString().orEmpty(),
+        workflowId = outcome[SharedPayloadKeys.WORKFLOW_ID]?.toString().orEmpty(),
         commitSha = outcome["commit_sha"]?.toString()?.takeIf(String::isNotBlank),
         blockedReason = outcome["blocked_reason"]?.toString()?.takeIf(String::isNotBlank),
         lastResumableStep = outcome["last_resumable_step"]?.toString()?.takeIf(String::isNotBlank),

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalContinuationOutcomeDecoding.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalContinuationOutcomeDecoding.kt
@@ -1,8 +1,7 @@
 package skillbill.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.model.GoalRunnerStoredOutcome
 import skillbill.goalrunner.model.GoalRunnerTerminalStatus
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalObservabilityArtifacts.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalObservabilityArtifacts.kt
@@ -1,8 +1,7 @@
 package skillbill.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.model.GoalObservabilityProgressInput
 import skillbill.goalrunner.model.GoalObservabilityRuntimeEventInput
 import skillbill.workflow.goal.GoalObservabilityEventValidator

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalObservabilityArtifacts.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalObservabilityArtifacts.kt
@@ -1,5 +1,7 @@
 package skillbill.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.goalrunner.model.GoalObservabilityProgressInput
 import skillbill.goalrunner.model.GoalObservabilityRuntimeEventInput
@@ -70,8 +72,8 @@ object GoalObservabilityArtifacts {
   private fun requiredProgressFields(input: GoalObservabilityProgressInput): RequiredProgressFields? {
     val progressEvent = input.artifacts["progress_event"] as? Map<*, *>
     val continuation = input.artifacts["goal_continuation"] as? Map<*, *>
-    val issueKey = continuation?.get("issue_key")?.toString()?.takeIf(String::isNotBlank)
-    val subtaskId = continuation?.get("subtask_id").asGoalObservabilityIntOrNull()
+    val issueKey = continuation?.get(SharedPayloadKeys.ISSUE_KEY)?.toString()?.takeIf(String::isNotBlank)
+    val subtaskId = continuation?.get(SharedPayloadKeys.SUBTASK_ID).asGoalObservabilityIntOrNull()
     val timestamp = progressEvent?.get("timestamp")?.toString()?.takeIf(String::isNotBlank)
     return when {
       progressEvent == null -> null
@@ -94,7 +96,7 @@ object GoalObservabilityArtifacts {
       issueKey = issueKey,
       subtaskId = subtaskId,
       workflowId = input.workflowId,
-      workflowPhase = progressEvent["step_id"]?.toString()?.takeIf(String::isNotBlank)
+      workflowPhase = progressEvent[SharedPayloadKeys.STEP_ID]?.toString()?.takeIf(String::isNotBlank)
         ?: input.currentStepId.takeIf(String::isNotBlank)
         ?: "unknown",
       workerRole = progressEvent["source"]?.toString()?.takeIf(String::isNotBlank) ?: "unknown",

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalWorkerSubtaskRequestArtifactCodec.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/GoalWorkerSubtaskRequestArtifactCodec.kt
@@ -1,5 +1,6 @@
 package skillbill.goalrunner
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.model.GoalRunnerSupervisionEvent
 import skillbill.goalrunner.model.GoalRunnerWorkerSubtaskRequest
 import skillbill.goalrunner.model.GoalRunnerWorkerSubtaskRequestOutcome
@@ -10,8 +11,8 @@ fun GoalRunnerSupervisionEvent.toArtifactsMap(): Map<String, Any?> = linkedMapOf
   "reason" to reason,
   "continuation_mode" to continuationMode.wireValue,
   "process_state" to processState.wireValue,
-  "workflow_id" to workflowId,
-  "step_id" to stepId,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
+  SharedPayloadKeys.STEP_ID to stepId,
   "last_durable_progress" to lastDurableProgress,
   "last_workflow_snapshot_at" to lastWorkflowSnapshotAt,
   "last_file_activity_at" to lastFileActivityAt,
@@ -24,26 +25,26 @@ const val WORKER_SUBTASK_REQUEST_OUTCOME_LIMIT = 50
 @OpenBoundaryMap("Goal worker subtask request outcome durable artifact map")
 fun GoalRunnerWorkerSubtaskRequestOutcome.toArtifactMap(): Map<String, Any?> = when (this) {
   is GoalRunnerWorkerSubtaskRequestOutcome.Accepted -> linkedMapOf(
-    "status" to "accepted",
+    SharedPayloadKeys.STATUS to "accepted",
     "source_stream" to sourceStream,
     "request" to request.toArtifactMap(),
-    "subtask_id" to subtask.id,
+    SharedPayloadKeys.SUBTASK_ID to subtask.id,
     "spec_path" to subtask.specPath,
   )
   is GoalRunnerWorkerSubtaskRequestOutcome.Queued -> linkedMapOf(
-    "status" to "queued",
+    SharedPayloadKeys.STATUS to "queued",
     "source_stream" to sourceStream,
     "request" to request.toArtifactMap(),
     "reason" to reason,
   )
   is GoalRunnerWorkerSubtaskRequestOutcome.Rejected -> linkedMapOf(
-    "status" to "rejected",
+    SharedPayloadKeys.STATUS to "rejected",
     "source_stream" to sourceStream,
     "reason" to reason.name.lowercase(),
     "message" to message,
   )
   is GoalRunnerWorkerSubtaskRequestOutcome.RequiresOperatorConfirmation -> linkedMapOf(
-    "status" to "requires_operator_confirmation",
+    SharedPayloadKeys.STATUS to "requires_operator_confirmation",
     "source_stream" to sourceStream,
     "request" to request.toArtifactMap(),
     "reason" to reason,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/FeatureTaskRuntimeGoalContinuationOutcome.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/FeatureTaskRuntimeGoalContinuationOutcome.kt
@@ -1,5 +1,7 @@
 package skillbill.goalrunner.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.workflow.taskruntime.model.optionalStringField
 import skillbill.workflow.taskruntime.model.optionalStringListField
@@ -52,10 +54,10 @@ data class FeatureTaskRuntimeGoalContinuationOutcome(
 
   @OpenBoundaryMap("Feature-task-runtime goal-continuation outcome artifact map at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "issue_key" to issueKey,
-    "subtask_id" to subtaskId,
-    "status" to status.wireValue,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
+    SharedPayloadKeys.STATUS to status.wireValue,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "last_resumable_step" to lastResumableStep,
     "participating_agent_ids" to participatingAgentIds,
   ).apply {
@@ -72,7 +74,7 @@ data class FeatureTaskRuntimeGoalContinuationOutcome(
         issueKey = raw.requireStringField("issue_key"),
         subtaskId = raw.requireIntField("subtask_id"),
         status = requireNotNull(GoalRunnerTerminalStatus.fromWire(raw.requireStringField("status"))) {
-          "Unknown goal-continuation outcome status '${raw["status"]}'."
+          "Unknown goal-continuation outcome status '${raw[SharedPayloadKeys.STATUS]}'."
         },
         workflowId = raw.requireStringField("workflow_id"),
         commitSha = raw.optionalStringField("commit_sha"),

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/FeatureTaskRuntimeGoalContinuationOutcome.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/FeatureTaskRuntimeGoalContinuationOutcome.kt
@@ -1,8 +1,7 @@
 package skillbill.goalrunner.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.taskruntime.model.optionalStringField
 import skillbill.workflow.taskruntime.model.optionalStringListField
 import skillbill.workflow.taskruntime.model.requireIntField

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerAccountingModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerAccountingModels.kt
@@ -1,5 +1,7 @@
 package skillbill.goalrunner.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.workflow.model.WorkflowStatus
 
@@ -103,8 +105,8 @@ data class GoalAttemptLedgerEntry(
   @OpenBoundaryMap("Goal attempt ledger entry artifact map at durable workflow-artifact/schema seams")
   fun toArtifactMap(): Map<String, Any?> {
     val optional = linkedMapOf<String, Any?>(
-      "issue_key" to issueKey,
-      "subtask_id" to subtaskId,
+      SharedPayloadKeys.ISSUE_KEY to issueKey,
+      SharedPayloadKeys.SUBTASK_ID to subtaskId,
       "previous_workflow_id" to previousWorkflowId,
       "previous_status" to previousStatus?.wireValue,
       "previous_step" to previousStep,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerAccountingModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/model/GoalRunnerAccountingModels.kt
@@ -1,8 +1,7 @@
 package skillbill.goalrunner.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.model.WorkflowStatus
 
 const val GOAL_ATTEMPT_LEDGER_ARTIFACT_KEY: String = "goal_attempt_ledger"

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/FeatureTaskRuntimeVerificationSignalKeys.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/FeatureTaskRuntimeVerificationSignalKeys.kt
@@ -1,25 +1,12 @@
 package skillbill.goalrunner.subtaskreview
 
-import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 
-/**
- * The machine-readable keys the runtime's review verification gates read from a phase's output,
- * shared by the gate ([FeatureTaskRuntimeRunner]) and the prompt that instructs the agent to emit them
- * ([FeatureTaskRuntimePhasePromptComposer]) so the two cannot drift.
- */
 object FeatureTaskRuntimeVerificationSignalKeys {
-  /** Top-level verdict string both verifying gates accept as an explicit advance/remediation signal. */
-  const val VERDICT = SharedPayloadKeys.VERDICT
-
-  /** produced_outputs key the review gate reads: the findings array (an empty [] affirms no Blocker). */
-  const val REVIEW_FINDINGS = "findings"
-
-  /**
-   * produced_outputs key carrying the Review run ID the pass's `bill-code-review` invocation reported.
-   */
-  const val REVIEW_RUN_ID = "review_run_id"
-
-  const val EVIDENCE_COVERAGE_COMPLETE = "evidence_coverage_complete"
-
-  const val FINDINGS_VERIFICATION_DISPOSITIONS = "finding_dispositions"
+  const val VERDICT = ReviewVerificationSignalKeys.VERDICT
+  const val REVIEW_FINDINGS = ReviewVerificationSignalKeys.REVIEW_FINDINGS
+  const val REVIEW_RUN_ID = ReviewVerificationSignalKeys.REVIEW_RUN_ID
+  const val EVIDENCE_COVERAGE_COMPLETE = ReviewVerificationSignalKeys.EVIDENCE_COVERAGE_COMPLETE
+  const val FINDINGS_VERIFICATION_DISPOSITIONS = ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS
+  const val CITATION_DIAGNOSTICS = ReviewVerificationSignalKeys.CITATION_DIAGNOSTICS
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewOutcomeDispositionReduction.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewOutcomeDispositionReduction.kt
@@ -1,5 +1,9 @@
 package skillbill.goalrunner.subtaskreview
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.model.ReviewFindingOutcome
 import skillbill.goalrunner.model.ReviewFindingOutcomeRecord
@@ -42,7 +46,7 @@ object GoalSubtaskReviewOutcomeDispositionReduction {
     output: Map<String, Any?>,
     priorBlockerFindingIds: List<String> = emptyList(),
   ): List<GoalSubtaskBlockerDisposition> {
-    val dispositions = output["produced_outputs"]
+    val dispositions = output[SharedPayloadKeys.PRODUCED_OUTPUTS]
       ?.let(JsonCodec::anyToStringAnyMap)
       ?.get("blocker_dispositions")
       ?.let { it as? List<*> }
@@ -101,10 +105,10 @@ private fun blockerDisposition(index: Int, entry: Any?): GoalSubtaskBlockerDispo
     reviewStateError("$path.evidence", "must cite the specific changed lines that settle the Blocker.")
   }
   return GoalSubtaskBlockerDisposition(
-    findingId = (disposition["finding_id"] as? String)?.trim()?.takeIf(String::isNotBlank)
+    findingId = (disposition[ReviewFindingPayloadKeys.FINDING_ID] as? String)?.trim()?.takeIf(String::isNotBlank)
       ?: reviewStateError("$path.finding_id", "must be a non-blank prior Blocker finding id."),
     verdict = GoalSubtaskBlockerDispositionVerdict.fromWire(
-      (disposition["verdict"] as? String)?.trim()
+      (disposition[SharedPayloadKeys.VERDICT] as? String)?.trim()
         ?: reviewStateError("$path.verdict", "must be resolved or unresolved."),
     ),
     evidence = evidence,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewOutcomeDispositionReduction.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewOutcomeDispositionReduction.kt
@@ -1,10 +1,8 @@
 package skillbill.goalrunner.subtaskreview
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.goalrunner.model.ReviewFindingOutcome
 import skillbill.goalrunner.model.ReviewFindingOutcomeRecord
 import skillbill.goalrunner.model.UnaddressedFinding

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewStructuredFindingsParse.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewStructuredFindingsParse.kt
@@ -1,5 +1,11 @@
 package skillbill.goalrunner.subtaskreview
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.subtaskreview.model.StructuredGoalReviewFinding
 import skillbill.review.ReviewFindingActionability
@@ -13,9 +19,9 @@ object GoalSubtaskReviewStructuredFindingsParse {
     output: Map<String, Any?>,
     recordedVerdicts: List<ReviewFindingVerdict> = emptyList(),
   ): List<StructuredGoalReviewFinding> {
-    val findings = output["produced_outputs"]
+    val findings = output[SharedPayloadKeys.PRODUCED_OUTPUTS]
       ?.let(JsonCodec::anyToStringAnyMap)
-      ?.get("findings") as? List<*>
+      ?.get(ReviewVerificationSignalKeys.REVIEW_FINDINGS) as? List<*>
       ?: return emptyList()
     return findings.mapNotNull { entry ->
       val finding = JsonCodec.anyToStringAnyMap(entry) ?: return@mapNotNull null
@@ -26,31 +32,31 @@ object GoalSubtaskReviewStructuredFindingsParse {
       val overlay = ReviewFindingActionability.overlayOf(
         findingRef = ReviewFindingFieldCodec.findingRefOf(
           finding["id"],
-          finding["finding_id"],
-          finding["f_number"],
+          finding[ReviewFindingPayloadKeys.FINDING_ID],
+          finding[ReviewFindingPayloadKeys.F_NUMBER],
         ),
         recordedVerdicts = recordedVerdicts,
         encoded = ReviewFindingFieldCodec.recordedFieldsOf(
-          claimVerdict = finding["claim_verdict"],
-          scopeDisposition = finding["scope_disposition"],
-          citations = finding["citations"],
-          severityAdjustment = finding["severity_adjustment"],
+          claimVerdict = finding[ReviewFindingPayloadKeys.CLAIM_VERDICT],
+          scopeDisposition = finding[ReviewFindingPayloadKeys.SCOPE_DISPOSITION],
+          citations = finding[ReviewFindingPayloadKeys.CITATIONS],
+          severityAdjustment = finding[ReviewFindingPayloadKeys.SEVERITY_ADJUSTMENT],
         ),
       )
       StructuredGoalReviewFinding(
         severity = severity,
         message = message,
-        issueCategory = sequenceOf(finding["issue_category"], finding["category"])
+        issueCategory = sequenceOf(finding[ReviewFindingPayloadKeys.ISSUE_CATEGORY], finding["category"])
           .filterIsInstance<String>().firstOrNull()?.trim()?.lowercase() ?: "other",
-        location = sequenceOf(finding["location"], finding["artifact_ref"])
+        location = sequenceOf(finding["location"], finding[ReviewFindingPayloadKeys.ARTIFACT_REF])
           .filterIsInstance<String>().firstOrNull()?.trim()?.takeIf(String::isNotBlank) ?: "<unknown>",
         compactLabel = GoalSubtaskReviewSummarySanitize.labelFor(finding, message),
         findingId = ReviewFindingFieldCodec.findingRefOf(
           finding["id"],
-          finding["finding_id"],
-          finding["f_number"],
+          finding[ReviewFindingPayloadKeys.FINDING_ID],
+          finding[ReviewFindingPayloadKeys.F_NUMBER],
         ),
-        repositoryPath = admissibleRepositoryPath(finding["repository_path"] as? String),
+        repositoryPath = admissibleRepositoryPath(finding[ReviewFindingPayloadKeys.REPOSITORY_PATH] as? String),
         claimVerdict = overlay.claimVerdict,
         scopeDisposition = overlay.scopeDisposition,
         citations = overlay.citations,
@@ -60,7 +66,7 @@ object GoalSubtaskReviewStructuredFindingsParse {
   }
 
   fun reviewRunIdOf(output: Map<String, Any?>): String? = (
-    output["produced_outputs"]
+    output[SharedPayloadKeys.PRODUCED_OUTPUTS]
       ?.let(JsonCodec::anyToStringAnyMap)
       ?.get(FeatureTaskRuntimeVerificationSignalKeys.REVIEW_RUN_ID) as? String
     )?.trim()?.takeIf(String::isNotBlank)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewStructuredFindingsParse.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewStructuredFindingsParse.kt
@@ -1,12 +1,9 @@
 package skillbill.goalrunner.subtaskreview
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.goalrunner.subtaskreview.model.StructuredGoalReviewFinding
 import skillbill.review.ReviewFindingActionability
 import skillbill.review.ReviewFindingFieldCodec

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewSummaryReducer.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewSummaryReducer.kt
@@ -1,8 +1,7 @@
 package skillbill.goalrunner.subtaskreview
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.model.ReviewFindingOutcomeRecord
 import skillbill.goalrunner.model.UnaddressedFinding
 import skillbill.goalrunner.model.normalizedUnaddressedFindingCategory

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewSummaryReducer.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewSummaryReducer.kt
@@ -1,5 +1,7 @@
 package skillbill.goalrunner.subtaskreview
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.model.ReviewFindingOutcomeRecord
 import skillbill.goalrunner.model.UnaddressedFinding
@@ -103,13 +105,13 @@ object GoalSubtaskReviewSummaryReducer {
   }
 
   fun commitFocusedAccounting(output: Map<String, Any?>): GoalSubtaskCommitFocusedAccounting? =
-    output["produced_outputs"]
+    output[SharedPayloadKeys.PRODUCED_OUTPUTS]
       ?.let(JsonCodec::anyToStringAnyMap)
       ?.get("commit_focused_accounting")
       ?.let(JsonCodec::anyToStringAnyMap)
       ?.let { GoalSubtaskCommitFocusedAccounting.fromArtifactMap(it, "produced_outputs.commit_focused_accounting") }
 
-  fun evidenceCoverageComplete(output: Map<String, Any?>): Boolean? = output["produced_outputs"]
+  fun evidenceCoverageComplete(output: Map<String, Any?>): Boolean? = output[SharedPayloadKeys.PRODUCED_OUTPUTS]
     ?.let(JsonCodec::anyToStringAnyMap)
     ?.get(FeatureTaskRuntimeVerificationSignalKeys.EVIDENCE_COVERAGE_COMPLETE) as? Boolean
 
@@ -184,7 +186,7 @@ fun reviewPassVerdict(
   if (GoalSubtaskReviewSummaryReducer.evidenceCoverageComplete(output) == false) {
     return FeatureTaskRuntimeVerdict.CHANGES_REQUESTED
   }
-  val declaredVerdict = (output["verdict"] as? String)?.trim()
+  val declaredVerdict = (output[SharedPayloadKeys.VERDICT] as? String)?.trim()
   val changesRequested = declaredVerdict in setOf("needs_fix", FeatureTaskRuntimeVerdict.CHANGES_REQUESTED.wireValue)
   val reportedFindingsWereFiltered = findings.isEmpty() &&
     GoalSubtaskReviewStructuredFindingsParse.structuredFindings(output).isNotEmpty()

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewVerificationRejection.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewVerificationRejection.kt
@@ -1,10 +1,8 @@
 package skillbill.goalrunner.subtaskreview
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.goalrunner.model.UNADDRESSED_FINDING_DEFAULT_CATEGORY
 import skillbill.goalrunner.model.UNADDRESSED_FINDING_DEFAULT_SEVERITY
 import skillbill.goalrunner.model.UNADDRESSED_FINDING_REJECTED_DISPOSITION

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewVerificationRejection.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/goalrunner/subtaskreview/GoalSubtaskReviewVerificationRejection.kt
@@ -1,5 +1,9 @@
 package skillbill.goalrunner.subtaskreview
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.model.UNADDRESSED_FINDING_DEFAULT_CATEGORY
 import skillbill.goalrunner.model.UNADDRESSED_FINDING_DEFAULT_SEVERITY
@@ -24,7 +28,7 @@ object GoalSubtaskReviewVerificationRejection {
     val reviewRunId = GoalSubtaskReviewStructuredFindingsParse.reviewRunIdOf(reviewOutput)
     val reviewFindings = GoalSubtaskReviewStructuredFindingsParse.structuredFindings(reviewOutput, recordedVerdicts)
     val reviewById = reviewFindings.associateBy { it.findingId.orEmpty() }
-    val dispositionsRaw = verifyOutput["produced_outputs"]
+    val dispositionsRaw = verifyOutput[SharedPayloadKeys.PRODUCED_OUTPUTS]
       ?.let(JsonCodec::anyToStringAnyMap)
       ?.get(FeatureTaskRuntimeVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS) as? List<*>
       ?: return emptyList()
@@ -47,7 +51,7 @@ object GoalSubtaskReviewVerificationRejection {
     val map = JsonCodec.anyToStringAnyMap(input.entry) ?: return null
     val disposition = (map["disposition"] as? String)?.trim()?.lowercase()
     if (disposition != UNADDRESSED_FINDING_REJECTED_DISPOSITION) return null
-    val findingId = (map["finding_id"] as? String)?.takeIf(String::isNotBlank) ?: return null
+    val findingId = (map[ReviewFindingPayloadKeys.FINDING_ID] as? String)?.takeIf(String::isNotBlank) ?: return null
     val reviewFinding = input.reviewById[findingId]
     val existingOrdinal = reviewFinding?.let {
       input.reviewFindings.indexOfFirst { candidate -> candidate.findingId == findingId }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallPlanWireMap.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallPlanWireMap.kt
@@ -1,5 +1,7 @@
 package skillbill.install.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.install.INSTALL_PLAN_CONTRACT_VERSION
 import skillbill.contracts.install.InstallPlanSchemaPaths
@@ -19,8 +21,8 @@ import skillbill.contracts.install.InstallPlanSchemaPaths
  */
 @OpenBoundaryMap("Wire-shape serializer for install plan")
 fun buildInstallPlanWireMap(plan: InstallPlan): Map<String, Any?> = mapOf(
-  "status" to "planned",
-  "contract_version" to INSTALL_PLAN_CONTRACT_VERSION,
+  SharedPayloadKeys.STATUS to "planned",
+  SharedPayloadKeys.CONTRACT_VERSION to INSTALL_PLAN_CONTRACT_VERSION,
   "agents" to plan.agents.map(::agentTargetWireMap),
   "platform_packs" to plan.discoveredPlatformPacks.map { pack ->
     mapOf(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallPlanWireMap.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/install/model/InstallPlanWireMap.kt
@@ -1,8 +1,7 @@
 package skillbill.install.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.install.INSTALL_PLAN_CONTRACT_VERSION
 import skillbill.contracts.install.InstallPlanSchemaPaths
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningEntry.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningEntry.kt
@@ -1,7 +1,6 @@
 package skillbill.learnings
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.learnings.model.LearningEntry
 import skillbill.learnings.model.LearningRecord
 import skillbill.learnings.model.LearningScope

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningEntry.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningEntry.kt
@@ -1,5 +1,7 @@
 package skillbill.learnings
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.learnings.model.LearningEntry
 import skillbill.learnings.model.LearningRecord
 import skillbill.learnings.model.LearningScope
@@ -21,7 +23,7 @@ fun learningEntryPayload(entry: LearningEntry): Map<String, Any?> = mapOf(
   "reference" to entry.reference,
   "scope" to entry.scope.wireName,
   "scope_key" to entry.scopeKey,
-  "status" to entry.status,
+  SharedPayloadKeys.STATUS to entry.status,
   "title" to entry.title,
   "rule_text" to entry.ruleText,
   "rationale" to entry.rationale,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningPayloads.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningPayloads.kt
@@ -1,8 +1,7 @@
 package skillbill.learnings
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.learnings.model.LearningRecord
 import skillbill.learnings.model.LearningScope
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningPayloads.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/learnings/LearningPayloads.kt
@@ -1,5 +1,7 @@
 package skillbill.learnings
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.learnings.model.LearningRecord
 import skillbill.learnings.model.LearningScope
@@ -10,7 +12,7 @@ fun learningPayload(record: LearningRecord): Map<String, Any?> = mapOf(
   "reference" to learningReference(record),
   "scope" to record.scope,
   "scope_key" to record.scopeKey,
-  "status" to record.status,
+  SharedPayloadKeys.STATUS to record.status,
   "title" to record.title,
   "rule_text" to record.ruleText,
   "rationale" to record.rationale,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewFindingParsing.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewFindingParsing.kt
@@ -1,9 +1,11 @@
 package skillbill.review
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.review.model.ImportedFinding
 
 fun requireMatch(pattern: Regex, text: String, errorMessage: String): String =
-  pattern.find(text)?.groups?.get("value")?.value ?: throw IllegalArgumentException(errorMessage)
+  pattern.find(text)?.groups?.get(SharedPayloadKeys.VALUE)?.value ?: throw IllegalArgumentException(errorMessage)
 
 fun parseReviewFindings(text: String): List<ImportedFinding> {
   val bulletFindings = parseBulletFindings(text)
@@ -39,7 +41,7 @@ private fun parseProvenanceLane(provenance: MatchResult): String? = provenance
   ?.value
   ?.let(findingSpecialistsProvenancePattern::find)
   ?.groups
-  ?.get("value")
+  ?.get(SharedPayloadKeys.VALUE)
   ?.value
   ?.split(",")
   ?.map(String::trim)
@@ -62,13 +64,13 @@ fun parseTableFindings(text: String): List<ImportedFinding> {
 }
 
 fun extractSummaryValue(text: String, key: String): String? =
-  summaryPatterns[key]?.find(text)?.groups?.get("value")?.value?.trim()
+  summaryPatterns[key]?.find(text)?.groups?.get(SharedPayloadKeys.VALUE)?.value?.trim()
 
 fun extractSpecialistReviews(text: String): List<String> {
   val seen = linkedSetOf<String>()
   specialistReviewsPattern.findAll(text).forEach { match ->
     match
-      .groups["value"]
+      .groups[SharedPayloadKeys.VALUE]
       ?.value
       .orEmpty()
       .split(",")

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewFindingParsing.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewFindingParsing.kt
@@ -1,7 +1,6 @@
 package skillbill.review
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.review.model.ImportedFinding
 
 fun requireMatch(pattern: Regex, text: String, errorMessage: String): String =

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewIssueCategory.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewIssueCategory.kt
@@ -1,5 +1,7 @@
 package skillbill.review
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.review.model.ImportedFinding
 import skillbill.review.model.ReviewIssueCategory
 
@@ -68,7 +70,7 @@ private fun resolveExplicitCategory(rawValue: String?): ReviewIssueCategory? = r
   ?.let(explicitCategoryAliases::get)
 
 private fun extractBulletCategory(findingText: String): String? =
-  bulletCategoryPattern.find(findingText)?.groups?.get("value")?.value
+  bulletCategoryPattern.find(findingText)?.groups?.get(SharedPayloadKeys.VALUE)?.value
 
 private fun resolveRoutedCategory(routedSkill: String?, specialistReviews: List<String>): ReviewIssueCategory? {
   val labels = listOfNotNull(routedSkill) + specialistReviews

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewIssueCategory.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewIssueCategory.kt
@@ -1,7 +1,6 @@
 package skillbill.review
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.review.model.ImportedFinding
 import skillbill.review.model.ReviewIssueCategory
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewParser.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewParser.kt
@@ -1,5 +1,7 @@
 package skillbill.review
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.review.model.ImportedReview
 import skillbill.review.model.ReviewExecutionMode
 import skillbill.review.model.ReviewIssueCategory
@@ -44,7 +46,7 @@ object ReviewParser {
   }
 
   private fun parseExecutionMode(text: String): ReviewExecutionMode? {
-    val reported = reportedExecutionModePattern.find(text)?.groups?.get("value")?.value?.trim()
+    val reported = reportedExecutionModePattern.find(text)?.groups?.get(SharedPayloadKeys.VALUE)?.value?.trim()
       ?: return null
     return ReviewExecutionMode.fromWire(extractSummaryValue(text, "execution_mode"))
       ?: throw IllegalArgumentException(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewParser.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewParser.kt
@@ -1,7 +1,6 @@
 package skillbill.review
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.review.model.ImportedReview
 import skillbill.review.model.ReviewExecutionMode
 import skillbill.review.model.ReviewIssueCategory

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewTableFindingParsing.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewTableFindingParsing.kt
@@ -1,5 +1,7 @@
 package skillbill.review
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.review.model.ImportedFinding
 
 fun isTableHeaderLine(line: String): Boolean {
@@ -14,7 +16,7 @@ fun buildColumnMap(headerCells: List<String>): Map<String, Int> = buildMap {
       "#", "id", "no", "no." -> put("number", index)
       "severity", "sev" -> put("severity", index)
       "confidence", "conf" -> put("confidence", index)
-      "category", "issue category", "issue_category" -> put("issue_category", index)
+      "category", "issue category", "issue_category" -> put(ReviewFindingPayloadKeys.ISSUE_CATEGORY, index)
       "file", "filename" -> put("file", index)
       "line", "lines", "line(s)" -> put("lines", index)
       "finding", "description", "issue" -> put("description", index)
@@ -55,7 +57,7 @@ fun parseTableFindingLine(stripped: String, columnMap: Map<String, Int>): Import
       findingId = "F-%03d".format(number),
       severity = normalizeSeverity(tableCell(cells, columnMap.getValue("severity"))),
       confidence = normalizeConfidence(confidenceValue),
-      issueCategory = normalizeReviewIssueCategory(tableCell(cells, columnMap["issue_category"])),
+      issueCategory = normalizeReviewIssueCategory(tableCell(cells, columnMap[ReviewFindingPayloadKeys.ISSUE_CATEGORY])),
       location = buildLocation(tableCell(cells, columnMap["file"]), tableCell(cells, columnMap["lines"])),
       description = description,
       findingText = stripped,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewTableFindingParsing.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/review/ReviewTableFindingParsing.kt
@@ -1,7 +1,6 @@
 package skillbill.review
 
 import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.review.model.ImportedFinding
 
 fun isTableHeaderLine(line: String): Boolean {
@@ -57,7 +56,9 @@ fun parseTableFindingLine(stripped: String, columnMap: Map<String, Int>): Import
       findingId = "F-%03d".format(number),
       severity = normalizeSeverity(tableCell(cells, columnMap.getValue("severity"))),
       confidence = normalizeConfidence(confidenceValue),
-      issueCategory = normalizeReviewIssueCategory(tableCell(cells, columnMap[ReviewFindingPayloadKeys.ISSUE_CATEGORY])),
+      issueCategory = normalizeReviewIssueCategory(
+        tableCell(cells, columnMap[ReviewFindingPayloadKeys.ISSUE_CATEGORY]),
+      ),
       location = buildLocation(tableCell(cells, columnMap["file"]), tableCell(cells, columnMap["lines"])),
       description = description,
       findingText = stripped,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/decomposition/DecompositionManifestWireMap.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/decomposition/DecompositionManifestWireMap.kt
@@ -1,7 +1,6 @@
 package skillbill.workflow.decomposition
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.workflow.decomposition.model.DecompositionManifest
 import skillbill.workflow.decomposition.model.SpecSource
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/decomposition/DecompositionManifestWireMap.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/decomposition/DecompositionManifestWireMap.kt
@@ -1,26 +1,28 @@
 package skillbill.workflow.decomposition
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.workflow.decomposition.model.DecompositionManifest
 import skillbill.workflow.decomposition.model.SpecSource
 
 fun DecompositionManifest.toWireMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to contractVersion,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "feature_name" to featureName,
   "parent_spec_path" to parentSpecPath,
-  "status" to status,
+  SharedPayloadKeys.STATUS to status,
   "execution_model" to executionModel.wireValue,
   "base_branch" to baseBranch,
   "feature_branch" to featureBranch,
   "stack_branches" to stackBranches.map { branch ->
     linkedMapOf(
-      "subtask_id" to branch.subtaskId,
+      SharedPayloadKeys.SUBTASK_ID to branch.subtaskId,
       "branch" to branch.branch,
       "base_branch" to branch.baseBranch,
     )
   },
   "current_subtask_intent" to linkedMapOf(
-    "subtask_id" to currentSubtaskIntent.subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to currentSubtaskIntent.subtaskId,
     "action" to currentSubtaskIntent.action,
   ),
   "subtasks" to subtasks.map { subtask ->
@@ -28,10 +30,10 @@ fun DecompositionManifest.toWireMap(): Map<String, Any?> = linkedMapOf(
       "id" to subtask.id,
       "name" to subtask.name,
       "spec_path" to subtask.specPath,
-      "status" to subtask.status,
+      SharedPayloadKeys.STATUS to subtask.status,
       "branch" to subtask.branch,
       "commit_sha" to subtask.commitSha,
-      "workflow_id" to subtask.workflowId,
+      SharedPayloadKeys.WORKFLOW_ID to subtask.workflowId,
       "blocked_reason" to subtask.blockedReason,
       "last_resumable_step" to subtask.lastResumableStep,
       "linear_issue_id" to subtask.linearIssueId,
@@ -39,7 +41,7 @@ fun DecompositionManifest.toWireMap(): Map<String, Any?> = linkedMapOf(
       "participating_agent_ids" to subtask.participatingAgentIds,
       "dependencies" to subtask.dependencies.map { dependency ->
         linkedMapOf(
-          "subtask_id" to dependency.subtaskId,
+          SharedPayloadKeys.SUBTASK_ID to dependency.subtaskId,
           "optional" to dependency.optional,
           "skipped" to dependency.skipped,
         )

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/AttemptLedgerWorkflowDecoding.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/AttemptLedgerWorkflowDecoding.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.engine
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.error.MalformedJsonTextError
 import skillbill.workflow.engine.model.WorkflowStateSnapshot

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/AttemptLedgerWorkflowDecoding.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/AttemptLedgerWorkflowDecoding.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.engine
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.error.MalformedJsonTextError
@@ -34,8 +36,8 @@ private fun decodeWorkflowStepAt(index: Int, raw: Any?): WorkflowStepState {
   val item = raw as? Map<*, *>
     ?: throw InvalidWorkflowStateSchemaError("Workflow steps[$index] must be an object.")
   return WorkflowStepState(
-    stepId = item["step_id"]?.toString().orEmpty(),
-    status = item["status"]?.toString().orEmpty(),
+    stepId = item[SharedPayloadKeys.STEP_ID]?.toString().orEmpty(),
+    status = item[SharedPayloadKeys.STATUS]?.toString().orEmpty(),
     attemptCount = item["attempt_count"].asLenientIntOrNull() ?: 0,
   )
 }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngine.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngine.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.engine
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.workflow.engine.model.WorkflowContinueDecision
 import skillbill.workflow.engine.model.WorkflowDefinition
 import skillbill.workflow.engine.model.WorkflowInputProjection
@@ -103,7 +105,7 @@ class WorkflowEngine(
     workflowName = snapshot.workflowName,
     workflowStatus = snapshot.workflowStatus,
     currentStepId = snapshot.currentStepId,
-    updatedStepIds = input.stepUpdates.orEmpty().mapNotNull { it["step_id"] as? String },
+    updatedStepIds = input.stepUpdates.orEmpty().mapNotNull { it[SharedPayloadKeys.STEP_ID] as? String },
     updatedArtifactKeys = input.artifactsPatch.orEmpty().keys.sorted(),
     readOnlyFullStateGuidance =
     "Update returns a compact acknowledgement. Use explicit read-only workflow get/show for full state, " +

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngine.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngine.kt
@@ -1,7 +1,6 @@
 package skillbill.workflow.engine
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.workflow.engine.model.WorkflowContinueDecision
 import skillbill.workflow.engine.model.WorkflowDefinition
 import skillbill.workflow.engine.model.WorkflowInputProjection

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineSnapshotCodec.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineSnapshotCodec.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.engine
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.workflow.engine.model.WorkflowDefinition
@@ -10,8 +12,8 @@ import skillbill.workflow.engine.model.WorkflowStepState
 internal fun snapshotViewFrom(record: WorkflowStateSnapshot): WorkflowSnapshotView {
   val steps = decodeSteps(record.stepsJson).map { stepMap ->
     WorkflowStepState(
-      stepId = stepMap["step_id"] as String,
-      status = stepMap["status"] as String,
+      stepId = stepMap[SharedPayloadKeys.STEP_ID] as String,
+      status = stepMap[SharedPayloadKeys.STATUS] as String,
       attemptCount = stepMap["attempt_count"].asExactIntOrNull()
         ?: throw InvalidWorkflowStateSchemaError(
           "Workflow state step attempt_count must decode to an integer.",
@@ -56,21 +58,21 @@ internal fun mergeStepUpdates(
   if (stepUpdates == null) {
     return existingSteps
   }
-  val byStepId = existingSteps.associateByTo(LinkedHashMap()) { it["step_id"].toString() }
+  val byStepId = existingSteps.associateByTo(LinkedHashMap()) { it[SharedPayloadKeys.STEP_ID].toString() }
   stepUpdates.forEach { update ->
-    val stepId = update["step_id"].toString()
+    val stepId = update[SharedPayloadKeys.STEP_ID].toString()
     val attemptCount = requireNotNull(update["attempt_count"].asExactIntOrNull()) {
       "step_updates.attempt_count must be an integer >= 0."
     }
     require(attemptCount >= 0) {
       "step_updates.attempt_count must be an integer >= 0."
     }
-    byStepId[stepId] = workflowStep(stepId, update["status"].toString(), attemptCount)
+    byStepId[stepId] = workflowStep(stepId, update[SharedPayloadKeys.STATUS].toString(), attemptCount)
   }
   return definition.stepIds.mapNotNull(byStepId::get)
 }
 
 internal fun workflowStep(stepId: String, status: String, attemptCount: Int): Map<String, Any?> =
-  linkedMapOf("step_id" to stepId, "status" to status, "attempt_count" to attemptCount)
+  linkedMapOf(SharedPayloadKeys.STEP_ID to stepId, SharedPayloadKeys.STATUS to status, "attempt_count" to attemptCount)
 
 internal fun jsonString(value: Any?): String = JsonCodec.valueToJsonString(value)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineSnapshotCodec.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineSnapshotCodec.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.engine
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.workflow.engine.model.WorkflowDefinition
 import skillbill.workflow.engine.model.WorkflowSnapshotView

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineValidation.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineValidation.kt
@@ -1,7 +1,6 @@
 package skillbill.workflow.engine
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.workflow.engine.model.WorkflowDefinition
 import skillbill.workflow.engine.model.WorkflowUpdateInput
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineValidation.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/engine/WorkflowEngineValidation.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.engine
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.workflow.engine.model.WorkflowDefinition
 import skillbill.workflow.engine.model.WorkflowUpdateInput
 
@@ -28,7 +30,7 @@ private fun validateOneStepUpdate(
   update: Map<String, Any?>,
   seenStepIds: MutableSet<String>,
 ): String? {
-  val stepId = update["step_id"] as? String
+  val stepId = update[SharedPayloadKeys.STEP_ID] as? String
   if (stepId.isNullOrBlank()) {
     return "step_updates[$index].step_id must be a non-empty string."
   }
@@ -44,7 +46,7 @@ private fun validateStepStatusAndAttempt(
   index: Int,
   update: Map<String, Any?>,
 ): String? {
-  val status = update["status"] as? String
+  val status = update[SharedPayloadKeys.STATUS] as? String
   if (status.isNullOrBlank()) {
     return "step_updates[$index].status must be a non-empty string."
   }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityModels.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.goal.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.GOAL_OBSERVABILITY_EVENT_CONTRACT_VERSION
 import skillbill.contracts.workflow.GOAL_PROGRESS_EVENT_CONTRACT_VERSION
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.goal.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.GOAL_OBSERVABILITY_EVENT_CONTRACT_VERSION
 import skillbill.contracts.workflow.GOAL_PROGRESS_EVENT_CONTRACT_VERSION
@@ -97,15 +99,15 @@ data class GoalProgressEvent(
 
   @OpenBoundaryMap("Goal progress event artifact map at durable workflow-artifact/schema seams")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to contractVersion,
+    SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
     "event_kind" to eventKind.wireValue,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "workflow_phase" to workflowPhase,
     "process_alive" to processAlive,
     "sequence_number" to sequenceNumber,
     "timestamp" to timestamp,
   ).apply {
-    stepId?.takeIf(String::isNotBlank)?.let { put("step_id", it) }
+    stepId?.takeIf(String::isNotBlank)?.let { put(SharedPayloadKeys.STEP_ID, it) }
     operationName?.takeIf(String::isNotBlank)?.let { put("operation_name", it) }
     operationKind?.takeIf(String::isNotBlank)?.let { put("operation_kind", it) }
     if (eventKind.isOperationEvent) {
@@ -185,11 +187,11 @@ data class GoalObservabilityEvent(
 ) {
   @OpenBoundaryMap("Goal observability event artifact map at durable workflow-artifact/schema seams")
   fun toArtifactMap(includeHeavyFields: Boolean = false): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to contractVersion,
+    SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
     "record_kind" to recordKind.wireValue,
-    "issue_key" to issueKey,
-    "subtask_id" to subtaskId,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "workflow_phase" to workflowPhase,
     "worker_role" to workerRole,
     "liveness_class" to livenessClass,
@@ -234,8 +236,8 @@ data class GoalObservabilityEvent(
 
   @OpenBoundaryMap("Compact goal observability summary map rendered by CLI/MCP workflow adapters")
   fun toCompactSummaryMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "issue_key" to issueKey,
-    "subtask_id" to subtaskId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
     "workflow_phase" to workflowPhase,
     "worker_role" to workerRole,
     "liveness_class" to livenessClass,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityParsing.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityParsing.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.goal.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.GOAL_OBSERVABILITY_EVENT_CONTRACT_VERSION
@@ -20,7 +22,7 @@ fun goalObservabilityLatestEventForLiveness(
 ): GoalObservabilityEvent? {
   val raw = artifacts[GOAL_OBSERVABILITY_LATEST_EVENT_ARTIFACT_KEY] ?: return null
   val eventMap = JsonCodec.anyToStringAnyMap(raw) ?: return null
-  if (eventMap["contract_version"] != GOAL_OBSERVABILITY_EVENT_CONTRACT_VERSION) return null
+  if (eventMap[SharedPayloadKeys.CONTRACT_VERSION] != GOAL_OBSERVABILITY_EVENT_CONTRACT_VERSION) return null
   return runCatching {
     goalObservabilityEventFromArtifact(raw, GOAL_OBSERVABILITY_LATEST_EVENT_ARTIFACT_KEY, validator)
   }.getOrNull()

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityParsing.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalObservabilityParsing.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.goal.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.GOAL_OBSERVABILITY_EVENT_CONTRACT_VERSION
 import skillbill.workflow.goal.GoalObservabilityEventValidator
 import skillbill.workflow.goal.invalidGoalObservabilityEvent

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewConstantsAndDispositions.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewConstantsAndDispositions.kt
@@ -1,10 +1,8 @@
 package skillbill.workflow.goal.model
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 
 const val GOAL_SUBTASK_REVIEW_STATE_ARTIFACT_KEY: String = "goal_subtask_review_state"
 const val GOAL_SUBTASK_REVIEW_INPUT_ARTIFACT_KEY: String = "goal_subtask_review_input"

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewConstantsAndDispositions.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewConstantsAndDispositions.kt
@@ -1,5 +1,9 @@
 package skillbill.workflow.goal.model
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 
 const val GOAL_SUBTASK_REVIEW_STATE_ARTIFACT_KEY: String = "goal_subtask_review_state"
@@ -72,8 +76,8 @@ data class GoalSubtaskBlockerDisposition(
 
   @OpenBoundaryMap("Blocker disposition at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf(
-    "finding_id" to findingId,
-    "verdict" to verdict.wireValue,
+    ReviewFindingPayloadKeys.FINDING_ID to findingId,
+    SharedPayloadKeys.VERDICT to verdict.wireValue,
     "evidence" to evidence,
   )
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewFindingArtifacts.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewFindingArtifacts.kt
@@ -1,5 +1,11 @@
 package skillbill.workflow.goal.model
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -47,7 +53,7 @@ data class GoalSubtaskReviewCompactFinding(
     "severity" to severity,
     "label" to label,
     "text" to text,
-  ).apply { findingId?.let { put("finding_id", it) } }
+  ).apply { findingId?.let { put(ReviewFindingPayloadKeys.FINDING_ID, it) } }
 
   companion object {
     @OpenBoundaryMap("Compact goal-review finding decode from the durable workflow-artifact map")
@@ -103,10 +109,10 @@ data class GoalSubtaskReviewPassResult(
   @OpenBoundaryMap("Goal-review pass result at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
     "pass_number" to passNumber,
-    "verdict" to verdict.wireValue,
+    SharedPayloadKeys.VERDICT to verdict.wireValue,
     "review_result_artifact" to reviewResultArtifact,
     "unresolved_finding_count" to unresolvedFindingCount,
-    "findings" to findings.map(GoalSubtaskReviewCompactFinding::toArtifactMap),
+    ReviewVerificationSignalKeys.REVIEW_FINDINGS to findings.map(GoalSubtaskReviewCompactFinding::toArtifactMap),
   ).apply {
     executedMode?.let { put("executed_mode", it.wireValue) }
     commitFocusedAccounting?.let { put("commit_focused_accounting", it.toArtifactMap()) }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewFindingArtifacts.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewFindingArtifacts.kt
@@ -1,12 +1,9 @@
 package skillbill.workflow.goal.model
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.review.context.model.CodeReviewExecutionMode

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewState.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewState.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.goal.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.GOAL_SUBTASK_REVIEW_STATE_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimeRepairReceiptError
@@ -212,7 +214,7 @@ data class GoalSubtaskReviewState(
 
   @OpenBoundaryMap("Goal-review state at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to contractVersion,
+    SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
     "review_base_sha" to reviewBaseSha,
     "code_review_mode" to codeReviewMode.wireValue,
     "completed_pass_count" to completedPassCount,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewState.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/goal/model/GoalSubtaskReviewState.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.goal.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.GOAL_SUBTASK_REVIEW_STATE_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimeRepairReceiptError
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionFinalization.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionFinalization.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffProjectionInputs
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutput
 import skillbill.workflow.taskruntime.model.PhaseHandoffProjectionDeclaration

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionFinalization.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionFinalization.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffProjectionInputs
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutput
@@ -41,7 +43,7 @@ internal object FeatureTaskRuntimeHandoffProjectionFinalization {
       ?: JsonCodec.parseObjectOrNull(output.payload)?.let(JsonCodec::jsonElementToValue)
         ?.let(JsonCodec::anyToStringAnyMap)
       ?: return emptyMap()
-    return JsonCodec.anyToStringAnyMap(envelope["produced_outputs"]).orEmpty()
+    return JsonCodec.anyToStringAnyMap(envelope[SharedPayloadKeys.PRODUCED_OUTPUTS]).orEmpty()
   }
 
   private fun finalizationProjectionContext(
@@ -70,7 +72,7 @@ internal object FeatureTaskRuntimeHandoffProjectionFinalization {
     "validation_summary" to (
       context.validation["validation_result"]
         ?: context.validation["validation_summary"]
-        ?: context.validation["summary"]
+        ?: context.validation[SharedPayloadKeys.SUMMARY]
         ?: "completed"
       ),
     "base_branch" to context.base,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValueBuilder.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValueBuilder.kt
@@ -1,12 +1,9 @@
 package skillbill.workflow.taskruntime
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.error.FeatureTaskRuntimeHandoffProjectionFailureKind
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeCompactReferenceKind
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeFindingVerificationDisposition
@@ -97,7 +94,8 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
       REPOSITORY_CHECKPOINT_FIELD to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.FINDINGS_VERIFICATION_DISPOSITIONS -> mapOf(
-      ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS to produced[ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS],
+      ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS to
+        produced[ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS],
       REPOSITORY_CHECKPOINT_FIELD to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.CHANGE_RECEIPT -> mapOf(
@@ -189,7 +187,9 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
       .map { finding ->
         val severity = (finding["severity"] as? String)?.takeIf(String::isNotBlank) ?: "blocker"
         mapOf(
-          ReviewFindingPayloadKeys.FINDING_ID to (finding[ReviewFindingPayloadKeys.FINDING_ID] ?: finding[ReviewFindingPayloadKeys.F_NUMBER] ?: finding["id"]),
+          ReviewFindingPayloadKeys.FINDING_ID to (
+            finding[ReviewFindingPayloadKeys.FINDING_ID] ?: finding[ReviewFindingPayloadKeys.F_NUMBER] ?: finding["id"]
+            ),
           "severity" to severity,
           "location" to (
             finding["location"] ?: finding[ReviewFindingPayloadKeys.REPOSITORY_PATH] ?: finding["path"] ?: "repository"
@@ -197,7 +197,9 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
           "message" to (
             finding["message"] ?: finding["description"] ?: finding["expected_outcome"] ?: "Review finding."
             ),
-          ReviewFindingPayloadKeys.ISSUE_CATEGORY to (finding[ReviewFindingPayloadKeys.ISSUE_CATEGORY] ?: finding["category"] ?: "other"),
+          ReviewFindingPayloadKeys.ISSUE_CATEGORY to (
+            finding[ReviewFindingPayloadKeys.ISSUE_CATEGORY] ?: finding["category"] ?: "other"
+            ),
           ReviewFindingPayloadKeys.CLAIM_VERDICT to finding[ReviewFindingPayloadKeys.CLAIM_VERDICT],
           ReviewFindingPayloadKeys.SCOPE_DISPOSITION to finding[ReviewFindingPayloadKeys.SCOPE_DISPOSITION],
         ).filterValues { it != null }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValueBuilder.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/FeatureTaskRuntimeHandoffProjectionValueBuilder.kt
@@ -1,5 +1,11 @@
 package skillbill.workflow.taskruntime
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.error.FeatureTaskRuntimeHandoffProjectionFailureKind
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeCompactReferenceKind
@@ -52,7 +58,7 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
         FeatureTaskRuntimeHandoffProjectionFailureKind.MALFORMED_FIELD,
         "validated producer output could not be decoded as an object.",
       )
-    val produced = JsonCodec.anyToStringAnyMap(envelope["produced_outputs"]).orEmpty()
+    val produced = JsonCodec.anyToStringAnyMap(envelope[SharedPayloadKeys.PRODUCED_OUTPUTS]).orEmpty()
     val runtimeOwned = runtimeOwnedPhaseProjectionValues(inputs, declaration, produced, envelope)
     return declaration.declaredFieldNames.mapNotNull { name ->
       val value = runtimeOwned[name] ?: when {
@@ -80,18 +86,18 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
         .reviewScope
         .wireValue,
       REPOSITORY_CHECKPOINT_FIELD to checkpointFingerprint(inputs),
-      "verdict" to auditClearanceStatus(envelope),
+      SharedPayloadKeys.VERDICT to auditClearanceStatus(envelope),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.REVIEW_REPAIR_REQUEST -> mapOf(
       "unresolved_blocker_findings" to verifiedFindingsProjection(inputs, produced),
       REPOSITORY_CHECKPOINT_FIELD to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.FINDINGS_VERIFICATION_INPUT -> mapOf(
-      "findings" to reviewFindingsForVerificationProjection(produced),
+      ReviewVerificationSignalKeys.REVIEW_FINDINGS to reviewFindingsForVerificationProjection(produced),
       REPOSITORY_CHECKPOINT_FIELD to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.FINDINGS_VERIFICATION_DISPOSITIONS -> mapOf(
-      "finding_dispositions" to produced["finding_dispositions"],
+      ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS to produced[ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS],
       REPOSITORY_CHECKPOINT_FIELD to checkpointFingerprint(inputs),
     )
     FeatureTaskRuntimePhaseWorkflowDefinition.PhaseProjectionContract.CHANGE_RECEIPT -> mapOf(
@@ -130,7 +136,7 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
         "produced_outputs.value must contain non-blank prose for phase handoff.",
       )
     }
-    val fields = linkedMapOf<String, Any?>("value" to valueText)
+    val fields = linkedMapOf<String, Any?>(SharedPayloadKeys.VALUE to valueText)
     resolveDeclaredPhaseField(produced, "prompt")
       ?.toString()
       ?.takeIf(String::isNotBlank)
@@ -139,7 +145,7 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
   }
 
   private fun auditClearanceStatus(envelope: Map<String, Any?>): String? =
-    (envelope["verdict"] as? String)?.takeIf(String::isNotBlank)
+    (envelope[SharedPayloadKeys.VERDICT] as? String)?.takeIf(String::isNotBlank)
 
   private fun verifiedFindingsProjection(
     inputs: FeatureTaskRuntimeHandoffProjectionInputs,
@@ -149,9 +155,9 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
       FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW,
     ]?.let(FeatureTaskRuntimeHandoffProjectionFinalization::genericProducedOutputs).orEmpty()
     val reviewFindingsById = reviewFindingsForVerificationProjection(reviewProduced)
-      .associateBy { it["finding_id"]?.toString().orEmpty() }
+      .associateBy { it[ReviewFindingPayloadKeys.FINDING_ID]?.toString().orEmpty() }
     return FeatureTaskRuntimeFindingVerificationDisposition.parseList(
-      produced["finding_dispositions"],
+      produced[ReviewVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS],
       "produced_outputs.finding_dispositions",
     )
       .filter { it.disposition == FeatureTaskRuntimeFindingVerificationDispositionVerdict.VERIFIED }
@@ -163,7 +169,7 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
           ?.takeIf(String::isNotBlank)
           ?: "blocker"
         mapOf(
-          "finding_id" to disposition.findingId,
+          ReviewFindingPayloadKeys.FINDING_ID to disposition.findingId,
           "severity" to severity,
           "location" to (review?.get("location") ?: "repository"),
           "expected_outcome" to (
@@ -178,22 +184,22 @@ internal object FeatureTaskRuntimeHandoffProjectionValueBuilder {
   }
 
   private fun reviewFindingsForVerificationProjection(produced: Map<String, Any?>): List<Map<String, Any?>> =
-    (produced["findings"] as? List<*>).orEmpty()
+    (produced[ReviewVerificationSignalKeys.REVIEW_FINDINGS] as? List<*>).orEmpty()
       .mapNotNull(JsonCodec::anyToStringAnyMap)
       .map { finding ->
         val severity = (finding["severity"] as? String)?.takeIf(String::isNotBlank) ?: "blocker"
         mapOf(
-          "finding_id" to (finding["finding_id"] ?: finding["f_number"] ?: finding["id"]),
+          ReviewFindingPayloadKeys.FINDING_ID to (finding[ReviewFindingPayloadKeys.FINDING_ID] ?: finding[ReviewFindingPayloadKeys.F_NUMBER] ?: finding["id"]),
           "severity" to severity,
           "location" to (
-            finding["location"] ?: finding["repository_path"] ?: finding["path"] ?: "repository"
+            finding["location"] ?: finding[ReviewFindingPayloadKeys.REPOSITORY_PATH] ?: finding["path"] ?: "repository"
             ),
           "message" to (
             finding["message"] ?: finding["description"] ?: finding["expected_outcome"] ?: "Review finding."
             ),
-          "issue_category" to (finding["issue_category"] ?: finding["category"] ?: "other"),
-          "claim_verdict" to finding["claim_verdict"],
-          "scope_disposition" to finding["scope_disposition"],
+          ReviewFindingPayloadKeys.ISSUE_CATEGORY to (finding[ReviewFindingPayloadKeys.ISSUE_CATEGORY] ?: finding["category"] ?: "other"),
+          ReviewFindingPayloadKeys.CLAIM_VERDICT to finding[ReviewFindingPayloadKeys.CLAIM_VERDICT],
+          ReviewFindingPayloadKeys.SCOPE_DISPOSITION to finding[ReviewFindingPayloadKeys.SCOPE_DISPOSITION],
         ).filterValues { it != null }
       }
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputRecover.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputRecover.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 
 internal object ProsePhaseOutputRecover {
   private val LEGACY_VALUE_KEYS: List<String> = listOf(
@@ -49,7 +48,11 @@ internal object ProsePhaseOutputRecover {
   }
 
   fun recoverSummary(parsed: Map<String, Any?>?, value: String): String {
-    val fromField = parsed?.get(SharedPayloadKeys.SUMMARY)?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+    val fromField = parsed
+      ?.get(SharedPayloadKeys.SUMMARY)
+      ?.toString()
+      ?.trim()
+      ?.takeIf { it.any { ch -> !ch.isWhitespace() } }
     if (fromField != null) return fromField
     val compact = value.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty()
     return when {
@@ -74,8 +77,11 @@ internal object ProsePhaseOutputRecover {
     }
   }
 
-  fun recoverFailureDisposition(parsed: Map<String, Any?>?): String? =
-    parsed?.get(SharedPayloadKeys.FAILURE_DISPOSITION)?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+  fun recoverFailureDisposition(parsed: Map<String, Any?>?): String? = parsed
+    ?.get(SharedPayloadKeys.FAILURE_DISPOSITION)
+    ?.toString()
+    ?.trim()
+    ?.takeIf { it.any { ch -> !ch.isWhitespace() } }
 }
 
 private fun stuffSibling(sibling: Any?): String? = when (sibling) {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputRecover.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/ProsePhaseOutputRecover.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 
 internal object ProsePhaseOutputRecover {
@@ -14,19 +16,19 @@ internal object ProsePhaseOutputRecover {
   private const val SUMMARY_ELLIPSIS_PREFIX: Int = 237
 
   fun directValue(parsed: Map<String, Any?>): String? {
-    val produced = JsonCodec.anyToStringAnyMap(parsed["produced_outputs"]) ?: return null
-    return produced["value"]?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+    val produced = JsonCodec.anyToStringAnyMap(parsed[SharedPayloadKeys.PRODUCED_OUTPUTS]) ?: return null
+    return produced[SharedPayloadKeys.VALUE]?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
   }
 
   fun recoverLegacyValue(parsed: Map<String, Any?>): String? {
-    val produced = JsonCodec.anyToStringAnyMap(parsed["produced_outputs"])
+    val produced = JsonCodec.anyToStringAnyMap(parsed[SharedPayloadKeys.PRODUCED_OUTPUTS])
     if (produced != null) {
       for (key in LEGACY_VALUE_KEYS) {
         val stuffed = stuffSibling(produced[key])
         if (stuffed != null) return stuffed
       }
     }
-    listValue(parsed["produced_outputs"])?.let { return it }
+    listValue(parsed[SharedPayloadKeys.PRODUCED_OUTPUTS])?.let { return it }
     return LEGACY_VALUE_KEYS.firstNotNullOfOrNull { key -> stuffSibling(parsed[key]) }
   }
 
@@ -34,20 +36,20 @@ internal object ProsePhaseOutputRecover {
     val entries = (producedOutputs as? List<*>)?.takeIf { it.isNotEmpty() } ?: return null
     val singleValue = entries.singleOrNull()
       ?.let(JsonCodec::anyToStringAnyMap)
-      ?.get("value")
+      ?.get(SharedPayloadKeys.VALUE)
       ?.toString()
       ?.takeIf { it.any { ch -> !ch.isWhitespace() } }
     return singleValue ?: stuffSibling(entries)
   }
 
   fun recoverPrompt(parsed: Map<String, Any?>?): String? {
-    val produced = JsonCodec.anyToStringAnyMap(parsed?.get("produced_outputs"))
-    return produced?.get("prompt")?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
-      ?: parsed?.get("prompt")?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+    val produced = JsonCodec.anyToStringAnyMap(parsed?.get(SharedPayloadKeys.PRODUCED_OUTPUTS))
+    return produced?.get(SharedPayloadKeys.PROMPT)?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+      ?: parsed?.get(SharedPayloadKeys.PROMPT)?.toString()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
   }
 
   fun recoverSummary(parsed: Map<String, Any?>?, value: String): String {
-    val fromField = parsed?.get("summary")?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+    val fromField = parsed?.get(SharedPayloadKeys.SUMMARY)?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
     if (fromField != null) return fromField
     val compact = value.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty()
     return when {
@@ -57,10 +59,10 @@ internal object ProsePhaseOutputRecover {
   }
 
   fun recoverAuditVerdict(parsed: Map<String, Any?>?, rawText: String): String? {
-    val fromField = parsed?.get("verdict")?.toString()?.trim()?.lowercase()
+    val fromField = parsed?.get(SharedPayloadKeys.VERDICT)?.toString()?.trim()?.lowercase()
     if (fromField in AUDIT_VERDICTS) return fromField
-    val produced = JsonCodec.anyToStringAnyMap(parsed?.get("produced_outputs"))
-    val fromProduced = produced?.get("verdict")?.toString()?.trim()?.lowercase()
+    val produced = JsonCodec.anyToStringAnyMap(parsed?.get(SharedPayloadKeys.PRODUCED_OUTPUTS))
+    val fromProduced = produced?.get(SharedPayloadKeys.VERDICT)?.toString()?.trim()?.lowercase()
     if (fromProduced in AUDIT_VERDICTS) return fromProduced
     val lower = rawText.lowercase()
     val hasSatisfied = Regex("""\bsatisfied\b""").containsMatchIn(lower)
@@ -73,7 +75,7 @@ internal object ProsePhaseOutputRecover {
   }
 
   fun recoverFailureDisposition(parsed: Map<String, Any?>?): String? =
-    parsed?.get("failure_disposition")?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
+    parsed?.get(SharedPayloadKeys.FAILURE_DISPOSITION)?.toString()?.trim()?.takeIf { it.any { ch -> !ch.isWhitespace() } }
 }
 
 private fun stuffSibling(sibling: Any?): String? = when (sibling) {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeAuditGapPersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeAuditGapPersistenceModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -53,7 +55,7 @@ data class FeatureTaskRuntimeAuditGapPause(
 
   @OpenBoundaryMap("Feature-task-runtime audit-gap pause artifact map at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
     "record_kind" to "audit_gap_pause",
     "pause_kind" to pauseKind.wireValue,
     "reason" to reason,
@@ -68,10 +70,10 @@ data class FeatureTaskRuntimeAuditGapPause(
     @OpenBoundaryMap("Feature-task-runtime audit-gap pause decode from the durable workflow-artifact map")
     fun fromArtifactMap(raw: Map<String, Any?>): FeatureTaskRuntimeAuditGapPause {
       requireExactAuditGapPauseFields(raw)
-      if (raw["contract_version"] != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION) {
+      if (raw[SharedPayloadKeys.CONTRACT_VERSION] != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION) {
         throw InvalidWorkflowStateSchemaError(
           "Feature-task-runtime audit-gap pause artifact uses unsupported persistence contract " +
-            "version '${raw["contract_version"]}'; $FEATURE_TASK_RUNTIME_INCOMPATIBLE_RECORD_GUIDANCE.",
+            "version '${raw[SharedPayloadKeys.CONTRACT_VERSION]}'; $FEATURE_TASK_RUNTIME_INCOMPATIBLE_RECORD_GUIDANCE.",
         )
       }
       if (raw["record_kind"] != "audit_gap_pause") {
@@ -123,7 +125,7 @@ data class FeatureTaskRuntimeAuditGapProgress(
 
   @OpenBoundaryMap("Feature-task-runtime audit-gap progress artifact map at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
     "record_kind" to "audit_gap_progress",
     "previous_criterion_refs" to criterionRefs.sorted(),
   ).apply {
@@ -137,10 +139,10 @@ data class FeatureTaskRuntimeAuditGapProgress(
     @OpenBoundaryMap("Feature-task-runtime audit-gap progress decode from the durable workflow-artifact map")
     fun fromArtifactMap(raw: Map<String, Any?>): FeatureTaskRuntimeAuditGapProgress {
       requireExactAuditGapProgressFields(raw)
-      if (raw["contract_version"] != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION) {
+      if (raw[SharedPayloadKeys.CONTRACT_VERSION] != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION) {
         throw InvalidWorkflowStateSchemaError(
           "Feature-task-runtime audit-gap progress artifact uses unsupported persistence contract " +
-            "version '${raw["contract_version"]}'; $FEATURE_TASK_RUNTIME_INCOMPATIBLE_RECORD_GUIDANCE.",
+            "version '${raw[SharedPayloadKeys.CONTRACT_VERSION]}'; $FEATURE_TASK_RUNTIME_INCOMPATIBLE_RECORD_GUIDANCE.",
         )
       }
       if (raw["record_kind"] != "audit_gap_progress") {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeAuditGapPersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeAuditGapPersistenceModels.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeCheckpointIdentityModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeCheckpointIdentityModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITY_CONTRACT_VERSION
@@ -114,11 +116,11 @@ data class FeatureTaskRuntimeCheckpointIdentity(
   @OpenBoundaryMap("Feature-task-runtime checkpoint-identity entry at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
     "sequence_number" to sequenceNumber,
-    "issue_key" to issueKey,
-    "subtask_id" to subtaskId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
     "checkpoint_ref" to checkpointRef,
     "branch" to branch,
-    "phase_id" to phaseId,
+    SharedPayloadKeys.PHASE_ID to phaseId,
     "generation" to generation,
     "owned_path_digest" to ownedPathDigest,
     "owned_path_count" to ownedPathCount,
@@ -207,7 +209,7 @@ fun featureTaskRuntimeOwnedPathDigest(ownedPaths: List<String>): String {
 fun featureTaskRuntimeCheckpointIdentitiesToArtifact(
   identities: List<FeatureTaskRuntimeCheckpointIdentity>,
 ): Map<String, Any?> = linkedMapOf(
-  "contract_version" to FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITY_CONTRACT_VERSION,
+  SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITY_CONTRACT_VERSION,
   "checkpoints" to identities.map { it.toArtifactMap() },
 )
 
@@ -221,7 +223,7 @@ fun featureTaskRuntimeCheckpointIdentitiesFromArtifact(raw: Any?): List<FeatureT
   if (raw == null) return emptyList()
   val map = JsonCodec.anyToStringAnyMap(raw)
     ?: checkpointIdentityError("Feature-task-runtime checkpoint-identity record must be an object.")
-  val version = map["contract_version"] as? String
+  val version = map[SharedPayloadKeys.CONTRACT_VERSION] as? String
   if (version != FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITY_CONTRACT_VERSION) {
     throw InvalidFeatureTaskRuntimeCheckpointIdentityVersionError(
       expectedContractVersion = FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITY_CONTRACT_VERSION,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeCheckpointIdentityModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeCheckpointIdentityModels.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITY_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimeCheckpointIdentityVersionError
 import skillbill.error.InvalidWorkflowStateSchemaError

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDeliveredProjectionRecord.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDeliveredProjectionRecord.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDeliveredProjectionRecord.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDeliveredProjectionRecord.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
@@ -39,13 +41,13 @@ data class FeatureTaskRuntimeDeliveredProjectionRecord(
 
   @OpenBoundaryMap("Feature-task-runtime delivered-projection record at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
     "record_kind" to "delivered_projection",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "consumer_phase_id" to consumerPhaseId,
     "consumer_delivery_iteration" to iteration,
     "source_producer_iterations" to sourceProducerIterations.map {
-      mapOf("phase_id" to it.phaseId, "iteration" to it.iteration)
+      mapOf(SharedPayloadKeys.PHASE_ID to it.phaseId, "iteration" to it.iteration)
     },
     REPOSITORY_CHECKPOINT_FIELD to mapOf("fingerprint" to repositoryCheckpointFingerprint),
     "handoff_envelope" to envelope.toEnvelopeMap(),
@@ -63,7 +65,7 @@ data class FeatureTaskRuntimeDeliveredProjectionRecord(
     }
 
     private fun requireSupportedPersistenceContract(raw: Map<String, Any?>) {
-      val contractVersion = raw["contract_version"] as? String ?: missing("contract_version")
+      val contractVersion = raw[SharedPayloadKeys.CONTRACT_VERSION] as? String ?: missing("contract_version")
       if (contractVersion != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION) {
         throw InvalidWorkflowStateSchemaError(
           "Feature-task-runtime delivered projection uses unsupported persistence contract version " +
@@ -82,7 +84,7 @@ data class FeatureTaskRuntimeDeliveredProjectionRecord(
     }
 
     private fun decodeDeliveredProjection(raw: Map<String, Any?>) = FeatureTaskRuntimeDeliveredProjectionRecord(
-      workflowId = raw["workflow_id"] as? String ?: missing("workflow_id"),
+      workflowId = raw[SharedPayloadKeys.WORKFLOW_ID] as? String ?: missing("workflow_id"),
       consumerPhaseId = raw["consumer_phase_id"] as? String ?: missing("consumer_phase_id"),
       iteration = (raw["consumer_delivery_iteration"] as? Number)?.toInt()
         ?: missing("consumer_delivery_iteration"),
@@ -100,7 +102,7 @@ data class FeatureTaskRuntimeDeliveredProjectionRecord(
         ?.map { identity ->
           val map = JsonCodec.anyToStringAnyMap(identity) ?: missing("source_producer_iterations")
           FeatureTaskRuntimeProducerIteration(
-            phaseId = map["phase_id"] as? String ?: missing("source_producer_iterations.phase_id"),
+            phaseId = map[SharedPayloadKeys.PHASE_ID] as? String ?: missing("source_producer_iterations.phase_id"),
             iteration = (map["iteration"] as? Number)?.toInt()
               ?: missing("source_producer_iterations.iteration"),
           )

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDiagnosticSignalModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDiagnosticSignalModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -71,7 +73,7 @@ data class FeatureTaskRuntimeDiagnosticSignal(
     "operation" to operation,
     "failure_class" to failureClass.wireValue,
     "conflicting_key" to conflictingKey,
-    "phase_id" to phaseId,
+    SharedPayloadKeys.PHASE_ID to phaseId,
     "attempt" to attempt,
     "repair_turn" to repairTurn,
     "generation" to generation,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDiagnosticSignalModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeDiagnosticSignalModels.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidWorkflowStateSchemaError
 
 /**

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeFindingVerificationDisposition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeFindingVerificationDisposition.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidFeatureTaskRuntimeFindingVerificationRecordError
@@ -35,7 +37,7 @@ data class FeatureTaskRuntimeFindingVerificationDisposition(
 
   @OpenBoundaryMap("Finding verification disposition at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = buildMap {
-    put("finding_id", findingId)
+    put(ReviewFindingPayloadKeys.FINDING_ID, findingId)
     put("disposition", disposition.wireValue)
     reason?.let { put("reason", it) }
     if (selectedBoundaryHeadings.isNotEmpty()) {
@@ -47,7 +49,7 @@ data class FeatureTaskRuntimeFindingVerificationDisposition(
   companion object {
     @OpenBoundaryMap("Finding verification disposition decode from the durable workflow-artifact map")
     fun fromArtifactMap(raw: Map<String, Any?>, path: String): FeatureTaskRuntimeFindingVerificationDisposition {
-      val findingId = (raw["finding_id"] as? String)?.trim()?.takeIf(String::isNotBlank) ?: invalid(path, "finding_id")
+      val findingId = (raw[ReviewFindingPayloadKeys.FINDING_ID] as? String)?.trim()?.takeIf(String::isNotBlank) ?: invalid(path, "finding_id")
       val disposition = (raw["disposition"] as? String)
         ?.let(FeatureTaskRuntimeFindingVerificationDispositionVerdict::fromWire)
         ?: invalid(path, "disposition")

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeFindingVerificationDisposition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeFindingVerificationDisposition.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.error.InvalidFeatureTaskRuntimeFindingVerificationRecordError
 
 enum class FeatureTaskRuntimeFindingVerificationDispositionVerdict(val wireValue: String) {
@@ -49,7 +48,11 @@ data class FeatureTaskRuntimeFindingVerificationDisposition(
   companion object {
     @OpenBoundaryMap("Finding verification disposition decode from the durable workflow-artifact map")
     fun fromArtifactMap(raw: Map<String, Any?>, path: String): FeatureTaskRuntimeFindingVerificationDisposition {
-      val findingId = (raw[ReviewFindingPayloadKeys.FINDING_ID] as? String)?.trim()?.takeIf(String::isNotBlank) ?: invalid(path, "finding_id")
+      val findingId =
+        (raw[ReviewFindingPayloadKeys.FINDING_ID] as? String)
+          ?.trim()
+          ?.takeIf(String::isNotBlank)
+          ?: invalid(path, "finding_id")
       val disposition = (raw["disposition"] as? String)
         ?.let(FeatureTaskRuntimeFindingVerificationDispositionVerdict::fromWire)
         ?: invalid(path, "disposition")

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationArtifact.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationArtifact.kt
@@ -1,10 +1,9 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.review.context.model.CodeReviewExecutionMode
 import skillbill.workflow.goal.model.ValidationDepth

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationArtifact.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationArtifact.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
 import skillbill.boundary.OpenBoundaryMap
@@ -37,8 +39,8 @@ data class FeatureTaskRuntimeGoalContinuationArtifact(
 
   @OpenBoundaryMap("Feature-task-runtime goal-continuation artifact map at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "issue_key" to issueKey,
-    "subtask_id" to subtaskId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
     "suppress_pr" to suppressPr,
     "goal_branch" to goalBranch,
     "code_review_mode" to codeReviewMode.wireValue,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationPersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationPersistenceModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 
 /**
@@ -71,7 +73,7 @@ data class FeatureTaskRuntimeGoalPlanningImport(
     "planning_contract_version" to planningContractVersion,
     "phase_output_contract_id" to phaseOutputContractId,
     "phase_output_contract_version" to phaseOutputContractVersion,
-    "subtask_id" to subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
     "manifest_order" to manifestOrder,
     "governed_sub_spec_path" to governedSubSpecPath,
     "sub_spec_hash" to subSpecHash,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationPersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeGoalContinuationPersistenceModels.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 
 /**
  * One silent heal of a goal-continuation field on resume: the launcher value was adopted because the

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffEnvelope.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffEnvelope.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_HANDOFF_ENVELOPE_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimePhaseHandoffSchemaError
@@ -30,7 +32,7 @@ data class FeatureTaskRuntimeHandoffEnvelope(
 
   @OpenBoundaryMap("Feature-task-runtime handoff envelope at the durable workflow-artifact seam")
   fun toEnvelopeMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to contractVersion,
+    SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
     "consumer_phase_id" to consumerPhaseId,
     "projections" to projections.map { it.toEnvelopeMap() },
   ).apply {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffEnvelope.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffEnvelope.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_HANDOFF_ENVELOPE_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimePhaseHandoffSchemaError
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffFoundationModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffFoundationModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_DIAGNOSTIC_DEGRADATION_MEASUREMENT_CONTRACT_VERSION
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PROJECTION_MEASUREMENT_CONTRACT_VERSION
@@ -64,12 +66,12 @@ data class FeatureTaskRuntimeProjectionMeasurement(
 
   @OpenBoundaryMap("Content-free feature-task-runtime projection measurement telemetry seam")
   fun toTelemetryMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_PROJECTION_MEASUREMENT_CONTRACT_VERSION,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_PROJECTION_MEASUREMENT_CONTRACT_VERSION,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "consumer_phase_id" to consumerPhaseId,
     "projection_contract_id" to projectionContractId,
     "producer_iteration" to mapOf(
-      "phase_id" to producerIteration.phaseId,
+      SharedPayloadKeys.PHASE_ID to producerIteration.phaseId,
       "iteration" to producerIteration.iteration,
     ),
     "repository_checkpoint_fingerprint" to repositoryCheckpointFingerprint,
@@ -113,8 +115,8 @@ data class FeatureTaskRuntimeSharedEvidenceMeasurement(
 
   @OpenBoundaryMap("Content-free feature-task-runtime shared-evidence measurement telemetry seam")
   fun toTelemetryMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_SHARED_EVIDENCE_PROJECTION_CONTRACT_VERSION,
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_SHARED_EVIDENCE_PROJECTION_CONTRACT_VERSION,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "checkpoint_fingerprint" to checkpointFingerprint,
     "consumer_phase_id" to consumerPhaseId,
     "outcome" to outcome.wireValue,
@@ -167,9 +169,9 @@ data class FeatureTaskRuntimeRejectionMeasurement(
 
   @OpenBoundaryMap("Content-free feature-task-runtime rejection measurement telemetry seam")
   fun toTelemetryMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_REJECTION_MEASUREMENT_CONTRACT_VERSION,
-    "workflow_id" to workflowId,
-    "phase_id" to phaseId,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_REJECTION_MEASUREMENT_CONTRACT_VERSION,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.PHASE_ID to phaseId,
     "iteration" to iteration,
     "rule" to rule,
     "pointer_path" to pointerPath,
@@ -223,9 +225,9 @@ data class FeatureTaskRuntimeDiagnosticDegradationMeasurement(
 
   @OpenBoundaryMap("Content-free feature-task-runtime diagnostic-degradation measurement telemetry seam")
   fun toTelemetryMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_DIAGNOSTIC_DEGRADATION_MEASUREMENT_CONTRACT_VERSION,
-    "workflow_id" to workflowId,
-    "phase_id" to phaseId,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_DIAGNOSTIC_DEGRADATION_MEASUREMENT_CONTRACT_VERSION,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.PHASE_ID to phaseId,
     "attempt" to attempt,
     "generation" to generation,
     "operation" to operation,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffFoundationModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffFoundationModels.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_DIAGNOSTIC_DEGRADATION_MEASUREMENT_CONTRACT_VERSION
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PROJECTION_MEASUREMENT_CONTRACT_VERSION
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_REJECTION_MEASUREMENT_CONTRACT_VERSION

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffProjection.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffProjection.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 
@@ -62,7 +64,7 @@ data class FeatureTaskRuntimeHandoffProjection(
     "projection_contract_version" to projectionContractVersion,
     "prompt_visibility" to promptVisibility.wireValue,
     "producer_iteration" to mapOf(
-      "phase_id" to producerIteration.phaseId,
+      SharedPayloadKeys.PHASE_ID to producerIteration.phaseId,
       "iteration" to producerIteration.iteration,
     ),
     "fields" to fields.map { field ->

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffProjection.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeHandoffProjection.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 
 /** One validated projection actually delivered to a consumer phase. */
 data class FeatureTaskRuntimeHandoffProjection(

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeImplementationAttemptModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeImplementationAttemptModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_IMPLEMENTATION_ATTEMPT_CONTRACT_VERSION
@@ -43,17 +45,17 @@ data class FeatureTaskRuntimeImplementationAttempt(
   @OpenBoundaryMap("Feature-task-runtime implementation-attempt entry at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
     "sequence_number" to sequenceNumber,
-    "phase_id" to phaseId,
+    SharedPayloadKeys.PHASE_ID to phaseId,
     "attempt_number" to attemptNumber,
     "agent_id" to agentId,
-    "status" to status.wireValue,
+    SharedPayloadKeys.STATUS to status.wireValue,
     "recorded_at" to recordedAt,
-    "value" to value,
+    SharedPayloadKeys.VALUE to value,
   ).apply {
     loopId?.let { put("loop_id", it) }
     edgeIteration?.let { put("edge_iteration", it) }
-    failureDisposition?.let { put("failure_disposition", it.wireValue) }
-    prompt?.let { put("prompt", it) }
+    failureDisposition?.let { put(SharedPayloadKeys.FAILURE_DISPOSITION, it.wireValue) }
+    prompt?.let { put(SharedPayloadKeys.PROMPT, it) }
   }
 
   companion object {
@@ -119,7 +121,7 @@ enum class FeatureTaskRuntimeImplementationAttemptStatus(val wireValue: String) 
 fun featureTaskRuntimeImplementationAttemptRecordToWire(
   attempts: List<FeatureTaskRuntimeImplementationAttempt>,
 ): Map<String, Any?> = linkedMapOf(
-  "contract_version" to FEATURE_TASK_RUNTIME_IMPLEMENTATION_ATTEMPT_CONTRACT_VERSION,
+  SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_IMPLEMENTATION_ATTEMPT_CONTRACT_VERSION,
   "attempts" to attempts.map { it.toArtifactMap() },
 )
 
@@ -127,7 +129,7 @@ fun featureTaskRuntimeImplementationAttemptRecordToWire(
 fun featureTaskRuntimeImplementationAttemptsFromWire(raw: Any?): List<FeatureTaskRuntimeImplementationAttempt> {
   val map = raw as? Map<*, *>
     ?: implementationAttemptError("Feature-task-runtime implementation-attempt record must be an object.")
-  val version = map["contract_version"]
+  val version = map[SharedPayloadKeys.CONTRACT_VERSION]
   if (version != FEATURE_TASK_RUNTIME_IMPLEMENTATION_ATTEMPT_CONTRACT_VERSION) {
     implementationAttemptError(
       "Feature-task-runtime implementation-attempt record uses unsupported contract version '$version'; " +

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeImplementationAttemptModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeImplementationAttemptModels.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_IMPLEMENTATION_ATTEMPT_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.workflow.goal.model.appendBoundedHistoryBySequence

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseLedgerPersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseLedgerPersistenceModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.error.InvalidWorkflowStateSchemaError
 
@@ -97,7 +99,7 @@ data class FeatureTaskRuntimePhaseLedgerEntry(
     "action" to action.wireValue,
     "sequence_number" to sequenceNumber,
     "timestamp" to timestamp,
-    "phase_id" to phaseId,
+    SharedPayloadKeys.PHASE_ID to phaseId,
     "attempt_count" to attemptCount,
   ).apply {
     resolvedAgentId?.let { put("resolved_agent_id", it) }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseLedgerPersistenceModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseLedgerPersistenceModels.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidWorkflowStateSchemaError
 
 enum class FeatureTaskRuntimePhaseExecutionOrigin(val wireValue: String) {

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseOutputValidationModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseOutputValidationModels.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PHASE_OUTPUT_VALIDATION_CONTRACT_VERSION
 import skillbill.error.FailureWireCode
 import skillbill.error.FeatureTaskRuntimePhaseOutputFailureKind

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseOutputValidationModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseOutputValidationModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PHASE_OUTPUT_VALIDATION_CONTRACT_VERSION
 import skillbill.error.FailureWireCode
@@ -160,7 +162,7 @@ data class FeatureTaskRuntimePhaseOutputRepairEvidence(
 
   @OpenBoundaryMap("Typed phase-output repair evidence at the private workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to contractVersion,
+    SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
     "validator_version" to validatorVersion,
     "format" to format.wireValue,
     "original_digest" to originalDigest,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseRecord.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseRecord.kt
@@ -1,10 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.workflow.model.WorkflowStepStatus

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseRecord.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePhaseRecord.kt
@@ -1,5 +1,9 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -142,10 +146,10 @@ data class FeatureTaskRuntimePhaseRecord(
 
   @OpenBoundaryMap("Feature-task-runtime per-phase record artifact map at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
     "record_kind" to "private_phase_record",
-    "phase_id" to phaseId,
-    "status" to status.wireValue,
+    SharedPayloadKeys.PHASE_ID to phaseId,
+    SharedPayloadKeys.STATUS to status.wireValue,
     "attempt_count" to attemptCount,
     "started_at" to startedAt,
     "first_started_at" to firstStartedAt,
@@ -156,7 +160,7 @@ data class FeatureTaskRuntimePhaseRecord(
     durationMillis?.let { put("duration_millis", it) }
     outputArtifact?.let { put("output_artifact", it) }
     blockedReason?.let { put("blocked_reason", it) }
-    failureDisposition?.let { put("failure_disposition", it.wireValue) }
+    failureDisposition?.let { put(SharedPayloadKeys.FAILURE_DISPOSITION, it.wireValue) }
     if (fileManifestBefore.isNotEmpty()) put("file_manifest_before", fileManifestBefore)
     if (fileManifestAfter.isNotEmpty()) put("file_manifest_after", fileManifestAfter)
     if (fileManifestIntroduced.isNotEmpty()) put("file_manifest_introduced", fileManifestIntroduced)
@@ -170,7 +174,7 @@ data class FeatureTaskRuntimePhaseRecord(
   private fun MutableMap<String, Any?>.putLaunchPair() {
     launchedModel?.let { put("launched_model", it) }
     launchedEffort?.let { put("launched_effort", it) }
-    reviewRunId?.let { put("review_run_id", it) }
+    reviewRunId?.let { put(ReviewVerificationSignalKeys.REVIEW_RUN_ID, it) }
   }
 
   companion object {
@@ -183,7 +187,7 @@ data class FeatureTaskRuntimePhaseRecord(
         FeatureTaskRuntimePhaseRecord(
           phaseId = phaseId,
           status = WorkflowStepStatus.fromWire(raw.requireStringField("status"))
-            ?: incompatiblePhaseRecord(listOf("unknown status '${raw["status"]}'")),
+            ?: incompatiblePhaseRecord(listOf("unknown status '${raw[SharedPayloadKeys.STATUS]}'")),
           attemptCount = raw.requireIntField("attempt_count"),
           startedAt = raw.requireStringField("started_at"),
           firstStartedAt = raw.requireStringField("first_started_at"),
@@ -237,8 +241,8 @@ data class FeatureTaskRuntimePhaseRecord(
       val unknown = raw.keys - allowed
       val identityDetail = when {
         raw["record_kind"] != "private_phase_record" -> "record_kind was '${raw["record_kind"]}'"
-        raw["contract_version"] != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION ->
-          "contract_version was '${raw["contract_version"]}'"
+        raw[SharedPayloadKeys.CONTRACT_VERSION] != FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION ->
+          "contract_version was '${raw[SharedPayloadKeys.CONTRACT_VERSION]}'"
 
         else -> null
       }

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanOutcome.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanOutcome.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.decomposition.model.SpecSource
 
 private const val DECOMPOSE_MODE: String = "decompose"

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanOutcome.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimePlanOutcome.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.workflow.decomposition.model.SpecSource
 
@@ -68,7 +70,7 @@ fun featureTaskRuntimeDecomposePlanOutcomeOrNull(
   val producedOutputs = phaseOutput.stringAnyMap("produced_outputs") ?: return null
   val packageMap = producedOutputs.stringAnyMap("decomposition_package") ?: return null
   if (packageMap["mode"]?.toString() != DECOMPOSE_MODE) return null
-  val summary = phaseOutput["summary"]?.toString().orEmpty()
+  val summary = phaseOutput[SharedPayloadKeys.SUMMARY]?.toString().orEmpty()
   return FeatureTaskRuntimeDecomposePlanOutcome(
     reason = packageMap.firstString("reason", "decomposition_reason").ifBlank { summary },
     featureName = packageMap.firstString("feature_name", "name").ifBlank { "feature" },

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeQuarantineModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeQuarantineModels.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidWorkflowStateSchemaError
 
 /**

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeQuarantineModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeQuarantineModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -160,7 +162,7 @@ data class FeatureTaskRuntimeQuarantineEntry(
 @OpenBoundaryMap("Feature-task-runtime quarantine record artifact map at the durable workflow-artifact seam")
 fun featureTaskRuntimeQuarantineRecordToWire(entries: List<FeatureTaskRuntimeQuarantineEntry>): Map<String, Any?> =
   linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_QUARANTINE_ARTIFACT_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_QUARANTINE_ARTIFACT_CONTRACT_VERSION,
     "entries" to entries.map { it.toArtifactMap() },
   )
 
@@ -178,7 +180,7 @@ fun featureTaskRuntimeQuarantineEntriesFromWire(raw: Any?): List<FeatureTaskRunt
         "the store is left untouched rather than rewritten without that evidence.",
     )
   }
-  val version = map["contract_version"] as? String
+  val version = map[SharedPayloadKeys.CONTRACT_VERSION] as? String
   if (version != FEATURE_TASK_RUNTIME_QUARANTINE_ARTIFACT_CONTRACT_VERSION) {
     quarantineSchemaError(
       "Feature-task-runtime quarantine record uses unsupported contract version " +

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairLedger.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairLedger.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_REPAIR_LEDGER_CONTRACT_VERSION
@@ -86,7 +88,7 @@ data class FeatureTaskRuntimeRepairLedgerEntry(
     "finding_ref" to disturbanceRef,
     "severity" to severity,
     "label" to label,
-    "status" to status.wireValue,
+    SharedPayloadKeys.STATUS to status.wireValue,
     "origin_round" to originRound,
     "status_round" to statusRound,
     "constructs" to constructs.map { construct ->
@@ -168,7 +170,7 @@ data class FeatureTaskRuntimeRepairLedgerProjection(
   @OpenBoundaryMap("Bounded repair ledger projection at the declared phase-handoff seam")
   fun toProjectionMap(): Map<String, Any?> {
     val payload = linkedMapOf<String, Any?>(
-      "contract_version" to contractVersion,
+      SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
       "summarized" to summarized,
       "entry_count" to entryCount,
     )

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairLedger.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairLedger.kt
@@ -1,9 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_REPAIR_LEDGER_CONTRACT_VERSION
 import skillbill.workflow.goal.model.GoalSubtaskReviewCompactFinding
 import skillbill.workflow.goal.model.GoalSubtaskReviewPassResult

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairReceipt.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairReceipt.kt
@@ -1,5 +1,9 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_REPAIR_RECEIPT_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimeRepairReceiptError
@@ -164,7 +168,7 @@ data class FeatureTaskRuntimeRepairReceiptEntry(
 
   @OpenBoundaryMap("Repair receipt entry at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = buildMap {
-    put("finding_id", findingId)
+    put(ReviewFindingPayloadKeys.FINDING_ID, findingId)
     put("outcome", outcome.wireValue)
     noEditReason?.let { put("no_edit_reason", it) }
     unresolvedReason?.let { put("unresolved_reason", it) }
@@ -226,7 +230,7 @@ data class FeatureTaskRuntimeRepairReceipt(
 
   @OpenBoundaryMap("Repair receipt at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "contract_version" to contractVersion,
+    SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
     "round_number" to roundNumber,
     "pre_fix_checkpoint_sha" to preFixCheckpointSha,
     "entries" to entries.map(FeatureTaskRuntimeRepairReceiptEntry::toArtifactMap),

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairReceipt.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRepairReceipt.kt
@@ -1,10 +1,8 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_REPAIR_RECEIPT_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimeRepairReceiptError
 import skillbill.workflow.goal.model.GoalSubtaskReviewCompactFinding

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRunInvariantsPersistence.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRunInvariantsPersistence.kt
@@ -1,10 +1,9 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_RUN_INVARIANTS_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimePhaseHandoffSchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRunInvariantsPersistence.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeRunInvariantsPersistence.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.agentaddon.model.PersistedAgentAddonSelectionEntry
 import skillbill.boundary.OpenBoundaryMap
@@ -16,7 +18,7 @@ const val FEATURE_TASK_RUNTIME_RUN_INVARIANTS_ARTIFACT_KEY: String = "feature_ta
 
 @OpenBoundaryMap("Feature-task-runtime run-invariants artifact map at the durable workflow-artifact seam")
 fun FeatureTaskRuntimeRunInvariants.toArtifactMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to FEATURE_TASK_RUNTIME_RUN_INVARIANTS_CONTRACT_VERSION,
+  SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_RUN_INVARIANTS_CONTRACT_VERSION,
   "spec_reference" to specReference,
   "feature_size" to featureSize.name,
   "acceptance_criteria" to acceptanceCriteria,
@@ -95,7 +97,7 @@ private fun Map<String, Any?>.optionalAgentAddonSelection(): AgentAddonSelection
 }
 
 private fun Map<String, Any?>.requireRunInvariantsContractVersion() {
-  val declared = this["contract_version"]
+  val declared = this[SharedPayloadKeys.CONTRACT_VERSION]
     ?: runInvariantSchemaError(
       "Feature-task-runtime run-invariants artifact is missing 'contract_version'; records written " +
         "before $FEATURE_TASK_RUNTIME_RUN_INVARIANTS_CONTRACT_VERSION carry pre-SKILL-159 " +

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeValidationGateProgressModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeValidationGateProgressModels.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -81,7 +83,7 @@ data class FeatureTaskRuntimeValidationGateProgress(
 
   @OpenBoundaryMap("Runtime-owned validation gate progress at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION,
     "gate_run_count" to gateRunCount,
     "gate_runs" to gateRuns.map { it.toArtifactMap() },
     "remaining_findings" to remainingFindings,

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeValidationGateProgressModels.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/FeatureTaskRuntimeValidationGateProgressModels.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PERSISTENCE_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
 

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/PhaseHandoffProjectionDeclaration.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/PhaseHandoffProjectionDeclaration.kt
@@ -1,8 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PHASE_HANDOFF_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimePhaseHandoffSchemaError
 import skillbill.workflow.taskruntime.FeatureTaskRuntimeHandoffFoundationValidator

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/PhaseHandoffProjectionDeclaration.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/taskruntime/model/PhaseHandoffProjectionDeclaration.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.taskruntime.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PHASE_HANDOFF_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimePhaseHandoffSchemaError
@@ -61,7 +63,7 @@ data class PhaseHandoffProjectionDeclaration(
 
   @OpenBoundaryMap("Feature-task-runtime phase-handoff declaration wire seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to FEATURE_TASK_RUNTIME_PHASE_HANDOFF_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_PHASE_HANDOFF_CONTRACT_VERSION,
     "consumer_phase_id" to consumerPhaseId,
     "projection_name" to projectionName,
     "source" to sourceRef.toDeclarationMap(),
@@ -73,7 +75,7 @@ data class PhaseHandoffProjectionDeclaration(
     ),
     "checkpoint_policy" to checkpointPolicy.wireValue,
     "producer_iteration" to mapOf(
-      "phase_id" to producerIteration.phaseId,
+      SharedPayloadKeys.PHASE_ID to producerIteration.phaseId,
       "iteration" to producerIteration.iteration,
     ),
     "declared_fields" to declaredFieldNames,
@@ -100,7 +102,7 @@ data class PhaseHandoffProjectionDeclaration(
       )
       invalidIf(
         raw.keys.any { it !in allowed } ||
-          raw["contract_version"] != FEATURE_TASK_RUNTIME_PHASE_HANDOFF_CONTRACT_VERSION,
+          raw[SharedPayloadKeys.CONTRACT_VERSION] != FEATURE_TASK_RUNTIME_PHASE_HANDOFF_CONTRACT_VERSION,
       )
       val source = raw["source"] as? Map<*, *> ?: invalid()
       val sourceRef = sourceRefOf(source)

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowDefinition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowDefinition.kt
@@ -1,5 +1,7 @@
 package skillbill.workflow.verify
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.workflow.WORKFLOW_STATE_CONTRACT_VERSION
 import skillbill.workflow.engine.model.WorkflowDefinition
 import skillbill.workflow.engine.model.WorkflowInputProjectionDeclaration
@@ -86,7 +88,7 @@ object FeatureVerifyWorkflowDefinition {
       "code_review" to "Step 5: Code Review",
       "unit_test_value_check" to "Step 6: Unit Test Value Check",
       "completeness_audit" to "Step 7: Completeness Audit",
-      "verdict" to "Step 8: Consolidated Verdict",
+      SharedPayloadKeys.VERDICT to "Step 8: Consolidated Verdict",
       "finish" to "Finish",
     ),
     requiredArtifactsByStep =
@@ -98,7 +100,7 @@ object FeatureVerifyWorkflowDefinition {
       "code_review" to listOf("criteria_summary", "review_rubric", "diff_projection"),
       "unit_test_value_check" to listOf("criteria_summary", "unit_test_value_rubric", "diff_projection"),
       "completeness_audit" to listOf("criteria_summary", "completeness_rubric", "diff_projection"),
-      "verdict" to listOf(
+      SharedPayloadKeys.VERDICT to listOf(
         "feature_flag_audit_receipt",
         "code_review_receipt",
         "unit_test_value_receipt",
@@ -124,7 +126,7 @@ object FeatureVerifyWorkflowDefinition {
         "Run bill-unit-test-value-check independently against criteria, its rubric, and diff_projection.",
       "completeness_audit" to
         "Run completeness independently against criteria, its rubric, and diff_projection.",
-      "verdict" to
+      SharedPayloadKeys.VERDICT to
         "Reuse only compact typed evaluator receipts to produce the final verdict without rerunning earlier phases.",
       "finish" to "Close the workflow by marking the verdict complete and emitting the terminal summary.",
     ),
@@ -154,7 +156,7 @@ object FeatureVerifyWorkflowDefinition {
         "content.md :: Step 7: Completeness Audit",
         "content.md :: Completeness Audit",
       ),
-      "verdict" to listOf(
+      SharedPayloadKeys.VERDICT to listOf(
         "content.md :: Continuation Mode",
         "content.md :: Step 8: Consolidated Verdict",
         "content.md :: Consolidated Verdict",
@@ -185,7 +187,7 @@ object FeatureVerifyWorkflowDefinition {
       "completeness_audit" to
         "Run independently from sibling evaluators using criteria_summary, completeness_rubric, and the " +
         "checkpoint-scoped diff_projection. Refresh the projection if the target changed materially.",
-      "verdict" to
+      SharedPayloadKeys.VERDICT to
         "Reuse only compact typed evaluator receipts to produce the final verdict without rerunning earlier phases.",
       "finish" to
         "Do not re-run analysis. Close the workflow using the saved verdict_result and return the terminal summary " +
@@ -247,7 +249,7 @@ object FeatureVerifyWorkflowDefinition {
           "diff_projection" to diffFields,
         ),
       ),
-      "verdict" to projection(
+      SharedPayloadKeys.VERDICT to projection(
         "feature_flag_audit_receipt",
         "code_review_receipt",
         "unit_test_value_receipt",

--- a/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowDefinition.kt
+++ b/runtime-kotlin/runtime-domain/src/main/kotlin/skillbill/workflow/verify/FeatureVerifyWorkflowDefinition.kt
@@ -1,7 +1,6 @@
 package skillbill.workflow.verify
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.workflow.WORKFLOW_STATE_CONTRACT_VERSION
 import skillbill.workflow.engine.model.WorkflowDefinition
 import skillbill.workflow.engine.model.WorkflowInputProjectionDeclaration

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskPhaseSettlementService.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskPhaseSettlementService.kt
@@ -1,10 +1,9 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import me.tatarka.inject.annotations.Inject
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskPhaseSettlementAuditRequest
 import skillbill.engine.featuretask.model.FeatureTaskPhaseSettlementBlockRequest
 import skillbill.engine.featuretask.model.FeatureTaskPhaseSettlementCompleteRequest

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskPhaseSettlementService.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskPhaseSettlementService.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import me.tatarka.inject.annotations.Inject
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
@@ -121,9 +123,9 @@ class FeatureTaskPhaseSettlementService(
       ),
     )
     return linkedMapOf(
-      "status" to "ok",
-      "workflow_id" to request.workflowId,
-      "phase_id" to request.phaseId,
+      SharedPayloadKeys.STATUS to "ok",
+      SharedPayloadKeys.WORKFLOW_ID to request.workflowId,
+      SharedPayloadKeys.PHASE_ID to request.phaseId,
       "attempt" to request.attempt,
       "kind" to request.kind.wireValue,
       "envelope" to request.envelope,

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeCompletedUpstreamRepairCheckpoint.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeCompletedUpstreamRepairCheckpoint.kt
@@ -1,7 +1,6 @@
 package skillbill.engine.featuretask
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.engine.featuretask.model.CompletedUpstreamRepairRequest
 import skillbill.workflow.engine.model.WorkflowUpdateInput
 import skillbill.workflow.model.WorkflowStepStatus

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeCompletedUpstreamRepairCheckpoint.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeCompletedUpstreamRepairCheckpoint.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.engine.featuretask.model.CompletedUpstreamRepairRequest
 import skillbill.workflow.engine.model.WorkflowUpdateInput
 import skillbill.workflow.model.WorkflowStepStatus
@@ -52,8 +54,8 @@ fun completedUpstreamRepairWorkflowUpdate(
   currentStepId = request.resumePhaseId,
   stepUpdates = phasesToReopen.map { phaseId ->
     mapOf(
-      "step_id" to phaseId,
-      "status" to "pending",
+      SharedPayloadKeys.STEP_ID to phaseId,
+      SharedPayloadKeys.STATUS to "pending",
       "attempt_count" to 0,
     )
   },
@@ -65,7 +67,7 @@ fun completedUpstreamRepairWorkflowUpdate(
         FEATURE_TASK_RUNTIME_PHASE_LEDGER_LIMIT,
       ),
     FEATURE_TASK_RUNTIME_OPERATOR_BLOCK_RETRY_ARTIFACT_KEY to mapOf(
-      "phase_id" to request.resumePhaseId,
+      SharedPayloadKeys.PHASE_ID to request.resumePhaseId,
       "reason" to request.reason,
       "retried_at" to OffsetDateTime.now(ZoneOffset.UTC).toString(),
       "previous_blocked_reason" to "completed_upstream_missing_output",

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationArtifactPatcher.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationArtifactPatcher.kt
@@ -1,9 +1,8 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.application.workflow.model.WorkflowFamily
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError
 import skillbill.ports.workflow.WorkflowStateRepository
 import skillbill.ports.workflow.gitops.model.GoalSubtaskReviewBaseline

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationArtifactPatcher.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationArtifactPatcher.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.agentaddon.model.AgentAddonSelection
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError
@@ -81,7 +83,7 @@ fun continuationPatch(
   existing == null -> mapOf(
     FEATURE_TASK_RUNTIME_GOAL_CONTINUATION_ARTIFACT_KEY to continuation.toArtifactMap(),
     "install_sync_result" to mapOf(
-      "status" to "deferred",
+      SharedPayloadKeys.STATUS to "deferred",
       "reason" to
         "goal-continuation defers installer, uninstall, and install-sync flows until the parent goal exits; " +
         "deferred install sync must not block subtask completion",

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationOutcomeProjection.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationOutcomeProjection.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeGoalContinuationContext
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunReport
@@ -153,7 +155,7 @@ fun commitShaFromPhaseRecords(
 }
 
 fun Map<String, Any?>.commitShaFromPhasePayload(): String? {
-  val producedOutputs = JsonCodec.anyToStringAnyMap(this["produced_outputs"])
+  val producedOutputs = JsonCodec.anyToStringAnyMap(this[SharedPayloadKeys.PRODUCED_OUTPUTS])
   return (this["commit_push_result"] as? Map<*, *>)?.get("commit_sha")?.toString()?.takeIf(String::isNotBlank)
     ?: (producedOutputs?.get("commit_push_result") as? Map<*, *>)?.get("commit_sha")?.toString()
       ?.takeIf(String::isNotBlank)

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationOutcomeProjection.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeGoalContinuationOutcomeProjection.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeGoalContinuationContext
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunReport
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunRequest

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeOutputVerification.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeOutputVerification.kt
@@ -1,5 +1,9 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.subtaskreview.FeatureTaskRuntimeVerificationSignalKeys
 import skillbill.review.ReviewFindingActionability
@@ -15,7 +19,7 @@ import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeVerdict
 
 object FeatureTaskRuntimeOutputVerification {
   fun verdictFor(phaseId: String, outputObject: Map<String, Any?>?): FeatureTaskRuntimeVerdict {
-    val wireVerdict = (outputObject?.get("verdict") as? String)
+    val wireVerdict = (outputObject?.get(SharedPayloadKeys.VERDICT) as? String)
       ?.takeIf(String::isNotBlank)
       ?.let { value -> FeatureTaskRuntimeVerdict.rejectRemovedVerdict(value, "phase output verdict") }
     return when (phaseId) {
@@ -43,9 +47,9 @@ object FeatureTaskRuntimeOutputVerification {
   fun unresolvedReviewFindings(outputObject: Map<String, Any?>?): List<FeatureTaskRuntimeReviewFinding> =
     reviewVerdictFrom(outputObject)?.unresolvedFindings.orEmpty()
 
-  fun auditProseValue(outputObject: Map<String, Any?>?): String? = outputObject?.get("produced_outputs")
+  fun auditProseValue(outputObject: Map<String, Any?>?): String? = outputObject?.get(SharedPayloadKeys.PRODUCED_OUTPUTS)
     ?.let(JsonCodec::anyToStringAnyMap)
-    ?.get("value")
+    ?.get(SharedPayloadKeys.VALUE)
     ?.toString()
     ?.takeIf(String::isNotBlank)
 }
@@ -58,7 +62,7 @@ private fun findingVerificationVerdict(wireVerdict: FeatureTaskRuntimeVerdict?):
 private fun findingVerificationVerdictFrom(
   outputObject: Map<String, Any?>?,
 ): FeatureTaskRuntimeFindingVerificationVerdict? {
-  val dispositionsRaw = outputObject?.get("produced_outputs")
+  val dispositionsRaw = outputObject?.get(SharedPayloadKeys.PRODUCED_OUTPUTS)
     ?.let(JsonCodec::anyToStringAnyMap)
     ?.get(FeatureTaskRuntimeVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS) as? List<*>
     ?: return null
@@ -83,7 +87,7 @@ private fun auditVerdict(wireVerdict: FeatureTaskRuntimeVerdict?): FeatureTaskRu
 }
 
 private fun reviewVerdictFrom(outputObject: Map<String, Any?>?): FeatureTaskRuntimeReviewVerdict? {
-  val findingsRaw = outputObject?.get("produced_outputs")
+  val findingsRaw = outputObject?.get(SharedPayloadKeys.PRODUCED_OUTPUTS)
     ?.let(JsonCodec::anyToStringAnyMap)
     ?.get(FeatureTaskRuntimeVerificationSignalKeys.REVIEW_FINDINGS) as? List<*>
     ?: return null
@@ -96,8 +100,8 @@ private fun actionableReviewFinding(entry: Any?): FeatureTaskRuntimeReviewFindin
   val severity = (map["severity"] as? String)?.takeIf(String::isNotBlank)
   val message = (map["message"] as? String)?.takeIf(String::isNotBlank)
   if (severity == null || message == null) return null
-  val claimVerdict = optionalClaimVerdict(map["claim_verdict"])
-  val scopeDisposition = optionalScopeDisposition(map["scope_disposition"])
+  val claimVerdict = optionalClaimVerdict(map[ReviewFindingPayloadKeys.CLAIM_VERDICT])
+  val scopeDisposition = optionalScopeDisposition(map[ReviewFindingPayloadKeys.SCOPE_DISPOSITION])
   if (!ReviewFindingActionability.isActionable(claimVerdict, scopeDisposition)) {
     return null
   }

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeOutputVerification.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeOutputVerification.kt
@@ -1,10 +1,8 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.goalrunner.subtaskreview.FeatureTaskRuntimeVerificationSignalKeys
 import skillbill.review.ReviewFindingActionability
 import skillbill.review.model.ReviewClaimVerdict

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseSafetyPolicy.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseSafetyPolicy.kt
@@ -1,7 +1,6 @@
 package skillbill.engine.featuretask
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeFailureDisposition

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseSafetyPolicy.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseSafetyPolicy.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeFailureDisposition
@@ -43,11 +45,11 @@ object FeatureTaskRuntimePhaseSafetyPolicy {
     .sorted()
 
   fun dispositionForTerminalOutput(phaseId: String, output: Map<String, Any?>): FeatureTaskRuntimeFailureDisposition {
-    val explicit = (output["failure_disposition"] as? String)
+    val explicit = (output[SharedPayloadKeys.FAILURE_DISPOSITION] as? String)
       ?.let(FeatureTaskRuntimeFailureDisposition::fromWireValue)
     if (explicit != null) return explicit
     return if (
-      (output["status"] as? String).workflowStepStatus() == WorkflowStepStatus.FAILED ||
+      (output[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() == WorkflowStepStatus.FAILED ||
       phaseId == "validate"
     ) {
       FeatureTaskRuntimeFailureDisposition.RETRYABLE

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseStateRecorder.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseStateRecorder.kt
@@ -1,10 +1,9 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimePhaseStateRequest
 import skillbill.ports.db.DatabaseSessionFactory
 import skillbill.ports.workflow.get

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseStateRecorder.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePhaseStateRecorder.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.contracts.JsonCodec
@@ -211,10 +213,10 @@ fun FeatureTaskRuntimePhaseStateRecorder.implementationAttemptPatch(
 ): Map<String, Any?> {
   if (!FeatureTaskRuntimePhaseWorkflowDefinition.isMutatingPhase(request.phaseId)) return emptyMap()
   val produced = request.normalizedOutput?.envelope
-    ?.let { JsonCodec.anyToStringAnyMap(it["produced_outputs"]) }
-  val value = produced?.get("value")?.toString()?.trim().orEmpty()
+    ?.let { JsonCodec.anyToStringAnyMap(it[SharedPayloadKeys.PRODUCED_OUTPUTS]) }
+  val value = produced?.get(SharedPayloadKeys.VALUE)?.toString()?.trim().orEmpty()
   if (produced == null || value.isBlank()) return emptyMap()
-  val prompt = produced["prompt"]?.toString()?.trim()?.takeIf(String::isNotBlank)
+  val prompt = produced[SharedPayloadKeys.PROMPT]?.toString()?.trim()?.takeIf(String::isNotBlank)
   val existing = implementationAttemptsFrom(artifacts)
   val appended = featureTaskRuntimeAppendImplementationAttempt(
     existing = existing,

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePlanningProjectionGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePlanningProjectionGate.kt
@@ -1,7 +1,6 @@
 package skillbill.engine.featuretask
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidGoalPlanningPreparationSchemaError
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePlanningProjectionGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimePlanningProjectionGate.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidGoalPlanningPreparationSchemaError
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus
@@ -11,7 +13,7 @@ fun producerProjectionGateReason(
   outputMap: Map<String, Any?>,
   planningProjectionValidator: FeatureTaskRuntimePlanningProjectionValidator,
 ): String? {
-  if ((outputMap["status"] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED) return null
+  if ((outputMap[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED) return null
   val expectedKind = FeatureTaskRuntimePlanningProjectionContract.producedProjectionKindFor(phaseId)
     ?: return null
   return unresolvedProducerProjectionKindReason(phaseId, expectedKind, planningProjectionValidator)

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRemediationBaseReconciler.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRemediationBaseReconciler.kt
@@ -1,9 +1,8 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.workflow.model.WorkflowFamily
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.PersistHealedRemediationBaseRequest
 import skillbill.engine.featuretask.model.RemediationBaseBlocked
 import skillbill.engine.featuretask.model.RemediationBaseCoherenceResult

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRemediationBaseReconciler.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRemediationBaseReconciler.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.engine.featuretask.model.PersistHealedRemediationBaseRequest
@@ -70,7 +72,7 @@ class FeatureTaskRuntimeRemediationBaseReconciler(
           FEATURE_TASK_RUNTIME_CHECKPOINT_IDENTITIES_ARTIFACT_KEY to null,
           CHECKPOINT_IDENTITY_QUARANTINE_ARTIFACT_KEY to existing + listOf(
             linkedMapOf(
-              "workflow_id" to workflowId,
+              SharedPayloadKeys.WORKFLOW_ID to workflowId,
               "rejection_detail" to error.message.orEmpty(),
               "quarantined_at" to clock.instant().toString(),
               "rejected_record" to rejected,

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeReviewDriver.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeReviewDriver.kt
@@ -1,5 +1,9 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.agentaddon.model.AgentAddonPromptFormatter
 import skillbill.agentaddon.model.HydratedAgentAddonSelection
 import skillbill.application.review.RuntimeOwnedReviewMode
@@ -112,11 +116,11 @@ object FeatureTaskRuntimeReviewEnvelope {
     }
     CRITERION_GAP_KEYS.forEach { key -> produced.remove(key) }
     val envelope = linkedMapOf<String, Any?>(
-      "contract_version" to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
-      "phase_id" to "review",
-      "status" to STATUS_COMPLETED,
-      "summary" to prose.take(SUMMARY_MAX_CHARS),
-      "produced_outputs" to produced,
+      SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
+      SharedPayloadKeys.PHASE_ID to "review",
+      SharedPayloadKeys.STATUS to STATUS_COMPLETED,
+      SharedPayloadKeys.SUMMARY to prose.take(SUMMARY_MAX_CHARS),
+      SharedPayloadKeys.PRODUCED_OUTPUTS to produced,
       FeatureTaskRuntimeVerificationSignalKeys.VERDICT to extractReviewVerdict(prose).wireValue,
     )
     val outcome = GoalSubtaskReviewSummaryReducer.outcomeFor(envelope)
@@ -160,15 +164,15 @@ object FeatureTaskRuntimeReviewEnvelope {
   }
 
   private fun findingPayload(finding: ParallelReviewMergedFinding): Map<String, Any?> = buildMap {
-    put("finding_id", finding.fNumber)
+    put(ReviewFindingPayloadKeys.FINDING_ID, finding.fNumber)
     put("severity", finding.severity.name.lowercase())
     put("message", finding.description)
     put("location", finding.location)
-    finding.repositoryPath?.let { put("repository_path", it) }
-    finding.claimVerdict?.let { put("claim_verdict", it.wireValue) }
-    finding.scopeDisposition?.let { put("scope_disposition", it.wireValue) }
+    finding.repositoryPath?.let { put(ReviewFindingPayloadKeys.REPOSITORY_PATH, it) }
+    finding.claimVerdict?.let { put(ReviewFindingPayloadKeys.CLAIM_VERDICT, it.wireValue) }
+    finding.scopeDisposition?.let { put(ReviewFindingPayloadKeys.SCOPE_DISPOSITION, it.wireValue) }
     if (finding.citations.isNotEmpty()) {
-      put("citations", finding.citations.map(::citationPayload))
+      put(ReviewFindingPayloadKeys.CITATIONS, finding.citations.map(::citationPayload))
     }
   }
 

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeReviewDriver.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeReviewDriver.kt
@@ -1,9 +1,5 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.agentaddon.model.AgentAddonPromptFormatter
 import skillbill.agentaddon.model.HydratedAgentAddonSelection
 import skillbill.application.review.RuntimeOwnedReviewMode
@@ -11,6 +7,8 @@ import skillbill.application.review.model.ParallelCodeReviewRequest
 import skillbill.application.review.model.ParallelCodeReviewResult
 import skillbill.application.reviewevidence.model.ParallelReviewScope
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.goalrunner.subtaskreview.FeatureTaskRuntimeVerificationSignalKeys
 import skillbill.goalrunner.subtaskreview.GoalSubtaskReviewSummaryReducer

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopAttemptSettlement.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopAttemptSettlement.kt
@@ -1,10 +1,9 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.diagnostics.model.FeatureTaskRuntimeRejectedOutputWrite
 import skillbill.application.diagnostics.model.RejectedOutputDiagnosticRequest
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCommitPushHandoffInvalid
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCommitPushHandoffValid
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeSubtaskFinalisationBlocked
@@ -662,7 +661,8 @@ object FeatureTaskRuntimeRunLoopAttemptSettlement {
   ): CommitPushFinalisation {
     if (
       run.phaseId != FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH ||
-      (normalizedOutput.envelope[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED
+      (normalizedOutput.envelope[SharedPayloadKeys.STATUS] as? String)
+        .workflowStepStatus() != WorkflowStepStatus.COMPLETED
     ) {
       return CommitPushNotApplicable
     }

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopAttemptSettlement.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopAttemptSettlement.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.diagnostics.model.FeatureTaskRuntimeRejectedOutputWrite
 import skillbill.application.diagnostics.model.RejectedOutputDiagnosticRequest
 import skillbill.contracts.JsonCodec
@@ -660,7 +662,7 @@ object FeatureTaskRuntimeRunLoopAttemptSettlement {
   ): CommitPushFinalisation {
     if (
       run.phaseId != FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_COMMIT_PUSH ||
-      (normalizedOutput.envelope["status"] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED
+      (normalizedOutput.envelope[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED
     ) {
       return CommitPushNotApplicable
     }

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopCheckpointRemediation.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopCheckpointRemediation.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCheckpointDecision
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeSubtaskCommitIdentity
@@ -101,9 +103,9 @@ object FeatureTaskRuntimeRunLoopCheckpointRemediation {
     outputMap
       .takeIf {
         run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_IMPLEMENT_FIX &&
-          (it["status"] as? String)?.let(WorkflowStepStatus::fromWire) == WorkflowStepStatus.COMPLETED
+          (it[SharedPayloadKeys.STATUS] as? String)?.let(WorkflowStepStatus::fromWire) == WorkflowStepStatus.COMPLETED
       }
-      ?.let { JsonCodec.anyToStringAnyMap(it["produced_outputs"]).orEmpty() }
+      ?.let { JsonCodec.anyToStringAnyMap(it[SharedPayloadKeys.PRODUCED_OUTPUTS]).orEmpty() }
 
   fun establishRemediationCheckpoint(
     runLoop: FeatureTaskRuntimeRunLoop,

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopCheckpointRemediation.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopCheckpointRemediation.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCheckpointDecision
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeSubtaskCommitIdentity
 import skillbill.ports.workflow.gitops.captureIndexState

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopOutputVerification.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopOutputVerification.kt
@@ -1,10 +1,9 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.reviewevidence.FeatureTaskRuntimeSharedReviewEvidenceResolver
 import skillbill.application.reviewevidence.model.FeatureTaskRuntimeSharedReviewEvidenceResolved
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeFindingBoundaryMemoryRequest
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeFindingBoundaryMemorySection
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeImplementationContinuation
@@ -55,7 +54,8 @@ object FeatureTaskRuntimeRunLoopOutputVerification {
   ): NormalizedFeatureTaskRuntimePhaseOutput {
     val eligible = run.agentRunValidateFallback &&
       run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE &&
-      (normalizedOutput.envelope[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() == WorkflowStepStatus.COMPLETED
+      (normalizedOutput.envelope[SharedPayloadKeys.STATUS] as? String)
+        .workflowStepStatus() == WorkflowStepStatus.COMPLETED
     if (!eligible) return normalizedOutput
     val produced = JsonCodec.anyToStringAnyMap(normalizedOutput.envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])
       ?.toMutableMap()

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopOutputVerification.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopOutputVerification.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.reviewevidence.FeatureTaskRuntimeSharedReviewEvidenceResolver
 import skillbill.application.reviewevidence.model.FeatureTaskRuntimeSharedReviewEvidenceResolved
 import skillbill.contracts.JsonCodec
@@ -53,9 +55,9 @@ object FeatureTaskRuntimeRunLoopOutputVerification {
   ): NormalizedFeatureTaskRuntimePhaseOutput {
     val eligible = run.agentRunValidateFallback &&
       run.phaseId == FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE &&
-      (normalizedOutput.envelope["status"] as? String).workflowStepStatus() == WorkflowStepStatus.COMPLETED
+      (normalizedOutput.envelope[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() == WorkflowStepStatus.COMPLETED
     if (!eligible) return normalizedOutput
-    val produced = JsonCodec.anyToStringAnyMap(normalizedOutput.envelope["produced_outputs"])
+    val produced = JsonCodec.anyToStringAnyMap(normalizedOutput.envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])
       ?.toMutableMap()
       ?: return normalizedOutput
     val validationResult = JsonCodec.anyToStringAnyMap(produced["validation_result"])
@@ -66,7 +68,7 @@ object FeatureTaskRuntimeRunLoopOutputVerification {
     validationResult.remove("suppression_justifications")
     produced["validation_result"] = validationResult
     val envelope = normalizedOutput.envelope.toMutableMap()
-    envelope["produced_outputs"] = produced
+    envelope[SharedPayloadKeys.PRODUCED_OUTPUTS] = produced
     return runLoop.outputValidator.validatePhaseOutput(
       JsonCodec.mapToJsonString(envelope),
       sourceLabel = run.phaseId,
@@ -355,8 +357,8 @@ object FeatureTaskRuntimeRunLoopOutputVerification {
     val envelope = JsonCodec.parseObjectOrNull(auditOutputArtifact)
       ?.let(JsonCodec::jsonElementToValue)
       ?.let(JsonCodec::anyToStringAnyMap)
-    val produced = envelope?.let { JsonCodec.anyToStringAnyMap(it["produced_outputs"]) }
-    val value = when (val raw = produced?.get("value")) {
+    val produced = envelope?.let { JsonCodec.anyToStringAnyMap(it[SharedPayloadKeys.PRODUCED_OUTPUTS]) }
+    val value = when (val raw = produced?.get(SharedPayloadKeys.VALUE)) {
       is String -> JsonCodec.parseObjectOrNull(raw)
         ?.let(JsonCodec::jsonElementToValue)
         ?.let(JsonCodec::anyToStringAnyMap)

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopValidationGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopValidationGate.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.engine.featuretask.validation.FeatureTaskRuntimeBuildGateCoordinator
 import skillbill.engine.featuretask.validation.model.ValidationGateAgentRepairLauncher
@@ -78,7 +77,9 @@ object FeatureTaskRuntimeRunLoopValidationGate {
     val accepted = runLoop.outputValidator.validatePhaseOutput(outputText, sourceLabel = run.phaseId)
       .requireAcceptedOutput(run.phaseId)
     val buildReceipt = JsonCodec.anyToStringAnyMap(
-      JsonCodec.anyToStringAnyMap(accepted.normalizedOutput.envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])?.get("build_receipt"),
+      JsonCodec.anyToStringAnyMap(
+        accepted.normalizedOutput.envelope[SharedPayloadKeys.PRODUCED_OUTPUTS],
+      )?.get("build_receipt"),
     )
     runLoop.buildReceiptValidator.validateBuildReceipt(buildReceipt ?: emptyMap(), sourceLabel = run.phaseId)
     accepted

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopValidationGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunLoopValidationGate.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.engine.featuretask.validation.FeatureTaskRuntimeBuildGateCoordinator
@@ -76,7 +78,7 @@ object FeatureTaskRuntimeRunLoopValidationGate {
     val accepted = runLoop.outputValidator.validatePhaseOutput(outputText, sourceLabel = run.phaseId)
       .requireAcceptedOutput(run.phaseId)
     val buildReceipt = JsonCodec.anyToStringAnyMap(
-      JsonCodec.anyToStringAnyMap(accepted.normalizedOutput.envelope["produced_outputs"])?.get("build_receipt"),
+      JsonCodec.anyToStringAnyMap(accepted.normalizedOutput.envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])?.get("build_receipt"),
     )
     runLoop.buildReceiptValidator.validateBuildReceipt(buildReceipt ?: emptyMap(), sourceLabel = run.phaseId)
     accepted
@@ -273,10 +275,10 @@ object FeatureTaskRuntimeRunLoopValidationGate {
 
   fun gateTriageCapturedProducedOutputs(outputText: String): Map<String, Any?> {
     val produced = looseOutputEnvelope(outputText)
-      ?.let { JsonCodec.anyToStringAnyMap(it["produced_outputs"]) }
+      ?.let { JsonCodec.anyToStringAnyMap(it[SharedPayloadKeys.PRODUCED_OUTPUTS]) }
       ?: return emptyMap()
     return buildMap {
-      produced["value"]?.let { put("value", it) }
+      produced[SharedPayloadKeys.VALUE]?.let { put(SharedPayloadKeys.VALUE, it) }
       produced["validation_repair_plan"]?.let { put("validation_repair_plan", it) }
     }
   }
@@ -297,11 +299,11 @@ object FeatureTaskRuntimeRunLoopValidationGate {
   ): FeatureTaskRuntimePhaseOutput {
     val captured = gateTriageCapturedProducedOutputs(outputText)
     val payload = mapOf(
-      "contract_version" to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
-      "phase_id" to run.phaseId,
-      "status" to "completed",
-      "summary" to "Gate triage segment.",
-      "produced_outputs" to captured,
+      SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
+      SharedPayloadKeys.PHASE_ID to run.phaseId,
+      SharedPayloadKeys.STATUS to "completed",
+      SharedPayloadKeys.SUMMARY to "Gate triage segment.",
+      SharedPayloadKeys.PRODUCED_OUTPUTS to captured,
     )
     return FeatureTaskRuntimePhaseOutput(
       phaseId = run.phaseId,
@@ -313,9 +315,9 @@ object FeatureTaskRuntimeRunLoopValidationGate {
   fun extractValidationGateTriagePlan(output: FeatureTaskRuntimePhaseOutput): ValidationGateTriageResult {
     val envelope = FeatureTaskRuntimeRunLoopLaunch.outputEnvelopeOf(output)
       ?: return ValidationGateTriageResult.Empty
-    val produced = JsonCodec.anyToStringAnyMap(envelope["produced_outputs"])
+    val produced = JsonCodec.anyToStringAnyMap(envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])
       ?: return ValidationGateTriageResult.Empty
-    FeatureTaskRuntimeRunLoopValidationGate.planFromProducedValue(produced["value"])?.let { return it }
+    FeatureTaskRuntimeRunLoopValidationGate.planFromProducedValue(produced[SharedPayloadKeys.VALUE])?.let { return it }
     val directPlan = FeatureTaskRuntimeRunLoopValidationGate
       .extractTriagePlanProse(produced["validation_repair_plan"])
     return if (!directPlan.isNullOrBlank()) {

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunState.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunState.kt
@@ -1,7 +1,6 @@
 package skillbill.engine.featuretask
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunState.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunState.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus
@@ -340,9 +342,9 @@ class FeatureTaskRuntimeRunState(
       validatedOutput == null ->
         "Audit-gap remediation requires a valid completed original '$phaseId' output; " +
           "its durable record carries no normalized output."
-      validatedOutput["phase_id"] != phaseId ->
+      validatedOutput[SharedPayloadKeys.PHASE_ID] != phaseId ->
         "Audit-gap remediation requires a valid completed original '$phaseId' output; " +
-          "the persisted record declares phase_id '${validatedOutput["phase_id"]}'."
+          "the persisted record declares phase_id '${validatedOutput[SharedPayloadKeys.PHASE_ID]}'."
       record?.loopId != null || record?.edgeIteration != null ->
         "Audit-gap remediation cannot prove original planning-context identity because '$phaseId' " +
           "carries legacy backward-edge metadata. Migrate or restart this experimental durable workflow; " +

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerLaunchOutcomes.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerLaunchOutcomes.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.agentoutput.agentFailureExcerpt
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeGoalContinuationContext
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunReport
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunRequest

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerLaunchOutcomes.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerLaunchOutcomes.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.agentoutput.agentFailureExcerpt
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeGoalContinuationContext
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunReport
@@ -25,14 +27,14 @@ import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeProviderLimitSigna
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeQualityGateSelection
 
 fun terminalBlockedReasonFrom(phaseId: String, outputMap: Map<String, Any?>): String? {
-  val status = outputMap["status"] as? String
+  val status = outputMap[SharedPayloadKeys.STATUS] as? String
   if (status.workflowStepStatus() != WorkflowStepStatus.BLOCKED &&
     status.workflowStepStatus() != WorkflowStepStatus.FAILED
   ) {
     return null
   }
-  val summary = (outputMap["summary"] as? String).orEmpty().trim()
-  val blockingReasons = (outputMap["produced_outputs"] as? Map<*, *>)
+  val summary = (outputMap[SharedPayloadKeys.SUMMARY] as? String).orEmpty().trim()
+  val blockingReasons = (outputMap[SharedPayloadKeys.PRODUCED_OUTPUTS] as? Map<*, *>)
     ?.get("blocking_reasons")
     ?.let { value ->
       when (value) {

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerPolicies.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerPolicies.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunRequest
 import skillbill.workflow.model.WorkflowStepStatus
@@ -77,8 +79,8 @@ fun mutatingReconciliationGateReason(phaseId: String, outputMap: Map<String, Any
   // schema-valid terminal outcome that never claimed the tree reached target, so charging it with a
   // missing reconciliation report converted it into a schema-gate rejection and denied it the terminal
   // path it belongs on.
-  if ((outputMap["status"] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED) return null
-  val producedOutputs = outputMap["produced_outputs"] as? Map<*, *>
+  if ((outputMap[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED) return null
+  val producedOutputs = outputMap[SharedPayloadKeys.PRODUCED_OUTPUTS] as? Map<*, *>
   val nestedReconciled = (producedOutputs?.get("reconciled_state") as? Map<*, *>)?.get("reconciled")
   val reconciled = nestedReconciled == true || producedOutputs?.get("reconciled") == true
   return if (reconciled) {

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerPolicies.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeRunnerPolicies.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeRunRequest
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeSubtaskFinalisationHandoff.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeSubtaskFinalisationHandoff.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCommitPushHandoff
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCommitPushHandoffInvalid
@@ -29,20 +31,20 @@ object FeatureTaskRuntimeSubtaskFinalisationHandoff {
   }
 
   fun withCommitSha(envelope: Map<String, Any?>, commitSha: String): Map<String, Any?> {
-    val produced = JsonCodec.anyToStringAnyMap(envelope["produced_outputs"])?.toMutableMap()
+    val produced = JsonCodec.anyToStringAnyMap(envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])?.toMutableMap()
       ?: return envelope
     val result = JsonCodec.anyToStringAnyMap(produced[COMMIT_PUSH_RESULT_KEY])?.toMutableMap()
       ?: return envelope
     result[COMMIT_SHA_KEY] = commitSha
     produced[COMMIT_PUSH_RESULT_KEY] = result
-    return envelope.toMutableMap().apply { this["produced_outputs"] = produced }
+    return envelope.toMutableMap().apply { this[SharedPayloadKeys.PRODUCED_OUTPUTS] = produced }
   }
 
   private fun changedPaths(result: Map<String, Any?>): List<String>? =
     (result[CHANGED_PATHS_KEY] as? List<*>)?.mapNotNull { it?.toString()?.trim()?.takeIf(String::isNotBlank) }
 
   private fun commitPushResult(envelope: Map<String, Any?>): Map<String, Any?>? =
-    JsonCodec.anyToStringAnyMap(envelope["produced_outputs"])?.let { produced ->
+    JsonCodec.anyToStringAnyMap(envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])?.let { produced ->
       JsonCodec.anyToStringAnyMap(produced[COMMIT_PUSH_RESULT_KEY])
     } ?: JsonCodec.anyToStringAnyMap(envelope[COMMIT_PUSH_RESULT_KEY])
 

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeSubtaskFinalisationHandoff.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeSubtaskFinalisationHandoff.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCommitPushHandoff
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCommitPushHandoffInvalid
 import skillbill.engine.featuretask.model.FeatureTaskRuntimeCommitPushHandoffResult

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeVerificationGateReasons.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeVerificationGateReasons.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidFeatureTaskRuntimeFindingVerificationRecordError
 import skillbill.goalrunner.subtaskreview.FeatureTaskRuntimeVerificationSignalKeys
@@ -17,7 +19,7 @@ object FeatureTaskRuntimeVerificationGateReasons {
       return null
     }
     val dispositionsKey = FeatureTaskRuntimeVerificationSignalKeys.FINDINGS_VERIFICATION_DISPOSITIONS
-    val dispositionsRaw = outputMap["produced_outputs"]
+    val dispositionsRaw = outputMap[SharedPayloadKeys.PRODUCED_OUTPUTS]
       ?.let(JsonCodec::anyToStringAnyMap)
       ?.get(dispositionsKey) as? List<*>
       ?: return "verify_findings reported 'completed' without produced_outputs.$dispositionsKey."
@@ -41,7 +43,7 @@ object FeatureTaskRuntimeVerificationGateReasons {
   fun reviewVerificationSignal(phaseId: String, outputMap: Map<String, Any?>): String? {
     if (phaseId != FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_REVIEW) return null
     val hasVerdict = (outputMap[FeatureTaskRuntimeVerificationSignalKeys.VERDICT] as? String)?.isNotBlank() == true
-    val producedOutputs = outputMap["produced_outputs"] as? Map<*, *>
+    val producedOutputs = outputMap[SharedPayloadKeys.PRODUCED_OUTPUTS] as? Map<*, *>
     val findingsKey = FeatureTaskRuntimeVerificationSignalKeys.REVIEW_FINDINGS
     val hasFindingsArray = producedOutputs?.containsKey(findingsKey) == true && producedOutputs[findingsKey] is List<*>
     return if (hasVerdict || hasFindingsArray) {

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeVerificationGateReasons.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeVerificationGateReasons.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidFeatureTaskRuntimeFindingVerificationRecordError
 import skillbill.goalrunner.subtaskreview.FeatureTaskRuntimeVerificationSignalKeys
 import skillbill.workflow.taskruntime.FeatureTaskRuntimePhaseWorkflowDefinition

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeWorkflowPersistence.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeWorkflowPersistence.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.featuretask
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.WorkflowFamily
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.issuekey.normalizeIssueKey
 import skillbill.engine.featuretask.model.FeatureTaskRuntimePhaseStateRequest
 import skillbill.error.InvalidWorkflowStateSchemaError

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeWorkflowPersistence.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/FeatureTaskRuntimeWorkflowPersistence.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.contracts.issuekey.normalizeIssueKey
 import skillbill.engine.featuretask.model.FeatureTaskRuntimePhaseStateRequest
@@ -125,8 +127,8 @@ fun stepUpdatesFrom(records: Map<String, FeatureTaskRuntimePhaseRecord>): List<M
   }
   return records.values.map { record ->
     linkedMapOf<String, Any?>(
-      "step_id" to record.phaseId,
-      "status" to stepStatusFor(record),
+      SharedPayloadKeys.STEP_ID to record.phaseId,
+      SharedPayloadKeys.STATUS to stepStatusFor(record),
       "attempt_count" to record.attemptCount,
     )
   }

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/model/FeatureTaskRuntimePhaseLaunchBriefing.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/model/FeatureTaskRuntimePhaseLaunchBriefing.kt
@@ -1,9 +1,8 @@
 package skillbill.engine.featuretask.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PHASE_LAUNCH_BRIEFING_CONTRACT_VERSION
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimeHandoffEnvelope

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/model/FeatureTaskRuntimePhaseLaunchBriefing.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/model/FeatureTaskRuntimePhaseLaunchBriefing.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_PHASE_LAUNCH_BRIEFING_CONTRACT_VERSION
@@ -56,8 +58,8 @@ data class FeatureTaskRuntimePhaseLaunchBriefing(
   /** Serializes the briefing for the durable artifact store, preserving all three handoff layers. */
   @OpenBoundaryMap("Feature-task-runtime per-phase launch briefing artifact map at the durable workflow-artifact seam")
   fun toArtifactMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to CONTRACT_VERSION,
-    "phase_id" to phaseId,
+    SharedPayloadKeys.CONTRACT_VERSION to CONTRACT_VERSION,
+    SharedPayloadKeys.PHASE_ID to phaseId,
     "spec_reference" to specReference,
     "feature_size" to featureSize,
     "acceptance_criteria" to acceptanceCriteria,
@@ -88,7 +90,7 @@ data class FeatureTaskRuntimePhaseLaunchBriefing(
             "to briefing contract $CONTRACT_VERSION before retrying.",
         )
       }
-      val version = raw["contract_version"]
+      val version = raw[SharedPayloadKeys.CONTRACT_VERSION]
       if (version != CONTRACT_VERSION) {
         schemaError(
           "Feature-task-runtime briefing artifact contract_version must be '$CONTRACT_VERSION', was " +

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeBuildGateCoordinator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeBuildGateCoordinator.kt
@@ -1,10 +1,9 @@
 package skillbill.engine.featuretask.validation
 
-import skillbill.contracts.SharedPayloadKeys
-
 import me.tatarka.inject.annotations.Inject
 import skillbill.config.model.applyValidationGateGradleWrapper
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_BUILD_RECEIPT_CONTRACT_VERSION
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.engine.featuretask.emitFeatureTaskRuntimeEventSafely

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeBuildGateCoordinator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeBuildGateCoordinator.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask.validation
 
+import skillbill.contracts.SharedPayloadKeys
+
 import me.tatarka.inject.annotations.Inject
 import skillbill.config.model.applyValidationGateGradleWrapper
 import skillbill.contracts.JsonCodec
@@ -304,7 +306,7 @@ class FeatureTaskRuntimeBuildGateCoordinator(
       checks: List<String>,
     ): FeatureTaskRuntimePhaseOutput {
       val buildReceipt = linkedMapOf<String, Any?>(
-        "contract_version" to FEATURE_TASK_RUNTIME_BUILD_RECEIPT_CONTRACT_VERSION,
+        SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_BUILD_RECEIPT_CONTRACT_VERSION,
         "validation_status" to "passed",
         "checks" to checks,
         "repository_checkpoint" to mapOf("fingerprint" to repositoryCheckpoint),
@@ -313,12 +315,12 @@ class FeatureTaskRuntimeBuildGateCoordinator(
       )
       val payload = JsonCodec.mapToJsonString(
         mapOf(
-          "contract_version" to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
-          "phase_id" to FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_BUILD,
-          "status" to BUILD_PHASE_STATUS_COMPLETED,
-          "summary" to "Build satisfied by runtime-owned gate execution.",
-          "verdict" to FeatureTaskRuntimeVerdict.SATISFIED.wireValue,
-          "produced_outputs" to mapOf(
+          SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
+          SharedPayloadKeys.PHASE_ID to FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_BUILD,
+          SharedPayloadKeys.STATUS to BUILD_PHASE_STATUS_COMPLETED,
+          SharedPayloadKeys.SUMMARY to "Build satisfied by runtime-owned gate execution.",
+          SharedPayloadKeys.VERDICT to FeatureTaskRuntimeVerdict.SATISFIED.wireValue,
+          SharedPayloadKeys.PRODUCED_OUTPUTS to mapOf(
             "build_receipt" to buildReceipt,
           ),
         ),

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeValidationGateCoordinator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeValidationGateCoordinator.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.featuretask.validation
 
+import skillbill.contracts.SharedPayloadKeys
+
 import me.tatarka.inject.annotations.Inject
 import skillbill.config.model.applyValidationGateGradleWrapper
 import skillbill.contracts.JsonCodec
@@ -344,12 +346,12 @@ class FeatureTaskRuntimeValidationGateCoordinator(
       )
       val payload = JsonCodec.mapToJsonString(
         mapOf(
-          "contract_version" to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
-          "phase_id" to FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE,
-          "status" to VALIDATE_PHASE_STATUS_COMPLETED,
-          "summary" to "Validation satisfied by runtime-owned gate execution.",
-          "verdict" to FeatureTaskRuntimeVerdict.SATISFIED.wireValue,
-          "produced_outputs" to mapOf(
+          SharedPayloadKeys.CONTRACT_VERSION to FEATURE_TASK_RUNTIME_CONTRACT_VERSION,
+          SharedPayloadKeys.PHASE_ID to FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_VALIDATE,
+          SharedPayloadKeys.STATUS to VALIDATE_PHASE_STATUS_COMPLETED,
+          SharedPayloadKeys.SUMMARY to "Validation satisfied by runtime-owned gate execution.",
+          SharedPayloadKeys.VERDICT to FeatureTaskRuntimeVerdict.SATISFIED.wireValue,
+          SharedPayloadKeys.PRODUCED_OUTPUTS to mapOf(
             "validation_result" to validationResult,
           ),
         ),

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeValidationGateCoordinator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/featuretask/validation/FeatureTaskRuntimeValidationGateCoordinator.kt
@@ -1,10 +1,9 @@
 package skillbill.engine.featuretask.validation
 
-import skillbill.contracts.SharedPayloadKeys
-
 import me.tatarka.inject.annotations.Inject
 import skillbill.config.model.applyValidationGateGradleWrapper
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.engine.featuretask.FeatureTaskRuntimePhaseRecorder
 import skillbill.engine.featuretask.emitFeatureTaskRuntimeEventSafely

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationCheckpoint.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationCheckpoint.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalplanning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import me.tatarka.inject.annotations.Inject
 import skillbill.contracts.JsonCodec
 import skillbill.engine.planningprojection.producerProjectionGateReason
@@ -176,8 +178,8 @@ class GoalPlanningPreparationCheckpoint(
         val parsed = JsonCodec.parseObjectOrNull(plan.planPayload)
           ?.let(JsonCodec::jsonElementToValue)
           ?.let(JsonCodec::anyToStringAnyMap)
-        val status = parsed?.get("status")?.toString()
-        val produced = parsed?.get("produced_outputs") as? Map<*, *>
+        val status = parsed?.get(SharedPayloadKeys.STATUS)?.toString()
+        val produced = parsed?.get(SharedPayloadKeys.PRODUCED_OUTPUTS) as? Map<*, *>
         if (status.workflowStepStatus() != WorkflowStepStatus.COMPLETED || produced?.isEmpty() != false) {
           throw IncompatibleGoalPlanningPreparationRecoveryError(
             identity.parentGoalWorkflowId,
@@ -381,8 +383,8 @@ private fun planningRecordRejection(compute: () -> String?): String? = try {
 }
 
 private fun Map<String, Any?>.requirePrepared(label: String) {
-  if (get("status").workflowStepStatus() != WorkflowStepStatus.COMPLETED ||
-    (get("produced_outputs") as? Map<*, *>)?.isEmpty() != false
+  if (get(SharedPayloadKeys.STATUS).workflowStepStatus() != WorkflowStepStatus.COMPLETED ||
+    (get(SharedPayloadKeys.PRODUCED_OUTPUTS) as? Map<*, *>)?.isEmpty() != false
   ) {
     throw InvalidGoalPlanningPreparationSchemaError(
       label,
@@ -393,7 +395,7 @@ private fun Map<String, Any?>.requirePrepared(label: String) {
 }
 
 private fun SharedGoalPreplanCheckpoint.toEnvelopeMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to contractVersion,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
   "record_type" to "shared_preplan",
   "identity" to identity.asMap(),
   "preparation_status" to preparationStatus.wireValue,
@@ -404,8 +406,8 @@ private fun SharedGoalPreplanCheckpoint.toEnvelopeMap(): Map<String, Any?> = lin
 ).filterValues { it != null }
 
 private fun GoalSubtaskPlanCheckpoint.toEnvelopeMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to contractVersion, "record_type" to "subtask_plan", "identity" to identity.asMap(),
-  "subtask_id" to subtaskId, "manifest_order" to manifestOrder, "governed_sub_spec_path" to governedSubSpecPath,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion, "record_type" to "subtask_plan", "identity" to identity.asMap(),
+  SharedPayloadKeys.SUBTASK_ID to subtaskId, "manifest_order" to manifestOrder, "governed_sub_spec_path" to governedSubSpecPath,
   "sub_spec_hash" to subSpecHash, "preparation_status" to preparationStatus.wireValue,
   "provenance" to provenance.asMap(), "payload_sha256" to payloadSha256, "plan_payload" to planPayload,
   "repair_evidence" to repairEvidence?.toArtifactMap(),

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationCheckpoint.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationCheckpoint.kt
@@ -1,9 +1,8 @@
 package skillbill.engine.goalplanning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import me.tatarka.inject.annotations.Inject
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.planningprojection.producerProjectionGateReason
 import skillbill.engine.planningprojection.requireValidPlanningProjection
 import skillbill.error.IncompatibleGoalPlanningPreparationRecoveryError
@@ -406,8 +405,12 @@ private fun SharedGoalPreplanCheckpoint.toEnvelopeMap(): Map<String, Any?> = lin
 ).filterValues { it != null }
 
 private fun GoalSubtaskPlanCheckpoint.toEnvelopeMap(): Map<String, Any?> = linkedMapOf(
-  SharedPayloadKeys.CONTRACT_VERSION to contractVersion, "record_type" to "subtask_plan", "identity" to identity.asMap(),
-  SharedPayloadKeys.SUBTASK_ID to subtaskId, "manifest_order" to manifestOrder, "governed_sub_spec_path" to governedSubSpecPath,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
+  "record_type" to "subtask_plan",
+  "identity" to identity.asMap(),
+  SharedPayloadKeys.SUBTASK_ID to subtaskId,
+  "manifest_order" to manifestOrder,
+  "governed_sub_spec_path" to governedSubSpecPath,
   "sub_spec_hash" to subSpecHash, "preparation_status" to preparationStatus.wireValue,
   "provenance" to provenance.asMap(), "payload_sha256" to payloadSha256, "plan_payload" to planPayload,
   "repair_evidence" to repairEvidence?.toArtifactMap(),

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationRecordMapping.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationRecordMapping.kt
@@ -1,7 +1,6 @@
 package skillbill.engine.goalplanning
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.ports.goalrunner.model.GoalPlanningPreparationProvenance
 import skillbill.ports.goalrunner.model.GoalPlanningPreparationRecord
 import skillbill.ports.goalrunner.model.GoalPlanningPreparationState

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationRecordMapping.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationRecordMapping.kt
@@ -1,15 +1,17 @@
 package skillbill.engine.goalplanning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.ports.goalrunner.model.GoalPlanningPreparationProvenance
 import skillbill.ports.goalrunner.model.GoalPlanningPreparationRecord
 import skillbill.ports.goalrunner.model.GoalPlanningPreparationState
 
 fun GoalPlanningPreparationRecord.toEnvelopeMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to contractVersion,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
   "parent_goal_workflow_id" to parentGoalWorkflowId,
   "normalized_issue_key" to normalizedIssueKey,
   "repository_identity" to repositoryIdentity,
-  "subtask_id" to subtaskId,
+  SharedPayloadKeys.SUBTASK_ID to subtaskId,
   "governed_sub_spec_path" to governedSubSpecPath,
   "preparation_status" to preparationStatus.wireValue,
   "provenance" to linkedMapOf(
@@ -29,7 +31,7 @@ fun Map<String, Any?>.toGoalPlanningPreparationRecord(): GoalPlanningPreparation
     parentGoalWorkflowId = stringValue("parent_goal_workflow_id"),
     normalizedIssueKey = stringValue("normalized_issue_key"),
     repositoryIdentity = stringValue("repository_identity"),
-    subtaskId = (this["subtask_id"] as Number).toInt(),
+    subtaskId = (this[SharedPayloadKeys.SUBTASK_ID] as Number).toInt(),
     governedSubSpecPath = stringValue("governed_sub_spec_path"),
     preparationStatus = GoalPlanningPreparationState.fromWireValue(stringValue("preparation_status")),
     provenance = GoalPlanningPreparationProvenance(

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationValidator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationValidator.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalplanning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.contracts.workflow.FeatureTaskRuntimePhaseOutputSchemaPaths
@@ -47,7 +49,7 @@ class GoalPlanningPreparationValidator(
   }
 
   private fun requireCompleted(payload: Map<String, Any?>, phaseId: String, label: String) {
-    val status = payload["status"]?.toString()
+    val status = payload[SharedPayloadKeys.STATUS]?.toString()
     if (status.workflowStepStatus() != WorkflowStepStatus.COMPLETED) {
       throw InvalidGoalPlanningPreparationSchemaError(
         sourceLabel = label,

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationValidator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalplanning/GoalPlanningPreparationValidator.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalplanning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.contracts.workflow.FeatureTaskRuntimePhaseOutputSchemaPaths
 import skillbill.engine.planningprojection.requireValidPlanningProjection

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodec.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodec.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
@@ -25,8 +27,8 @@ import skillbill.workflow.taskruntime.model.requireAcceptedOutput
 @OpenBoundaryMap("Goal continuation artifact decode from durable workflow artifacts")
 fun goalContinuation(artifacts: Map<String, Any?>): GoalContinuation? =
   (artifacts["goal_continuation"] as? Map<*, *>)?.let { payload ->
-    val issueKey = payload["issue_key"]?.toString()?.takeIf(String::isNotBlank)
-    val subtaskId = payload["subtask_id"].asGoalRunnerIntOrNull()
+    val issueKey = payload[SharedPayloadKeys.ISSUE_KEY]?.toString()?.takeIf(String::isNotBlank)
+    val subtaskId = payload[SharedPayloadKeys.SUBTASK_ID].asGoalRunnerIntOrNull()
     if (issueKey == null || subtaskId == null) {
       null
     } else {

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodec.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodec.kt
@@ -1,10 +1,9 @@
 package skillbill.engine.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.goalrunner.model.GoalContinuation
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodecWireDecode.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodecWireDecode.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.model.GoalRunnerSupervisionEvent
 import skillbill.goalrunner.model.GoalRunnerWorkerSubtaskRequest
 import skillbill.goalrunner.model.GoalRunnerWorkerSubtaskRequestOutcome

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodecWireDecode.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalContinuationArtifactCodecWireDecode.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.goalrunner.model.GoalRunnerSupervisionEvent
 import skillbill.goalrunner.model.GoalRunnerWorkerSubtaskRequest
@@ -12,8 +14,8 @@ fun GoalRunnerSupervisionEvent.toArtifactsMap(): Map<String, Any?> = linkedMapOf
   "reason" to reason,
   "continuation_mode" to continuationMode.wireValue,
   "process_state" to processState.wireValue,
-  "workflow_id" to workflowId,
-  "step_id" to stepId,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
+  SharedPayloadKeys.STEP_ID to stepId,
   "last_durable_progress" to lastDurableProgress,
   "last_workflow_snapshot_at" to lastWorkflowSnapshotAt,
   "last_file_activity_at" to lastFileActivityAt,
@@ -26,26 +28,26 @@ const val WORKER_SUBTASK_REQUEST_OUTCOME_LIMIT = 50
 @OpenBoundaryMap("Goal worker subtask request outcome durable artifact map")
 fun GoalRunnerWorkerSubtaskRequestOutcome.toArtifactMap(): Map<String, Any?> = when (this) {
   is GoalRunnerWorkerSubtaskRequestOutcome.Accepted -> linkedMapOf(
-    "status" to "accepted",
+    SharedPayloadKeys.STATUS to "accepted",
     "source_stream" to sourceStream,
     "request" to request.toArtifactMap(),
-    "subtask_id" to subtask.id,
+    SharedPayloadKeys.SUBTASK_ID to subtask.id,
     "spec_path" to subtask.specPath,
   )
   is GoalRunnerWorkerSubtaskRequestOutcome.Queued -> linkedMapOf(
-    "status" to "queued",
+    SharedPayloadKeys.STATUS to "queued",
     "source_stream" to sourceStream,
     "request" to request.toArtifactMap(),
     "reason" to reason,
   )
   is GoalRunnerWorkerSubtaskRequestOutcome.Rejected -> linkedMapOf(
-    "status" to "rejected",
+    SharedPayloadKeys.STATUS to "rejected",
     "source_stream" to sourceStream,
     "reason" to reason.name.lowercase(),
     "message" to message,
   )
   is GoalRunnerWorkerSubtaskRequestOutcome.RequiresOperatorConfirmation -> linkedMapOf(
-    "status" to "requires_operator_confirmation",
+    SharedPayloadKeys.STATUS to "requires_operator_confirmation",
     "source_stream" to sourceStream,
     "request" to request.toArtifactMap(),
     "reason" to reason,

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerChildRepairWedgeApplyLoop.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerChildRepairWedgeApplyLoop.kt
@@ -1,9 +1,9 @@
 package skillbill.engine.goalrunner
 import skillbill.application.decomposition.decodeArtifacts
-import skillbill.contracts.SharedPayloadKeys
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.application.workflow.updateGoalParentForBlockedPhaseRetry
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.featuretask.buildCompletedUpstreamMissingOutputRepair
 import skillbill.engine.featuretask.diagnoseUnsettledCompletedUpstreamPhaseId
 import skillbill.engine.featuretask.featureSizeFromArtifacts

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerChildRepairWedgeApplyLoop.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerChildRepairWedgeApplyLoop.kt
@@ -1,5 +1,6 @@
 package skillbill.engine.goalrunner
 import skillbill.application.decomposition.decodeArtifacts
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.application.workflow.model.WorkflowFamily
 import skillbill.application.workflow.updateGoalParentForBlockedPhaseRetry
 import skillbill.contracts.JsonCodec
@@ -369,8 +370,8 @@ fun childRepairWedgeEvidenceMap(repair: GoalRunnerAppliedRepair, clock: Clock): 
   "field" to repair.field,
   "prior_value" to repair.priorValue,
   "new_value" to repair.newValue,
-  "subtask_id" to repair.subtaskId,
-  "workflow_id" to repair.workflowId,
+  SharedPayloadKeys.SUBTASK_ID to repair.subtaskId,
+  SharedPayloadKeys.WORKFLOW_ID to repair.workflowId,
   "repaired_at" to clock.instant().toString(),
 )
 

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerLaunchModels.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerLaunchModels.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.goalContinuationTerminalStatus
 import skillbill.goalrunner.model.GoalRunnerReconciledOutcome
 import skillbill.goalrunner.model.GoalRunnerStopReason

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerLaunchModels.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerLaunchModels.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.goalContinuationTerminalStatus
 import skillbill.goalrunner.model.GoalRunnerReconciledOutcome
@@ -106,8 +108,8 @@ fun Map<String, Any?>.isImplementationReturnContract(): Boolean = keys.containsA
 )
 
 fun Map<String, Any?>.isRuntimeTerminalEnvelope(): Boolean =
-  goalContinuationTerminalStatus(this["status"]?.toString()) != null &&
-    this["workflow_id"]?.toString().orEmpty().isNotBlank()
+  goalContinuationTerminalStatus(this[SharedPayloadKeys.STATUS]?.toString()) != null &&
+    this[SharedPayloadKeys.WORKFLOW_ID]?.toString().orEmpty().isNotBlank()
 
 fun topLevelJsonObjectCandidates(text: String): List<String> {
   val candidates = mutableListOf<String>()

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerManifestSnapshotProjection.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerManifestSnapshotProjection.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.withParentStatus
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.goalrunner.model.GoalRunnerResetSnapshot
 import skillbill.engine.goalrunner.model.GoalRunnerResetSubtaskSnapshot
 import skillbill.goalrunner.model.GoalObservabilityProgressEvent

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerManifestSnapshotProjection.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalRunnerManifestSnapshotProjection.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.withParentStatus
 import skillbill.engine.goalrunner.model.GoalRunnerResetSnapshot
 import skillbill.engine.goalrunner.model.GoalRunnerResetSubtaskSnapshot
@@ -121,8 +123,8 @@ fun DecompositionManifest.toResetSnapshot(): GoalRunnerResetSnapshot = GoalRunne
 )
 
 fun GoalObservabilityProgressEvent.toStatusMap(): Map<String, Any?> = linkedMapOf(
-  "issue_key" to issueKey,
-  "subtask_id" to subtaskId,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
+  SharedPayloadKeys.SUBTASK_ID to subtaskId,
   "workflow_phase" to workflowPhase,
   "worker_role" to workerRole,
   "liveness_class" to livenessClass,

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalTerminalOutcomeDerivationSweepAggregate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalTerminalOutcomeDerivationSweepAggregate.kt
@@ -1,9 +1,8 @@
 package skillbill.engine.goalrunner
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.goalrunner.model.GoalContinuationCandidate
 import skillbill.goalrunner.asGoalRunnerIntOrNull
 import skillbill.goalrunner.goalContinuationTerminalStatus
@@ -78,7 +77,9 @@ fun Map<String, Any?>.toMissingResultPrefixOutcomeArtifact(
   SharedPayloadKeys.ISSUE_KEY to issueKey,
   SharedPayloadKeys.SUBTASK_ID to subtaskId,
   SharedPayloadKeys.STATUS to status.toGoalContinuationWireStatus(),
-  SharedPayloadKeys.WORKFLOW_ID to (this[SharedPayloadKeys.WORKFLOW_ID]?.toString()?.takeIf(String::isNotBlank) ?: workflowId),
+  SharedPayloadKeys.WORKFLOW_ID to (
+    this[SharedPayloadKeys.WORKFLOW_ID]?.toString()?.takeIf(String::isNotBlank) ?: workflowId
+    ),
   "last_resumable_step" to (
     this["last_resumable_step"]?.toString()?.takeIf(String::isNotBlank) ?: "preplan"
     ),

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalTerminalOutcomeDerivationSweepAggregate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/GoalTerminalOutcomeDerivationSweepAggregate.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.engine.goalrunner.model.GoalContinuationCandidate
@@ -56,14 +58,14 @@ fun missingResultPrefixTerminalOutcomeArtifact(
 ): Map<String, Any?>? = (JsonCodec.anyToStringAnyMap(output["subtask_outcome"]) ?: output)
   .takeIf { candidate -> candidate.matchesGoalContinuation(issueKey, subtaskId) }
   ?.let { candidate ->
-    candidate["status"]?.toString()?.let(::goalContinuationTerminalStatus)?.let { status ->
+    candidate[SharedPayloadKeys.STATUS]?.toString()?.let(::goalContinuationTerminalStatus)?.let { status ->
       candidate.toMissingResultPrefixOutcomeArtifact(issueKey, subtaskId, workflowId, status)
     }
   }
 
 fun Map<String, Any?>.matchesGoalContinuation(issueKey: String, subtaskId: Int): Boolean {
-  val candidateIssueKey = this["issue_key"]?.toString()?.takeIf(String::isNotBlank) ?: issueKey
-  val candidateSubtaskId = this["subtask_id"].asGoalRunnerIntOrNull() ?: subtaskId
+  val candidateIssueKey = this[SharedPayloadKeys.ISSUE_KEY]?.toString()?.takeIf(String::isNotBlank) ?: issueKey
+  val candidateSubtaskId = this[SharedPayloadKeys.SUBTASK_ID].asGoalRunnerIntOrNull() ?: subtaskId
   return candidateIssueKey == issueKey && candidateSubtaskId == subtaskId
 }
 
@@ -73,10 +75,10 @@ fun Map<String, Any?>.toMissingResultPrefixOutcomeArtifact(
   workflowId: String,
   status: GoalRunnerTerminalStatus,
 ): Map<String, Any?> = linkedMapOf<String, Any?>(
-  "issue_key" to issueKey,
-  "subtask_id" to subtaskId,
-  "status" to status.toGoalContinuationWireStatus(),
-  "workflow_id" to (this["workflow_id"]?.toString()?.takeIf(String::isNotBlank) ?: workflowId),
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
+  SharedPayloadKeys.SUBTASK_ID to subtaskId,
+  SharedPayloadKeys.STATUS to status.toGoalContinuationWireStatus(),
+  SharedPayloadKeys.WORKFLOW_ID to (this[SharedPayloadKeys.WORKFLOW_ID]?.toString()?.takeIf(String::isNotBlank) ?: workflowId),
   "last_resumable_step" to (
     this["last_resumable_step"]?.toString()?.takeIf(String::isNotBlank) ?: "preplan"
     ),

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalChildPlanningHydrator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalChildPlanningHydrator.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.decodeArtifacts
 import skillbill.engine.goalrunner.planning.model.GoalChildPlanningHydration
 import skillbill.engine.planningprojection.requireValidPlanningProjection
@@ -242,7 +244,7 @@ private class PreparedPlanningPayloadValidator(
     val decoded = accepted.normalizedOutput.envelope
     // The projection gate is a no-op on a non-completed envelope, because a blocked or failed producer
     // makes no projection claim. An import, by contrast, only ever admits a settled completed payload.
-    if (decoded["phase_id"] != phaseId || decoded["status"].workflowStepStatus() != WorkflowStepStatus.COMPLETED) {
+    if (decoded[SharedPayloadKeys.PHASE_ID] != phaseId || decoded[SharedPayloadKeys.STATUS].workflowStepStatus() != WorkflowStepStatus.COMPLETED) {
       invalidPlanningPreparation(
         workflowId,
         "$phaseId.payload",
@@ -395,8 +397,8 @@ private class GoalChildPlanningImportMatcher(
   // producer lands running/running, and blocked is an interrupt that the quarantine produces and the
   // fix loop handles. Accepting a status the recorder cannot emit would admit forged state.
   private fun settledStepStatus(record: Map<*, *>?, phaseId: String): WorkflowStepStatus? {
-    if (record == null || record["phase_id"] != phaseId) return null
-    return when (record["status"].workflowStepStatus()) {
+    if (record == null || record[SharedPayloadKeys.PHASE_ID] != phaseId) return null
+    return when (record[SharedPayloadKeys.STATUS].workflowStepStatus()) {
       WorkflowStepStatus.COMPLETED ->
         WorkflowStepStatus.COMPLETED
           .takeIf { (record["output_artifact"] as? String)?.isNotBlank() == true }
@@ -416,7 +418,7 @@ private class GoalChildPlanningImportMatcher(
         (entry["action"] as? String)?.let(FeatureTaskRuntimePhaseLedgerAction::fromWire) ==
           FeatureTaskRuntimePhaseLedgerAction.COMPLETE,
         (entry["sequence_number"] as? Number)?.toInt() == index,
-        entry["phase_id"] == PLANNING_PHASE_IDS[index],
+        entry[SharedPayloadKeys.PHASE_ID] == PLANNING_PHASE_IDS[index],
         (entry["attempt_count"] as? Number)?.toInt() == 1,
         entry["resolved_agent_id"] == null,
       ).all { it }
@@ -438,7 +440,7 @@ private fun expectedProvenance(request: GoalChildPlanningHydrationRequest): Map<
   "parent_goal_workflow_id" to request.identity.parentGoalWorkflowId,
   "normalized_issue_key" to request.identity.normalizedIssueKey,
   "repository_identity" to request.identity.repositoryIdentity,
-  "subtask_id" to request.descriptor.subtaskId,
+  SharedPayloadKeys.SUBTASK_ID to request.descriptor.subtaskId,
   "manifest_order" to request.descriptor.manifestOrder,
   "governed_sub_spec_path" to request.descriptor.governedSubSpecPath,
   "sub_spec_hash" to request.descriptor.subSpecHash,
@@ -451,8 +453,8 @@ private fun expectedProvenance(request: GoalChildPlanningHydrationRequest): Map<
 )
 
 private fun completedStep(phaseId: String): Map<String, Any?> = linkedMapOf(
-  "step_id" to phaseId,
-  "status" to "completed",
+  SharedPayloadKeys.STEP_ID to phaseId,
+  SharedPayloadKeys.STATUS to "completed",
   "attempt_count" to 1,
 )
 

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalChildPlanningHydrator.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalChildPlanningHydrator.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.decodeArtifacts
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.goalrunner.planning.model.GoalChildPlanningHydration
 import skillbill.engine.planningprojection.requireValidPlanningProjection
 import skillbill.error.IncompatibleGoalPlanningPreparationRecoveryError
@@ -244,7 +243,10 @@ private class PreparedPlanningPayloadValidator(
     val decoded = accepted.normalizedOutput.envelope
     // The projection gate is a no-op on a non-completed envelope, because a blocked or failed producer
     // makes no projection claim. An import, by contrast, only ever admits a settled completed payload.
-    if (decoded[SharedPayloadKeys.PHASE_ID] != phaseId || decoded[SharedPayloadKeys.STATUS].workflowStepStatus() != WorkflowStepStatus.COMPLETED) {
+    if (
+      decoded[SharedPayloadKeys.PHASE_ID] != phaseId ||
+      decoded[SharedPayloadKeys.STATUS].workflowStepStatus() != WorkflowStepStatus.COMPLETED
+    ) {
       invalidPlanningPreparation(
         workflowId,
         "$phaseId.payload",

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningContextPromptFormatter.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningContextPromptFormatter.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.goalrunner.planning.model.GoalPlanningContext
 import skillbill.ports.goalrunner.planning.model.GoalPlanningResolvedBoundaryBodies
 import skillbill.workflow.decomposition.model.DecompositionSubtask

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningContextPromptFormatter.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningContextPromptFormatter.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.ports.goalrunner.planning.model.GoalPlanningContext
 import skillbill.ports.goalrunner.planning.model.GoalPlanningResolvedBoundaryBodies
@@ -44,10 +46,10 @@ object GoalPlanningContextPromptFormatter {
       append(
         JsonCodec.mapToJsonString(
           mapOf(
-            "subtask_id" to currentSubtask.id,
+            SharedPayloadKeys.SUBTASK_ID to currentSubtask.id,
             "dependencies" to currentSubtask.dependencies.map { dependency ->
               mapOf(
-                "subtask_id" to dependency.subtaskId,
+                SharedPayloadKeys.SUBTASK_ID to dependency.subtaskId,
                 "optional" to dependency.optional,
                 "skipped" to dependency.skipped,
               )

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningPhaseAttemptGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningPhaseAttemptGate.kt
@@ -1,7 +1,6 @@
 package skillbill.engine.goalrunner.planning
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.engine.featuretask.FeatureTaskRuntimePhaseSafetyPolicy
 import skillbill.engine.goalrunner.planning.model.GoalPlanningPhaseProduction
 import skillbill.engine.goalrunner.planning.model.GoalPlanningSweepOutcome

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningPhaseAttemptGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningPhaseAttemptGate.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.engine.featuretask.FeatureTaskRuntimePhaseSafetyPolicy
 import skillbill.engine.goalrunner.planning.model.GoalPlanningPhaseProduction
 import skillbill.engine.goalrunner.planning.model.GoalPlanningSweepOutcome
@@ -155,7 +157,7 @@ internal fun DefaultGoalPlanningSweep.validatePlanningAttemptOutput(
 }.fold(
   onSuccess = { accepted ->
     val payload = accepted.normalizedOutput.envelope
-    if (payload["status"].workflowStepStatus() != WorkflowStepStatus.COMPLETED) {
+    if (payload[SharedPayloadKeys.STATUS].workflowStepStatus() != WorkflowStepStatus.COMPLETED) {
       val reason = unsuccessfulStatusReason(phaseId, payload)
       val canonical = accepted.normalizedOutput.canonicalJson
       if (FeatureTaskRuntimePhaseSafetyPolicy.dispositionForTerminalOutput(phaseId, payload).retryOnResume) {

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningProvenanceRecoverability.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningProvenanceRecoverability.kt
@@ -1,5 +1,6 @@
 package skillbill.engine.goalrunner.planning
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.goalrunner.model.GoalPlanningContractProvenance
 import skillbill.ports.goalrunner.model.SharedGoalPreplanCheckpoint
 import skillbill.text.sha256HexUtf8
@@ -44,9 +45,9 @@ fun preplanProseValue(preplanPayload: String): String = runCatching {
   JsonCodec.parseObjectOrNull(preplanPayload)
     ?.let(JsonCodec::jsonElementToValue)
     ?.let(JsonCodec::anyToStringAnyMap)
-    ?.get("produced_outputs")
+    ?.get(SharedPayloadKeys.PRODUCED_OUTPUTS)
     ?.let(JsonCodec::anyToStringAnyMap)
-    ?.get("value")
+    ?.get(SharedPayloadKeys.VALUE)
     ?.toString()
     .orEmpty()
 }.getOrDefault("")
@@ -55,9 +56,9 @@ fun preplanProsePrompt(preplanPayload: String): String? = runCatching {
   JsonCodec.parseObjectOrNull(preplanPayload)
     ?.let(JsonCodec::jsonElementToValue)
     ?.let(JsonCodec::anyToStringAnyMap)
-    ?.get("produced_outputs")
+    ?.get(SharedPayloadKeys.PRODUCED_OUTPUTS)
     ?.let(JsonCodec::anyToStringAnyMap)
-    ?.get("prompt")
+    ?.get(SharedPayloadKeys.PROMPT)
     ?.toString()
     ?.takeIf(String::isNotBlank)
 }.getOrNull()

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacket.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacket.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.goalplanning.GoalPlanningDiscoveryExclusions
 import skillbill.ports.goalrunner.planning.model.GoalPlanningContext
@@ -128,7 +130,7 @@ object GoalPlanningSharedContextPacket {
       },
       "dependencies" to subtask.dependencies.map { dependency ->
         linkedMapOf(
-          "subtask_id" to dependency.subtaskId,
+          SharedPayloadKeys.SUBTASK_ID to dependency.subtaskId,
           "optional" to dependency.optional,
           "skipped" to dependency.skipped,
         )

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacket.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacket.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.goalplanning.GoalPlanningDiscoveryExclusions
 import skillbill.ports.goalrunner.planning.model.GoalPlanningContext
 import skillbill.workflow.decomposition.model.DecompositionSubtask

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacketHashing.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacketHashing.kt
@@ -1,12 +1,13 @@
 package skillbill.engine.goalrunner.planning
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.text.sha256HexUtf8
 import skillbill.workflow.decomposition.model.DecompositionManifest
 
 fun goalPlanningImmutableDecompositionHash(manifest: DecompositionManifest): String {
   val immutable = linkedMapOf<String, Any?>(
-    "contract_version" to manifest.contractVersion,
-    "issue_key" to manifest.issueKey,
+    SharedPayloadKeys.CONTRACT_VERSION to manifest.contractVersion,
+    SharedPayloadKeys.ISSUE_KEY to manifest.issueKey,
     "feature_name" to manifest.featureName,
     "parent_spec_path" to manifest.parentSpecPath,
     "spec_source" to manifest.specSource.wireValue,
@@ -14,7 +15,7 @@ fun goalPlanningImmutableDecompositionHash(manifest: DecompositionManifest): Str
     "base_branch" to manifest.baseBranch,
     "feature_branch" to manifest.featureBranch,
     "stack_branches" to manifest.stackBranches.map {
-      linkedMapOf("subtask_id" to it.subtaskId, "branch" to it.branch, "base_branch" to it.baseBranch)
+      linkedMapOf(SharedPayloadKeys.SUBTASK_ID to it.subtaskId, "branch" to it.branch, "base_branch" to it.baseBranch)
     },
     "subtasks" to manifest.subtasks.map { subtask ->
       linkedMapOf(
@@ -24,7 +25,7 @@ fun goalPlanningImmutableDecompositionHash(manifest: DecompositionManifest): Str
         "linear_issue_id" to subtask.linearIssueId,
         "dependencies" to subtask.dependencies.map { dependency ->
           linkedMapOf(
-            "subtask_id" to dependency.subtaskId,
+            SharedPayloadKeys.SUBTASK_ID to dependency.subtaskId,
             "optional" to dependency.optional,
             "skipped" to dependency.skipped,
           )

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacketValidation.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedContextPacketValidation.kt
@@ -1,5 +1,6 @@
 package skillbill.engine.goalrunner.planning
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.ports.goalrunner.planning.model.GoalPlanningBoundaryHeadingKind
 import skillbill.ports.goalrunner.planning.model.GoalPlanningContext
 import skillbill.text.sha256HexUtf8
@@ -75,8 +76,8 @@ object GoalPlanningSharedContextPacketValidation {
       val dependency = entry as? Map<*, *> ?: error("shared context subtask dependency must be an object")
       require(dependency.keys == DEPENDENCY_FIELDS) { "shared context subtask dependency fields are invalid" }
       linkedMapOf(
-        "subtask_id" to (
-          (dependency["subtask_id"] as? Number)?.toInt()
+        SharedPayloadKeys.SUBTASK_ID to (
+          (dependency[SharedPayloadKeys.SUBTASK_ID] as? Number)?.toInt()
             ?: error("shared context dependency subtask id is invalid")
           ),
         "optional" to (

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedPreplanProduction.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedPreplanProduction.kt
@@ -1,9 +1,8 @@
 package skillbill.engine.goalrunner.planning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.decomposition.DECOMPOSITION_MANIFEST_FILENAME
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.goalrunner.model.GoalRunnerRunRequest
 import skillbill.engine.goalrunner.planning.model.GoalPlanningPhaseProduction
 import skillbill.ports.goalrunner.model.GoalPlanningContractProvenance
@@ -64,7 +63,10 @@ fun enrichPreplan(payload: String, packet: Map<String, Any?>): String {
   val produced = JsonCodec.anyToStringAnyMap(root[SharedPayloadKeys.PRODUCED_OUTPUTS])
     ?: error("preplan produced_outputs is not an object")
   return JsonCodec.mapToJsonString(
-    root + (SharedPayloadKeys.PRODUCED_OUTPUTS to (produced + (GoalPlanningSweepConstants.SHARED_CONTEXT_FIELD to packet))),
+    root + (
+      SharedPayloadKeys.PRODUCED_OUTPUTS to
+        (produced + (GoalPlanningSweepConstants.SHARED_CONTEXT_FIELD to packet))
+      ),
   )
 }
 

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedPreplanProduction.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSharedPreplanProduction.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.decomposition.DECOMPOSITION_MANIFEST_FILENAME
 import skillbill.contracts.JsonCodec
 import skillbill.engine.goalrunner.model.GoalRunnerRunRequest
@@ -59,10 +61,10 @@ fun enrichPreplan(payload: String, packet: Map<String, Any?>): String {
     ?.let(JsonCodec::jsonElementToValue)
     ?.let(JsonCodec::anyToStringAnyMap)
     ?: error("preplan payload is not a JSON object")
-  val produced = JsonCodec.anyToStringAnyMap(root["produced_outputs"])
+  val produced = JsonCodec.anyToStringAnyMap(root[SharedPayloadKeys.PRODUCED_OUTPUTS])
     ?: error("preplan produced_outputs is not an object")
   return JsonCodec.mapToJsonString(
-    root + ("produced_outputs" to (produced + (GoalPlanningSweepConstants.SHARED_CONTEXT_FIELD to packet))),
+    root + (SharedPayloadKeys.PRODUCED_OUTPUTS to (produced + (GoalPlanningSweepConstants.SHARED_CONTEXT_FIELD to packet))),
   )
 }
 
@@ -70,7 +72,7 @@ fun planningPacketFrom(record: SharedGoalPreplanCheckpoint): Map<String, Any?>? 
   JsonCodec.parseObjectOrNull(record.preplanPayload)
     ?.let(JsonCodec::jsonElementToValue)
     ?.let(JsonCodec::anyToStringAnyMap)
-    ?.get("produced_outputs")
+    ?.get(SharedPayloadKeys.PRODUCED_OUTPUTS)
     ?.let(JsonCodec::anyToStringAnyMap)
     ?.get(GoalPlanningSweepConstants.SHARED_CONTEXT_FIELD)
     ?.let(JsonCodec::anyToStringAnyMap)

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningStatusReasonCoherence.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningStatusReasonCoherence.kt
@@ -1,7 +1,7 @@
 package skillbill.engine.goalrunner.planning
 import me.tatarka.inject.annotations.Inject
-import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.GoalPlanningPreparationSchemaPaths
 import skillbill.engine.goalplanning.GoalPlanningPreparationCheckpoint
 import skillbill.engine.goalrunner.planning.model.GoalPlanningStatusAlignRequest

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningStatusReasonCoherence.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningStatusReasonCoherence.kt
@@ -1,5 +1,6 @@
 package skillbill.engine.goalrunner.planning
 import me.tatarka.inject.annotations.Inject
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
 import skillbill.contracts.workflow.GoalPlanningPreparationSchemaPaths
 import skillbill.engine.goalplanning.GoalPlanningPreparationCheckpoint
@@ -87,7 +88,7 @@ class LaunchAlignedGoalPlanningStatusReasonCoherence(
     val packet = JsonCodec.parseObjectOrNull(existing.preplanPayload)
       ?.let(JsonCodec::jsonElementToValue)
       ?.let(JsonCodec::anyToStringAnyMap)
-      ?.get("produced_outputs")
+      ?.get(SharedPayloadKeys.PRODUCED_OUTPUTS)
       ?.let(JsonCodec::anyToStringAnyMap)
       ?.get("_goal_planning_shared_context")
       ?.let(JsonCodec::anyToStringAnyMap)

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSweepOutcomeDerivationTerminalClass.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSweepOutcomeDerivationTerminalClass.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.agentoutput.stderrExcerpt
 import skillbill.engine.goalrunner.planning.model.GoalPlanningEmptyTurnEvidence
 import skillbill.engine.goalrunner.planning.model.GoalPlanningPhaseProduction
@@ -32,11 +34,11 @@ fun unexpectedPlanningFailureReason(phaseId: String, error: Throwable): String =
     "${error::class.simpleName ?: "Throwable"}: ${error.message.orEmpty()}"
 
 fun unsuccessfulStatusReason(phaseId: String, payload: Map<String, Any?>): String {
-  val status = payload["status"] ?: "missing"
-  val disposition = (payload["failure_disposition"] as? String)
+  val status = payload[SharedPayloadKeys.STATUS] ?: "missing"
+  val disposition = (payload[SharedPayloadKeys.FAILURE_DISPOSITION] as? String)
     ?.let { " disposition '$it'" }
     .orEmpty()
-  val summary = (payload["summary"] as? String)
+  val summary = (payload[SharedPayloadKeys.SUMMARY] as? String)
     ?.trim()
     ?.takeIf { it.isNotEmpty() }
     ?.let { " Agent reported: ${it.take(GoalPlanningSweepConstants.PLANNING_STOP_DETAIL_MAX_CHARS)}" }

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSweepOutcomeDerivationTerminalClass.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/goalrunner/planning/GoalPlanningSweepOutcomeDerivationTerminalClass.kt
@@ -1,8 +1,7 @@
 package skillbill.engine.goalrunner.planning
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.agentoutput.stderrExcerpt
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.engine.goalrunner.planning.model.GoalPlanningEmptyTurnEvidence
 import skillbill.engine.goalrunner.planning.model.GoalPlanningPhaseProduction
 import skillbill.error.IncompatibleGoalPlanningPreparationRecoveryError

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/planningprojection/FeatureTaskRuntimePlanningProjectionGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/planningprojection/FeatureTaskRuntimePlanningProjectionGate.kt
@@ -1,5 +1,7 @@
 package skillbill.engine.planningprojection
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidGoalPlanningPreparationSchemaError
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus
@@ -20,7 +22,7 @@ fun producerProjectionGateReason(
   outputMap: Map<String, Any?>,
   planningProjectionValidator: FeatureTaskRuntimePlanningProjectionValidator,
 ): String? {
-  if ((outputMap["status"] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED) return null
+  if ((outputMap[SharedPayloadKeys.STATUS] as? String).workflowStepStatus() != WorkflowStepStatus.COMPLETED) return null
   val expectedKind = FeatureTaskRuntimePlanningProjectionContract.producedProjectionKindFor(phaseId)
     ?: return null
   return unresolvedProducerProjectionKindReason(phaseId, expectedKind, planningProjectionValidator)

--- a/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/planningprojection/FeatureTaskRuntimePlanningProjectionGate.kt
+++ b/runtime-kotlin/runtime-engine/src/main/kotlin/skillbill/engine/planningprojection/FeatureTaskRuntimePlanningProjectionGate.kt
@@ -1,7 +1,6 @@
 package skillbill.engine.planningprojection
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidGoalPlanningPreparationSchemaError
 import skillbill.workflow.model.WorkflowStepStatus
 import skillbill.workflow.model.workflowStepStatus

--- a/runtime-kotlin/runtime-engine/src/test/kotlin/skillbill/engine/FeatureTaskRuntimeRunnerTest.kt
+++ b/runtime-kotlin/runtime-engine/src/test/kotlin/skillbill/engine/FeatureTaskRuntimeRunnerTest.kt
@@ -4032,9 +4032,8 @@ class FeatureTaskRuntimeReconcileOnResumeTest {
     assertContains(blocked.blockedReason, "index was restored")
   }
 
-  // AC-001/AC-002: the checkpoint commits its owned inventory and nothing else, whatever else is dirty.
   @Test
-  fun `checkpoint stages only implementation paths while specs and foreign dirt stay alone`() {
+  fun `checkpoint stages every non-runtime-private path`() {
     val git = checkpointGit(
       ownedPaths = listOf("src/Owned.kt", SPEC_REFERENCE),
       stagedPaths = listOf("unrelated/ForeignStaged.kt"),
@@ -4044,17 +4043,15 @@ class FeatureTaskRuntimeReconcileOnResumeTest {
     val report = harness.runner.run(harness.request(IMPLEMENT_FIX_CYCLE))
 
     assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
-    assertTrue(git.stagePathsCalls.isNotEmpty(), "the owned inventory must be staged")
     assertEquals(
-      setOf("src/Owned.kt"),
+      setOf("src/Owned.kt", SPEC_REFERENCE, "unrelated/ForeignStaged.kt"),
       git.stagePathsCalls.toSet(),
-      "no foreign path may ever reach the staging call",
+      "every non-runtime-private path must reach the staging call",
     )
   }
 
-  // AC-001: foreign dirt alone is not this workflow's work, so it must not produce a checkpoint commit.
   @Test
-  fun `only foreign dirt present produces no checkpoint commit and does not block the phase transition`() {
+  fun `foreign dirt is included in the checkpoint commit`() {
     val git = checkpointGit(ownedPaths = emptyList(), stagedPaths = listOf("unrelated/ForeignStaged.kt"))
     git.worktreeStatusValue = " M unrelated/ForeignStaged.kt"
     val harness = checkpointRunHarness(git)
@@ -4062,10 +4059,12 @@ class FeatureTaskRuntimeReconcileOnResumeTest {
     val report = harness.runner.run(harness.request(IMPLEMENT_FIX_CYCLE))
 
     assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
-    assertTrue(git.createCommitMessages.isEmpty(), "an empty owned delta must not commit foreign dirt")
-    assertTrue(git.stagePathsCalls.isEmpty())
-    assertTrue(git.amendCommitMessages.isEmpty(), "a Skip verdict must neither create nor amend")
-    assertTrue(git.checkpointRefs.isEmpty(), "a Skip verdict must write no checkpoint ref")
+    assertEquals(setOf("unrelated/ForeignStaged.kt"), git.stagePathsCalls.toSet())
+    assertTrue(
+      (git.createCommitMessages + git.amendCommitMessages).isNotEmpty(),
+      "foreign dirt must be committed",
+    )
+    assertTrue(git.checkpointRefs.isNotEmpty(), "the checkpoint must write its ref")
   }
 
   // AC-005: an owned path staged outside the workflow is adopted on-branch, never a reason to refuse.
@@ -4515,10 +4514,8 @@ class FeatureTaskRuntimeCheckpointHistoryOnResumeTest {
     assertTrue(git.stagePathsCalls.isNotEmpty(), "the run's checkpoint must stage phase-written paths")
   }
 
-  // AC-001/AC-002: a foreign path that appears after the ownership baseline is not this run's work,
-  // so being dirty must not enrol it in the inventory the checkpoint stages and commits.
   @Test
-  fun `a foreign path appearing after the baseline is never staged merely because it is dirty`() {
+  fun `a foreign path appearing after the baseline is included in the checkpoint`() {
     val foreign = "unrelated/SiblingAgentWrote.kt"
     val git = checkpointGit(ownedPaths = listOf("src/Owned.kt"))
     val harness = checkpointRunHarness(git) { phaseId ->
@@ -4529,7 +4526,7 @@ class FeatureTaskRuntimeCheckpointHistoryOnResumeTest {
     val report = harness.runner.run(harness.request(IMPLEMENT_FIX_CYCLE))
 
     assertIs<FeatureTaskRuntimeRunReport.Completed>(report)
-    assertFalse(foreign in git.stagePathsCalls, "a path this run never wrote must never be staged")
+    assertTrue(foreign in git.stagePathsCalls, "a non-runtime-private path must be staged")
     assertTrue(git.stagePathsCalls.isNotEmpty(), "the run's own owned inventory is still checkpointed")
   }
 

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/DecompositionManifestBundleJournalOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/DecompositionManifestBundleJournalOperations.kt
@@ -1,9 +1,8 @@
 package skillbill.infrastructure.fs
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidDecompositionManifestSchemaError
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/DecompositionManifestBundleJournalOperations.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/DecompositionManifestBundleJournalOperations.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidDecompositionManifestSchemaError
@@ -83,7 +85,7 @@ internal object DecompositionManifestBundleJournalCreate {
       marker,
       yamlMapper.writeValueAsString(
         mapOf(
-          "contract_version" to DecompositionManifestBundleJournal.BUNDLE_CONTRACT_VERSION,
+          SharedPayloadKeys.CONTRACT_VERSION to DecompositionManifestBundleJournal.BUNDLE_CONTRACT_VERSION,
           "staging_directory" to stagingDirectory.toString(),
           "entries" to entries.map { entry ->
             mapOf(
@@ -122,7 +124,7 @@ internal object DecompositionManifestBundleJournalIo {
     val raw = requireNotNull(
       JsonCodec.anyToStringAnyMap(yamlMapper.readValue(Files.readString(marker), Map::class.java)),
     )
-    require(raw["contract_version"] == DecompositionManifestBundleJournal.BUNDLE_CONTRACT_VERSION) {
+    require(raw[SharedPayloadKeys.CONTRACT_VERSION] == DecompositionManifestBundleJournal.BUNDLE_CONTRACT_VERSION) {
       "Unsupported decomposition manifest bundle journal contract."
     }
     val stagingDirectory = Path.of(requireNotNull(raw["staging_directory"] as? String))

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FeatureTaskRuntimePhaseOutputValidatorAdapter.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FeatureTaskRuntimePhaseOutputValidatorAdapter.kt
@@ -1,9 +1,8 @@
 package skillbill.infrastructure.fs
 
-import skillbill.contracts.SharedPayloadKeys
-
 import me.tatarka.inject.annotations.Inject
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidFeatureTaskRuntimeBuildReceiptSchemaError
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
 import skillbill.infrastructure.fs.contracts.workflow.FeatureTaskRuntimeBuildReceiptSchemaValidator

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FeatureTaskRuntimePhaseOutputValidatorAdapter.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FeatureTaskRuntimePhaseOutputValidatorAdapter.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs
 
+import skillbill.contracts.SharedPayloadKeys
+
 import me.tatarka.inject.annotations.Inject
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidFeatureTaskRuntimeBuildReceiptSchemaError
@@ -126,7 +128,7 @@ class FeatureTaskRuntimePhaseOutputValidatorAdapter : FeatureTaskRuntimePhaseOut
 
   private fun validateNestedBuildReceipt(normalized: NormalizedFeatureTaskRuntimePhaseOutput, sourceLabel: String) {
     if (sourceLabel != FeatureTaskRuntimePhaseWorkflowDefinition.PHASE_BUILD) return
-    val produced = JsonCodec.anyToStringAnyMap(normalized.envelope["produced_outputs"])
+    val produced = JsonCodec.anyToStringAnyMap(normalized.envelope[SharedPayloadKeys.PRODUCED_OUTPUTS])
       ?: throw InvalidFeatureTaskRuntimeBuildReceiptSchemaError(
         sourceLabel = sourceLabel,
         reason = "produced_outputs must be present for the build phase envelope.",

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemBaselineManifestWire.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemBaselineManifestWire.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.fs
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.UnreadableBaselineManifestError
 import skillbill.install.model.BaselineManifest
 import java.nio.file.Path

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemBaselineManifestWire.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemBaselineManifestWire.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.error.UnreadableBaselineManifestError
 import skillbill.install.model.BaselineManifest
@@ -16,7 +18,7 @@ import java.nio.file.Path
 internal fun BaselineManifest.toBaselineManifestJson(): String = JsonCodec.mapToJsonString(toWireMap())
 
 private fun BaselineManifest.toWireMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to BASELINE_MANIFEST_CONTRACT_VERSION,
+  SharedPayloadKeys.CONTRACT_VERSION to BASELINE_MANIFEST_CONTRACT_VERSION,
   // Sorted keys give a deterministic, byte-stable serialization for idempotent writes.
   "baselines" to LinkedHashMap<String, Any?>(entries.toSortedMap()),
 )

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemFeatureTaskRuntimeSharedEvidenceStoreReads.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemFeatureTaskRuntimeSharedEvidenceStoreReads.kt
@@ -1,10 +1,9 @@
 package skillbill.infrastructure.fs
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_SHARED_EVIDENCE_PROJECTION_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskRuntimeSharedEvidenceProjectionSchemaError
 import skillbill.infrastructure.fs.contracts.workflow.FeatureTaskRuntimeSharedEvidenceProjectionSchemaValidator

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemFeatureTaskRuntimeSharedEvidenceStoreReads.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemFeatureTaskRuntimeSharedEvidenceStoreReads.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -96,8 +98,8 @@ private fun resolutionOf(
     diffPayload = stored.payloadRef,
   )
   val projection = linkedMapOf<String, Any?>(
-    "contract_version" to contractVersion,
-    "workflow_id" to context.workflowId,
+    SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
+    SharedPayloadKeys.WORKFLOW_ID to context.workflowId,
     "repository_checkpoint_fingerprint" to stored.recorded,
     "store_path" to context.storePath,
     "changed_file_count" to files.size,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.fs
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.McpRegistrationChoice
 import skillbill.install.model.PlatformPackSelection

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/FileSystemInstallSelectionWire.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.install.model.InstallAgent
 import skillbill.install.model.McpRegistrationChoice
@@ -9,7 +11,7 @@ import skillbill.install.model.SharedInstallSelection
 internal fun SharedInstallSelection.toInstallSelectionJson(): String = JsonCodec.mapToJsonString(toWireMap())
 
 private fun SharedInstallSelection.toWireMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to INSTALL_SELECTION_CONTRACT_VERSION,
+  SharedPayloadKeys.CONTRACT_VERSION to INSTALL_SELECTION_CONTRACT_VERSION,
   "selected_agents" to selectedAgents.map(InstallAgent::id).sorted(),
   "platform_pack_selection" to platformPackSelection.toWireMap(),
   "telemetry_level" to telemetryLevel.id,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/WorkflowStateSnapshotWireMapper.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/WorkflowStateSnapshotWireMapper.kt
@@ -1,9 +1,8 @@
 package skillbill.infrastructure.fs
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.error.MalformedJsonTextError
 import skillbill.workflow.engine.model.WorkflowStateSnapshot

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/WorkflowStateSnapshotWireMapper.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/WorkflowStateSnapshotWireMapper.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -9,10 +11,10 @@ import skillbill.workflow.engine.model.WorkflowStateSnapshot
 object WorkflowStateSnapshotWireMapper {
   @OpenBoundaryMap("Canonical workflow-state snapshot map at the schema-validation seam")
   fun wireMap(snapshot: WorkflowStateSnapshot): Map<String, Any?> = linkedMapOf<String, Any?>(
-    "workflow_id" to snapshot.workflowId,
+    SharedPayloadKeys.WORKFLOW_ID to snapshot.workflowId,
     "session_id" to snapshot.sessionId.orEmpty(),
     "workflow_name" to snapshot.workflowName,
-    "contract_version" to snapshot.contractVersion,
+    SharedPayloadKeys.CONTRACT_VERSION to snapshot.contractVersion,
     "workflow_status" to snapshot.workflowStatus,
     "current_step_id" to snapshot.currentStepId.orEmpty(),
     "steps" to decodeArray(snapshot.stepsJson, "stepsJson"),

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/review/ReviewContextSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/review/ReviewContextSchemaValidator.kt
@@ -1,7 +1,5 @@
 package skillbill.infrastructure.fs.contracts.review
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -11,6 +9,7 @@ import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.logSchemaLoadFailure
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
 import skillbill.contracts.review.ReviewContextSchemaPaths

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/review/ReviewContextSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/review/ReviewContextSchemaValidator.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.contracts.review
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -111,7 +113,7 @@ private fun validateExpectedKind(
 }
 
 private fun requireMatchingContractVersion(payload: Map<String, Any?>, sourceLabel: String, definitionName: String?) {
-  val declared = payload["contract_version"] ?: return
+  val declared = payload[SharedPayloadKeys.CONTRACT_VERSION] ?: return
   val declaredText = declared as? String ?: declared.toString()
   if (declaredText == REVIEW_CONTEXT_CONTRACT_VERSION) return
   throw InvalidReviewContextSchemaError(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/DecompositionManifestCoherenceValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/DecompositionManifestCoherenceValidator.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidDecompositionManifestSchemaError
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -42,7 +44,7 @@ internal object DecompositionManifestCoherenceValidator {
     val dependencies = (subtask["dependencies"] as? List<*>).orEmpty().mapNotNull { it as? Map<*, *> }
     dependencies.forEachIndexed { depIndex, dependency ->
       val path = "subtasks[$index].dependencies[$depIndex].subtask_id"
-      val dependencyId = dependency["subtask_id"].asExactInt(sourceLabel, path)
+      val dependencyId = dependency[SharedPayloadKeys.SUBTASK_ID].asExactInt(sourceLabel, path)
       if (dependencyId !in subtaskIds || dependencyId == id) {
         throw coherenceError(
           sourceLabel,
@@ -97,7 +99,7 @@ internal object DecompositionManifestCoherenceValidator {
       subtask["id"].asExactInt(sourceLabel, "subtasks[$index].id")
     }
     val actualStackIds = stackBranches.mapIndexed { index, branch ->
-      branch["subtask_id"].asExactInt(sourceLabel, "stack_branches[$index].subtask_id")
+      branch[SharedPayloadKeys.SUBTASK_ID].asExactInt(sourceLabel, "stack_branches[$index].subtask_id")
     }
     if (actualStackIds != expectedStackIds || actualStackIds.toSet() != subtaskIds) {
       throw coherenceError(
@@ -110,7 +112,7 @@ internal object DecompositionManifestCoherenceValidator {
 
   private fun validateCurrentIntent(manifest: Map<String, Any?>, subtaskIds: Set<Int>, sourceLabel: String) {
     val intent = manifest["current_subtask_intent"] as? Map<*, *> ?: return
-    val intentId = intent["subtask_id"].asExactInt(sourceLabel, "current_subtask_intent.subtask_id")
+    val intentId = intent[SharedPayloadKeys.SUBTASK_ID].asExactInt(sourceLabel, "current_subtask_intent.subtask_id")
     val intentAction = intent["action"]?.toString().orEmpty()
     val isTerminalAction = intentAction == "none" || intentAction == "complete"
     if (isTerminalAction && intentId != 0) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/DecompositionManifestCoherenceValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/DecompositionManifestCoherenceValidator.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidDecompositionManifestSchemaError
 import java.math.BigDecimal
 import java.math.BigInteger

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidator.kt
@@ -1,7 +1,5 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
@@ -10,6 +8,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.ValidationMessage
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_CONTRACT_VERSION
 import skillbill.contracts.workflow.FeatureTaskRuntimePhaseOutputSchemaPaths
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidator.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
@@ -34,7 +36,7 @@ object FeatureTaskRuntimePhaseOutputSchemaValidator {
         payloadFreeReason = reasons.payloadFree,
       )
     }
-    val phaseId = phaseOutput["phase_id"] as? String
+    val phaseId = phaseOutput[SharedPayloadKeys.PHASE_ID] as? String
     if (phaseId != sourceLabel) {
       throw InvalidFeatureTaskRuntimePhaseOutputSchemaError(
         sourceLabel = sourceLabel,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidatorSupportParsing.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidatorSupportParsing.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
@@ -44,7 +46,7 @@ internal fun readPhaseOutputObjectNodeLenient(phaseOutputText: String, sourceLab
 }
 
 internal fun validateVerifyingEnvelopeShell(parsed: Map<String, Any?>, sourceLabel: String) {
-  val phaseId = parsed["phase_id"] as? String
+  val phaseId = parsed[SharedPayloadKeys.PHASE_ID] as? String
   if (phaseId != sourceLabel) {
     throw InvalidFeatureTaskRuntimePhaseOutputSchemaError(
       sourceLabel = sourceLabel,
@@ -53,7 +55,7 @@ internal fun validateVerifyingEnvelopeShell(parsed: Map<String, Any?>, sourceLab
       failureCode = "phase_id_mismatch",
     )
   }
-  val status = parsed["status"] as? String
+  val status = parsed[SharedPayloadKeys.STATUS] as? String
   if (status.isNullOrBlank()) {
     throw InvalidFeatureTaskRuntimePhaseOutputSchemaError(
       sourceLabel = sourceLabel,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidatorSupportParsing.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/FeatureTaskRuntimePhaseOutputSchemaValidatorSupportParsing.kt
@@ -1,9 +1,8 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidFeatureTaskRuntimePhaseOutputSchemaError
 import java.util.logging.Level
 

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
@@ -18,9 +20,9 @@ object ProducerOutputEvidenceSchemaValidator {
 
   fun validate(evidence: ProducerOutputEvidence) {
     val instance = mapper.createObjectNode().apply {
-      put("contract_version", PRODUCER_OUTPUT_EVIDENCE_CONTRACT_VERSION)
-      put("workflow_id", evidence.workflowId)
-      put("phase_id", evidence.phaseId)
+      put(SharedPayloadKeys.CONTRACT_VERSION, PRODUCER_OUTPUT_EVIDENCE_CONTRACT_VERSION)
+      put(SharedPayloadKeys.WORKFLOW_ID, evidence.workflowId)
+      put(SharedPayloadKeys.PHASE_ID, evidence.phaseId)
       put("generation", evidence.generation)
       put("attempt", evidence.attempt)
       put("repair_turn", evidence.repairTurn)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/ProducerOutputEvidenceSchemaValidator.kt
@@ -1,13 +1,12 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.PRODUCER_OUTPUT_EVIDENCE_CONTRACT_VERSION
 import skillbill.contracts.workflow.ProducerOutputEvidenceSchemaPaths
 import skillbill.error.InvalidProducerOutputEvidenceSchemaError

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
@@ -1,13 +1,12 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.workflow.REJECTED_OUTPUT_DIAGNOSTIC_CONTRACT_VERSION
 import skillbill.contracts.workflow.RejectedOutputDiagnosticSchemaPaths
 import skillbill.error.InvalidRejectedOutputDiagnosticSchemaError

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/contracts/workflow/RejectedOutputDiagnosticSchemaValidator.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.contracts.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
@@ -18,10 +20,10 @@ object RejectedOutputDiagnosticSchemaValidator {
 
   fun validate(metadata: RejectedOutputDiagnostic) {
     val instance = mapper.createObjectNode().apply {
-      put("contract_version", REJECTED_OUTPUT_DIAGNOSTIC_CONTRACT_VERSION)
+      put(SharedPayloadKeys.CONTRACT_VERSION, REJECTED_OUTPUT_DIAGNOSTIC_CONTRACT_VERSION)
       put("identity", metadata.identity)
-      put("workflow_id", metadata.workflowId)
-      put("phase_id", metadata.phaseId)
+      put(SharedPayloadKeys.WORKFLOW_ID, metadata.workflowId)
+      put(SharedPayloadKeys.PHASE_ID, metadata.phaseId)
       put("attempt", metadata.attempt)
       put("repair_turn", metadata.repairTurn)
       put("rule", metadata.rule)

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/identity/SkillContentIdentity.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/identity/SkillContentIdentity.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.install.identity
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidSkillContentIdentityError
 import skillbill.error.SkillContentIdentityMismatchError
@@ -32,7 +34,7 @@ internal data class SkillContentIdentity(
   fun compact(): String = JsonCodec.mapToJsonString(toMap())
 
   fun toMap(): Map<String, Any?> = linkedMapOf(
-    "contract_version" to SKILL_CONTENT_IDENTITY_CONTRACT_VERSION,
+    SharedPayloadKeys.CONTRACT_VERSION to SKILL_CONTENT_IDENTITY_CONTRACT_VERSION,
     "canonical_source_identity" to canonicalSourceIdentity,
     "exact_content_sha256" to exactContentSha256,
     "normalized_metadata" to normalizedMetadata.toSortedMap(),
@@ -81,7 +83,7 @@ internal data class SkillContentIdentity(
       if (parsed.keys != expectedFields) {
         invalidIdentity(stagingDir.toString(), "identity marker fields are invalid")
       }
-      if (parsed["contract_version"] != SKILL_CONTENT_IDENTITY_CONTRACT_VERSION) {
+      if (parsed[SharedPayloadKeys.CONTRACT_VERSION] != SKILL_CONTENT_IDENTITY_CONTRACT_VERSION) {
         invalidIdentity(stagingDir.toString(), "identity marker contract version is invalid")
       }
       val source = parsed["canonical_source_identity"] as? String
@@ -118,7 +120,7 @@ internal data class SkillContentIdentity(
       if (parsed.keys != expectedFields) {
         invalidIdentity(sourceLabel, "compact identity fields are invalid")
       }
-      if (parsed["contract_version"] != SKILL_CONTENT_IDENTITY_CONTRACT_VERSION) {
+      if (parsed[SharedPayloadKeys.CONTRACT_VERSION] != SKILL_CONTENT_IDENTITY_CONTRACT_VERSION) {
         invalidIdentity(sourceLabel, "compact identity contract version is invalid")
       }
       val source = parsed["canonical_source_identity"] as? String

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/identity/SkillContentIdentity.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/identity/SkillContentIdentity.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.fs.install.identity
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidSkillContentIdentityError
 import skillbill.error.SkillContentIdentityMismatchError
 import skillbill.infrastructure.fs.scaffold.validation.parseSkillFrontmatter

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/nativeagent/NativeAgentLinkInventoryWrite.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/nativeagent/NativeAgentLinkInventoryWrite.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.install.nativeagent
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.nativeagent.NATIVE_AGENT_LINK_INVENTORY_CONTRACT_VERSION
 import java.io.IOException
 import java.nio.file.AtomicMoveNotSupportedException
@@ -15,7 +17,7 @@ internal object NativeAgentLinkInventoryWrite {
       journalMissingAncestors(parent, request.beforeMutation)
       Files.createDirectories(parent)
     }
-    val root = request.mapper.createObjectNode().put("contract_version", NATIVE_AGENT_LINK_INVENTORY_CONTRACT_VERSION)
+    val root = request.mapper.createObjectNode().put(SharedPayloadKeys.CONTRACT_VERSION, NATIVE_AGENT_LINK_INVENTORY_CONTRACT_VERSION)
     val array = root.putArray("entries")
     request.entries.forEach { entry ->
       array.addObject()

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/nativeagent/NativeAgentLinkInventoryWrite.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/install/nativeagent/NativeAgentLinkInventoryWrite.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.fs.install.nativeagent
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.nativeagent.NATIVE_AGENT_LINK_INVENTORY_CONTRACT_VERSION
 import java.io.IOException
 import java.nio.file.AtomicMoveNotSupportedException
@@ -17,7 +16,8 @@ internal object NativeAgentLinkInventoryWrite {
       journalMissingAncestors(parent, request.beforeMutation)
       Files.createDirectories(parent)
     }
-    val root = request.mapper.createObjectNode().put(SharedPayloadKeys.CONTRACT_VERSION, NATIVE_AGENT_LINK_INVENTORY_CONTRACT_VERSION)
+    val root = request.mapper.createObjectNode()
+      .put(SharedPayloadKeys.CONTRACT_VERSION, NATIVE_AGENT_LINK_INVENTORY_CONTRACT_VERSION)
     val array = root.putArray("entries")
     request.entries.forEach { entry ->
       array.addObject()

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/launcher/agentrun/AgentRunCommandBuildersLaunch.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/launcher/agentrun/AgentRunCommandBuildersLaunch.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.launcher.agentrun
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import skillbill.error.GovernedReviewLaunchCapabilityError
 import skillbill.install.model.InstallAgent
@@ -124,7 +126,7 @@ internal fun MutableList<String>.addGoalContinuationArguments(context: SkillRunG
     add(
       ObjectMapper().writeValueAsString(
         linkedMapOf(
-          "contract_version" to "0.1",
+          SharedPayloadKeys.CONTRACT_VERSION to "0.1",
           "entries" to context.agentAddonSelection.entries.map { entry ->
             linkedMapOf(
               "slug" to entry.slug,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/launcher/agentrun/AgentRunCommandBuildersLaunch.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/launcher/agentrun/AgentRunCommandBuildersLaunch.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.fs.launcher.agentrun
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.databind.ObjectMapper
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.GovernedReviewLaunchCapabilityError
 import skillbill.install.model.InstallAgent
 import skillbill.ports.agentrun.model.ConversationIsolation

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/nativeagent/composition/NativeAgentSource.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/nativeagent/composition/NativeAgentSource.kt
@@ -1,9 +1,8 @@
 package skillbill.infrastructure.fs.nativeagent.composition
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.infrastructure.fs.nativeagent.rendering.YAML_DOUBLE_QUOTE_ESCAPES
 import java.nio.file.Files
 import java.nio.file.Path

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/nativeagent/composition/NativeAgentSource.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/nativeagent/composition/NativeAgentSource.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.nativeagent.composition
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import skillbill.infrastructure.fs.nativeagent.rendering.YAML_DOUBLE_QUOTE_ESCAPES
@@ -97,7 +99,7 @@ fun parseNativeAgentSourceText(text: String, label: String = "native agent sourc
   frontmatter["name"]?.let { instance.put("name", it) }
   frontmatter["description"]?.let { instance.put("description", it) }
   frontmatter["compose"]?.let { instance.put("compose", it) }
-  frontmatter["contract_version"]?.let { instance.put("contract_version", it) }
+  frontmatter[SharedPayloadKeys.CONTRACT_VERSION]?.let { instance.put(SharedPayloadKeys.CONTRACT_VERSION, it) }
   if (tools.isNotEmpty()) {
     instance.putArray("tools").apply { tools.forEach { add(it) } }
   }

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/phaseoutput/FeatureTaskRuntimePhaseOutputEnvelopeWalker.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/phaseoutput/FeatureTaskRuntimePhaseOutputEnvelopeWalker.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.phaseoutput
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
@@ -199,7 +201,7 @@ internal object PhaseOutputExpectedShape {
 
   fun align(node: JsonNode, phaseId: String): Pair<JsonNode, Boolean> {
     val root = (node as? ObjectNode)?.deepCopy() ?: return node to false
-    val produced = root.get("produced_outputs") as? ObjectNode ?: return node to false
+    val produced = root.get(SharedPayloadKeys.PRODUCED_OUTPUTS) as? ObjectNode ?: return node to false
     var changed = false
     requiredFields(phaseId).forEach { field ->
       if (!root.hasNonNull(field) && produced.hasNonNull(field)) {

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/phaseoutput/FeatureTaskRuntimePhaseOutputEnvelopeWalker.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/phaseoutput/FeatureTaskRuntimePhaseOutputEnvelopeWalker.kt
@@ -1,11 +1,10 @@
 package skillbill.infrastructure.fs.phaseoutput
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutputFailureCode
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutputFormat
 import skillbill.workflow.taskruntime.model.FeatureTaskRuntimePhaseOutputRepairEvidence

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/platformpack/ShellContentLoaderValidationGate.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/platformpack/ShellContentLoaderValidationGate.kt
@@ -1,6 +1,7 @@
 
 package skillbill.infrastructure.fs.scaffold.platformpack
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.error.InvalidValidationGateDeclarationError
 import skillbill.scaffold.model.ValidationGateCompilerDiagnosticsFormat
 import skillbill.scaffold.model.ValidationGateCompilerDiagnosticsLocator
@@ -117,7 +118,7 @@ internal fun parseGateArgv(raw: Any?, slug: String, key: String): List<String> {
 }
 
 internal fun parseValidationGateFindings(gate: Map<*, *>, slug: String): ValidationGateFindingsLocator {
-  val raw = gate["findings"] ?: invalidValidationGateDeclaration(
+  val raw = gate[ReviewVerificationSignalKeys.REVIEW_FINDINGS] ?: invalidValidationGateDeclaration(
     "Platform pack '$slug': 'validation_gate.findings' is required when validation_gate is present.",
   )
   val findings = raw as? Map<*, *> ?: invalidValidationGateDeclaration(

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/RepoValidationRuntime.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.scaffold.runtime
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.infrastructure.fs.nativeagent.composition.NativeAgentCompositionContext
 import java.nio.file.Files
 import java.nio.file.Path
@@ -17,7 +19,7 @@ data class RepoValidationReport(
   val passed: Boolean = issues.isEmpty()
 
   fun toPayload(): Map<String, Any?> = mapOf(
-    "status" to if (passed) "passed" else "failed",
+    SharedPayloadKeys.STATUS to if (passed) "passed" else "failed",
     "skill_count" to skillCount,
     "governed_addon_count" to addonCount,
     "platform_pack_count" to platformPackCount,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/RepoValidationRuntime.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/RepoValidationRuntime.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.fs.scaffold.runtime
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.infrastructure.fs.nativeagent.composition.NativeAgentCompositionContext
 import java.nio.file.Files
 import java.nio.file.Path

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/ScaffoldServicePlanningPayloadMerge.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/ScaffoldServicePlanningPayloadMerge.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.scaffold.runtime
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.agentaddon.model.AgentAddonConsumer
 import skillbill.error.InvalidScaffoldPayloadError
 import skillbill.error.MissingPlatformPackError
@@ -80,7 +82,7 @@ internal fun planAgentAddon(payload: Map<String, Any?>, repoRoot: Path): Scaffol
   val consumers = requireStringListPayload(payload["consumers"], "consumers")
   AgentAddonSchemaValidator().validate(
     mapOf(
-      "contract_version" to "1.0",
+      SharedPayloadKeys.CONTRACT_VERSION to "1.0",
       "slug" to slug,
       "description" to description,
       "agent_ids" to agentIds,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/ScaffoldServicePlanningPayloadMerge.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/runtime/ScaffoldServicePlanningPayloadMerge.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.fs.scaffold.runtime
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.agentaddon.model.AgentAddonConsumer
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidScaffoldPayloadError
 import skillbill.error.MissingPlatformPackError
 import skillbill.error.UnknownPreShellFamilyError

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/substance/PlatformPackSubstanceReportMain.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/substance/PlatformPackSubstanceReportMain.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.fs.scaffold.substance
 
+import skillbill.contracts.SharedPayloadKeys
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.nio.file.Path
 
@@ -41,7 +43,7 @@ internal fun PlatformPackSubstanceReport.toHumanReadable(): String = buildString
 }
 
 internal fun PlatformPackSubstanceReport.toWireMap(): Map<String, Any?> = linkedMapOf(
-  "contract_version" to contractVersion,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
   "packs" to packs.map { pack ->
     linkedMapOf(
       "pack" to pack.pack,

--- a/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/substance/PlatformPackSubstanceReportMain.kt
+++ b/runtime-kotlin/runtime-infra-fs/src/main/kotlin/skillbill/infrastructure/fs/scaffold/substance/PlatformPackSubstanceReportMain.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.fs.scaffold.substance
 
-import skillbill.contracts.SharedPayloadKeys
-
 import com.fasterxml.jackson.databind.ObjectMapper
+import skillbill.contracts.SharedPayloadKeys
 import java.nio.file.Path
 
 fun main(arguments: Array<String>) {

--- a/runtime-kotlin/runtime-infra-http/src/main/kotlin/skillbill/infrastructure/http/HttpTelemetryResultMappers.kt
+++ b/runtime-kotlin/runtime-infra-http/src/main/kotlin/skillbill/infrastructure/http/HttpTelemetryResultMappers.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.http
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.telemetry.model.TelemetryProxyCapabilities
 import skillbill.telemetry.model.TelemetryRemoteStatsResult
 

--- a/runtime-kotlin/runtime-infra-http/src/main/kotlin/skillbill/infrastructure/http/HttpTelemetryResultMappers.kt
+++ b/runtime-kotlin/runtime-infra-http/src/main/kotlin/skillbill/infrastructure/http/HttpTelemetryResultMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.http
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.telemetry.model.TelemetryProxyCapabilities
 import skillbill.telemetry.model.TelemetryRemoteStatsResult
 
@@ -19,7 +21,7 @@ internal fun Map<String, Any?>.toTelemetryProxyCapabilities(): TelemetryProxyCap
       "supported_workflows",
     )
   return TelemetryProxyCapabilities(
-    contractVersion = this["contract_version"]?.toString().orEmpty(),
+    contractVersion = this[SharedPayloadKeys.CONTRACT_VERSION]?.toString().orEmpty(),
     source = this["source"]?.toString().orEmpty(),
     proxyUrl = this["proxy_url"]?.toString().orEmpty(),
     capabilitiesUrl = this["capabilities_url"]?.toString().orEmpty(),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteLearningStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteLearningStore.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.sqlite
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.learnings.LearningsRuntime
 import skillbill.learnings.model.CreateLearningRequest
 import skillbill.learnings.model.LearningRecord

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteLearningStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SQLiteLearningStore.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.learnings.LearningsRuntime
 import skillbill.learnings.model.CreateLearningRequest
@@ -322,7 +324,7 @@ private fun ResultSet.toLearningRecord(): LearningRecord = LearningRecord(
   title = getString("title"),
   ruleText = getString("rule_text"),
   rationale = getString("rationale").orEmpty(),
-  status = getString("status"),
+  status = getString(SharedPayloadKeys.STATUS),
   sourceReviewRunId = getString("source_review_run_id"),
   sourceFindingId = getString("source_finding_id"),
   createdAt = getString("created_at"),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepository.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepository.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidProducerOutputEvidenceSchemaError
 import skillbill.ports.diagnostics.RejectedOutputDiagnosticRepository
 import skillbill.ports.diagnostics.model.ProducerOutputEvidence

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepository.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/SqliteRejectedOutputDiagnosticRepository.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidProducerOutputEvidenceSchemaError
 import skillbill.ports.diagnostics.RejectedOutputDiagnosticRepository
 import skillbill.ports.diagnostics.model.ProducerOutputEvidence
@@ -221,8 +223,8 @@ private fun ResultSet.toRecord(): RejectedOutputDiagnosticRecord {
     RejectedOutputDiagnosticRecord(
       metadata = RejectedOutputDiagnostic(
         identity = identity,
-        workflowId = getString("workflow_id"),
-        phaseId = getString("phase_id"),
+        workflowId = getString(SharedPayloadKeys.WORKFLOW_ID),
+        phaseId = getString(SharedPayloadKeys.PHASE_ID),
         attempt = getInt("attempt"),
         rule = getString("rule"),
         path = getString("rejection_path"),
@@ -296,8 +298,8 @@ private fun Connection.queryProducerEvidence(lookup: ProducerEvidenceLookup): Pr
 }
 
 private fun ResultSet.toProducerEvidence(): ProducerOutputEvidence {
-  val workflowId = getString("workflow_id")
-  val phaseId = getString("phase_id")
+  val workflowId = getString(SharedPayloadKeys.WORKFLOW_ID)
+  val phaseId = getString(SharedPayloadKeys.PHASE_ID)
   val attempt = getInt("attempt")
   val generation = getInt("generation")
   if (getObject("generation") == null || generation < 0) {

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/core/ReviewAttributionBackfillMigration.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/core/ReviewAttributionBackfillMigration.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.core
 
 import skillbill.contracts.review.ReviewVerificationSignalKeys
-
 import skillbill.review.EXECUTION_MODE_DELEGATED
 import skillbill.review.UNRESOLVED_ATTRIBUTION
 import skillbill.review.canonicalPackSkillNames

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/core/ReviewAttributionBackfillMigration.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/core/ReviewAttributionBackfillMigration.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.core
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
 import skillbill.review.EXECUTION_MODE_DELEGATED
 import skillbill.review.UNRESOLVED_ATTRIBUTION
 import skillbill.review.canonicalPackSkillNames
@@ -103,7 +105,7 @@ internal object ReviewAttributionBackfillMigration {
         while (rows.next()) {
           add(
             PendingRow(
-              reviewRunId = rows.getString("review_run_id"),
+              reviewRunId = rows.getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
               raw = RawAttribution(
                 routedSkill = rows.getString("routed_skill"),
                 stack = rows.getString("detected_stack"),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsLedgerRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsLedgerRuntime.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.goal
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.goalrunner.model.UnaddressedFinding
 import skillbill.review.model.ReviewFindingCitation
 import java.sql.Connection

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsLedgerRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsLedgerRuntime.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.goal
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.model.UnaddressedFinding
 import skillbill.review.model.ReviewFindingCitation
 import java.sql.Connection
@@ -62,7 +64,7 @@ internal class UnaddressedFindingsLedgerRuntime(private val connection: Connecti
     statement.executeQuery().use { rows ->
       buildList {
         while (rows.next()) {
-          rows.getString("workflow_id")?.takeIf(String::isNotBlank)?.let(::add)
+          rows.getString(SharedPayloadKeys.WORKFLOW_ID)?.takeIf(String::isNotBlank)?.let(::add)
         }
       }
     }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsOutcomeRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsOutcomeRuntime.kt
@@ -1,5 +1,11 @@
 package skillbill.infrastructure.sqlite.goal
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.model.ReviewFindingOutcome
 import skillbill.goalrunner.model.ReviewFindingOutcomeRecord
 import java.sql.Connection
@@ -53,12 +59,12 @@ internal class UnaddressedFindingsOutcomeRuntime(private val connection: Connect
         while (rows.next()) {
           add(
             ReviewFindingOutcomeRecord(
-              workflowId = rows.getString("workflow_id"),
+              workflowId = rows.getString(SharedPayloadKeys.WORKFLOW_ID),
               reviewPassNumber = rows.getInt("review_pass_number"),
               findingOrdinal = rows.getInt("finding_ordinal"),
               outcome = ReviewFindingOutcome.fromWireValue(rows.getString("outcome")),
-              reviewRunId = rows.getString("review_run_id"),
-              findingId = rows.getString("finding_id"),
+              reviewRunId = rows.getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
+              findingId = rows.getString(ReviewFindingPayloadKeys.FINDING_ID),
               findingKey = rows.getString("finding_key"),
             ),
           )

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsOutcomeRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsOutcomeRuntime.kt
@@ -1,11 +1,8 @@
 package skillbill.infrastructure.sqlite.goal
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.contracts.SharedPayloadKeys
-
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.goalrunner.model.ReviewFindingOutcome
 import skillbill.goalrunner.model.ReviewFindingOutcomeRecord
 import java.sql.Connection

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsRows.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsRows.kt
@@ -1,11 +1,8 @@
 package skillbill.infrastructure.sqlite.goal
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.contracts.SharedPayloadKeys
-
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.goalrunner.model.UnaddressedFinding
 import skillbill.review.model.ReviewClaimVerdict
 import skillbill.review.model.ReviewFindingCitation
@@ -26,7 +23,10 @@ internal fun readUnaddressedFinding(rows: ResultSet): UnaddressedFinding = Unadd
   summary = rows.getString(SharedPayloadKeys.SUMMARY),
   reviewRunId = rows.getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
   findingId = rows.getString(ReviewFindingPayloadKeys.FINDING_ID),
-  claimVerdict = rows.getString(ReviewFindingPayloadKeys.CLAIM_VERDICT)?.trim()?.takeIf(String::isNotBlank)?.let(ReviewClaimVerdict::fromWire),
+  claimVerdict = rows.getString(ReviewFindingPayloadKeys.CLAIM_VERDICT)
+    ?.trim()
+    ?.takeIf(String::isNotBlank)
+    ?.let(ReviewClaimVerdict::fromWire),
   scopeDisposition = rows.getString(ReviewFindingPayloadKeys.SCOPE_DISPOSITION)?.trim()?.takeIf(String::isNotBlank)
     ?.let(ReviewScopeDisposition::fromWire),
   citations = ReviewFindingCitation.decodeList(rows.getString(ReviewFindingPayloadKeys.CITATIONS)),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsRows.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goal/UnaddressedFindingsRows.kt
@@ -1,5 +1,11 @@
 package skillbill.infrastructure.sqlite.goal
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.model.UnaddressedFinding
 import skillbill.review.model.ReviewClaimVerdict
 import skillbill.review.model.ReviewFindingCitation
@@ -9,21 +15,21 @@ import skillbill.review.model.ReviewSeverityAdjustmentDirection
 import java.sql.ResultSet
 
 internal fun readUnaddressedFinding(rows: ResultSet): UnaddressedFinding = UnaddressedFinding(
-  issueKey = rows.getString("issue_key"),
-  workflowId = rows.getString("workflow_id"),
+  issueKey = rows.getString(SharedPayloadKeys.ISSUE_KEY),
+  workflowId = rows.getString(SharedPayloadKeys.WORKFLOW_ID),
   subtaskId = rows.getInt("subtask_id"),
   reviewPassNumber = rows.getInt("review_pass_number"),
   findingOrdinal = rows.getInt("finding_ordinal"),
   severity = rows.getString("severity"),
-  issueCategory = rows.getString("issue_category"),
+  issueCategory = rows.getString(ReviewFindingPayloadKeys.ISSUE_CATEGORY),
   location = rows.getString("location"),
-  summary = rows.getString("summary"),
-  reviewRunId = rows.getString("review_run_id"),
-  findingId = rows.getString("finding_id"),
-  claimVerdict = rows.getString("claim_verdict")?.trim()?.takeIf(String::isNotBlank)?.let(ReviewClaimVerdict::fromWire),
-  scopeDisposition = rows.getString("scope_disposition")?.trim()?.takeIf(String::isNotBlank)
+  summary = rows.getString(SharedPayloadKeys.SUMMARY),
+  reviewRunId = rows.getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
+  findingId = rows.getString(ReviewFindingPayloadKeys.FINDING_ID),
+  claimVerdict = rows.getString(ReviewFindingPayloadKeys.CLAIM_VERDICT)?.trim()?.takeIf(String::isNotBlank)?.let(ReviewClaimVerdict::fromWire),
+  scopeDisposition = rows.getString(ReviewFindingPayloadKeys.SCOPE_DISPOSITION)?.trim()?.takeIf(String::isNotBlank)
     ?.let(ReviewScopeDisposition::fromWire),
-  citations = ReviewFindingCitation.decodeList(rows.getString("citations")),
+  citations = ReviewFindingCitation.decodeList(rows.getString(ReviewFindingPayloadKeys.CITATIONS)),
   severityAdjustment = severityAdjustment(
     rows.getString("severity_adjustment_direction"),
     rows.getString("severity_adjustment_justification"),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationArtifactCodec.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationArtifactCodec.kt
@@ -1,7 +1,7 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.boundary.OpenBoundaryMap
-import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.goalrunner.asGoalRunnerIntOrNull

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationArtifactCodec.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationArtifactCodec.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
 import skillbill.error.InvalidGoalSubtaskReviewStateSchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError
@@ -24,8 +25,8 @@ import skillbill.workflow.taskruntime.model.requireAcceptedOutput
 @OpenBoundaryMap("Goal continuation artifact decode from durable workflow artifacts")
 fun goalContinuation(artifacts: Map<String, Any?>): GoalContinuation? =
   (artifacts["goal_continuation"] as? Map<*, *>)?.let { payload ->
-    val issueKey = payload["issue_key"]?.toString()?.takeIf(String::isNotBlank)
-    val subtaskId = payload["subtask_id"].asGoalRunnerIntOrNull()
+    val issueKey = payload[SharedPayloadKeys.ISSUE_KEY]?.toString()?.takeIf(String::isNotBlank)
+    val subtaskId = payload[SharedPayloadKeys.SUBTASK_ID].asGoalRunnerIntOrNull()
     if (issueKey == null || subtaskId == null) {
       null
     } else {

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationOutcomeSelection.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationOutcomeSelection.kt
@@ -1,7 +1,7 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.boundary.OpenBoundaryMap
-import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.asGoalRunnerIntOrNull
 import skillbill.goalrunner.goalContinuationTerminalStatus
 import skillbill.goalrunner.model.GoalRunnerStoredOutcome
@@ -76,7 +76,9 @@ fun Map<String, Any?>.toMissingResultPrefixOutcomeArtifact(
   SharedPayloadKeys.ISSUE_KEY to issueKey,
   SharedPayloadKeys.SUBTASK_ID to subtaskId,
   SharedPayloadKeys.STATUS to status.toGoalContinuationWireStatus(),
-  SharedPayloadKeys.WORKFLOW_ID to (this[SharedPayloadKeys.WORKFLOW_ID]?.toString()?.takeIf(String::isNotBlank) ?: workflowId),
+  SharedPayloadKeys.WORKFLOW_ID to (
+    this[SharedPayloadKeys.WORKFLOW_ID]?.toString()?.takeIf(String::isNotBlank) ?: workflowId
+    ),
   "last_resumable_step" to (
     this["last_resumable_step"]?.toString()?.takeIf(String::isNotBlank) ?: "preplan"
     ),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationOutcomeSelection.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/GoalContinuationOutcomeSelection.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.asGoalRunnerIntOrNull
 import skillbill.goalrunner.goalContinuationTerminalStatus
@@ -55,14 +56,14 @@ fun missingResultPrefixTerminalOutcomeArtifact(
 ): Map<String, Any?>? = (JsonCodec.anyToStringAnyMap(output["subtask_outcome"]) ?: output)
   .takeIf { candidate -> candidate.matchesGoalContinuation(issueKey, subtaskId) }
   ?.let { candidate ->
-    candidate["status"]?.toString()?.let(::goalContinuationTerminalStatus)?.let { status ->
+    candidate[SharedPayloadKeys.STATUS]?.toString()?.let(::goalContinuationTerminalStatus)?.let { status ->
       candidate.toMissingResultPrefixOutcomeArtifact(issueKey, subtaskId, workflowId, status)
     }
   }
 
 fun Map<String, Any?>.matchesGoalContinuation(issueKey: String, subtaskId: Int): Boolean {
-  val candidateIssueKey = this["issue_key"]?.toString()?.takeIf(String::isNotBlank) ?: issueKey
-  val candidateSubtaskId = this["subtask_id"].asGoalRunnerIntOrNull() ?: subtaskId
+  val candidateIssueKey = this[SharedPayloadKeys.ISSUE_KEY]?.toString()?.takeIf(String::isNotBlank) ?: issueKey
+  val candidateSubtaskId = this[SharedPayloadKeys.SUBTASK_ID].asGoalRunnerIntOrNull() ?: subtaskId
   return candidateIssueKey == issueKey && candidateSubtaskId == subtaskId
 }
 
@@ -72,10 +73,10 @@ fun Map<String, Any?>.toMissingResultPrefixOutcomeArtifact(
   workflowId: String,
   status: GoalRunnerTerminalStatus,
 ): Map<String, Any?> = linkedMapOf<String, Any?>(
-  "issue_key" to issueKey,
-  "subtask_id" to subtaskId,
-  "status" to status.toGoalContinuationWireStatus(),
-  "workflow_id" to (this["workflow_id"]?.toString()?.takeIf(String::isNotBlank) ?: workflowId),
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
+  SharedPayloadKeys.SUBTASK_ID to subtaskId,
+  SharedPayloadKeys.STATUS to status.toGoalContinuationWireStatus(),
+  SharedPayloadKeys.WORKFLOW_ID to (this[SharedPayloadKeys.WORKFLOW_ID]?.toString()?.takeIf(String::isNotBlank) ?: workflowId),
   "last_resumable_step" to (
     this["last_resumable_step"]?.toString()?.takeIf(String::isNotBlank) ?: "preplan"
     ),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/LegacyGoalRunnerControlMigration.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/LegacyGoalRunnerControlMigration.kt
@@ -1,7 +1,7 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.boundary.OpenBoundaryMap
-import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.goalrunner.GOAL_OUT_OF_BAND_ACCEPTANCE_ARTIFACT_KEY
 import skillbill.goalrunner.GOAL_REVIEW_POLICY_ARTIFACT_KEY
 import skillbill.infrastructure.sqlite.decomposition.decodeArtifacts

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/LegacyGoalRunnerControlMigration.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/LegacyGoalRunnerControlMigration.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.JsonCodec
 import skillbill.goalrunner.GOAL_OUT_OF_BAND_ACCEPTANCE_ARTIFACT_KEY
 import skillbill.goalrunner.GOAL_REVIEW_POLICY_ARTIFACT_KEY
@@ -57,7 +58,7 @@ fun outOfBandAcceptancesFromLegacyArtifacts(artifacts: Map<String, Any?>): Map<I
     val entry = JsonCodec.anyToStringAnyMap(element)
       ?: error("Goal acceptance artifact '$GOAL_OUT_OF_BAND_ACCEPTANCE_ARTIFACT_KEY' entries must be maps.")
     val acceptance = GoalRunnerOutOfBandAcceptance(
-      subtaskId = (entry["subtask_id"] as? Number)?.toInt()
+      subtaskId = (entry[SharedPayloadKeys.SUBTASK_ID] as? Number)?.toInt()
         ?: error("Goal acceptance artifact entry is missing a numeric subtask_id."),
       commitSha = entry["commit_sha"] as? String
         ?: error("Goal acceptance artifact entry is missing commit_sha."),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerBlockWrites.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerBlockWrites.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.goalrunner.model.GoalRunnerSupervisionEvent
 import skillbill.goalrunner.toArtifactsMap
 import skillbill.infrastructure.sqlite.decomposition.decodeArtifacts
@@ -73,7 +72,11 @@ internal class WorkflowGoalRunnerBlockWrites(
         workflowStatus = "blocked",
         currentStepId = stepId,
         stepUpdates = listOf(
-          mapOf(SharedPayloadKeys.STEP_ID to stepId, SharedPayloadKeys.STATUS to "blocked", "attempt_count" to attemptCount),
+          mapOf(
+            SharedPayloadKeys.STEP_ID to stepId,
+            SharedPayloadKeys.STATUS to "blocked",
+            "attempt_count" to attemptCount,
+          ),
         ),
         artifactsPatch = buildMap {
           put("blocked_reason", write.blockedReason)

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerBlockWrites.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerBlockWrites.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.model.GoalRunnerSupervisionEvent
 import skillbill.goalrunner.toArtifactsMap
 import skillbill.infrastructure.sqlite.decomposition.decodeArtifacts
@@ -71,7 +73,7 @@ internal class WorkflowGoalRunnerBlockWrites(
         workflowStatus = "blocked",
         currentStepId = stepId,
         stepUpdates = listOf(
-          mapOf("step_id" to stepId, "status" to "blocked", "attempt_count" to attemptCount),
+          mapOf(SharedPayloadKeys.STEP_ID to stepId, SharedPayloadKeys.STATUS to "blocked", "attempt_count" to attemptCount),
         ),
         artifactsPatch = buildMap {
           put("blocked_reason", write.blockedReason)
@@ -148,8 +150,8 @@ internal class WorkflowGoalRunnerBlockWrites(
       currentStepId = blockedRecord.phaseId,
       stepUpdates = listOf(
         mapOf(
-          "step_id" to blockedRecord.phaseId,
-          "status" to "pending",
+          SharedPayloadKeys.STEP_ID to blockedRecord.phaseId,
+          SharedPayloadKeys.STATUS to "pending",
           "attempt_count" to 0,
         ),
       ),
@@ -161,7 +163,7 @@ internal class WorkflowGoalRunnerBlockWrites(
             FEATURE_TASK_RUNTIME_PHASE_LEDGER_LIMIT,
           ),
         FEATURE_TASK_RUNTIME_OPERATOR_BLOCK_RETRY_ARTIFACT_KEY to mapOf(
-          "phase_id" to blockedRecord.phaseId,
+          SharedPayloadKeys.PHASE_ID to blockedRecord.phaseId,
           "reason" to reason,
           "retried_at" to OffsetDateTime.now(ZoneOffset.UTC).toString(),
           "previous_blocked_reason" to blockedRecord.blockedReason,

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerChildWorkflowPersistence.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerChildWorkflowPersistence.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.contracts.issuekey.normalizeRequiredIssueKey
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.IncompatibleGoalPlanningPreparationRecoveryError
 import skillbill.goalrunner.GoalRunnerQualityGateSelectionResolver
 import skillbill.infrastructure.sqlite.decomposition.decodeArtifacts
@@ -139,8 +140,8 @@ internal class WorkflowGoalRunnerChildWorkflowPersistence(
   ) {
     val continuation = decodeArtifacts(existing.artifactsJson)[FEATURE_TASK_RUNTIME_GOAL_CONTINUATION_ARTIFACT_KEY]
       as? Map<*, *>
-    val matches = continuation?.get("issue_key") == state.manifest.issueKey &&
-      (continuation["subtask_id"] as? Number)?.toInt() == setup.subtaskId &&
+    val matches = continuation?.get(SharedPayloadKeys.ISSUE_KEY) == state.manifest.issueKey &&
+      (continuation[SharedPayloadKeys.SUBTASK_ID] as? Number)?.toInt() == setup.subtaskId &&
       continuation["parent_workflow_id"] == state.parentWorkflowId &&
       continuation["goal_branch"] == setup.goalBranch && continuation["suppress_pr"] == true
     if (!matches) {
@@ -244,7 +245,7 @@ internal class WorkflowGoalRunnerChildWorkflowPersistence(
       codeReviewMode = setup.reviewPolicy.codeReviewMode,
     ).toArtifactMap(),
     "install_sync_result" to mapOf(
-      "status" to "deferred",
+      SharedPayloadKeys.STATUS to "deferred",
       "reason" to
         "goal-continuation defers installer, uninstall, and install-sync flows until the parent goal exits; " +
         "deferred install sync must not block subtask completion",

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerChildWorkflowPersistence.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerChildWorkflowPersistence.kt
@@ -1,6 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
-import skillbill.contracts.issuekey.normalizeRequiredIssueKey
 import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.issuekey.normalizeRequiredIssueKey
 import skillbill.error.IncompatibleGoalPlanningPreparationRecoveryError
 import skillbill.goalrunner.GoalRunnerQualityGateSelectionResolver
 import skillbill.infrastructure.sqlite.decomposition.decodeArtifacts

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerManifestLoader.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerManifestLoader.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 import skillbill.contracts.issuekey.normalizeRequiredIssueKey
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.infrastructure.sqlite.decomposition.resolveDecompositionManifest
 import skillbill.infrastructure.sqlite.decomposition.withParentStatus
 import skillbill.infrastructure.sqlite.workflow.decompositionRuntime
@@ -100,8 +101,8 @@ internal class WorkflowGoalRunnerManifestLoader(
             null
           } else {
             listOf(
-              mapOf("step_id" to "preplan", "status" to "completed", "attempt_count" to 1),
-              mapOf("step_id" to "plan", "status" to "completed", "attempt_count" to 1),
+              mapOf(SharedPayloadKeys.STEP_ID to "preplan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
+              mapOf(SharedPayloadKeys.STEP_ID to "plan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
             )
           },
           artifactsPatch = parentProjection.artifacts(manifest, base.artifactsJson),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerManifestLoader.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerManifestLoader.kt
@@ -1,6 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
-import skillbill.contracts.issuekey.normalizeRequiredIssueKey
 import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.issuekey.normalizeRequiredIssueKey
 import skillbill.infrastructure.sqlite.decomposition.resolveDecompositionManifest
 import skillbill.infrastructure.sqlite.decomposition.withParentStatus
 import skillbill.infrastructure.sqlite.workflow.decompositionRuntime
@@ -101,8 +101,16 @@ internal class WorkflowGoalRunnerManifestLoader(
             null
           } else {
             listOf(
-              mapOf(SharedPayloadKeys.STEP_ID to "preplan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
-              mapOf(SharedPayloadKeys.STEP_ID to "plan", SharedPayloadKeys.STATUS to "completed", "attempt_count" to 1),
+              mapOf(
+                SharedPayloadKeys.STEP_ID to "preplan",
+                SharedPayloadKeys.STATUS to "completed",
+                "attempt_count" to 1,
+              ),
+              mapOf(
+                SharedPayloadKeys.STEP_ID to "plan",
+                SharedPayloadKeys.STATUS to "completed",
+                "attempt_count" to 1,
+              ),
             )
           },
           artifactsPatch = parentProjection.artifacts(manifest, base.artifactsJson),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerOutcomeTerminalPersistence.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerOutcomeTerminalPersistence.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.commitShaFrom
 import skillbill.goalrunner.goalContinuationOutcome
 import skillbill.goalrunner.model.GoalRunnerStoredOutcome
@@ -129,10 +131,10 @@ internal class WorkflowGoalRunnerOutcomeTerminalPersistence(
             stepUpdates = null,
             artifactsPatch = mapOf(
               "goal_continuation_outcome" to mapOf(
-                "issue_key" to issueKey,
-                "subtask_id" to subtaskId,
-                "status" to "complete",
-                "workflow_id" to workflowId,
+                SharedPayloadKeys.ISSUE_KEY to issueKey,
+                SharedPayloadKeys.SUBTASK_ID to subtaskId,
+                SharedPayloadKeys.STATUS to "complete",
+                SharedPayloadKeys.WORKFLOW_ID to workflowId,
                 "commit_sha" to outcome.commitSha,
                 "last_resumable_step" to (outcome.lastResumableStep ?: "commit_push"),
               ),
@@ -168,9 +170,9 @@ internal class WorkflowGoalRunnerOutcomeTerminalPersistence(
     val existingArtifacts = decodeArtifacts(record.artifactsJson)
     val artifactsPatch = linkedMapOf<String, Any?>(
       "goal_runner_missing_result_prefix_recovery" to linkedMapOf(
-        "issue_key" to issueKey,
-        "subtask_id" to subtaskId,
-        "workflow_id" to workflowId,
+        SharedPayloadKeys.ISSUE_KEY to issueKey,
+        SharedPayloadKeys.SUBTASK_ID to subtaskId,
+        SharedPayloadKeys.WORKFLOW_ID to workflowId,
         "output" to output,
       ),
     )

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerOutcomeTerminalPersistence.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerOutcomeTerminalPersistence.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.goalrunner.commitShaFrom
 import skillbill.goalrunner.goalContinuationOutcome
 import skillbill.goalrunner.model.GoalRunnerStoredOutcome

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerStaleBlockedOutcomeDisplacement.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerStaleBlockedOutcomeDisplacement.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.goalrunner
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.goalrunner.GOAL_CONTINUATION_OUTCOME_DISPLACEMENT_ARTIFACT_KEY
 import skillbill.goalrunner.derivedTerminalOutcomeFor
 import skillbill.goalrunner.goalContinuationOutcome

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerStaleBlockedOutcomeDisplacement.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/goalrunner/WorkflowGoalRunnerStaleBlockedOutcomeDisplacement.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.goalrunner
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.GOAL_CONTINUATION_OUTCOME_DISPLACEMENT_ARTIFACT_KEY
 import skillbill.goalrunner.derivedTerminalOutcomeFor
 import skillbill.goalrunner.goalContinuationOutcome
@@ -74,9 +76,9 @@ internal class WorkflowGoalRunnerStaleBlockedOutcomeDisplacement(
             put(
               GOAL_CONTINUATION_OUTCOME_DISPLACEMENT_ARTIFACT_KEY,
               linkedMapOf(
-                "workflow_id" to context.workflowId,
-                "issue_key" to context.issueKey,
-                "subtask_id" to context.subtaskId,
+                SharedPayloadKeys.WORKFLOW_ID to context.workflowId,
+                SharedPayloadKeys.ISSUE_KEY to context.issueKey,
+                SharedPayloadKeys.SUBTASK_ID to context.subtaskId,
                 "displaced_status" to "blocked",
                 "original_blocked_reason" to context.stored.blockedReason,
                 "failed_corroboration" to linkedMapOf(

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/GoalWorkflowStats.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/GoalWorkflowStats.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.review
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.review.model.GoalBlockedSubtaskSummary
 import skillbill.review.model.GoalModeStats
 import skillbill.review.model.GoalRunSummary
@@ -138,7 +140,7 @@ internal data class GoalSubtaskRow(
 )
 
 private fun parseGoalRunRow(row: Map<String, Any?>): GoalRunRow {
-  val identity = "goal_run_sessions[workflow_id=${row["workflow_id"] ?: "<null>"}]"
+  val identity = "goal_run_sessions[workflow_id=${row[SharedPayloadKeys.WORKFLOW_ID] ?: "<null>"}]"
   val finishedAtRaw = row["finished_at"]?.toString().orEmpty()
   val finished = finishedAtRaw.isNotBlank()
   if (finished) {
@@ -164,8 +166,8 @@ private fun parseGoalRunRow(row: Map<String, Any?>): GoalRunRow {
 
 private fun parseGoalSubtaskRow(row: Map<String, Any?>): GoalSubtaskRow {
   val identity =
-    "goal_subtask_events[issue_key=${row["issue_key"] ?: "<null>"}, " +
-      "subtask_id=${row["subtask_id"] ?: "<null>"}, workflow_id=${row["workflow_id"] ?: "<null>"}]"
+    "goal_subtask_events[issue_key=${row[SharedPayloadKeys.ISSUE_KEY] ?: "<null>"}, " +
+      "subtask_id=${row[SharedPayloadKeys.SUBTASK_ID] ?: "<null>"}, workflow_id=${row[SharedPayloadKeys.WORKFLOW_ID] ?: "<null>"}]"
   row.requireNonBlankString("started_at", identity)
   row.requireNonBlankString("finished_at", identity)
   val status = row.requireEnum("status", goalSubtaskStatuses.map { it.wireValue }, identity)

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/GoalWorkflowStats.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/GoalWorkflowStats.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.review
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.review.model.GoalBlockedSubtaskSummary
 import skillbill.review.model.GoalModeStats
 import skillbill.review.model.GoalRunSummary
@@ -167,7 +166,8 @@ private fun parseGoalRunRow(row: Map<String, Any?>): GoalRunRow {
 private fun parseGoalSubtaskRow(row: Map<String, Any?>): GoalSubtaskRow {
   val identity =
     "goal_subtask_events[issue_key=${row[SharedPayloadKeys.ISSUE_KEY] ?: "<null>"}, " +
-      "subtask_id=${row[SharedPayloadKeys.SUBTASK_ID] ?: "<null>"}, workflow_id=${row[SharedPayloadKeys.WORKFLOW_ID] ?: "<null>"}]"
+      "subtask_id=${row[SharedPayloadKeys.SUBTASK_ID] ?: "<null>"}, " +
+      "workflow_id=${row[SharedPayloadKeys.WORKFLOW_ID] ?: "<null>"}]"
   row.requireNonBlankString("started_at", identity)
   row.requireNonBlankString("finished_at", identity)
   val status = row.requireEnum("status", goalSubtaskStatuses.map { it.wireValue }, identity)

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewAccountingPersistence.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewAccountingPersistence.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.review
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
 import skillbill.infrastructure.sqlite.PARAM_FOUR
 import skillbill.infrastructure.sqlite.PARAM_ONE
@@ -43,7 +44,7 @@ fun loadReviewAccounting(connection: Connection, reviewId: String): ReviewAccoun
       val payload = requireNotNull(decodeBoundedAccounting(rows.getString("bounded_payload_json"))) {
         "Malformed bounded review accounting for '$reviewId'."
       }
-      val declaredVersion = payload["contract_version"]?.toString()
+      val declaredVersion = payload[SharedPayloadKeys.CONTRACT_VERSION]?.toString()
       if (
         declaredVersion != REVIEW_CONTEXT_CONTRACT_VERSION &&
         declaredVersion != LEGACY_REVIEW_CONTEXT_CONTRACT_VERSION

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewFindingStats.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewFindingStats.kt
@@ -1,5 +1,9 @@
 package skillbill.infrastructure.sqlite.review
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.review.model.FindingOutcomeRow
 import skillbill.review.model.ReviewFindingDetail
 import skillbill.review.model.ReviewFindingStats
@@ -120,11 +124,11 @@ fun queryLatestFindingOutcomes(connection: Connection, reviewRunId: String?): Li
         while (resultSet.next()) {
           add(
             FindingOutcomeRow(
-              reviewRunId = resultSet.getString("review_run_id"),
-              findingId = resultSet.getString("finding_id"),
+              reviewRunId = resultSet.getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
+              findingId = resultSet.getString(ReviewFindingPayloadKeys.FINDING_ID),
               severity = resultSet.getString("severity"),
               confidence = resultSet.getString("confidence"),
-              issueCategory = resultSet.getString("issue_category"),
+              issueCategory = resultSet.getString(ReviewFindingPayloadKeys.ISSUE_CATEGORY),
               location = resultSet.getString("location"),
               description = resultSet.getString("description"),
               outcomeType = resultSet.getString("outcome_type").orEmpty(),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewFindingStats.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewFindingStats.kt
@@ -1,9 +1,7 @@
 package skillbill.infrastructure.sqlite.review
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
 import skillbill.contracts.review.ReviewFindingPayloadKeys
-
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.review.model.FindingOutcomeRow
 import skillbill.review.model.ReviewFindingDetail
 import skillbill.review.model.ReviewFindingStats

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewHealthAggregation.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewHealthAggregation.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.review
 
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 private val reviewHealthSources = listOf("standalone", "embedded", "malformed")
 private val reviewHealthOutcomes =
   listOf("finding_accepted", "fix_applied", "finding_edited", "fix_rejected", "false_positive")
@@ -61,7 +63,7 @@ fun aggregateCategorySeverityCrossTab(payloads: List<ReviewHealthPayload>): Map<
   val crossTab = mutableMapOf<String, MutableMap<String, Int>>()
   payloads.forEach { payload ->
     reviewFindingDetails(payload.payload).forEach { detail ->
-      val category = detail["issue_category"]?.toString().orEmpty()
+      val category = detail[ReviewFindingPayloadKeys.ISSUE_CATEGORY]?.toString().orEmpty()
       val severity = normalizeFindingDetailValue("severity", detail["severity"]?.toString().orEmpty())
       if (category.isNotBlank() && severity.isNotBlank()) {
         crossTab.getOrPut(category) { mutableMapOf() }[severity] =

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewHealthPayloadMaterialization.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewHealthPayloadMaterialization.kt
@@ -1,7 +1,7 @@
 package skillbill.infrastructure.sqlite.review
 import skillbill.contracts.JsonCodec
-import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.infrastructure.sqlite.PARAM_TWO
 import skillbill.infrastructure.sqlite.telemetry.enqueueTelemetry
@@ -39,7 +39,9 @@ internal fun persistLegacyReviewFinishedRow(connection: Connection, outboxId: Lo
       "event_name" to REVIEW_FINISHED_LEGACY_REGENERATED_EVENT_NAME,
       SharedPayloadKeys.CONTRACT_VERSION to REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION,
       ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
-      "from_version" to (payload[SharedPayloadKeys.CONTRACT_VERSION]?.toString() ?: REVIEW_FINISHED_LEGACY_CONTRACT_VERSION),
+      "from_version" to (
+        payload[SharedPayloadKeys.CONTRACT_VERSION]?.toString() ?: REVIEW_FINISHED_LEGACY_CONTRACT_VERSION
+        ),
       "to_version" to REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION,
     ),
   )

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewHealthPayloadMaterialization.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewHealthPayloadMaterialization.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.review
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.infrastructure.sqlite.PARAM_TWO
 import skillbill.infrastructure.sqlite.telemetry.enqueueTelemetry
@@ -16,7 +18,7 @@ fun materializeReviewFinishedPayload(connection: Connection, payload: Map<String
   if (reviewRunRowExists(connection, reviewRunId)) {
     return regenerateReviewFinishedPayload(connection, payload, reviewRunId)
   }
-  return if (payload["contract_version"]?.toString() == REVIEW_FINISHED_LEGACY_CONTRACT_VERSION) {
+  return if (payload[SharedPayloadKeys.CONTRACT_VERSION]?.toString() == REVIEW_FINISHED_LEGACY_CONTRACT_VERSION) {
     emptyMap()
   } else {
     payload
@@ -35,16 +37,16 @@ internal fun persistLegacyReviewFinishedRow(connection: Connection, outboxId: Lo
     REVIEW_FINISHED_LEGACY_REGENERATED_EVENT_NAME,
     linkedMapOf(
       "event_name" to REVIEW_FINISHED_LEGACY_REGENERATED_EVENT_NAME,
-      "contract_version" to REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION,
-      "review_run_id" to reviewRunId,
-      "from_version" to (payload["contract_version"]?.toString() ?: REVIEW_FINISHED_LEGACY_CONTRACT_VERSION),
+      SharedPayloadKeys.CONTRACT_VERSION to REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION,
+      ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
+      "from_version" to (payload[SharedPayloadKeys.CONTRACT_VERSION]?.toString() ?: REVIEW_FINISHED_LEGACY_CONTRACT_VERSION),
       "to_version" to REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION,
     ),
   )
 }
 
 private fun isLegacyReviewFinished(payload: Map<String, Any?>): Boolean {
-  val version = payload["contract_version"]?.toString()
+  val version = payload[SharedPayloadKeys.CONTRACT_VERSION]?.toString()
   return version == REVIEW_FINISHED_LEGACY_CONTRACT_VERSION ||
     !payload.containsKey("verification") ||
     !payload.containsKey("adjudication") ||
@@ -66,7 +68,7 @@ private fun regenerateReviewFinishedPayload(
     .toPayload()
   return LinkedHashMap(payload).apply {
     putAll(regenerated)
-    put("contract_version", REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION)
+    put(SharedPayloadKeys.CONTRACT_VERSION, REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION)
   }
 }
 

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewLaneAttribution.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewLaneAttribution.kt
@@ -1,6 +1,6 @@
 package skillbill.infrastructure.sqlite.review
-import skillbill.infrastructure.sqlite.PARAM_FOUR
 import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.infrastructure.sqlite.PARAM_FOUR
 import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.infrastructure.sqlite.PARAM_THREE
 import skillbill.infrastructure.sqlite.PARAM_TWO

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewLaneAttribution.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewLaneAttribution.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.review
 import skillbill.infrastructure.sqlite.PARAM_FOUR
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.infrastructure.sqlite.PARAM_THREE
 import skillbill.infrastructure.sqlite.PARAM_TWO
@@ -241,7 +242,7 @@ fun fetchFindingLaneAttribution(connection: Connection, reviewRunId: String): Ma
     statement.executeQuery().use { resultSet ->
       buildMap {
         while (resultSet.next()) {
-          put(resultSet.getString("finding_id"), resultSet.getString("lane_skill_name"))
+          put(resultSet.getString(ReviewFindingPayloadKeys.FINDING_ID), resultSet.getString("lane_skill_name"))
         }
       }
     }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRowMappers.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRowMappers.kt
@@ -1,5 +1,9 @@
 package skillbill.infrastructure.sqlite.review
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.review.model.ImportedFinding
 import skillbill.review.model.NumberedFinding
 import skillbill.review.model.ReviewClaimVerdict
@@ -12,10 +16,10 @@ import skillbill.review.model.ReviewSummary
 import java.sql.ResultSet
 
 fun ResultSet.toImportedFinding(): ImportedFinding = ImportedFinding(
-  findingId = getString("finding_id"),
+  findingId = getString(ReviewFindingPayloadKeys.FINDING_ID),
   severity = getString("severity"),
   confidence = getString("confidence"),
-  issueCategory = getString("issue_category"),
+  issueCategory = getString(ReviewFindingPayloadKeys.ISSUE_CATEGORY),
   location = getString("location"),
   description = getString("description"),
   findingText = getString("finding_text"),
@@ -23,7 +27,7 @@ fun ResultSet.toImportedFinding(): ImportedFinding = ImportedFinding(
 )
 
 fun ResultSet.toReviewSummary(): ReviewSummary = ReviewSummary(
-  reviewRunId = getString("review_run_id"),
+  reviewRunId = getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
   reviewSessionId = getString("review_session_id"),
   routedSkill = getString("routed_skill"),
   detectedScope = getString("detected_scope"),
@@ -41,15 +45,15 @@ fun ResultSet.toReviewSummary(): ReviewSummary = ReviewSummary(
 
 fun ResultSet.toNumberedFinding(number: Int): NumberedFinding = NumberedFinding(
   number = number,
-  findingId = getString("finding_id"),
+  findingId = getString(ReviewFindingPayloadKeys.FINDING_ID),
   severity = getString("severity"),
   confidence = getString("confidence"),
   location = getString("location"),
   description = getString("description"),
-  claimVerdict = getString("claim_verdict")?.trim()?.takeIf(String::isNotBlank)?.let(ReviewClaimVerdict::fromWire),
-  scopeDisposition = getString("scope_disposition")?.trim()?.takeIf(String::isNotBlank)
+  claimVerdict = getString(ReviewFindingPayloadKeys.CLAIM_VERDICT)?.trim()?.takeIf(String::isNotBlank)?.let(ReviewClaimVerdict::fromWire),
+  scopeDisposition = getString(ReviewFindingPayloadKeys.SCOPE_DISPOSITION)?.trim()?.takeIf(String::isNotBlank)
     ?.let(ReviewScopeDisposition::fromWire),
-  citations = ReviewFindingCitation.decodeList(getString("citations")),
+  citations = ReviewFindingCitation.decodeList(getString(ReviewFindingPayloadKeys.CITATIONS)),
   severityAdjustment = numberedFindingAdjustment(
     getString("severity_adjustment_direction"),
     getString("severity_adjustment_justification"),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRowMappers.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRowMappers.kt
@@ -1,9 +1,7 @@
 package skillbill.infrastructure.sqlite.review
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
 import skillbill.contracts.review.ReviewFindingPayloadKeys
-
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.review.model.ImportedFinding
 import skillbill.review.model.NumberedFinding
 import skillbill.review.model.ReviewClaimVerdict
@@ -50,7 +48,10 @@ fun ResultSet.toNumberedFinding(number: Int): NumberedFinding = NumberedFinding(
   confidence = getString("confidence"),
   location = getString("location"),
   description = getString("description"),
-  claimVerdict = getString(ReviewFindingPayloadKeys.CLAIM_VERDICT)?.trim()?.takeIf(String::isNotBlank)?.let(ReviewClaimVerdict::fromWire),
+  claimVerdict = getString(ReviewFindingPayloadKeys.CLAIM_VERDICT)
+    ?.trim()
+    ?.takeIf(String::isNotBlank)
+    ?.let(ReviewClaimVerdict::fromWire),
   scopeDisposition = getString(ReviewFindingPayloadKeys.SCOPE_DISPOSITION)?.trim()?.takeIf(String::isNotBlank)
     ?.let(ReviewScopeDisposition::fromWire),
   citations = ReviewFindingCitation.decodeList(getString(ReviewFindingPayloadKeys.CITATIONS)),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRuntime.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.review
 import skillbill.infrastructure.sqlite.PARAM_ONE
+import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.infrastructure.sqlite.PARAM_TWO
 import skillbill.review.ReviewParser
 import skillbill.review.model.FindingMetadata
@@ -54,7 +55,7 @@ object ReviewRuntime {
       statement.executeQuery().use { resultSet ->
         require(resultSet.next()) { "Unknown finding id '$findingId' for review run '$reviewRunId'." }
         FindingMetadata(
-          findingId = resultSet.getString("finding_id"),
+          findingId = resultSet.getString(ReviewFindingPayloadKeys.FINDING_ID),
           severity = resultSet.getString("severity"),
           confidence = resultSet.getString("confidence"),
         )

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRuntime.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewRuntime.kt
@@ -1,6 +1,6 @@
 package skillbill.infrastructure.sqlite.review
-import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.infrastructure.sqlite.PARAM_TWO
 import skillbill.review.ReviewParser
 import skillbill.review.model.FindingMetadata

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageMetrics.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageMetrics.kt
@@ -1,6 +1,6 @@
 package skillbill.infrastructure.sqlite.review
-import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.contracts.review.ReviewVerificationSignalKeys
+import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.review.context.model.ReviewClaimVerdictAdmission
 import skillbill.review.context.model.ReviewSpecAdjudicationAdmission
 import skillbill.review.model.ReviewClaimVerdict

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageMetrics.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageMetrics.kt
@@ -1,5 +1,6 @@
 package skillbill.infrastructure.sqlite.review
 import skillbill.infrastructure.sqlite.PARAM_ONE
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.review.context.model.ReviewClaimVerdictAdmission
 import skillbill.review.context.model.ReviewSpecAdjudicationAdmission
 import skillbill.review.model.ReviewClaimVerdict
@@ -85,7 +86,7 @@ fun loadReviewRunTiers(connection: Connection): Map<String, String> = connection
     buildMap {
       while (resultSet.next()) {
         put(
-          resultSet.getString("review_run_id"),
+          resultSet.getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
           resolvedTier(resultSet.getString("execution_mode")?.let(ReviewExecutionMode::fromWire)),
         )
       }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageState.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageState.kt
@@ -1,7 +1,7 @@
 package skillbill.infrastructure.sqlite.review
-import skillbill.contracts.time.JvmSystemClock
-import skillbill.contracts.review.ReviewFindingPayloadKeys
 import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.time.JvmSystemClock
 import skillbill.infrastructure.sqlite.PARAM_FOUR
 import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.infrastructure.sqlite.PARAM_THREE

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageState.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageState.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.review
 import skillbill.contracts.time.JvmSystemClock
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.infrastructure.sqlite.PARAM_FOUR
 import skillbill.infrastructure.sqlite.PARAM_ONE
 import skillbill.infrastructure.sqlite.PARAM_THREE
@@ -82,11 +84,11 @@ fun fetchFindingVerdicts(connection: Connection, reviewRunId: String): List<Revi
           add(
             ReviewFindingVerdict(
               stage = ReviewStage.fromWire(resultSet.getString("stage")),
-              findingRef = resultSet.getString("finding_id"),
-              claimVerdict = ReviewClaimVerdict.fromWire(resultSet.getString("claim_verdict")),
-              scopeDisposition = resultSet.getString("scope_disposition")
+              findingRef = resultSet.getString(ReviewFindingPayloadKeys.FINDING_ID),
+              claimVerdict = ReviewClaimVerdict.fromWire(resultSet.getString(ReviewFindingPayloadKeys.CLAIM_VERDICT)),
+              scopeDisposition = resultSet.getString(ReviewFindingPayloadKeys.SCOPE_DISPOSITION)
                 ?.let(ReviewScopeDisposition::fromWire),
-              citations = decodeCitations(resultSet.getString("citations")),
+              citations = decodeCitations(resultSet.getString(ReviewFindingPayloadKeys.CITATIONS)),
               severityAdjustment = if (direction == null || justification == null) {
                 null
               } else {
@@ -96,7 +98,7 @@ fun fetchFindingVerdicts(connection: Connection, reviewRunId: String): List<Revi
                 )
               },
               recordedAt = resultSet.getString("recorded_at"),
-              contractVersion = resultSet.getString("contract_version"),
+              contractVersion = resultSet.getString(SharedPayloadKeys.CONTRACT_VERSION),
               rejectionReason = resultSet.getString("rejection_reason"),
             ),
           )
@@ -180,7 +182,7 @@ fun fetchStageBoundaries(connection: Connection, reviewRunId: String): List<Revi
               stage = ReviewStage.fromWire(resultSet.getString("stage")),
               reached = ReviewStageReached.fromWire(resultSet.getString("reached")),
               recordedAt = resultSet.getString("recorded_at"),
-              contractVersion = resultSet.getString("contract_version"),
+              contractVersion = resultSet.getString(SharedPayloadKeys.CONTRACT_VERSION),
             ),
           )
         }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageStateCodec.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageStateCodec.kt
@@ -1,5 +1,9 @@
 package skillbill.infrastructure.sqlite.review
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.review.model.ParallelReviewMergedFinding
 import skillbill.review.model.ParallelReviewSeverity
@@ -7,9 +11,9 @@ import skillbill.review.model.ReviewFindingCitation
 
 internal fun encodePassClaims(findings: List<ParallelReviewMergedFinding>): String = JsonCodec.mapToJsonString(
   mapOf(
-    "findings" to findings.map { finding ->
+    ReviewVerificationSignalKeys.REVIEW_FINDINGS to findings.map { finding ->
       mapOf(
-        "f_number" to finding.fNumber,
+        ReviewFindingPayloadKeys.F_NUMBER to finding.fNumber,
         "agent_ids" to finding.agentIds,
         "severity" to finding.severity.name,
         "confidence" to finding.confidence,
@@ -17,7 +21,7 @@ internal fun encodePassClaims(findings: List<ParallelReviewMergedFinding>): Stri
         "description" to finding.description,
         "specialist_skill_names" to finding.specialistSkillNames,
         "origin_layer_chains" to finding.originLayerChains,
-        "repository_path" to finding.repositoryPath,
+        ReviewFindingPayloadKeys.REPOSITORY_PATH to finding.repositoryPath,
         "line" to finding.line,
         "commit_shas" to finding.commitShas,
       )
@@ -30,10 +34,10 @@ internal fun decodePassClaims(raw: String): List<ParallelReviewMergedFinding> {
     ?.let(JsonCodec::jsonElementToValue)
     ?.let(JsonCodec::anyToStringAnyMap)
     ?: return emptyList()
-  val items = root["findings"] as? List<*> ?: return emptyList()
+  val items = root[ReviewVerificationSignalKeys.REVIEW_FINDINGS] as? List<*> ?: return emptyList()
   return items.mapNotNull { item ->
     val map = JsonCodec.anyToStringAnyMap(item) ?: return@mapNotNull null
-    val fNumber = map["f_number"] as? String ?: return@mapNotNull null
+    val fNumber = map[ReviewFindingPayloadKeys.F_NUMBER] as? String ?: return@mapNotNull null
     val severityName = map["severity"] as? String ?: return@mapNotNull null
     val severity = runCatching { ParallelReviewSeverity.valueOf(severityName) }.getOrNull()
       ?: return@mapNotNull null
@@ -46,7 +50,7 @@ internal fun decodePassClaims(raw: String): List<ParallelReviewMergedFinding> {
       description = map["description"] as? String ?: "",
       specialistSkillNames = stringList(map["specialist_skill_names"]),
       originLayerChains = chainList(map["origin_layer_chains"]),
-      repositoryPath = map["repository_path"] as? String,
+      repositoryPath = map[ReviewFindingPayloadKeys.REPOSITORY_PATH] as? String,
       line = intValue(map["line"]),
       commitShas = stringList(map["commit_shas"]),
     )

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageStateCodec.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/review/ReviewStageStateCodec.kt
@@ -1,10 +1,8 @@
 package skillbill.infrastructure.sqlite.review
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.review.model.ParallelReviewMergedFinding
 import skillbill.review.model.ParallelReviewSeverity
 import skillbill.review.model.ReviewFindingCitation

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/FeedbackEventMigration.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/FeedbackEventMigration.kt
@@ -1,5 +1,9 @@
 package skillbill.infrastructure.sqlite.telemetry
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.infrastructure.sqlite.core.DbConstants
 import java.sql.Connection
 
@@ -63,8 +67,8 @@ internal object FeedbackEventMigration {
             add(
               LegacyFeedbackEventRow(
                 id = resultSet.getLong("id"),
-                reviewRunId = resultSet.getString("review_run_id"),
-                findingId = resultSet.getString("finding_id"),
+                reviewRunId = resultSet.getString(ReviewVerificationSignalKeys.REVIEW_RUN_ID),
+                findingId = resultSet.getString(ReviewFindingPayloadKeys.FINDING_ID),
                 eventType = normalizeFeedbackEventType(resultSet.getString("event_type")),
                 note = resultSet.getString("note").orEmpty(),
                 createdAt = resultSet.getString("created_at"),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/FeedbackEventMigration.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/FeedbackEventMigration.kt
@@ -1,9 +1,7 @@
 package skillbill.infrastructure.sqlite.telemetry
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
 import skillbill.contracts.review.ReviewFindingPayloadKeys
-
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.infrastructure.sqlite.core.DbConstants
 import java.sql.Connection
 

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalIssueProgressRecovery.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalIssueProgressRecovery.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.telemetry
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.telemetry.model.GoalIssueFinishedRecord
 import java.sql.Connection
 
@@ -36,10 +38,10 @@ private fun loadRecoveredGoalSegments(
       while (resultSet.next()) {
         add(
           RecoveredGoalSegment(
-            workflowId = resultSet.getString("workflow_id"),
+            workflowId = resultSet.getString(SharedPayloadKeys.WORKFLOW_ID),
             startedAt = resultSet.getString("started_at"),
             resumed = resultSet.getInt("resumed") != 0,
-            status = resultSet.getString("status"),
+            status = resultSet.getString(SharedPayloadKeys.STATUS),
           ),
         )
       }

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalIssueProgressRecovery.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalIssueProgressRecovery.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.telemetry
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.telemetry.model.GoalIssueFinishedRecord
 import java.sql.Connection
 

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalTelemetryPayloads.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalTelemetryPayloads.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.telemetry
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import java.time.Duration
 import java.time.Instant
@@ -37,12 +39,12 @@ private fun Map<String, Any?>.redactedWorkflowId(column: String, level: String, 
 
 fun goalStartedPayload(row: Map<String, Any?>, level: String, salt: String): Map<String, Any?> =
   linkedMapOf<String, Any?>(
-    "workflow_id" to row.redactedWorkflowId("workflow_id", level, salt),
-    "issue_key" to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
+    SharedPayloadKeys.WORKFLOW_ID to row.redactedWorkflowId("workflow_id", level, salt),
+    SharedPayloadKeys.ISSUE_KEY to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
     "subtask_total" to row.intOrZero("subtask_total"),
     "resumed" to row.booleanFromInt("resumed"),
     "started_at" to row.stringOrEmpty("started_at"),
-    "status" to "running",
+    SharedPayloadKeys.STATUS to "running",
     "mode" to row.stringOrEmpty("mode").ifBlank { "runtime" },
   ).apply {
     if (level == "full") {
@@ -52,9 +54,9 @@ fun goalStartedPayload(row: Map<String, Any?>, level: String, salt: String): Map
 
 fun goalFinishedPayload(row: Map<String, Any?>, level: String, salt: String): Map<String, Any?> =
   linkedMapOf<String, Any?>(
-    "workflow_id" to row.redactedWorkflowId("workflow_id", level, salt),
-    "issue_key" to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
-    "status" to row.stringOrEmpty("status"),
+    SharedPayloadKeys.WORKFLOW_ID to row.redactedWorkflowId("workflow_id", level, salt),
+    SharedPayloadKeys.ISSUE_KEY to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
+    SharedPayloadKeys.STATUS to row.stringOrEmpty("status"),
     "started_at" to row.stringOrEmpty("started_at"),
     "finished_at" to row.stringOrEmpty("finished_at"),
     "duration_seconds" to secondsFromMillis(row.longOrZero("finished_duration_ms")),
@@ -70,8 +72,8 @@ fun goalIssueFinishedPayload(row: Map<String, Any?>, level: String, salt: String
   val finishedAt = row.stringOrEmpty("finished_at")
   return linkedMapOf<String, Any?>(
     "parent_workflow_id" to row.redactedWorkflowId("parent_workflow_id", level, salt),
-    "issue_key" to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
-    "status" to row.stringOrEmpty("status"),
+    SharedPayloadKeys.ISSUE_KEY to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
+    SharedPayloadKeys.STATUS to row.stringOrEmpty("status"),
     "subtasks_complete" to row.intOrZero("subtasks_complete"),
     "subtasks_blocked" to row.intOrZero("subtasks_blocked"),
     "subtasks_skipped" to row.intOrZero("subtasks_skipped"),
@@ -87,10 +89,10 @@ fun goalIssueFinishedPayload(row: Map<String, Any?>, level: String, salt: String
 
 fun goalSubtaskFinishedPayload(row: Map<String, Any?>, level: String, salt: String): Map<String, Any?> =
   linkedMapOf<String, Any?>(
-    "workflow_id" to row.redactedWorkflowId("workflow_id", level, salt),
-    "issue_key" to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
-    "subtask_id" to row.intOrZero("subtask_id"),
-    "status" to row.stringOrEmpty("status"),
+    SharedPayloadKeys.WORKFLOW_ID to row.redactedWorkflowId("workflow_id", level, salt),
+    SharedPayloadKeys.ISSUE_KEY to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
+    SharedPayloadKeys.SUBTASK_ID to row.intOrZero("subtask_id"),
+    SharedPayloadKeys.STATUS to row.stringOrEmpty("status"),
     "started_at" to row.stringOrEmpty("started_at"),
     "finished_at" to row.stringOrEmpty("finished_at"),
     "duration_seconds" to secondsFromMillis(row.longOrZero("duration_ms")),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalTelemetryPayloads.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/GoalTelemetryPayloads.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.sqlite.telemetry
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryMeasurementAdapter.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryMeasurementAdapter.kt
@@ -1,5 +1,9 @@
 package skillbill.infrastructure.sqlite.telemetry
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.ports.telemetry.FeatureTaskRuntimeTelemetryMeasurementRepository
 import skillbill.ports.telemetry.ReviewStageTelemetryMeasurementRepository
 import skillbill.review.model.REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION
@@ -43,8 +47,8 @@ internal class LifecycleTelemetryMeasurementAdapter(
 
 private fun ReviewStageDegradationMeasurement.toStageDegradationPayload(): Map<String, Any?> = linkedMapOf(
   "event_name" to REVIEW_STAGE_DEGRADATION_EVENT_NAME,
-  "contract_version" to REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION,
-  "review_run_id" to reviewRunId,
+  SharedPayloadKeys.CONTRACT_VERSION to REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION,
+  ReviewVerificationSignalKeys.REVIEW_RUN_ID to reviewRunId,
   "seam" to seam,
   "expected" to expected,
   "actual" to actual,

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryMeasurementAdapter.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryMeasurementAdapter.kt
@@ -1,9 +1,7 @@
 package skillbill.infrastructure.sqlite.telemetry
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
 import skillbill.contracts.SharedPayloadKeys
-
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.ports.telemetry.FeatureTaskRuntimeTelemetryMeasurementRepository
 import skillbill.ports.telemetry.ReviewStageTelemetryMeasurementRepository
 import skillbill.review.model.REVIEW_STAGE_DEGRADATION_CONTRACT_VERSION

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryPayloads.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryPayloads.kt
@@ -1,8 +1,7 @@
 package skillbill.infrastructure.sqlite.telemetry
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.review.normalizeRoutedSkill
 import skillbill.review.normalizeStackLabel
 import skillbill.telemetry.model.PrDescriptionGeneratedRecord

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryPayloads.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/telemetry/LifecycleTelemetryPayloads.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.telemetry
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.JsonCodec
 import skillbill.review.normalizeRoutedSkill
 import skillbill.review.normalizeStackLabel
@@ -9,7 +11,7 @@ fun featureTaskRuntimeStartedPayload(row: Map<String, Any?>, level: String, salt
   linkedMapOf<String, Any?>(
     "session_id" to row.stringOrEmpty("session_id"),
     "feature_size" to row.stringOrEmpty("feature_size"),
-    "issue_key" to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
+    SharedPayloadKeys.ISSUE_KEY to redactIssueKey(row.stringOrEmpty("issue_key"), level, salt),
   ).apply {
     if (level == "full") {
       put("feature_name", row.stringOrEmpty("feature_name"))

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskExecutionLookupStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskExecutionLookupStore.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidFeatureTaskExecutionIdentitySchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.ports.workflow.FeatureTaskExecutionLookupRepository
@@ -117,7 +119,7 @@ internal class FeatureTaskExecutionLookupStore(
     statement.executeQuery().use { rows ->
       buildList {
         while (rows.next()) {
-          val workflowId = rows.getString("workflow_id")
+          val workflowId = rows.getString(SharedPayloadKeys.WORKFLOW_ID)
           val workflow = connection.getFeatureTaskWorkflowRow(workflowId)
             ?: throw InvalidWorkflowStateSchemaError(
               "Feature-task identity '$workflowId' has no workflow row.",

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskExecutionLookupStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskExecutionLookupStore.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.workflow
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidFeatureTaskExecutionIdentitySchemaError
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.ports.workflow.FeatureTaskExecutionLookupRepository

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeAuditGenerationStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeAuditGenerationStore.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.infrastructure.sqlite.telemetry.bind
 import skillbill.ports.featuretask.FeatureTaskRuntimeAuditGenerationRepository
 import skillbill.ports.featuretask.model.FeatureTaskRuntimeAuditGenerationRow
@@ -50,10 +52,10 @@ internal class FeatureTaskRuntimeAuditGenerationStore(
           while (rows.next()) {
             add(
               FeatureTaskRuntimeAuditGenerationRow(
-                workflowId = rows.getString("workflow_id"),
+                workflowId = rows.getString(SharedPayloadKeys.WORKFLOW_ID),
                 generationOrdinal = rows.getInt("generation_ordinal"),
                 repositoryCheckpoint = rows.getString("repository_checkpoint"),
-                contractVersion = rows.getString("contract_version"),
+                contractVersion = rows.getString(SharedPayloadKeys.CONTRACT_VERSION),
                 generationJson = rows.getString("generation_json"),
               ),
             )

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeAuditGenerationStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeAuditGenerationStore.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.workflow
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.infrastructure.sqlite.telemetry.bind
 import skillbill.ports.featuretask.FeatureTaskRuntimeAuditGenerationRepository
 import skillbill.ports.featuretask.model.FeatureTaskRuntimeAuditGenerationRow

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeWorkerStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeWorkerStore.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.infrastructure.sqlite.core.inImmediateTransaction
 import skillbill.ports.featuretask.model.FeatureTaskRuntimeCrashReconciliationCandidate
 import skillbill.ports.featuretask.model.FeatureTaskRuntimeWorkerOwnership
@@ -126,7 +128,7 @@ internal class FeatureTaskRuntimeWorkerStore(
     statement.executeQuery().use { rows ->
       buildList {
         while (rows.next()) {
-          val workflowId = rows.getString("workflow_id")
+          val workflowId = rows.getString(SharedPayloadKeys.WORKFLOW_ID)
           val ownership = connection.featureTaskRuntimeWorkerOwnership(workflowId) ?: continue
           add(
             FeatureTaskRuntimeCrashReconciliationCandidate(

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeWorkerStore.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskRuntimeWorkerStore.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.workflow
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.infrastructure.sqlite.core.inImmediateTransaction
 import skillbill.ports.featuretask.model.FeatureTaskRuntimeCrashReconciliationCandidate
 import skillbill.ports.featuretask.model.FeatureTaskRuntimeWorkerOwnership

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskWorkflowStateStoreSql.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskWorkflowStateStoreSql.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_WORKER_OWNERSHIP_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskExecutionIdentitySchemaError
 import skillbill.error.InvalidFeatureTaskRuntimeWorkerOwnershipSchemaError
@@ -132,7 +134,7 @@ internal fun Connection.featureTaskIdentity(workflowId: String): FeatureTaskExec
     if (!row.next()) return null
     FeatureTaskExecutionIdentity(
       workflowId = workflowId,
-      contractVersion = row.getString("contract_version"),
+      contractVersion = row.getString(SharedPayloadKeys.CONTRACT_VERSION),
       normalizedIssueKey = row.getString("normalized_issue_key"),
       repositoryIdentity = row.getString("repository_identity"),
       governedSpecPath = row.getString("governed_spec_path"),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskWorkflowStateStoreSql.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/FeatureTaskWorkflowStateStoreSql.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.workflow
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.contracts.workflow.FEATURE_TASK_RUNTIME_WORKER_OWNERSHIP_CONTRACT_VERSION
 import skillbill.error.InvalidFeatureTaskExecutionIdentitySchemaError
 import skillbill.error.InvalidFeatureTaskRuntimeWorkerOwnershipSchemaError

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/GoalRunnerControlStoreEncode.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/GoalRunnerControlStoreEncode.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.workflow
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.goalrunner.model.GoalRunnerControlState
 import skillbill.goalrunner.model.GoalRunnerExecutionLease
 import skillbill.ports.goalrunner.runner.model.GoalRunnerOutOfBandAcceptance

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/GoalRunnerControlStoreEncode.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/GoalRunnerControlStoreEncode.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.goalrunner.model.GoalRunnerControlState
 import skillbill.goalrunner.model.GoalRunnerExecutionLease
 import skillbill.ports.goalrunner.runner.model.GoalRunnerOutOfBandAcceptance
@@ -22,7 +24,7 @@ internal fun GoalRunnerReviewPolicy.toArtifactMap(): Map<String, Any?> = buildMa
 }
 
 internal fun GoalRunnerOutOfBandAcceptance.toArtifactMap(): Map<String, Any?> = mapOf(
-  "subtask_id" to subtaskId,
+  SharedPayloadKeys.SUBTASK_ID to subtaskId,
   "commit_sha" to commitSha,
   "reason" to reason,
   "accepted_at" to acceptedAt,

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/WorkflowStateSqlReads.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/WorkflowStateSqlReads.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.ports.workflow.model.FeatureTaskWorkflowMode
 import skillbill.ports.workflow.model.WorkflowStateRecord
@@ -241,15 +243,15 @@ internal fun Connection.listFeatureTaskWorkflowRows(
 }
 
 internal fun ResultSet.toWorkflowStateRecord(): WorkflowStateRecord = WorkflowStateRecord(
-  workflowId = getString("workflow_id"),
+  workflowId = getString(SharedPayloadKeys.WORKFLOW_ID),
   sessionId = getString("session_id"),
   workflowName = getString("workflow_name"),
-  contractVersion = getString("contract_version"),
+  contractVersion = getString(SharedPayloadKeys.CONTRACT_VERSION),
   workflowStatus = getString("workflow_status"),
   currentStepId = getString("current_step_id"),
   stepsJson = getString("steps_json"),
   artifactsJson = getString("artifacts_json"),
-  issueKey = getString("issue_key"),
+  issueKey = getString(SharedPayloadKeys.ISSUE_KEY),
   startedAt = getString("started_at"),
   updatedAt = getString("updated_at"),
   stateEnteredAt = getString("state_entered_at"),
@@ -258,7 +260,7 @@ internal fun ResultSet.toWorkflowStateRecord(): WorkflowStateRecord = WorkflowSt
 )
 
 internal fun ResultSet.toFeatureTaskWorkflowStateRecord(): WorkflowStateRecord {
-  val workflowId = getString("workflow_id")
+  val workflowId = getString(SharedPayloadKeys.WORKFLOW_ID)
   val workflowName = getString("workflow_name")
   if (workflowName != "bill-feature-task") {
     throw InvalidWorkflowStateSchemaError(
@@ -274,12 +276,12 @@ internal fun ResultSet.toFeatureTaskWorkflowStateRecord(): WorkflowStateRecord {
     workflowId = workflowId,
     sessionId = getString("session_id"),
     workflowName = workflowName,
-    contractVersion = getString("contract_version"),
+    contractVersion = getString(SharedPayloadKeys.CONTRACT_VERSION),
     workflowStatus = getString("workflow_status"),
     currentStepId = getString("current_step_id"),
     stepsJson = getString("steps_json"),
     artifactsJson = getString("artifacts_json"),
-    issueKey = getString("issue_key"),
+    issueKey = getString(SharedPayloadKeys.ISSUE_KEY),
     startedAt = getString("started_at"),
     updatedAt = getString("updated_at"),
     stateEnteredAt = getString("state_entered_at"),

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/WorkflowStateSqlReads.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/workflow/WorkflowStateSqlReads.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.workflow
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidWorkflowStateSchemaError
 import skillbill.ports.workflow.model.FeatureTaskWorkflowMode
 import skillbill.ports.workflow.model.WorkflowStateRecord

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/worklist/SQLiteWorkListRepository.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/worklist/SQLiteWorkListRepository.kt
@@ -1,5 +1,7 @@
 package skillbill.infrastructure.sqlite.worklist
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.error.InvalidWorkListRowError
 import skillbill.ports.work.WorkListRepository
 import skillbill.ports.work.model.LEGACY_FEATURE_TASK_PROSE_WORKFLOW_STATUSES
@@ -105,7 +107,7 @@ private fun ResultSet.toWorkItem(): WorkItem {
     else -> invalid(workflowId, "invalid state_entered_at_estimated '$estimatedValue'")
   }
   return WorkItem(
-    issueKey = getString("issue_key")?.trim()?.takeIf(String::isNotEmpty),
+    issueKey = getString(SharedPayloadKeys.ISSUE_KEY)?.trim()?.takeIf(String::isNotEmpty),
     workflowKind = kind,
     workflowId = workflowId,
     startedAt = parseInstant(required("started_at"), workflowId, "started_at"),
@@ -123,9 +125,9 @@ private val validWorkStates: Set<String> =
     FeatureVerifyWorkflowDefinition.definition.workflowStatuses
 
 private fun ResultSet.required(column: String): String {
-  val value = getString(column) ?: invalid(getString("workflow_id").orEmpty(), "missing $column")
-  if (value.isBlank()) invalid(getString("workflow_id").orEmpty(), "missing $column")
-  if (value != value.trim()) invalid(getString("workflow_id").orEmpty(), "invalid $column '$value'")
+  val value = getString(column) ?: invalid(getString(SharedPayloadKeys.WORKFLOW_ID).orEmpty(), "missing $column")
+  if (value.isBlank()) invalid(getString(SharedPayloadKeys.WORKFLOW_ID).orEmpty(), "missing $column")
+  if (value != value.trim()) invalid(getString(SharedPayloadKeys.WORKFLOW_ID).orEmpty(), "invalid $column '$value'")
   return value
 }
 

--- a/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/worklist/SQLiteWorkListRepository.kt
+++ b/runtime-kotlin/runtime-infra-sqlite/src/main/kotlin/skillbill/infrastructure/sqlite/worklist/SQLiteWorkListRepository.kt
@@ -1,7 +1,6 @@
 package skillbill.infrastructure.sqlite.worklist
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.error.InvalidWorkListRowError
 import skillbill.ports.work.WorkListRepository
 import skillbill.ports.work.model.LEGACY_FEATURE_TASK_PROSE_WORKFLOW_STATUSES

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemaPrimitives.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemaPrimitives.kt
@@ -1,6 +1,7 @@
 package skillbill.mcp.core
 
 import skillbill.contracts.SharedPayloadKeys
+import skillbill.workflow.model.WorkflowStepStatus
 
 internal fun stringSchema(
   enum: List<String> = emptyList(),
@@ -27,7 +28,7 @@ internal fun stepUpdateSchema(stepIdEnum: List<String>): Map<String, Any?> = Mcp
   properties = mapOf(
     SharedPayloadKeys.STEP_ID to stringSchema(enum = stepIdEnum),
     SharedPayloadKeys.STATUS to stringSchema(
-      enum = listOf("pending", "running", "completed", "failed", "blocked", "skipped"),
+      enum = WorkflowStepStatus.entries.map(WorkflowStepStatus::wireValue),
     ),
     "attempt_count" to integerSchema,
   ),

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemaPrimitives.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemaPrimitives.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.core
 
+import skillbill.contracts.SharedPayloadKeys
+
 internal fun stringSchema(
   enum: List<String> = emptyList(),
   minLength: Int? = null,
@@ -23,8 +25,8 @@ internal fun arraySchema(items: Map<String, Any?>): Map<String, Any?> = mapOf(
 internal fun stepUpdateSchema(stepIdEnum: List<String>): Map<String, Any?> = McpToolSpec.strictObjectSchema(
   required = listOf("step_id", "status", "attempt_count"),
   properties = mapOf(
-    "step_id" to stringSchema(enum = stepIdEnum),
-    "status" to stringSchema(enum = listOf("pending", "running", "completed", "failed", "blocked", "skipped")),
+    SharedPayloadKeys.STEP_ID to stringSchema(enum = stepIdEnum),
+    SharedPayloadKeys.STATUS to stringSchema(enum = listOf("pending", "running", "completed", "failed", "blocked", "skipped")),
     "attempt_count" to integerSchema,
   ),
 )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemaPrimitives.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemaPrimitives.kt
@@ -26,7 +26,9 @@ internal fun stepUpdateSchema(stepIdEnum: List<String>): Map<String, Any?> = Mcp
   required = listOf("step_id", "status", "attempt_count"),
   properties = mapOf(
     SharedPayloadKeys.STEP_ID to stringSchema(enum = stepIdEnum),
-    SharedPayloadKeys.STATUS to stringSchema(enum = listOf("pending", "running", "completed", "failed", "blocked", "skipped")),
+    SharedPayloadKeys.STATUS to stringSchema(
+      enum = listOf("pending", "running", "completed", "failed", "blocked", "skipped"),
+    ),
     "attempt_count" to integerSchema,
   ),
 )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemas.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemas.kt
@@ -1,7 +1,6 @@
 package skillbill.mcp.core
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.ports.workflow.FeatureTaskExecutionIdentityPolicy
 
 internal val emptyObjectSchema: Map<String, Any?> = McpToolSpec.strictObjectSchema()

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemas.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpInputSchemas.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.core
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.ports.workflow.FeatureTaskExecutionIdentityPolicy
 
 internal val emptyObjectSchema: Map<String, Any?> = McpToolSpec.strictObjectSchema()
@@ -35,7 +37,7 @@ internal fun objectSchema(
 
 internal fun workflowIdSchema(): Map<String, Any?> = objectSchema(
   required = listOf("workflow_id"),
-  properties = mapOf("workflow_id" to stringSchema()),
+  properties = mapOf(SharedPayloadKeys.WORKFLOW_ID to stringSchema()),
 )
 
 internal fun workflowOpenSchema(required: List<String> = emptyList()): Map<String, Any?> = objectSchema(
@@ -43,7 +45,7 @@ internal fun workflowOpenSchema(required: List<String> = emptyList()): Map<Strin
   properties = mapOf(
     "session_id" to stringSchema(),
     "current_step_id" to stringSchema(),
-    "issue_key" to stringSchema(),
+    SharedPayloadKeys.ISSUE_KEY to stringSchema(),
     "repository_identity" to repositoryIdentitySchema,
     "governed_spec_path" to stringSchema(),
   ),
@@ -57,7 +59,7 @@ internal fun workflowUpdateSchema(workflowStatusEnum: List<String>, stepIdEnum: 
   objectSchema(
     required = listOf("workflow_id", "workflow_status", "current_step_id"),
     properties = mapOf(
-      "workflow_id" to stringSchema(),
+      SharedPayloadKeys.WORKFLOW_ID to stringSchema(),
       "workflow_status" to stringSchema(enum = workflowStatusEnum),
       "current_step_id" to stringSchema(enum = stepIdEnum),
       "step_updates" to arraySchema(stepUpdateSchema(stepIdEnum)),

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpRuntime.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpRuntime.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.core
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.review.toReviewFinishedTelemetryPayload
 import skillbill.contracts.mcp.McpLearningsSkippedContract
 import skillbill.contracts.mcp.McpOrchestratedPayloadContract
@@ -112,7 +114,7 @@ object McpRuntime {
   fun updateCheck(context: McpRuntimeContext = McpRuntimeContext()): Map<String, Any?> {
     val result = services(context).updateCheckService.check(includePrereleases = false)
     return mapOf(
-      "status" to result.status.wireName,
+      SharedPayloadKeys.STATUS to result.status.wireName,
       "installed_version" to result.installedVersion,
       "latest_version" to result.latestVersion,
       "recommended_install_command" to result.recommendedInstallCommand,

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpRuntime.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpRuntime.kt
@@ -1,8 +1,7 @@
 package skillbill.mcp.core
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.review.toReviewFinishedTelemetryPayload
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.mcp.McpLearningsSkippedContract
 import skillbill.contracts.mcp.McpOrchestratedPayloadContract
 import skillbill.contracts.mcp.McpReviewImportSkippedContract

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpStdioServer.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpStdioServer.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.core
 
+import skillbill.contracts.SharedPayloadKeys
+
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import skillbill.SkillBillVersion
@@ -55,7 +57,7 @@ object McpStdioServer {
     val arguments = JsonCodec.anyToStringAnyMap(params["arguments"]).orEmpty()
     validateStrictArguments(params)?.let { strictError ->
       return mcpToolResult(
-        mapOf("status" to "error", "tool" to toolName, "error" to strictError),
+        mapOf(SharedPayloadKeys.STATUS to "error", "tool" to toolName, "error" to strictError),
         isError = true,
       )
     }
@@ -105,7 +107,7 @@ private fun dispatchMcpToolCall(
 }
 
 private fun mcpToolErrorResult(toolName: String, error: Exception): Map<String, Any?> = mcpToolResult(
-  mapOf("status" to "error", "tool" to toolName, "error" to error.message.orEmpty()),
+  mapOf(SharedPayloadKeys.STATUS to "error", "tool" to toolName, "error" to error.message.orEmpty()),
   isError = true,
 )
 

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpStdioServer.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpStdioServer.kt
@@ -1,11 +1,10 @@
 package skillbill.mcp.core
 
-import skillbill.contracts.SharedPayloadKeys
-
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import skillbill.SkillBillVersion
 import skillbill.contracts.JsonCodec
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.error.ShellContentContractException
 import skillbill.mcp.shared.McpRuntimeContext
 import skillbill.mcp.shared.McpRuntimeLifecycle

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolDispatcher.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolDispatcher.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.core
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.WorkflowFamilyKind
 import skillbill.mcp.featuretask.featureTaskAuditSettle
 import skillbill.mcp.featuretask.featureTaskPhaseBlock
@@ -122,7 +124,7 @@ object McpToolDispatcher {
   internal fun telemetryEnvelope(toolName: String, arguments: Map<String, Any?>): Map<String, Any?> {
     val envelope = linkedMapOf<String, Any?>(
       "event_name" to toolName,
-      "contract_version" to TELEMETRY_EVENT_CONTRACT_VERSION,
+      SharedPayloadKeys.CONTRACT_VERSION to TELEMETRY_EVENT_CONTRACT_VERSION,
     )
     arguments.forEach { (key, value) ->
       // The wire envelope keeps caller-supplied `event_name` /

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolDispatcher.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolDispatcher.kt
@@ -1,8 +1,7 @@
 package skillbill.mcp.core
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.WorkflowFamilyKind
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.mcp.featuretask.featureTaskAuditSettle
 import skillbill.mcp.featuretask.featureTaskPhaseBlock
 import skillbill.mcp.featuretask.featureTaskPhaseComplete

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolRegistry.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolRegistry.kt
@@ -1,8 +1,7 @@
 package skillbill.mcp.core
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
 import skillbill.contracts.SharedPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 
 data class McpToolSpec(
   val name: String,

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolRegistry.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/core/McpToolRegistry.kt
@@ -1,5 +1,9 @@
 package skillbill.mcp.core
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.SharedPayloadKeys
+
 data class McpToolSpec(
   val name: String,
   val description: String,
@@ -99,22 +103,22 @@ object McpToolRegistry {
       "feature_task_phase_complete" to objectSchema(
         required = listOf("workflow_id", "phase_id", "attempt", "value"),
         properties = mapOf(
-          "workflow_id" to stringSchema(minLength = 1),
-          "phase_id" to stringSchema(enum = listOf("preplan", "plan", "implement")),
+          SharedPayloadKeys.WORKFLOW_ID to stringSchema(minLength = 1),
+          SharedPayloadKeys.PHASE_ID to stringSchema(enum = listOf("preplan", "plan", "implement")),
           "attempt" to mapOf("type" to "integer", "minimum" to 1),
-          "value" to stringSchema(minLength = 1),
-          "prompt" to stringSchema(minLength = 1),
-          "summary" to stringSchema(minLength = 1),
+          SharedPayloadKeys.VALUE to stringSchema(minLength = 1),
+          SharedPayloadKeys.PROMPT to stringSchema(minLength = 1),
+          SharedPayloadKeys.SUMMARY to stringSchema(minLength = 1),
         ),
       ),
       "feature_task_phase_block" to objectSchema(
         required = listOf("workflow_id", "phase_id", "attempt", "reason"),
         properties = mapOf(
-          "workflow_id" to stringSchema(minLength = 1),
-          "phase_id" to stringSchema(enum = listOf("preplan", "plan", "implement", "audit")),
+          SharedPayloadKeys.WORKFLOW_ID to stringSchema(minLength = 1),
+          SharedPayloadKeys.PHASE_ID to stringSchema(enum = listOf("preplan", "plan", "implement", "audit")),
           "attempt" to mapOf("type" to "integer", "minimum" to 1),
           "reason" to stringSchema(minLength = 1),
-          "failure_disposition" to stringSchema(
+          SharedPayloadKeys.FAILURE_DISPOSITION to stringSchema(
             enum = listOf(
               "retryable",
               "non_retryable_policy_conflict",
@@ -128,12 +132,12 @@ object McpToolRegistry {
       "feature_task_audit_settle" to objectSchema(
         required = listOf("workflow_id", "attempt", "verdict", "value"),
         properties = mapOf(
-          "workflow_id" to stringSchema(minLength = 1),
-          "phase_id" to stringSchema(enum = listOf("audit")),
+          SharedPayloadKeys.WORKFLOW_ID to stringSchema(minLength = 1),
+          SharedPayloadKeys.PHASE_ID to stringSchema(enum = listOf("audit")),
           "attempt" to mapOf("type" to "integer", "minimum" to 1),
-          "verdict" to stringSchema(enum = listOf("satisfied", "gaps_found")),
-          "value" to stringSchema(minLength = 1),
-          "summary" to stringSchema(minLength = 1),
+          SharedPayloadKeys.VERDICT to stringSchema(enum = listOf("satisfied", "gaps_found")),
+          SharedPayloadKeys.VALUE to stringSchema(minLength = 1),
+          SharedPayloadKeys.SUMMARY to stringSchema(minLength = 1),
         ),
       ),
       "feature_verify_started" to objectSchema(
@@ -295,7 +299,7 @@ object McpToolRegistry {
       "triage_findings" to objectSchema(
         required = listOf("review_run_id", "decisions"),
         properties = mapOf(
-          "review_run_id" to stringSchema(),
+          ReviewVerificationSignalKeys.REVIEW_RUN_ID to stringSchema(),
           "decisions" to arraySchema(stringSchema()),
           "orchestrated" to booleanSchema,
         ),

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/scaffold/McpScaffoldRuntimeMaps.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/scaffold/McpScaffoldRuntimeMaps.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.scaffold
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.scaffold.model.ScaffoldResult
 
 private const val SCAFFOLD_TELEMETRY_DURATION_SECONDS = 0
@@ -33,7 +35,7 @@ internal fun scaffoldSuccessMap(
     )
   } else {
     mapOf(
-      "status" to "ok",
+      SharedPayloadKeys.STATUS to "ok",
       "session_id" to sessionId,
       "skill_path" to result.skillPath.toString(),
       "notes" to result.notes,
@@ -66,7 +68,7 @@ internal fun scaffoldFailureMap(
   )
 } else {
   mapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "session_id" to sessionId,
     "error" to error.message.orEmpty(),
   )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/scaffold/McpScaffoldRuntimeMaps.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/scaffold/McpScaffoldRuntimeMaps.kt
@@ -1,7 +1,6 @@
 package skillbill.mcp.scaffold
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.scaffold.model.ScaffoldResult
 
 private const val SCAFFOLD_TELEMETRY_DURATION_SECONDS = 0

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/telemetry/TelemetryMcpResultMappers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/telemetry/TelemetryMcpResultMappers.kt
@@ -1,10 +1,12 @@
 package skillbill.mcp.telemetry
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.telemetry.model.TelemetryProxyCapabilities
 import skillbill.telemetry.model.TelemetryRemoteStatsResult
 
 internal fun TelemetryProxyCapabilities.toMcpMap(): Map<String, Any?> = linkedMapOf<String, Any?>(
-  "contract_version" to contractVersion,
+  SharedPayloadKeys.CONTRACT_VERSION to contractVersion,
   "source" to source,
   "proxy_url" to proxyUrl,
   "capabilities_url" to capabilitiesUrl,

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/telemetry/TelemetryMcpResultMappers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/telemetry/TelemetryMcpResultMappers.kt
@@ -1,7 +1,6 @@
 package skillbill.mcp.telemetry
 
 import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.telemetry.model.TelemetryProxyCapabilities
 import skillbill.telemetry.model.TelemetryRemoteStatsResult
 

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/McpWorkflowToolHandlers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/McpWorkflowToolHandlers.kt
@@ -1,9 +1,8 @@
 package skillbill.mcp.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.WorkflowFamilyKind
 import skillbill.application.workflow.model.WorkflowUpdateRequest
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.mcp.shared.McpRuntimeContext
 import skillbill.mcp.shared.int
 import skillbill.mcp.shared.optionalInt

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/McpWorkflowToolHandlers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/McpWorkflowToolHandlers.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.WorkflowFamilyKind
 import skillbill.application.workflow.model.WorkflowUpdateRequest
 import skillbill.mcp.shared.McpRuntimeContext
@@ -69,7 +71,7 @@ internal fun workflowContinue(
 ): Map<String, Any?> {
   val workflowIdOrIssueKey = arguments.optionalString("workflow_id")
     ?: arguments.optionalString("issue_key")
-    ?: return mapOf("status" to "error", "error" to "Provide workflow_id or issue_key.")
+    ?: return mapOf(SharedPayloadKeys.STATUS to "error", "error" to "Provide workflow_id or issue_key.")
   return McpWorkflowRuntime.continueWorkflow(
     kind,
     workflowIdOrIssueKey,

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsCore.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsCore.kt
@@ -1,8 +1,7 @@
 package skillbill.mcp.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.WorkflowContinueResult
+import skillbill.contracts.SharedPayloadKeys
 
 internal fun WorkflowContinueResult.Standard.toStandardMcpMap(): Map<String, Any?> =
   standardMcpContinueMap(view, dbPath, decompositionExtras = emptyMap())

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsCore.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsCore.kt
@@ -1,20 +1,22 @@
 package skillbill.mcp.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.WorkflowContinueResult
 
 internal fun WorkflowContinueResult.Standard.toStandardMcpMap(): Map<String, Any?> =
   standardMcpContinueMap(view, dbPath, decompositionExtras = emptyMap())
 
 internal fun WorkflowContinueResult.UnknownWorkflow.toUnknownWorkflowMcpMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "error",
-  "workflow_id" to workflowId,
+  SharedPayloadKeys.STATUS to "error",
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
   "error" to "Unknown workflow_id '$workflowId'.",
   "db_path" to dbPath,
 )
 
 internal fun WorkflowContinueResult.Error.toErrorMcpMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "error",
-  "workflow_id" to workflowId,
+  SharedPayloadKeys.STATUS to "error",
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
   "error" to error,
   "db_path" to dbPath,
 )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsDecomposition.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsDecomposition.kt
@@ -1,9 +1,8 @@
 package skillbill.mcp.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.model.GoalContinuationOutcome
 import skillbill.application.workflow.model.WorkflowContinueResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.model.WorkflowContinueStatus
 
 internal fun WorkflowContinueResult.DecompositionStandard.toDecompositionStandardMcpMap(): Map<String, Any?> =

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsDecomposition.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpBranchMapsDecomposition.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.model.GoalContinuationOutcome
 import skillbill.application.workflow.model.WorkflowContinueResult
 import skillbill.workflow.model.WorkflowContinueStatus
@@ -9,7 +11,7 @@ internal fun WorkflowContinueResult.DecompositionStandard.toDecompositionStandar
     view = view,
     dbPath = dbPath,
     decompositionExtras = linkedMapOf(
-      "issue_key" to (outcome?.issueKey ?: issueKey),
+      SharedPayloadKeys.ISSUE_KEY to (outcome?.issueKey ?: issueKey),
       "decomposition_subtask_id" to decompositionSubtaskId,
       "decomposition_subtask_spec_path" to decompositionSubtaskSpecPath,
       "goal_continuation_outcome" to outcome.toWireMap(),
@@ -19,9 +21,9 @@ internal fun WorkflowContinueResult.DecompositionStandard.toDecompositionStandar
 internal fun WorkflowContinueResult.DecompositionMissingSubtaskWorkflow.toDecompositionMissingSubtaskWorkflowMcpMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "subtask_id" to subtaskId,
+    SharedPayloadKeys.SUBTASK_ID to subtaskId,
     "blocked_reason" to blockedReason,
     "db_path" to dbPath,
   )
@@ -29,10 +31,10 @@ internal fun WorkflowContinueResult.DecompositionMissingSubtaskWorkflow.toDecomp
 internal fun WorkflowContinueResult.DecompositionBlockedSubtask.toDecompositionBlockedSubtaskMcpMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "decomposition_subtask_id" to subtaskId,
     "decomposition_subtask_spec_path" to subtaskSpecPath,
     "blocked_reason" to blockedReason,
@@ -43,19 +45,19 @@ internal fun WorkflowContinueResult.DecompositionBlockedSubtask.toDecompositionB
 internal fun WorkflowContinueResult.DecompositionBlockedBranchStart.toDecompositionBlockedBranchStartMcpMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "error" to blockedReason,
     "db_path" to dbPath,
   )
 
 internal fun WorkflowContinueResult.DecompositionDone.toDecompositionDoneMcpMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "ok",
+  SharedPayloadKeys.STATUS to "ok",
   "continue_status" to WorkflowContinueStatus.DONE.wireValue,
-  "workflow_id" to workflowId,
-  "issue_key" to issueKey,
+  SharedPayloadKeys.WORKFLOW_ID to workflowId,
+  SharedPayloadKeys.ISSUE_KEY to issueKey,
   "decomposition_status" to decompositionStatus,
   "db_path" to dbPath,
 )
@@ -63,10 +65,10 @@ internal fun WorkflowContinueResult.DecompositionDone.toDecompositionDoneMcpMap(
 internal fun WorkflowContinueResult.DecompositionSubtaskOutcome.toDecompositionSubtaskOutcomeMcpMap():
   Map<String, Any?> =
   linkedMapOf(
-    "status" to "ok",
+    SharedPayloadKeys.STATUS to "ok",
     "continue_status" to WorkflowContinueStatus.DONE.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "decomposition_subtask_id" to subtaskId,
     "decomposition_subtask_spec_path" to subtaskSpecPath,
     "goal_continuation_outcome" to outcome.toWireMap(),
@@ -75,10 +77,10 @@ internal fun WorkflowContinueResult.DecompositionSubtaskOutcome.toDecompositionS
 
 internal fun WorkflowContinueResult.DecompositionBlockedGit.toDecompositionBlockedGitMcpMap(): Map<String, Any?> =
   linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "continue_status" to WorkflowContinueStatus.BLOCKED.wireValue,
-    "workflow_id" to workflowId,
-    "issue_key" to issueKey,
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
+    SharedPayloadKeys.ISSUE_KEY to issueKey,
     "blocked_reason" to blockedReason,
     "error" to blockedReason,
     "db_path" to dbPath,
@@ -86,11 +88,11 @@ internal fun WorkflowContinueResult.DecompositionBlockedGit.toDecompositionBlock
 
 internal fun GoalContinuationOutcome?.toWireMap(): Map<String, Any?> = this?.let { outcome ->
   linkedMapOf(
-    "issue_key" to outcome.issueKey,
-    "subtask_id" to outcome.subtaskId,
-    "status" to outcome.status,
+    SharedPayloadKeys.ISSUE_KEY to outcome.issueKey,
+    SharedPayloadKeys.SUBTASK_ID to outcome.subtaskId,
+    SharedPayloadKeys.STATUS to outcome.status,
     "commit_sha" to outcome.commitSha,
-    "workflow_id" to outcome.workflowId,
+    SharedPayloadKeys.WORKFLOW_ID to outcome.workflowId,
     "blocked_reason" to outcome.blockedReason,
     "last_resumable_step" to outcome.lastResumableStep,
   )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpStandardMap.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpStandardMap.kt
@@ -1,8 +1,7 @@
 package skillbill.mcp.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.WorkflowWireProjections
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.engine.model.WorkflowContinueView
 import skillbill.workflow.model.WorkflowContinueStatus
 

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpStandardMap.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowContinueMcpStandardMap.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.workflow.engine.model.WorkflowContinueView
 import skillbill.workflow.model.WorkflowContinueStatus
@@ -19,12 +21,12 @@ internal fun standardMcpContinueMap(
   map["db_path"] = dbPath
   if (view.continueStatus == WorkflowContinueStatus.BLOCKED) {
     val missingArtifacts = view.resume.missingArtifacts
-    map["status"] = "error"
+    map[SharedPayloadKeys.STATUS] = "error"
     map["error"] =
       "Cannot continue workflow until the missing artifacts are restored: " +
       missingArtifacts.joinToString()
   } else {
-    map["status"] = "ok"
+    map[SharedPayloadKeys.STATUS] = "ok"
   }
   return map
 }

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowMcpResultMappers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowMcpResultMappers.kt
@@ -1,5 +1,7 @@
 package skillbill.mcp.workflow
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.application.workflow.model.WorkflowGetResult
 import skillbill.application.workflow.model.WorkflowLatestResult
@@ -28,12 +30,12 @@ internal fun WorkflowOpenResult.toMcpMap(
 ): Map<String, Any?> = when (this) {
   is WorkflowOpenResult.Ok -> workflowSnapshotMcpMap(snapshot, goalObservabilityEventValidator).apply {
     launchProjection?.let { put("launch_projection", WorkflowWireProjections.inputProjectionMap(it)) }
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowOpenResult.Error -> linkedMapOf(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
   )
 }
@@ -51,8 +53,8 @@ internal fun WorkflowUpdateResult.toMcpMap(): Map<String, Any?> = when (this) {
     put("db_path", dbPath)
   }
   is WorkflowUpdateResult.Error -> linkedMapOf<String, Any?>(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
   ).apply { dbPath?.let { put("db_path", it) } }
 }
@@ -61,19 +63,19 @@ internal fun WorkflowGetResult.toMcpMap(
   goalObservabilityEventValidator: GoalObservabilityEventValidator,
 ): Map<String, Any?> = when (this) {
   is WorkflowGetResult.Ok -> workflowSnapshotMcpMap(snapshot, goalObservabilityEventValidator).apply {
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowGetResult.Error -> linkedMapOf(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
     "db_path" to dbPath,
   )
 }
 
 internal fun WorkflowListResult.toMcpMap(): Map<String, Any?> = linkedMapOf(
-  "status" to "ok",
+  SharedPayloadKeys.STATUS to "ok",
   "db_path" to dbPath,
   "workflow_count" to workflowCount,
   "workflows" to workflows.map(WorkflowWireProjections::summaryMap),
@@ -81,11 +83,11 @@ internal fun WorkflowListResult.toMcpMap(): Map<String, Any?> = linkedMapOf(
 
 internal fun WorkflowLatestResult.toMcpMap(): Map<String, Any?> = when (this) {
   is WorkflowLatestResult.Ok -> LinkedHashMap(WorkflowWireProjections.summaryMap(summary)).apply {
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowLatestResult.Error -> linkedMapOf(
-    "status" to "error",
+    SharedPayloadKeys.STATUS to "error",
     "error" to error,
     "db_path" to dbPath,
   )
@@ -93,12 +95,12 @@ internal fun WorkflowLatestResult.toMcpMap(): Map<String, Any?> = when (this) {
 
 internal fun WorkflowResumeResult.toMcpMap(): Map<String, Any?> = when (this) {
   is WorkflowResumeResult.Ok -> LinkedHashMap(WorkflowWireProjections.resumeMap(resume)).apply {
-    put("status", "ok")
+    put(SharedPayloadKeys.STATUS, "ok")
     put("db_path", dbPath)
   }
   is WorkflowResumeResult.Error -> linkedMapOf(
-    "status" to "error",
-    "workflow_id" to workflowId,
+    SharedPayloadKeys.STATUS to "error",
+    SharedPayloadKeys.WORKFLOW_ID to workflowId,
     "error" to error,
     "db_path" to dbPath,
   )

--- a/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowMcpResultMappers.kt
+++ b/runtime-kotlin/runtime-mcp/src/main/kotlin/skillbill/mcp/workflow/WorkflowMcpResultMappers.kt
@@ -1,7 +1,5 @@
 package skillbill.mcp.workflow
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.application.workflow.WorkflowWireProjections
 import skillbill.application.workflow.model.WorkflowGetResult
 import skillbill.application.workflow.model.WorkflowLatestResult
@@ -9,6 +7,7 @@ import skillbill.application.workflow.model.WorkflowListResult
 import skillbill.application.workflow.model.WorkflowOpenResult
 import skillbill.application.workflow.model.WorkflowResumeResult
 import skillbill.application.workflow.model.WorkflowUpdateResult
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.workflow.goal.GoalObservabilityEventValidator
 
 /**

--- a/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
+++ b/runtime-kotlin/runtime-mcp/src/test/kotlin/skillbill/mcp/McpRuntimeTest.kt
@@ -507,7 +507,11 @@ class McpRuntimeTest {
     val workflowId = opened["workflow_id"] as String
     assertWorkflowIdShape(workflowId, "wfv")
     assertSqliteTimestampShape(opened["started_at"].toString(), "verify started_at")
-    assertEquals(opened["started_at"], opened["updated_at"])
+    assertSqliteTimestampShape(opened["updated_at"].toString(), "verify updated_at")
+    assertTrue(
+      opened["updated_at"].toString() >= opened["started_at"].toString(),
+      "verify updated_at must not precede started_at",
+    )
     val updated = markVerifyWorkflowVerdictBlocked(workflowId, context)
     val listed = McpWorkflowRuntime.list(WorkflowFamilyKind.VERIFY, context = context)
     val latest = McpWorkflowRuntime.latest(WorkflowFamilyKind.VERIFY, context)

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/review/model/ReviewAccountingRecord.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/review/model/ReviewAccountingRecord.kt
@@ -1,5 +1,7 @@
 package skillbill.ports.review.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
 import skillbill.error.InvalidReviewContextSchemaError
@@ -17,7 +19,7 @@ data class ReviewAccountingRecord(
 }
 
 private fun requireBoundedAccountingPayload(payload: Map<String, Any?>) {
-  val legacy = payload["contract_version"] == LEGACY_REVIEW_CONTEXT_CONTRACT_VERSION
+  val legacy = payload[SharedPayloadKeys.CONTRACT_VERSION] == LEGACY_REVIEW_CONTEXT_CONTRACT_VERSION
   val topKeys = if (legacy) {
     setOf(
       "contract_version", "kind", "review_id", "packet_digest", "parent", "lanes", "aggregate_counters",
@@ -33,7 +35,7 @@ private fun requireBoundedAccountingPayload(payload: Map<String, Any?>) {
     payload[key]?.let { require(it is Map<*, *>) { "Review accounting '$key' must be an object when present." } }
   }
   require(
-    payload["contract_version"] in setOf(REVIEW_CONTEXT_CONTRACT_VERSION, LEGACY_REVIEW_CONTEXT_CONTRACT_VERSION) &&
+    payload[SharedPayloadKeys.CONTRACT_VERSION] in setOf(REVIEW_CONTEXT_CONTRACT_VERSION, LEGACY_REVIEW_CONTEXT_CONTRACT_VERSION) &&
       payload["kind"] == "accounting_summary",
   )
   require(payload["review_id"] is String && payload["packet_digest"] is String)

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/review/model/ReviewAccountingRecord.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/review/model/ReviewAccountingRecord.kt
@@ -1,8 +1,7 @@
 package skillbill.ports.review.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 import skillbill.contracts.review.REVIEW_CONTEXT_CONTRACT_VERSION
 import skillbill.error.InvalidReviewContextSchemaError
 
@@ -35,7 +34,10 @@ private fun requireBoundedAccountingPayload(payload: Map<String, Any?>) {
     payload[key]?.let { require(it is Map<*, *>) { "Review accounting '$key' must be an object when present." } }
   }
   require(
-    payload[SharedPayloadKeys.CONTRACT_VERSION] in setOf(REVIEW_CONTEXT_CONTRACT_VERSION, LEGACY_REVIEW_CONTEXT_CONTRACT_VERSION) &&
+    payload[SharedPayloadKeys.CONTRACT_VERSION] in setOf(
+      REVIEW_CONTEXT_CONTRACT_VERSION,
+      LEGACY_REVIEW_CONTEXT_CONTRACT_VERSION,
+    ) &&
       payload["kind"] == "accounting_summary",
   )
   require(payload["review_id"] is String && payload["packet_digest"] is String)

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/telemetry/model/ReviewFinishedTelemetryPayload.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/telemetry/model/ReviewFinishedTelemetryPayload.kt
@@ -1,10 +1,8 @@
 package skillbill.ports.telemetry.model
 
-import skillbill.contracts.review.ReviewVerificationSignalKeys
-
-import skillbill.contracts.review.ReviewFindingPayloadKeys
-
 import skillbill.contracts.JsonPayloadContract
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+import skillbill.contracts.review.ReviewVerificationSignalKeys
 import skillbill.review.model.ReviewFindingDetail
 import skillbill.review.model.ReviewFinishedFindingStats
 import skillbill.review.model.ReviewFinishedTelemetry

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/telemetry/model/ReviewFinishedTelemetryPayload.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/telemetry/model/ReviewFinishedTelemetryPayload.kt
@@ -1,5 +1,9 @@
 package skillbill.ports.telemetry.model
 
+import skillbill.contracts.review.ReviewVerificationSignalKeys
+
+import skillbill.contracts.review.ReviewFindingPayloadKeys
+
 import skillbill.contracts.JsonPayloadContract
 import skillbill.review.model.ReviewFindingDetail
 import skillbill.review.model.ReviewFinishedFindingStats
@@ -16,7 +20,7 @@ private class ReviewFinishedTelemetryPayloadContract(
 ) : JsonPayloadContract {
   override fun toPayload(): Map<String, Any?> = LinkedHashMap<String, Any?>().apply {
     putAll(telemetry.findingStats.toPayload())
-    put("review_run_id", telemetry.reviewRunId)
+    put(ReviewVerificationSignalKeys.REVIEW_RUN_ID, telemetry.reviewRunId)
     put("review_session_id", telemetry.reviewSessionId)
     put("routed_skill", telemetry.routedSkill)
     put("review_subskills", telemetry.reviewSubskills)
@@ -47,8 +51,8 @@ private fun ReviewFinishedFindingStats.toPayload(): Map<String, Any?> = linkedMa
 )
 
 private fun ReviewFindingDetail.toReviewFinishedPayload(): Map<String, Any?> = linkedMapOf<String, Any?>(
-  "finding_id" to findingId,
-  "issue_category" to issueCategory,
+  ReviewFindingPayloadKeys.FINDING_ID to findingId,
+  ReviewFindingPayloadKeys.ISSUE_CATEGORY to issueCategory,
   "severity" to severity,
   "confidence" to confidence,
   "outcome_type" to outcomeType,
@@ -94,12 +98,12 @@ private fun ReviewStageMetrics.toStageMetricsPayload(): Map<String, Any?> = link
 )
 
 private fun ReviewStageVerdictDistribution.toStageMetricsPayload(): Map<String, Any?> = linkedMapOf(
-  "claim_verdict" to linkedMapOf(
+  ReviewFindingPayloadKeys.CLAIM_VERDICT to linkedMapOf(
     "confirmed" to confirmed,
     "refuted" to refuted,
     "unresolved" to unresolved,
   ),
-  "scope_disposition" to linkedMapOf(
+  ReviewFindingPayloadKeys.SCOPE_DISPOSITION to linkedMapOf(
     "in_scope" to inScope,
     "out_of_scope_preexisting" to outOfScopePreexisting,
     "spec_deviation" to specDeviation,

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/model/RepoValidationGatewayModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/model/RepoValidationGatewayModels.kt
@@ -1,8 +1,7 @@
 package skillbill.ports.validation.model
 
-import skillbill.contracts.SharedPayloadKeys
-
 import skillbill.boundary.OpenBoundaryMap
+import skillbill.contracts.SharedPayloadKeys
 
 data class RepoValidationReport(
   val issues: List<String>,

--- a/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/model/RepoValidationGatewayModels.kt
+++ b/runtime-kotlin/runtime-ports/src/main/kotlin/skillbill/ports/validation/model/RepoValidationGatewayModels.kt
@@ -1,5 +1,7 @@
 package skillbill.ports.validation.model
 
+import skillbill.contracts.SharedPayloadKeys
+
 import skillbill.boundary.OpenBoundaryMap
 
 data class RepoValidationReport(
@@ -14,7 +16,7 @@ data class RepoValidationReport(
 
   @OpenBoundaryMap("Wire-shape serializer for repo-validation report")
   fun toPayload(): Map<String, Any?> = mapOf(
-    "status" to if (passed) "passed" else "failed",
+    SharedPayloadKeys.STATUS to if (passed) "passed" else "failed",
     "skill_count" to skillCount,
     "governed_addon_count" to addonCount,
     "platform_pack_count" to platformPackCount,


### PR DESCRIPTION
## Summary
- Add `ReviewVerificationSignalKeys` and `ReviewFindingPayloadKeys` in `runtime-contracts` as the single owners for review wire vocabulary; `FeatureTaskRuntimeVerificationSignalKeys` now aliases those constants instead of restating strings.
- Replace inline workflow and review map-key literals across the runtime with `SharedPayloadKeys`, `ReviewVerificationSignalKeys`, and `ReviewFindingPayloadKeys` references.
- Enable payload-key access checking in `WireVocabularyArchitectureTest` and document the rule in `AGENTS.md`.

## Test plan
- [x] `./gradlew :runtime-core:test --tests skillbill.architecture.WireVocabularyArchitectureTest`
- [x] `./gradlew compileKotlin compileTestKotlin`
- [ ] CI


Made with [Cursor](https://cursor.com)